### PR TITLE
feat(gl-mr): list conflicting files + hunks + resolve commands

### DIFF
--- a/presets/gitlab/mr.py
+++ b/presets/gitlab/mr.py
@@ -21,6 +21,119 @@ def _glab_api(endpoint: str, timeout: int = 10) -> subprocess.CompletedProcess[s
     )
 
 
+_MERGE_TREE_NOISE_PREFIXES = (
+    "Auto-merging ",
+    "CONFLICT ",
+    "warning:",
+    "hint:",
+    "error:",
+)
+
+
+def _get_conflicting_files(source: str, target: str) -> list[str]:
+    """Find files in conflict between source and target via local git.
+
+    Uses `git merge-tree --name-only --write-tree` (git 2.38+). Returns
+    deduplicated list of conflicting paths, or empty list on any failure
+    (not a git repo, refs not fetched, old git version, cwd outside the
+    repo). Caller falls back to the plain "Conflicts: YES" message in
+    that case.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "merge-tree", "--name-only", "--write-tree",
+             f"origin/{target}", f"origin/{source}"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+    # Exit code 0 = clean merge; >0 = conflicts, file list + git status messages on stdout.
+    if result.returncode == 0:
+        return []
+    files: list[str] = []
+    seen: set[str] = set()
+    for raw in result.stdout.splitlines():
+        line = raw.strip()
+        if not line or line in seen:
+            continue
+        if re.fullmatch(r"[0-9a-f]{40}", line):
+            # First line of merge-tree output is the merged tree hash.
+            continue
+        if any(line.startswith(p) for p in _MERGE_TREE_NOISE_PREFIXES):
+            # Git's status messages get mixed into stdout; drop them.
+            continue
+        files.append(line)
+        seen.add(line)
+    return files
+
+
+_MERGE_TREE_HEADER_RE = re.compile(
+    r"^(changed in both|added in (?:local|remote)|removed in (?:local|remote))\b"
+)
+_MERGE_TREE_PATH_RE = re.compile(
+    r"^  (?:base|our|their)\s+\d+\s+[0-9a-f]+\s+(.+)$"
+)
+HUNK_LINES_PER_FILE = 40
+
+
+def _get_conflict_hunks(source: str, target: str) -> dict[str, str]:
+    """Return per-file conflict diff for hunk preview.
+
+    Uses the older `git merge-tree BASE TARGET SOURCE` syntax which
+    produces unified-diff-style output with `<<<<<<< / ======= / >>>>>>>`
+    conflict markers. Each per-file block is split off the section
+    headers ("changed in both", "added in local", etc.). Returns dict
+    mapping file path -> diff text. Empty dict on any failure.
+    """
+    try:
+        base_result = subprocess.run(
+            ["git", "merge-base", f"origin/{target}", f"origin/{source}"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return {}
+    if base_result.returncode != 0 or not base_result.stdout.strip():
+        return {}
+    base = base_result.stdout.strip()
+
+    try:
+        result = subprocess.run(
+            ["git", "merge-tree", base,
+             f"origin/{target}", f"origin/{source}"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return {}
+    if not result.stdout:
+        return {}
+
+    blocks: dict[str, list[str]] = {}
+    current_path: str | None = None
+    current_lines: list[str] = []
+
+    def _flush() -> None:
+        if current_path:
+            blocks.setdefault(current_path, []).extend(current_lines)
+
+    for line in result.stdout.splitlines():
+        if _MERGE_TREE_HEADER_RE.match(line):
+            _flush()
+            current_path = None
+            current_lines = []
+            continue
+        path_match = _MERGE_TREE_PATH_RE.match(line)
+        if path_match:
+            # Header is followed by 1-3 path lines (base/our/their) — same path.
+            if current_path is None:
+                current_path = path_match.group(1)
+            continue
+        if current_path is not None:
+            current_lines.append(line)
+    _flush()
+
+    return {p: "\n".join(lines).strip() for p, lines in blocks.items() if any(lines)}
+
+
 def _format_error(stderr: str, resource: str, identifier: str) -> str:
     """Classify glab errors into actionable messages for LLMs."""
     s = stderr.lower()
@@ -173,8 +286,13 @@ def main() -> int:
     print(f"Changes: {changes} files, +{additions} -{deletions}")
 
     # Conflicts
+    conflict_files: list[str] = []
     if has_conflicts:
-        print("Conflicts: YES — cannot merge")
+        conflict_files = _get_conflicting_files(source, target)
+        if conflict_files:
+            print(f"Conflicts: YES — cannot merge ({len(conflict_files)} file{'s' if len(conflict_files) != 1 else ''})")
+        else:
+            print("Conflicts: YES — cannot merge")
     else:
         print(f"Merge status: {merge_status}")
 
@@ -184,6 +302,36 @@ def main() -> int:
 
     if web_url:
         print(f"URL: {web_url}")
+
+    # Conflict file list + hunks — only when conflicts exist and we computed them
+    if conflict_files:
+        plural = "s" if len(conflict_files) != 1 else ""
+        print(f"\n## Conflicts ({len(conflict_files)} file{plural})")
+        for path in conflict_files:
+            print(f"  {path}")
+
+        hunks = _get_conflict_hunks(source, target)
+        for path in conflict_files:
+            block = hunks.get(path, "")
+            if not block:
+                continue
+            lines = block.splitlines()
+            truncated = ""
+            if len(lines) > HUNK_LINES_PER_FILE:
+                extra = len(lines) - HUNK_LINES_PER_FILE
+                lines = lines[:HUNK_LINES_PER_FILE]
+                truncated = f"\n  ... ({extra} more lines)"
+            print(f"\n### {path}")
+            for line in lines:
+                print(f"  {line}")
+            if truncated:
+                print(truncated)
+
+        print("\nTo resolve:")
+        print(f"  git checkout {source} && git fetch origin && git merge origin/{target}")
+        files_arg = " ".join(conflict_files)
+        print(f"  # Resolve <<<<<<< markers in the files above, then:")
+        print(f"  git add {files_arg} && git commit && git push")
 
     # Linked issue — extract from description or closing_issues
     description_raw = d.get("description") or ""

--- a/tests/test_gitlab_mr.py
+++ b/tests/test_gitlab_mr.py
@@ -1,0 +1,207 @@
+"""Unit tests for presets/gitlab/mr.py conflict-parsing helpers.
+
+These exercise the two helpers added to gl-mr that turn raw `git merge-tree`
+output into actionable info (file list + per-file hunk preview) so the LLM
+sees the conflict shape in one round-trip without opening files.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PRESET_PATH = Path(__file__).parent.parent / "presets" / "gitlab" / "mr.py"
+_spec = importlib.util.spec_from_file_location("gitlab_mr", PRESET_PATH)
+assert _spec is not None and _spec.loader is not None
+mr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mr)
+
+
+def _fake_run(stdout: str, returncode: int = 1) -> Any:
+    """Build a fake subprocess.run result."""
+    return subprocess.CompletedProcess(
+        args=["git"], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+# ---------------------------------------------------------------------------
+# _get_conflicting_files
+# ---------------------------------------------------------------------------
+
+def test_get_conflicting_files_filters_noise(monkeypatch) -> None:
+    """git merge-tree --name-only mixes file names with status messages.
+
+    Real-world output for one conflicted file: 1 path + Auto-merging line +
+    CONFLICT line. The helper must dedupe to the actual paths.
+    """
+    raw = (
+        "abc123def456abc123def456abc123def456abcd\n"
+        ".claude/findings.md\n"
+        "Auto-merging .claude/findings.md\n"
+        "CONFLICT (content): Merge conflict in .claude/findings.md\n"
+    )
+    monkeypatch.setattr(
+        mr.subprocess, "run", lambda *a, **kw: _fake_run(raw, returncode=1)
+    )
+    files = mr._get_conflicting_files("source", "master")
+    assert files == [".claude/findings.md"]
+
+
+def test_get_conflicting_files_multiple_files(monkeypatch) -> None:
+    raw = (
+        "abc123def456abc123def456abc123def456abcd\n"
+        "src/foo.py\n"
+        "Auto-merging src/foo.py\n"
+        "CONFLICT (content): Merge conflict in src/foo.py\n"
+        "src/bar.py\n"
+        "Auto-merging src/bar.py\n"
+        "CONFLICT (content): Merge conflict in src/bar.py\n"
+    )
+    monkeypatch.setattr(
+        mr.subprocess, "run", lambda *a, **kw: _fake_run(raw, returncode=1)
+    )
+    files = mr._get_conflicting_files("source", "master")
+    assert files == ["src/foo.py", "src/bar.py"]
+
+
+def test_get_conflicting_files_clean_merge_returns_empty(monkeypatch) -> None:
+    """Exit code 0 means no conflicts — output is just the merged tree hash."""
+    monkeypatch.setattr(
+        mr.subprocess, "run",
+        lambda *a, **kw: _fake_run("abc123def456abc123def456abc123def456abcd\n", returncode=0),
+    )
+    assert mr._get_conflicting_files("source", "master") == []
+
+
+def test_get_conflicting_files_handles_subprocess_error(monkeypatch) -> None:
+    """Not a git repo / git not installed / refs missing — return empty."""
+    def boom(*a: Any, **kw: Any) -> Any:
+        raise FileNotFoundError("git: not found")
+    monkeypatch.setattr(mr.subprocess, "run", boom)
+    assert mr._get_conflicting_files("source", "master") == []
+
+
+def test_get_conflicting_files_handles_timeout(monkeypatch) -> None:
+    def boom(*a: Any, **kw: Any) -> Any:
+        raise subprocess.TimeoutExpired(cmd="git", timeout=10)
+    monkeypatch.setattr(mr.subprocess, "run", boom)
+    assert mr._get_conflicting_files("source", "master") == []
+
+
+def test_get_conflicting_files_skips_warning_hint_error_lines(monkeypatch) -> None:
+    raw = (
+        "abc123def456abc123def456abc123def456abcd\n"
+        "warning: something might be wrong\n"
+        "hint: try this instead\n"
+        "error: minor non-fatal\n"
+        "real/path.txt\n"
+        "Auto-merging real/path.txt\n"
+    )
+    monkeypatch.setattr(
+        mr.subprocess, "run", lambda *a, **kw: _fake_run(raw, returncode=1)
+    )
+    assert mr._get_conflicting_files("source", "master") == ["real/path.txt"]
+
+
+# ---------------------------------------------------------------------------
+# _get_conflict_hunks
+# ---------------------------------------------------------------------------
+
+def test_get_conflict_hunks_parses_real_output(monkeypatch) -> None:
+    """Two-call shape: merge-base then merge-tree (old syntax).
+
+    The merge-tree output groups per file with a section header
+    ('changed in both' / 'added in remote' / etc.) followed by 1-3
+    `  base/our/their <mode> <oid> <path>` lines, then the diff body.
+    """
+    base_out = "deadbeef1234567890abcdef1234567890abcdef\n"
+    tree_out = (
+        "changed in both\n"
+        "  base   100644 e600561691646ac9d7c6eeab55de8388c8c136a0 path/to/file.md\n"
+        "  our    100644 3dbb3a53711179b78dbe9ac20c77be6d361e32a0 path/to/file.md\n"
+        "  their  100644 a6140bbda7525d73eb5f2fe5e87e2065ca505de0 path/to/file.md\n"
+        "@@ -1,3 +1,3 @@\n"
+        "<<<<<<< .our\n"
+        "ours line\n"
+        "=======\n"
+        "theirs line\n"
+        ">>>>>>> .their\n"
+    )
+
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(args))
+        if args[1] == "merge-base":
+            return _fake_run(base_out, returncode=0)
+        return _fake_run(tree_out, returncode=1)
+
+    monkeypatch.setattr(mr.subprocess, "run", fake_run)
+    hunks = mr._get_conflict_hunks("source", "master")
+    assert "path/to/file.md" in hunks
+    body = hunks["path/to/file.md"]
+    assert "<<<<<<< .our" in body
+    assert "=======" in body
+    assert ">>>>>>> .their" in body
+    # Section header and base/our/their lines must NOT be in the diff body
+    assert "changed in both" not in body
+    assert "  base   100644" not in body
+
+
+def test_get_conflict_hunks_multiple_files(monkeypatch) -> None:
+    base_out = "deadbeef1234567890abcdef1234567890abcdef\n"
+    tree_out = (
+        "changed in both\n"
+        "  base   100644 aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111 file_a.txt\n"
+        "  our    100644 bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222 file_a.txt\n"
+        "  their  100644 cccc3333cccc3333cccc3333cccc3333cccc3333 file_a.txt\n"
+        "@@ -1 +1 @@\n"
+        "diff for A\n"
+        "added in remote\n"
+        "  their  100644 dddd4444dddd4444dddd4444dddd4444dddd4444 file_b.txt\n"
+        "@@ -0,0 +1 @@\n"
+        "diff for B\n"
+    )
+    monkeypatch.setattr(
+        mr.subprocess, "run",
+        lambda args, **kw: _fake_run(base_out, returncode=0)
+        if args[1] == "merge-base"
+        else _fake_run(tree_out, returncode=1),
+    )
+    hunks = mr._get_conflict_hunks("source", "master")
+    assert set(hunks.keys()) == {"file_a.txt", "file_b.txt"}
+    assert "diff for A" in hunks["file_a.txt"]
+    assert "diff for B" in hunks["file_b.txt"]
+    # Cross-contamination check
+    assert "diff for B" not in hunks["file_a.txt"]
+    assert "diff for A" not in hunks["file_b.txt"]
+
+
+def test_get_conflict_hunks_merge_base_failure(monkeypatch) -> None:
+    """If merge-base fails (refs not fetched) we cannot compute hunks."""
+    monkeypatch.setattr(
+        mr.subprocess, "run",
+        lambda *a, **kw: _fake_run("", returncode=128),
+    )
+    assert mr._get_conflict_hunks("source", "master") == {}
+
+
+def test_get_conflict_hunks_empty_merge_tree_output(monkeypatch) -> None:
+    base_out = "deadbeef1234567890abcdef1234567890abcdef\n"
+    monkeypatch.setattr(
+        mr.subprocess, "run",
+        lambda args, **kw: _fake_run(base_out, returncode=0)
+        if args[1] == "merge-base"
+        else _fake_run("", returncode=0),
+    )
+    assert mr._get_conflict_hunks("source", "master") == {}
+
+
+def test_get_conflict_hunks_handles_subprocess_error(monkeypatch) -> None:
+    def boom(*a: Any, **kw: Any) -> Any:
+        raise FileNotFoundError("git: not found")
+    monkeypatch.setattr(mr.subprocess, "run", boom)
+    assert mr._get_conflict_hunks("source", "master") == {}


### PR DESCRIPTION
## Context

When an MR has conflicts, gl-mr previously emitted only \`Conflicts: YES — cannot merge\` — one bit of info. The LLM then has to dig: figure out which files conflict, where, and how to resolve. That dig regularly turned into 5–10 round-trips of \`git\`/\`glab\` archaeology. Today's session was the breaking point: ~20 turns to investigate one conflict that supertool should have surfaced upfront.

This PR makes \`gl-mr:NUMBER\` actionable in one round-trip.

## What changed

When \`has_conflicts: true\`, gl-mr now:

1. **Lists each conflicting file path** under a \`## Conflicts (N files)\` section.
2. **Shows the diff hunks per file** with \`<<<<<<< / ======= / >>>>>>>\` markers extracted from \`git merge-tree\`. The LLM sees what's clashing without opening the file.
3. **Prints the exact resolve commands** ready to copy-paste:
   \`\`\`
   git checkout <source> && git fetch origin && git merge origin/<target>
   # resolve markers, then:
   git add <files> && git commit && git push
   \`\`\`

Two new helpers:

- **\`_get_conflicting_files()\`** — runs \`git merge-tree --name-only --write-tree\` and filters out git's noise lines (\`Auto-merging\`, \`CONFLICT\`, \`warning:\`, \`hint:\`, \`error:\`) plus the leading tree hash. Dedupes paths.
- **\`_get_conflict_hunks()\`** — runs the older \`git merge-tree BASE TARGET SOURCE\` syntax to get unified-diff output, parses per-file blocks by section headers (\`changed in both\`, \`added in remote\`, etc.), returns \`dict[path → diff text]\`.

Both helpers fall back gracefully (empty result, existing behaviour preserved) on any failure: not a git repo, refs not fetched, old git version, timeouts.

## Why this matters

\`supertool\` exists to collapse N round-trips into 1. \"There's a conflict\" with no file list forced the LLM to do its own merge attempt to find them — N turns wasted, multiplied by every conflict-on-MR scenario in autonomous runs.

## Test plan

- [x] \`pytest tests/test_gitlab_mr.py\` — 11/11 pass (first tests for the gitlab preset)
- [x] Full suite — 480/480 pass
- [x] Smoke against !20591 (real conflict): file listed, hunks shown with conflict markers, resolve commands included
- [x] Smoke against !20598 (no conflict): falls through to plain \`Merge status: ...\` — no extra noise

🤖 Generated by Max — One bit of info became actionable; the next 9 turns can stay home.