### PR TITLE
Improve supertool hook-stdout cap handling

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -6,42 +6,42 @@
   "builtin-ops": {
     "read": {
       "syntax": "read:PATH[:OFFSET:LIMIT]",
-      "description": "Read file (first 300 lines, 20KB cap)",
+      "description": "Read file (300 lines, 20KB cap)",
       "example": "read:src/app/Module.py:10:50",
       "max_lines": 300,
       "max_bytes": 20000
     },
     "read-grep": {
       "syntax": "read:PATH:::grep=PATTERN",
-      "description": "Inline filter — only matching lines, original line numbers preserved",
+      "description": "Inline filter — matching lines, line nums kept",
       "example": "read:src/app/Module.py:::grep=class"
     },
     "grep": {
       "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]]",
-      "description": "Search (10 results default). CONTEXT shows N surrounding lines before/after each match",
+      "description": "Search (10 results def). CONTEXT=N lines around match",
       "example": "grep:class:src/app/:20",
       "max_results": 10,
       "extensions": []
     },
     "grep-count": {
       "syntax": "grep:PATTERN:PATH:LIMIT:CONTEXT:count",
-      "description": "Count mode — match counts per file, no content",
+      "description": "Count mode — match counts/file, no content",
       "example": "grep:TODO:src/:100:0:count"
     },
     "around": {
       "syntax": "around:PATTERN:PATH[:N]",
-      "description": "First match in a single file + N lines context (default 10). One-shot grep+read",
+      "description": "First match + N lines ctx (def 10). 1-shot grep+read",
       "example": "around:def main:src/app/Module.py:15"
     },
     "glob": {
       "syntax": "glob:PATTERN",
-      "description": "Find files (supports **). Auto-reads if concrete path (no wildcards)",
+      "description": "Find files (**). Auto-reads concrete paths",
       "example": "glob:src/app/**/*.py",
       "max_results": 50
     },
     "ls": {
       "syntax": "ls:PATH",
-      "description": "List directory contents (dirs get trailing /)",
+      "description": "List dir (dirs get /)",
       "example": "ls:src/app/"
     },
     "tail": {
@@ -61,27 +61,27 @@
     },
     "map": {
       "syntax": "map:PATH",
-      "description": "Symbol tree (classes, functions, methods, constants). Three-tier: tree-sitter > ctags > regex",
+      "description": "Symbol tree. tree-sitter>ctags>regex",
       "example": "map:src/app/"
     },
     "diff": {
       "syntax": "diff:PATH1:PATH2",
-      "description": "Unified diff between two files",
+      "description": "Unified diff of 2 files",
       "example": "diff:src/app/Module.py:src/app/Config.py"
     },
     "stat": {
       "syntax": "stat:PATH",
-      "description": "File/directory metadata: size, last modified, type",
+      "description": "File meta: size, mtime, type",
       "example": "stat:src/app/Module.py"
     },
     "around_line": {
       "syntax": "around_line:PATH:LINE[:N]",
-      "description": "Show N lines of context around a specific line number (default 10). Target line marked with →",
+      "description": "N lines around LINE (def 10). Target marked →",
       "example": "around_line:src/app/Module.py:42:5"
     },
     "between": {
       "syntax": "between:SYMBOL:PATH | between:re:START:END:PATH",
-      "description": "Return a chunk of a file. Symbol mode: full body of a named function/method/class via tree-sitter (any language tree-sitter parses). Pattern mode (re: prefix): inclusive line slice from first line matching START regex to first line after matching END regex.",
+      "description": "Chunk of file. Symbol mode (tree-sitter, multi-lang) or re:START:END pattern mode",
       "example": "between:op_dispatch:src/app/Module.py"
     },
     "version": {
@@ -91,12 +91,12 @@
     },
     "tree": {
       "syntax": "tree:PATH[:DEPTH]",
-      "description": "Directory structure with depth limit (default 3). Hides dotfiles.",
+      "description": "Dir tree, depth=N (def 3). Hides dotfiles",
       "example": "tree:src/app/:2"
     },
     "blame": {
       "syntax": "blame:PATH:LINE[:N]",
-      "description": "Git blame for N lines (default 5) around a specific line number",
+      "description": "Git blame N lines around LINE (def 5)",
       "example": "blame:src/app/Module.py:42:3"
     }
   },

--- a/.supertool.json
+++ b/.supertool.json
@@ -1,53 +1,59 @@
 {
   "compact": false,
   "rtk": false,
-  "presets": ["github", "git"],
-  "introduction": "supertool batches multiple file operations into one Bash call.\n\nInvoke via Bash:\n./supertool \\\n    'read:supertool.py' \\\n    'read:tests/test_ops.py' \\\n    'grep:def op_:supertool.py:20' \\\n    'map:supertool.py'\n\nRules:\n- One call, many ops. 6-7 per call is normal. Each separate call wastes money.\n- Paths are relative to project root.\n- Single quotes around each op.\n- Use Read tool ONLY for the file you're about to Edit \u2014 supertool for everything else.",
-  "output-format": "Each operation returns a header followed by its output:\n\n```\n--- read:supertool.py ---\n(979 lines, 35000 bytes)\n     1\u2192#!/usr/bin/env python3\n     2\u2192\n     3\u2192import os\n     4\u2192import sys\n\n--- grep:def op_:supertool.py:5 ---\n(3 results, limit 5)\nsupertool.py\n  362:def op_read  [362]\n  367:def op_grep  [367]\n  464:def op_around  [464]\n\n--- map:supertool.py ---\n(1 files, tier: tree-sitter)\nsupertool.py (979 lines)\n  def op_read  [362]\n  def op_grep  [367]\n  def op_around  [464]\n```",
+  "presets": [
+    "github",
+    "git"
+  ],
+  "introduction": "./supertool 'op:args' 'op:args'... Batch 6-7 ops/call. Single quotes per op. Paths from root. Use ops not raw cmds (mysql_read, phpstan, batched reads). Read only before Edit.",
+  "output-format": "Each op: header + body.\n```\n--- op:args ---\n(meta)\noutput\n```",
   "builtin-ops": {
     "read": {
       "syntax": "read:PATH[:OFFSET:LIMIT]",
-      "description": "Read file (first 300 lines, 20KB cap)",
+      "description": "Read file (300 lines, 20KB cap)",
       "example": "read:supertool.py:1:50"
     },
     "read-grep": {
       "syntax": "read:PATH:::grep=PATTERN",
-      "description": "Inline filter \u2014 only matching lines, original line numbers preserved",
-      "example": "read:supertool.py:::grep=def op_"
+      "description": "Inline filter — only matching lines, line nums kept",
+      "example": "read:supertool.py:::grep=def op_",
+      "hint": true
     },
     "grep": {
       "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]]",
-      "description": "Search (10 results default). CONTEXT shows N surrounding lines before/after each match",
+      "description": "Search (10 results def). CONTEXT=N lines around match",
       "example": "grep:dispatch:supertool.py:10:2"
     },
     "grep-count": {
       "syntax": "grep:PATTERN:PATH:LIMIT:CONTEXT:count",
-      "description": "Count mode \u2014 match counts per file, no content",
-      "example": "grep:def:supertool.py:100:0:count"
+      "description": "Count mode — match counts/file, no content",
+      "example": "grep:def:supertool.py:100:0:count",
+      "hint": true
     },
     "around": {
       "syntax": "around:PATTERN:PATH[:N]",
-      "description": "First match in a single file + N lines context (default 10). One-shot grep+read",
-      "example": "around:def dispatch:supertool.py:15"
+      "description": "First match + N lines ctx (def 10). 1-shot grep+read",
+      "example": "around:def dispatch:supertool.py:15",
+      "hint": true
     },
     "glob": {
       "syntax": "glob:PATTERN",
-      "description": "Find files (supports **). Auto-reads if concrete path (no wildcards)",
+      "description": "Find files (**). Auto-reads concrete paths",
       "example": "glob:tests/**/*.py"
     },
     "ls": {
       "syntax": "ls:PATH",
-      "description": "List directory contents (dirs get trailing /)",
+      "description": "List dir (dirs get /)",
       "example": "ls:tests/"
     },
     "tail": {
       "syntax": "tail:PATH:N",
-      "description": "Last N lines (default 20)",
+      "description": "Last N lines (def 20)",
       "example": "tail:supertool.py:30"
     },
     "head": {
       "syntax": "head:PATH:N",
-      "description": "First N lines (default 20)",
+      "description": "First N lines (def 20)",
       "example": "head:supertool.py:30"
     },
     "wc": {
@@ -57,28 +63,30 @@
     },
     "map": {
       "syntax": "map:PATH",
-      "description": "Symbol tree (classes, functions, methods, constants). Three-tier: tree-sitter > ctags > regex",
+      "description": "Symbol tree. tree-sitter>ctags>regex",
       "example": "map:supertool.py"
     },
     "diff": {
       "syntax": "diff:PATH1:PATH2",
-      "description": "Unified diff between two files",
+      "description": "Unified diff of 2 files",
       "example": "diff:supertool.py:tests/conftest.py"
     },
     "stat": {
       "syntax": "stat:PATH",
-      "description": "File/directory metadata: size, last modified, type",
+      "description": "File meta: size, mtime, type",
       "example": "stat:supertool.py"
     },
     "around_line": {
       "syntax": "around_line:PATH:LINE[:N]",
-      "description": "Show N lines of context around a specific line number (default 10). Target line marked with \u2192",
-      "example": "around_line:supertool.py:100:5"
+      "description": "N lines around LINE (def 10). Target marked →",
+      "example": "around_line:supertool.py:100:5",
+      "hint": true
     },
     "between": {
       "syntax": "between:SYMBOL:PATH | between:re:START:END:PATH",
-      "description": "Return a chunk of a file. Symbol mode: full body of a named function/method/class via tree-sitter (any language tree-sitter parses). Pattern mode (re: prefix): inclusive line slice from first line matching START regex to first line after matching END regex.",
-      "example": "between:op_dispatch:supertool.py"
+      "description": "Chunk of file. Symbol mode (tree-sitter, multi-lang) or re:START:END pattern mode",
+      "example": "between:op_dispatch:supertool.py",
+      "hint": true
     },
     "version": {
       "syntax": "version",
@@ -87,20 +95,22 @@
     },
     "tree": {
       "syntax": "tree:PATH[:DEPTH]",
-      "description": "Directory structure with depth limit (default 3). Hides dotfiles.",
+      "description": "Dir tree, depth=N (def 3). Hides dotfiles",
       "example": "tree:tests/:2"
     },
     "replace_dry": {
       "syntax": "replace_dry:OLD:NEW:PATH",
-      "description": "Preview replacements without modifying files. Shows diff-style output (- old / + new) per occurrence.",
+      "description": "Preview replace. -old/+new per match",
       "example": "replace_dry:TYPE_CUSTOMER:TYPE_ENUM_CUSTOMER:src/",
-      "status": 1
+      "status": 1,
+      "hint": true
     },
     "replace": {
       "syntax": "replace:OLD:NEW:PATH",
-      "description": "Find and replace OLD with NEW across all files in PATH. Returns receipt with files modified and count per file.",
+      "description": "Replace OLD→NEW in PATH. Returns receipt",
       "example": "replace:TYPE_CUSTOMER:TYPE_ENUM_CUSTOMER:src/",
-      "status": 1
+      "status": 1,
+      "hint": true
     }
   },
   "ops": {},

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ Standalone install doesn't wire up the hooks (no plugin system). You get the bin
 
 ### Interactive (permissive mode — default)
 
-Just install. The session-start hook runs `./supertool 'introduction' 'output-format' 'ops'` to output the project-specific operations reference from `.supertool.json`. The model learns what's available and how to batch. Falls back to native `Grep`/`Read` when those are better.
+Just install. The session-start hook runs `./supertool 'introduction' 'output-format' 'ops-compact'` to output the project-specific operations reference from `.supertool.json`. The model learns what's available and how to batch. Falls back to native `Grep`/`Read` when those are better.
+
+> **Heads-up — hook output cap.** Claude Code truncates hook stdout around 7KB; over that, only a ~2KB preview reaches the model and the rest is silently saved to disk. With many ops, the tail of the listing gets hidden until rediscovered mid-task.
+>
+> The session-start hook uses `ops-compact` to stay under the cap: examples are dropped on self-explanatory ops, and only kept on ops marked `"hint": true` in `.supertool.json`. If the body still exceeds the cap, `ops-compact` prepends a warning telling the model to fetch the full listing via `./supertool 'ops'`. Plain `'ops'` always returns everything.
 
 ### Autonomous / headless (enforced mode)
 
@@ -157,22 +161,22 @@ Create a `.supertool.json` in your project root. Supertool walks up from cwd to 
   "builtin-ops": {
     "read": {
       "syntax": "read:PATH[:OFFSET:LIMIT]",
-      "description": "Read file (first 300 lines, 20KB cap)",
+      "description": "Read file (300 lines, 20KB cap)",
       "example": "read:src/app/Module.py:1:50"
     },
     "read-grep": {
       "syntax": "read:PATH:::grep=PATTERN",
-      "description": "Inline filter — only matching lines, original line numbers preserved",
+      "description": "Inline filter — matching lines, line nums kept",
       "example": "read:src/app/Module.py:::grep=class"
     },
     "grep": {
       "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]]",
-      "description": "Search (10 results default). CONTEXT shows N surrounding lines",
+      "description": "Search (10 results def). CONTEXT=N lines around match",
       "example": "grep:def handle:src/:20:2"
     },
     "map": {
       "syntax": "map:PATH",
-      "description": "Symbol tree (classes, functions, methods, constants)",
+      "description": "Symbol tree. tree-sitter>ctags>regex",
       "example": "map:src/app/"
     }
   },

--- a/README.md
+++ b/README.md
@@ -371,6 +371,16 @@ Both forge presets include **actionable error messages** — when something fail
 
 `git-trail` answers "when was this added/changed/removed?" using `git log -S` (pickaxe), with regex fallback. Shows timeline + contextual diffs filtered to relevant hunks.
 
+**`claude-log`** — Inspect Claude Code session logs (`~/.claude/projects/<encoded-cwd>/*.jsonl`). No auth, no deps — pure stdlib Python.
+
+| Op | Syntax | What it does |
+|----|--------|-------------|
+| `claude-log-list` | `claude-log-list[:N]` | N most recent sessions for the current project: UUID, mtime, turn count, line count, first user-message excerpt |
+| `claude-log-tail` | `claude-log-tail:UUID[:N]` | Last N events in compact form: `[role] TOOL name(input)` / `[result] output` / `[result/ERR] msg` / `[bootstrap] preview` |
+| `claude-log-summary` | `claude-log-summary:UUID` | Full digest: model, duration, turn counts, tool calls + errors-by-tool, tokens (input/output/cache read/cache create) + cache hit %, final assistant text |
+
+Useful for measuring autonomous-run efficiency — spotting wasted round-trips, validating that a skill change reduced tool calls, comparing model performance across runs. Windows-friendly cwd encoding (handles `\` and drive colons), with closest-prefix sibling fallback when the encoded directory doesn't exist.
+
 #### Writing your own preset
 
 Create `./presets/mytools.json` in your project (or `~/.config/supertool/presets/mytools.json` for personal use):

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -7,5 +7,9 @@ if [ ! -e "./supertool" ]; then
     ln -sf "${CLAUDE_PLUGIN_ROOT}/supertool.py" "./supertool" 2>/dev/null
 fi
 
-# Output self-documentation from .supertool.json (fallback if no config)
-./supertool 'introduction' 'output-format' 'ops'
+# Output self-documentation from .supertool.json (fallback if no config).
+# Use 'ops-compact' to drop redundant examples and stay closer to the harness's
+# hook-stdout cap (~2KB). The compact view prepends a warning if the output
+# still exceeds the cap, so the model can detect truncation and fetch the full
+# listing on demand via `./supertool 'ops'`.
+./supertool 'introduction' 'output-format' 'ops-compact'

--- a/presets/claude-log.json
+++ b/presets/claude-log.json
@@ -1,0 +1,26 @@
+{
+  "description": "Claude Code session log inspection ops — list, tail, summarize .jsonl transcripts under ~/.claude/projects/.",
+  "ops": {
+    "claude-log-list": {
+      "cmd": "python3 {path}claude-log/list.py {arg}",
+      "timeout": 10,
+      "description": "List N most recent Claude Code sessions for the current project (default 10). Output: UUID, mtime, line count, first user-message excerpt — enough to pick the right session.",
+      "syntax": "claude-log-list[:N]",
+      "example": "claude-log-list:5"
+    },
+    "claude-log-tail": {
+      "cmd": "python3 {path}claude-log/tail.py {args}",
+      "timeout": 10,
+      "description": "Last N events of a Claude session in compact form: [role] TOOL name(input...) / [result] output / [text] message. Default N=30. Use after claude-log-list to grab the UUID.",
+      "syntax": "claude-log-tail:UUID[:N]",
+      "example": "claude-log-tail:84397aff-4925-45fd-afc5-3641e28c993c:50"
+    },
+    "claude-log-summary": {
+      "cmd": "python3 {path}claude-log/summary.py {arg}",
+      "timeout": 15,
+      "description": "Whole-session digest: tool call counts by name, error/retry count, final assistant text, total turns. Useful to know what a Kevin/sub-agent run actually did.",
+      "syntax": "claude-log-summary:UUID",
+      "example": "claude-log-summary:84397aff-4925-45fd-afc5-3641e28c993c"
+    }
+  }
+}

--- a/presets/claude-log.json
+++ b/presets/claude-log.json
@@ -4,21 +4,21 @@
     "claude-log-list": {
       "cmd": "python3 {path}claude-log/list.py {arg}",
       "timeout": 10,
-      "description": "List N most recent Claude Code sessions for the current project (default 10). Output: UUID, mtime, line count, first user-message excerpt — enough to pick the right session.",
+      "description": "List N recent Claude sessions for project (def 10). UUID, mtime, line count, first user msg",
       "syntax": "claude-log-list[:N]",
       "example": "claude-log-list:5"
     },
     "claude-log-tail": {
       "cmd": "python3 {path}claude-log/tail.py {args}",
       "timeout": 10,
-      "description": "Last N events of a Claude session in compact form: [role] TOOL name(input...) / [result] output / [text] message. Default N=30. Use after claude-log-list to grab the UUID.",
+      "description": "Last N events of session in compact form. Def N=30. Use after claude-log-list",
       "syntax": "claude-log-tail:UUID[:N]",
       "example": "claude-log-tail:84397aff-4925-45fd-afc5-3641e28c993c:50"
     },
     "claude-log-summary": {
       "cmd": "python3 {path}claude-log/summary.py {arg}",
       "timeout": 15,
-      "description": "Whole-session digest: tool call counts by name, error/retry count, final assistant text, total turns. Useful to know what a Kevin/sub-agent run actually did.",
+      "description": "Session digest: tool counts, errors, final msg, total turns",
       "syntax": "claude-log-summary:UUID",
       "example": "claude-log-summary:84397aff-4925-45fd-afc5-3641e28c993c"
     }

--- a/presets/claude-log/_common.py
+++ b/presets/claude-log/_common.py
@@ -1,0 +1,104 @@
+"""Shared helpers for claude-log ops."""
+import json
+import os
+from pathlib import Path
+
+
+def encode_cwd(cwd: str) -> str:
+    """Encode a cwd path to the directory name Claude Code uses under ~/.claude/projects/.
+
+    Claude Code names each project directory by replacing path separators with dashes:
+    - POSIX:  '/Users/foo/proj'  -> '-Users-foo-proj'
+    - Windows:'C:\\Users\\foo'    -> '-C--Users-foo' (drive colon and backslashes both become '-')
+
+    The exact Windows encoding may vary across Claude Code versions; if `project_dir()`
+    cannot find a matching directory, callers should fall back to scanning siblings.
+    """
+    enc = cwd.replace("\\", "/").replace("/", "-").replace(":", "-")
+    if not enc.startswith("-"):
+        enc = "-" + enc
+    return enc
+
+
+def claude_projects_root() -> Path:
+    """Root directory holding all per-project session logs."""
+    return Path.home() / ".claude" / "projects"
+
+
+def project_dir(cwd: str | None = None) -> Path:
+    """Resolve the ~/.claude/projects/<encoded-cwd>/ directory for the given (or current) cwd.
+
+    If the directly-encoded directory does not exist, fall back to the closest match
+    among siblings (longest common prefix). Returns the encoded path even when missing
+    so callers can produce a clear error.
+    """
+    cwd = cwd if cwd is not None else os.getcwd()
+    encoded = encode_cwd(cwd)
+    root = claude_projects_root()
+    direct = root / encoded
+    if direct.exists() or not root.exists():
+        return direct
+    # Fallback: pick the sibling whose name has the longest common prefix with `encoded`
+    best: Path | None = None
+    best_len = 0
+    for sibling in root.iterdir():
+        if not sibling.is_dir():
+            continue
+        n = _common_prefix_len(sibling.name, encoded)
+        if n > best_len:
+            best_len = n
+            best = sibling
+    return best if best is not None else direct
+
+
+def _common_prefix_len(a: str, b: str) -> int:
+    n = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        n += 1
+    return n
+
+
+def session_path(uuid: str) -> Path:
+    """Path to a session jsonl file in the current project."""
+    return project_dir() / f"{uuid}.jsonl"
+
+
+def read_jsonl(path: Path):
+    """Yield decoded JSON objects from a jsonl file, skipping bad lines."""
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def trunc(s: str, n: int) -> str:
+    """Truncate a string with an ellipsis if it exceeds n chars."""
+    if s is None:
+        return ""
+    s = str(s).replace("\n", " ").replace("\r", " ")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def event_role(d: dict) -> str:
+    """Best-effort role extraction from an event."""
+    msg = d.get("message", {}) if isinstance(d.get("message"), dict) else {}
+    return msg.get("role") or d.get("type", "")
+
+
+def event_content_parts(d: dict):
+    """Yield content parts from a message event (handles list and string content)."""
+    msg = d.get("message", {}) if isinstance(d.get("message"), dict) else {}
+    content = msg.get("content")
+    if isinstance(content, list):
+        yield from content
+    elif isinstance(content, str) and content:
+        yield {"type": "text", "text": content}

--- a/presets/claude-log/list.py
+++ b/presets/claude-log/list.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""List N most recent Claude Code sessions for the current project.
+
+For each session, output: UUID, mtime, line count, first user-message excerpt.
+Useful to pick the right UUID before running claude-log-tail / claude-log-summary.
+"""
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import event_content_parts, project_dir, read_jsonl, trunc  # noqa: E402
+
+
+def first_user_excerpt(path: Path, max_chars: int = 100) -> str:
+    """Find the first user-typed text in a session, skipping system prompts."""
+    for ev in read_jsonl(path):
+        # Skip queue-operation entries (system bootstrap content)
+        if ev.get("type") == "queue-operation":
+            continue
+        msg = ev.get("message", {}) if isinstance(ev.get("message"), dict) else {}
+        if msg.get("role") != "user":
+            continue
+        for part in event_content_parts(ev):
+            if part.get("type") == "text":
+                txt = part.get("text", "")
+                # Skip system reminders / hook context
+                if txt.startswith("<") or txt.startswith("# "):
+                    continue
+                if txt.strip():
+                    return trunc(txt.strip(), max_chars)
+    return ""
+
+
+def line_count(path: Path) -> int:
+    """Quick line count without loading whole file."""
+    n = 0
+    with path.open("rb") as f:
+        for _ in f:
+            n += 1
+    return n
+
+
+def turn_count(path: Path) -> int:
+    """Count user + assistant messages (skipping bootstrap entries)."""
+    n = 0
+    for ev in read_jsonl(path):
+        if ev.get("type") in ("user", "assistant"):
+            n += 1
+    return n
+
+
+def main() -> int:
+    limit = 10
+    if len(sys.argv) > 1 and sys.argv[1].isdigit():
+        limit = int(sys.argv[1])
+
+    pdir = project_dir()
+    if not pdir.exists():
+        print(f"ERROR: no Claude project log dir at {pdir}")
+        return 1
+
+    sessions = sorted(
+        pdir.glob("*.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[:limit]
+
+    if not sessions:
+        print(f"No sessions found in {pdir}")
+        return 0
+
+    print(f"Project: {pdir}")
+    print(f"Showing {len(sessions)} most recent sessions (of {len(list(pdir.glob('*.jsonl')))})")
+    print()
+    print(f"{'UUID':<36}  {'When':<19}  {'Turns':>5}  {'Lines':>6}  First user message")
+    print(f"{'-' * 36}  {'-' * 19}  {'-' * 5}  {'-' * 6}  {'-' * 60}")
+
+    for sp in sessions:
+        uuid = sp.stem
+        mtime = datetime.fromtimestamp(sp.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")
+        lines = line_count(sp)
+        turns = turn_count(sp)
+        excerpt = first_user_excerpt(sp)
+        print(f"{uuid}  {mtime}  {turns:>5}  {lines:>6}  {excerpt}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/presets/claude-log/summary.py
+++ b/presets/claude-log/summary.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Whole-session digest: model, duration, tokens, tool calls, errors, final text."""
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import event_content_parts, event_role, read_jsonl, session_path, trunc  # noqa: E402
+
+
+def _parse_ts(ts: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp ending in 'Z' or with offset."""
+    if not ts:
+        return None
+    try:
+        # Python's fromisoformat accepts offsets but not the 'Z' suffix prior to 3.11
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, seconds = divmod(int(seconds), 60)
+    if minutes < 60:
+        return f"{minutes}m {seconds}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m"
+
+
+def _format_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.2f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("ERROR: usage: claude-log-summary:UUID")
+        return 1
+
+    uuid = sys.argv[1]
+    sp = session_path(uuid)
+    if not sp.exists():
+        print(f"ERROR: session not found: {sp}")
+        return 1
+
+    tool_counts: Counter[str] = Counter()
+    error_results = 0
+    error_by_tool_position: list[str] = []  # tool name preceding each error result
+    last_tool_name: str | None = None
+    user_msgs = 0
+    assistant_msgs = 0
+    bootstrap_chars = 0
+    last_assistant_text = ""
+    first_user_text = ""
+
+    # Token + meta tracking
+    tokens_in = 0
+    tokens_out = 0
+    tokens_cache_read = 0
+    tokens_cache_creation = 0
+    model = ""
+    first_ts: datetime | None = None
+    last_ts: datetime | None = None
+
+    for ev in read_jsonl(sp):
+        if ev.get("type") == "queue-operation":
+            bootstrap_chars += len(ev.get("content", ""))
+            continue
+
+        ts = _parse_ts(ev.get("timestamp", ""))
+        if ts is not None:
+            if first_ts is None:
+                first_ts = ts
+            last_ts = ts
+
+        msg = ev.get("message", {}) if isinstance(ev.get("message"), dict) else {}
+        if not model and msg.get("model"):
+            model = msg["model"]
+
+        usage = msg.get("usage")
+        if isinstance(usage, dict):
+            tokens_in += int(usage.get("input_tokens") or 0)
+            tokens_out += int(usage.get("output_tokens") or 0)
+            tokens_cache_read += int(usage.get("cache_read_input_tokens") or 0)
+            tokens_cache_creation += int(usage.get("cache_creation_input_tokens") or 0)
+
+        role = event_role(ev)
+        if role == "user":
+            user_msgs += 1
+        elif role == "assistant":
+            assistant_msgs += 1
+
+        for part in event_content_parts(ev):
+            pt = part.get("type")
+            if pt == "tool_use":
+                name = part.get("name", "?")
+                tool_counts[name] += 1
+                last_tool_name = name
+            elif pt == "tool_result":
+                if part.get("is_error"):
+                    error_results += 1
+                    if last_tool_name:
+                        error_by_tool_position.append(last_tool_name)
+            elif pt == "text":
+                txt = part.get("text", "")
+                if role == "assistant" and txt.strip():
+                    last_assistant_text = txt
+                elif role == "user" and txt.strip() and not first_user_text:
+                    if not (txt.startswith("<") or txt.startswith("# ")):
+                        first_user_text = txt
+
+    total_tools = sum(tool_counts.values())
+    total_tokens = tokens_in + tokens_out + tokens_cache_read + tokens_cache_creation
+    cache_inputs = tokens_cache_read + tokens_cache_creation
+    cache_hit_pct = (tokens_cache_read / cache_inputs * 100) if cache_inputs else 0.0
+    duration = (last_ts - first_ts).total_seconds() if first_ts and last_ts else 0.0
+    error_tool_counts = Counter(error_by_tool_position)
+
+    print(f"Session: {uuid}")
+    print(f"File:    {sp}")
+    print()
+    if model:
+        print(f"Model:           {model}")
+    if duration:
+        print(f"Duration:        {_format_duration(duration)}")
+    print(f"Turns:           user={user_msgs}  assistant={assistant_msgs}")
+    print(f"Tool calls:      {total_tools}")
+    print(f"Tool errors:     {error_results}")
+    if bootstrap_chars:
+        print(f"Bootstrap chars: {bootstrap_chars}")
+    print()
+
+    if total_tokens:
+        print("Tokens:")
+        print(f"  input:          {_format_tokens(tokens_in)}")
+        print(f"  output:         {_format_tokens(tokens_out)}")
+        print(f"  cache read:     {_format_tokens(tokens_cache_read)}")
+        print(f"  cache create:   {_format_tokens(tokens_cache_creation)}")
+        print(f"  total:          {_format_tokens(total_tokens)}")
+        if cache_inputs:
+            print(f"  cache hit:      {cache_hit_pct:.1f}%")
+        print()
+
+    if tool_counts:
+        print("Tool usage:")
+        for name, count in tool_counts.most_common():
+            err = error_tool_counts.get(name, 0)
+            tag = f" ({err} err)" if err else ""
+            print(f"  {count:>4}  {name}{tag}")
+        print()
+
+    if first_user_text:
+        print("First user message:")
+        print(f"  {trunc(first_user_text, 300)}")
+        print()
+
+    if last_assistant_text:
+        print("Final assistant text:")
+        for line in last_assistant_text.splitlines()[:20]:
+            print(f"  {line}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/presets/claude-log/tail.py
+++ b/presets/claude-log/tail.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Tail the last N events of a Claude Code session in compact form.
+
+Output one line per content part:
+  [user] TEXT: ...
+  [assistant] TOOL Bash: {"command": "..."}
+  [result] PASS/FAIL/output: ...
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import event_content_parts, event_role, read_jsonl, session_path, trunc  # noqa: E402
+
+
+def format_part(role: str, part: dict, width: int) -> str | None:
+    """Format one content part as a single compact line."""
+    pt = part.get("type")
+    if pt == "text":
+        txt = part.get("text", "")
+        if not txt.strip():
+            return None
+        return f"[{role}] TEXT: {trunc(txt, width)}"
+    if pt == "tool_use":
+        name = part.get("name", "?")
+        inp = json.dumps(part.get("input", {}), ensure_ascii=False)
+        return f"[{role}] TOOL {name}: {trunc(inp, width)}"
+    if pt == "tool_result":
+        c = part.get("content", "")
+        if isinstance(c, list):
+            c = " ".join(x.get("text", "") for x in c if isinstance(x, dict))
+        is_error = part.get("is_error", False)
+        prefix = "[result/ERR]" if is_error else "[result]"
+        return f"{prefix} {trunc(c, width)}"
+    if pt == "thinking":
+        # Compact thinking — usually long, mostly skip
+        return None
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("ERROR: usage: claude-log-tail:UUID[:N]")
+        return 1
+
+    uuid = sys.argv[1]
+    n = 30
+    if len(sys.argv) > 2 and sys.argv[2].isdigit():
+        n = int(sys.argv[2])
+
+    sp = session_path(uuid)
+    if not sp.exists():
+        print(f"ERROR: session not found: {sp}")
+        return 1
+
+    # Build line list, then keep last N
+    lines: list[str] = []
+    for ev in read_jsonl(sp):
+        if ev.get("type") == "queue-operation":
+            # Bootstrap content — show first 200 chars of the original prompt
+            content = ev.get("content", "")
+            if content:
+                lines.append(f"[bootstrap] {trunc(content, 200)}")
+            continue
+        role = event_role(ev)
+        for part in event_content_parts(ev):
+            line = format_part(role, part, width=300)
+            if line:
+                lines.append(line)
+
+    if not lines:
+        print(f"No events in {sp}")
+        return 0
+
+    tail = lines[-n:]
+    total = len(lines)
+    print(f"Session: {uuid}")
+    print(f"Total events: {total}, showing last {len(tail)}")
+    print()
+    for ln in tail:
+        print(ln)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/presets/git.json
+++ b/presets/git.json
@@ -5,25 +5,25 @@
     "git-status": {
       "cmd": "python3 {path}git/status.py",
       "timeout": 5,
-      "description": "Where am I? Branch, commits, changes, stashes, open MR/PR — full context in one call.",
+      "description": "Branch, commits, changes, stashes, open MR/PR",
       "syntax": "git-status"
     },
     "git-investigate": {
       "cmd": "python3 {path}git/investigate.py {arg}",
       "timeout": 15,
-      "description": "What happened to this file? Commits, uncommitted changes, blame hotspots — answer 'why is this broken?' in one call.",
+      "description": "File history: commits, uncommitted, blame hotspots",
       "syntax": "git-investigate:PATH"
     },
     "git-trail": {
       "cmd": "python3 {path}git/trail.py {args}",
       "timeout": 15,
-      "description": "When was this added or changed? Trace a constant, function, or pattern through history — who introduced it and why.",
+      "description": "Trace pattern through history — who/when/why",
       "syntax": "git-trail:PATTERN:PATH"
     },
     "git-blame": {
       "cmd": "python3 {path}git/blame.py {args}",
       "timeout": 10,
-      "description": "Who wrote this line? Blame N lines around a specific line number with author, date, and commit.",
+      "description": "Git blame N lines around LINE",
       "syntax": "git-blame:PATH:LINE[:N]"
     }
   }

--- a/presets/gitlab.json
+++ b/presets/gitlab.json
@@ -5,25 +5,25 @@
     "gl-issue": {
       "cmd": "python3 {path}gitlab/issue.py {arg}",
       "timeout": 30,
-      "description": "Pick up a GitLab issue: description, comments, images downloaded locally, related MRs — everything to start working.",
+      "description": "GitLab issue: desc, comments, images downloaded, related MRs",
       "syntax": "gl-issue:NUMBER"
     },
     "gl-mr": {
       "cmd": "python3 {path}gitlab/mr.py {arg}",
       "timeout": 20,
-      "description": "Review a merge request: branch, pipeline, reviewer/approval, linked issue, diff stat, comments — the full dashboard.",
+      "description": "MR review: branch, pipeline, approval, linked issue, diff stat, comments",
       "syntax": "gl-mr:NUMBER_OR_BRANCH"
     },
     "gl-pipeline": {
       "cmd": "python3 {path}gitlab/pipeline.py {arg}",
       "timeout": 15,
-      "description": "What passed, what failed? Pipeline jobs grouped by stage with statuses and failed job IDs.",
+      "description": "Pipeline jobs by stage with statuses + failed job IDs",
       "syntax": "gl-pipeline:NUMBER"
     },
     "gl-job": {
       "cmd": "python3 {path}gitlab/job.py {arg}",
       "timeout": 30,
-      "description": "Why did this job fail? MR context + error pattern search + log tail — the actual error, not 500 lines of setup.",
+      "description": "Why job failed: MR ctx + error patterns + log tail",
       "syntax": "gl-job:NUMBER",
       "lines": 80,
       "error_patterns": "ERROR,FAILURES!,Fatal,Failed asserting",

--- a/supertool.py
+++ b/supertool.py
@@ -95,7 +95,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-VERSION = "0.7.0"
+VERSION = "0.8.0"
 
 MAX_READ_LINES = 300
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"

--- a/supertool.py
+++ b/supertool.py
@@ -1901,10 +1901,11 @@ def op_version() -> str:
 
 
 # Threshold above which compact ops output gets a "truncation likely" warning.
-# Claude Code's hook-stdout cap appears to be ~2KB; anything over that gets
-# saved to disk and only a 2KB preview is injected into the model's context,
-# silently hiding the tail of the ops list.
-_HOOK_OUTPUT_CAP_BYTES = 2048
+# Claude Code's hook-stdout cap appears to be ~7KB; anything over that gets
+# saved to disk and only a ~2KB preview is injected into the model's context,
+# silently hiding the tail of the ops list. (Empirical: 6.6KB landed full,
+# 11KB+ got truncated — threshold sits in between.)
+_HOOK_OUTPUT_CAP_BYTES = 7168
 
 
 def op_ops(compact: bool = False) -> str:

--- a/supertool.py
+++ b/supertool.py
@@ -95,7 +95,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-VERSION = "0.6.0"
+VERSION = "0.7.0"
 
 MAX_READ_LINES = 300
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"

--- a/supertool.py
+++ b/supertool.py
@@ -1900,11 +1900,24 @@ def op_version() -> str:
     return f"supertool {VERSION}\n"
 
 
-def op_ops() -> str:
+# Threshold above which compact ops output gets a "truncation likely" warning.
+# Claude Code's hook-stdout cap appears to be ~2KB; anything over that gets
+# saved to disk and only a 2KB preview is injected into the model's context,
+# silently hiding the tail of the ops list.
+_HOOK_OUTPUT_CAP_BYTES = 2048
+
+
+def op_ops(compact: bool = False) -> str:
     """Output the ops reference from .supertool.json (builtin-ops + ops sections).
 
     Source of truth is the JSON config. If no config exists, falls back to
     listing built-in op names without descriptions.
+
+    When compact=True, drops example lines for ops that don't have hint=true,
+    and — if the resulting body still exceeds _HOOK_OUTPUT_CAP_BYTES — prepends
+    a warning telling the reader that the tail is hidden and to call 'ops' for
+    the full listing. Used by the SessionStart hook to maximize information
+    density under the harness's hook-output cap.
     """
     config = _load_config()
     builtin_ops = config.get("builtin-ops", {})
@@ -1921,6 +1934,29 @@ def op_ops() -> str:
         lines.append("Add a \"builtin-ops\" section to .supertool.json to describe them.")
         return "\n".join(lines) + "\n"
 
+    def _emit_example(info: dict) -> bool:
+        """Whether to print the Example: line for this op given current mode."""
+        if not info.get("example"):
+            return False
+        if not compact:
+            return True
+        return bool(info.get("hint"))
+
+    def _emit_desc(info: dict) -> str:
+        """Return description if it should be shown, else empty string.
+
+        In compact mode, descriptions are only kept for ops marked
+        ``hint: true`` — the rest are considered self-explanatory from
+        their signature alone (read:PATH, grep:PATTERN:PATH, etc.) and
+        their description adds no information.
+        """
+        desc = info.get("description", "")
+        if not desc:
+            return ""
+        if not compact:
+            return desc
+        return desc if info.get("hint") else ""
+
     # Operations section — built-in and custom merged into one flat list
     has_ops = False
     if builtin_ops or custom_ops:
@@ -1934,22 +1970,20 @@ def op_ops() -> str:
             if not info.get("status", 1):
                 continue
             syntax = info.get("syntax", name)
-            desc = info.get("description", "")
-            example = info.get("example", "")
+            desc = _emit_desc(info)
             lines.append(f"- `{syntax}` — {desc}" if desc else f"- `{syntax}`")
-            if example:
-                lines.append(f"  Example: `{example}`")
+            if _emit_example(info):
+                lines.append(f"  Example: `{info['example']}`")
 
     active_custom = {k: v for k, v in custom_ops.items()
                      if isinstance(v, dict) and v.get("status", 1)}
     if active_custom:
         for name, info in active_custom.items():
-            desc = info.get("description", "")
-            example = info.get("example", "")
+            desc = _emit_desc(info)
             syntax = info.get("syntax", f"{name}:PATH")
             lines.append(f"- `{syntax}` — {desc}" if desc else f"- `{syntax}`")
-            if example:
-                lines.append(f"  Example: `{example}`")
+            if _emit_example(info):
+                lines.append(f"  Example: `{info['example']}`")
 
     if has_ops:
         lines.append("")
@@ -1960,16 +1994,29 @@ def op_ops() -> str:
     if active_aliases:
         lines.append("## Aliases (multi-op batches)\n")
         for name, info in active_aliases.items():
-            desc = info.get("description", "")
-            example = info.get("example", "")
+            desc = _emit_desc(info)
             ops_list = info.get("ops", [])
             syntax = info.get("syntax", f"{name}:PATH")
             lines.append(f"- `{syntax}` — {desc}" if desc else f"- `{syntax}`")
-            if example:
-                lines.append(f"  Example: `{example}`")
+            if _emit_example(info):
+                lines.append(f"  Example: `{info['example']}`")
         lines.append("")
 
-    return "\n".join(lines) + "\n"
+    body = "\n".join(lines) + "\n"
+
+    # In compact mode, only warn if the body still won't fit the harness cap.
+    # When it fits, no warning — the absence is itself a signal that the listing
+    # is complete.
+    if compact and len(body.encode("utf-8")) > _HOOK_OUTPUT_CAP_BYTES:
+        warning = (
+            f"> ⚠ Output is {len(body.encode('utf-8'))} bytes, exceeds the "
+            f"~{_HOOK_OUTPUT_CAP_BYTES}-byte SessionStart hook cap. The tail "
+            f"of this listing will be truncated — ops below the cut-off are "
+            f"hidden. Run `./supertool 'ops'` to see the full listing.\n\n"
+        )
+        body = warning + body
+
+    return body
 
 
 def dispatch(arg: str) -> str:
@@ -2065,7 +2112,7 @@ def dispatch(arg: str) -> str:
             rpath = parts[3] if len(parts) > 3 and parts[3] else "."
             dry = op == "replace_dry"
             body = op_replace(old_str, new_str, rpath, dry=dry)
-        elif op in ("introduction", "output-format", "ops", "version"):
+        elif op in ("introduction", "output-format", "ops", "ops-compact", "version"):
             # Meta-ops use markdown headers instead of --- header ---
             header = ""
             if op == "introduction":
@@ -2074,6 +2121,8 @@ def dispatch(arg: str) -> str:
                 body = op_output_format()
             elif op == "version":
                 body = op_version()
+            elif op == "ops-compact":
+                body = op_ops(compact=True)
             else:
                 body = op_ops()
         else:

--- a/tests/test_claude_log.py
+++ b/tests/test_claude_log.py
@@ -1,0 +1,390 @@
+"""Tests for the claude-log preset (list / tail / summary).
+
+Covers:
+- POSIX and Windows cwd encoding (encode_cwd)
+- project_dir() fallback to longest-common-prefix sibling
+- list.py: ranking by mtime, line count, first user excerpt extraction
+- tail.py: compact event formatting, bootstrap line, error marker
+- summary.py: tool counts, error counts, final assistant text
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+PRESET_DIR = Path(__file__).resolve().parent.parent / "presets" / "claude-log"
+sys.path.insert(0, str(PRESET_DIR))
+
+import _common  # noqa: E402
+
+
+# ---------- helpers ----------------------------------------------------------
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for ev in events:
+            f.write(json.dumps(ev) + "\n")
+
+
+def _user_text(text: str) -> dict:
+    return {
+        "type": "user",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _assistant_text(text: str, *, model: str | None = None, usage: dict | None = None, ts: str | None = None) -> dict:
+    msg: dict = {"role": "assistant", "content": [{"type": "text", "text": text}]}
+    if model:
+        msg["model"] = model
+    if usage:
+        msg["usage"] = usage
+    ev: dict = {"type": "assistant", "message": msg}
+    if ts:
+        ev["timestamp"] = ts
+    return ev
+
+
+def _assistant_tool(name: str, inp: dict) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": name, "input": inp}],
+        },
+    }
+
+
+def _tool_result(content: str, is_error: bool = False) -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": content,
+                    "is_error": is_error,
+                }
+            ],
+        },
+    }
+
+
+@dataclass
+class FakeProject:
+    cwd: Path
+    home: Path
+    proj_dir: Path
+
+    def add_session(self, uuid: str, events: list[dict]) -> Path:
+        path = self.proj_dir / f"{uuid}.jsonl"
+        _write_jsonl(path, events)
+        return path
+
+    def run(self, script: str, *args: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["HOME"] = str(self.home)
+        env["USERPROFILE"] = str(self.home)  # Windows
+        return subprocess.run(
+            [sys.executable, str(PRESET_DIR / script), *args],
+            capture_output=True,
+            text=True,
+            cwd=self.cwd,
+            env=env,
+            timeout=15,
+        )
+
+
+def make_project(tmp_path: Path) -> FakeProject:
+    """Build an isolated home + cwd for a preset script invocation."""
+    cwd = tmp_path / "work" / "proj"
+    cwd.mkdir(parents=True)
+    home = tmp_path / "fake-home"
+    encoded = _common.encode_cwd(str(cwd))
+    proj_dir = home / ".claude" / "projects" / encoded
+    proj_dir.mkdir(parents=True)
+    return FakeProject(cwd=cwd, home=home, proj_dir=proj_dir)
+
+
+# ---------- encode_cwd -------------------------------------------------------
+
+
+class TestEncodeCwd:
+    def test_posix_path(self) -> None:
+        assert _common.encode_cwd("/Users/foo/proj") == "-Users-foo-proj"
+
+    def test_posix_root(self) -> None:
+        assert _common.encode_cwd("/") == "-"
+
+    def test_windows_drive_path(self) -> None:
+        # Backslashes and the drive colon both become hyphens.
+        assert _common.encode_cwd(r"C:\Users\foo\proj") == "-C--Users-foo-proj"
+
+    def test_windows_forward_slashes(self) -> None:
+        assert _common.encode_cwd("C:/Users/foo") == "-C--Users-foo"
+
+    def test_relative_path_gets_dash_prefix(self) -> None:
+        assert _common.encode_cwd("relative/path") == "-relative-path"
+
+    def test_already_dash_prefixed(self) -> None:
+        # Idempotent on the leading dash.
+        assert _common.encode_cwd("-foo-bar") == "-foo-bar"
+
+
+# ---------- project_dir fallback --------------------------------------------
+
+
+class TestProjectDir:
+    def test_direct_match(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        encoded = _common.encode_cwd("/Users/foo/proj")
+        target = tmp_path / ".claude" / "projects" / encoded
+        target.mkdir(parents=True)
+        assert _common.project_dir("/Users/foo/proj") == target
+
+    def test_fallback_to_closest_sibling(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        root = tmp_path / ".claude" / "projects"
+        # A sibling that shares a long prefix but is not exact
+        (root / "-Users-foo-proj-old").mkdir(parents=True)
+        (root / "-totally-unrelated").mkdir(parents=True)
+        result = _common.project_dir("/Users/foo/proj")
+        assert result.name == "-Users-foo-proj-old"
+
+    def test_returns_encoded_when_no_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # No ~/.claude/projects/ exists yet
+        result = _common.project_dir("/Users/foo/proj")
+        assert result.name == "-Users-foo-proj"
+        assert not result.exists()
+
+
+# ---------- list.py ----------------------------------------------------------
+
+
+class TestList:
+    def test_lists_recent_sessions(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        a = p.add_session("aaaa", [_user_text("hello from A")])
+        b = p.add_session("bbbb", [_user_text("hello from B")])
+        os.utime(a, (1_700_000_000, 1_700_000_000))
+        os.utime(b, (1_700_000_100, 1_700_000_100))
+
+        r = p.run("list.py")
+        assert r.returncode == 0, r.stderr + r.stdout
+        # Most recent first
+        assert r.stdout.index("bbbb") < r.stdout.index("aaaa")
+        assert "hello from B" in r.stdout
+        assert "hello from A" in r.stdout
+        # Header includes Turns column
+        assert "Turns" in r.stdout
+
+    def test_turn_count_column(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        # Session with 2 user + 1 assistant = 3 turns; bootstrap should not count
+        p.add_session("turny", [
+            {"type": "queue-operation", "content": "ignored"},
+            _user_text("first"),
+            _assistant_text("reply"),
+            _user_text("follow up"),
+        ])
+        r = p.run("list.py")
+        assert r.returncode == 0
+        # Find the row for our session and verify turn count column is 3
+        for line in r.stdout.splitlines():
+            if line.startswith("turny"):
+                # Format: UUID  WHEN  TURNS  LINES  EXCERPT
+                fields = line.split()
+                # fields[0]=uuid, [1]=date, [2]=time, [3]=turns, [4]=lines
+                assert fields[3] == "3", f"expected 3 turns, got {fields[3]} in {line!r}"
+                break
+        else:
+            raise AssertionError("session 'turny' not found in output")
+
+    def test_no_sessions(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        r = p.run("list.py")
+        assert r.returncode == 0
+        assert "No sessions found" in r.stdout
+
+    def test_skips_system_reminders_in_excerpt(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        p.add_session("abcd", [
+            _user_text("<system-reminder>ignore me</system-reminder>"),
+            _user_text("the real ask"),
+        ])
+        r = p.run("list.py")
+        assert "the real ask" in r.stdout
+        assert "system-reminder" not in r.stdout
+
+    def test_limit_respected(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        for i in range(5):
+            p.add_session(f"s{i}", [_user_text(f"msg {i}")])
+        r = p.run("list.py", "2")
+        assert r.returncode == 0
+        listed = sum(1 for line in r.stdout.splitlines() if line.startswith("s"))
+        assert listed == 2
+
+
+# ---------- tail.py ----------------------------------------------------------
+
+
+class TestTail:
+    def test_compact_output(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        uuid = "feed-face"
+        p.add_session(uuid, [
+            _user_text("hi"),
+            _assistant_tool("Bash", {"command": "ls"}),
+            _tool_result("file1\nfile2", is_error=False),
+            _assistant_text("done"),
+        ])
+        r = p.run("tail.py", uuid)
+        assert r.returncode == 0, r.stderr + r.stdout
+        out = r.stdout
+        assert "[user] TEXT: hi" in out
+        assert "[assistant] TOOL Bash:" in out
+        assert "[result]" in out
+        assert "[assistant] TEXT: done" in out
+
+    def test_marks_errors(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        uuid = "errs"
+        p.add_session(uuid, [
+            _assistant_tool("Bash", {"command": "false"}),
+            _tool_result("boom", is_error=True),
+        ])
+        r = p.run("tail.py", uuid)
+        assert "[result/ERR]" in r.stdout
+
+    def test_session_not_found(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        p.add_session("present", [_user_text("x")])
+        r = p.run("tail.py", "nonexistent-uuid")
+        assert r.returncode == 1
+        assert "session not found" in r.stdout
+
+    def test_n_argument(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        uuid = "many"
+        p.add_session(uuid, [_assistant_text(f"line {i}") for i in range(10)])
+        r = p.run("tail.py", uuid, "3")
+        lines = [ln for ln in r.stdout.splitlines() if ln.startswith("[assistant]")]
+        assert len(lines) == 3
+        assert "line 9" in r.stdout
+        assert "line 0" not in r.stdout
+
+    def test_bootstrap_line(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        uuid = "boot"
+        p.add_session(uuid, [
+            {"type": "queue-operation", "content": "bootstrap prompt content"},
+            _user_text("first ask"),
+        ])
+        r = p.run("tail.py", uuid)
+        assert "[bootstrap]" in r.stdout
+        assert "bootstrap prompt content" in r.stdout
+
+
+# ---------- summary.py -------------------------------------------------------
+
+
+class TestSummary:
+    def test_counts_and_final_text(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        uuid = "sum"
+        p.add_session(uuid, [
+            _user_text("kick off the work"),
+            _assistant_tool("Bash", {"command": "ls"}),
+            _tool_result("ok"),
+            _assistant_tool("Bash", {"command": "pwd"}),
+            _tool_result("/tmp"),
+            _assistant_tool("Read", {"file_path": "/x"}),
+            _tool_result("err", is_error=True),
+            _assistant_text("done summary"),
+        ])
+        r = p.run("summary.py", uuid)
+        assert r.returncode == 0, r.stderr + r.stdout
+        out = r.stdout
+        assert "Tool calls:      3" in out
+        assert "Tool errors:     1" in out
+        assert "2  Bash" in out
+        assert "1  Read" in out
+        assert "kick off the work" in out
+        assert "done summary" in out
+
+    def test_session_not_found(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        p.add_session("present", [_user_text("x")])
+        r = p.run("summary.py", "nope")
+        assert r.returncode == 1
+
+    def test_model_duration_and_tokens(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        uuid = "tok"
+        p.add_session(uuid, [
+            _assistant_text(
+                "msg",
+                model="claude-opus-4-7",
+                usage={
+                    "input_tokens": 10,
+                    "output_tokens": 200,
+                    "cache_read_input_tokens": 1500,
+                    "cache_creation_input_tokens": 500,
+                },
+                ts="2026-04-29T20:38:00.000Z",
+            ),
+            _assistant_text(
+                "msg2",
+                usage={
+                    "input_tokens": 20,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 1500,
+                    "cache_creation_input_tokens": 0,
+                },
+                ts="2026-04-29T20:40:09.000Z",  # 2m 9s later
+            ),
+        ])
+        r = p.run("summary.py", uuid)
+        assert r.returncode == 0, r.stderr + r.stdout
+        out = r.stdout
+        assert "Model:           claude-opus-4-7" in out
+        assert "Duration:        2m 9s" in out
+        # 30 input + 300 output + 3000 cache_read + 500 cache_creation
+        assert "input:          30" in out
+        assert "output:         300" in out
+        assert "cache read:     3.0k" in out
+        assert "cache create:   500" in out
+        # Cache hit = 3000 / (3000 + 500) = 85.7%
+        assert "cache hit:      85.7%" in out
+
+    def test_per_tool_error_counts(self, tmp_path: Path) -> None:
+        p = make_project(tmp_path)
+        uuid = "errsplit"
+        p.add_session(uuid, [
+            _assistant_tool("Bash", {"command": "ls"}),
+            _tool_result("ok"),
+            _assistant_tool("Edit", {"file_path": "/x"}),
+            _tool_result("not read", is_error=True),
+            _assistant_tool("Bash", {"command": "false"}),
+            _tool_result("boom", is_error=True),
+        ])
+        r = p.run("summary.py", uuid)
+        out = r.stdout
+        # Bash: 2 calls, 1 error. Edit: 1 call, 1 error.
+        assert "2  Bash (1 err)" in out
+        assert "1  Edit (1 err)" in out

--- a/tests/test_meta_ops.py
+++ b/tests/test_meta_ops.py
@@ -244,3 +244,139 @@ def test_alias_ops_not_a_list() -> None:
     out = supertool._resolve_alias("bad", ["bad", "file.php"])
     assert "ERROR" in out
     assert "must be a list" in out
+
+
+# ---------------------------------------------------------------------------
+# op_ops compact mode — fits the SessionStart hook's ~2KB stdout cap by
+# dropping examples on self-explanatory ops, keeping them only on ops marked
+# `"hint": true`. Adds a truncation warning if the body still exceeds the cap.
+# ---------------------------------------------------------------------------
+
+def _set_config(monkeypatch, tmp_path: Path, cfg: dict) -> None:
+    """Helper: write cfg to a tmp .supertool.json and reset module cache."""
+    (tmp_path / ".supertool.json").write_text(json.dumps(cfg))
+    monkeypatch.chdir(tmp_path)
+    supertool._CONFIG = None
+    supertool._CONFIG_CHECKED = False
+
+
+def test_ops_compact_drops_example_and_desc_without_hint(tmp_path: Path, monkeypatch) -> None:
+    """Compact mode treats `hint: true` as the single signal: keep example AND
+    description. Without hint, both are dropped and only the syntax line remains
+    — the op is assumed self-explanatory from its signature alone."""
+    _set_config(monkeypatch, tmp_path, {
+        "builtin-ops": {
+            "read": {
+                "syntax": "read:PATH",
+                "description": "Read file",
+                "example": "read:src/foo.py:1:50",
+            }
+        }
+    })
+    out = supertool.op_ops(compact=True)
+    assert "read:PATH" in out
+    # Both description and example must be dropped — no hint flag.
+    assert "Read file" not in out
+    assert "read:src/foo.py:1:50" not in out
+    assert "Example:" not in out
+
+
+def test_ops_compact_keeps_example_and_desc_with_hint(tmp_path: Path, monkeypatch) -> None:
+    """Compact mode keeps both example AND description for ops with `hint: true`
+    — these are the ops where the signature alone is misleading or insufficient."""
+    _set_config(monkeypatch, tmp_path, {
+        "builtin-ops": {
+            "between": {
+                "syntax": "between:SYMBOL:PATH | between:re:START:END:PATH",
+                "description": "Return a chunk of a file",
+                "example": "between:foo:src/bar.py",
+                "hint": True,
+            }
+        }
+    })
+    out = supertool.op_ops(compact=True)
+    assert "between:SYMBOL:PATH | between:re:START:END:PATH" in out
+    assert "Return a chunk of a file" in out
+    assert "between:foo:src/bar.py" in out
+    assert "Example:" in out
+
+
+def test_ops_full_mode_always_shows_examples(tmp_path: Path, monkeypatch) -> None:
+    """Plain op_ops() (compact=False) shows examples regardless of hint flag."""
+    _set_config(monkeypatch, tmp_path, {
+        "builtin-ops": {
+            "read": {
+                "syntax": "read:PATH",
+                "description": "Read file",
+                "example": "read:src/foo.py:1:50",
+            }
+        }
+    })
+    out = supertool.op_ops()
+    assert "read:src/foo.py:1:50" in out
+    assert "Example:" in out
+
+
+def test_ops_compact_no_warning_when_under_cap(tmp_path: Path, monkeypatch) -> None:
+    """Small configs that fit under the cap render with no truncation banner."""
+    _set_config(monkeypatch, tmp_path, {
+        "builtin-ops": {
+            "read": {"syntax": "read:PATH", "description": "Read", "example": "x"}
+        }
+    })
+    out = supertool.op_ops(compact=True)
+    assert len(out.encode("utf-8")) <= supertool._HOOK_OUTPUT_CAP_BYTES
+    assert "exceeds the" not in out
+    assert "truncated" not in out
+
+
+def test_ops_compact_warning_when_over_cap(tmp_path: Path, monkeypatch) -> None:
+    """When compact body exceeds the cap, a warning is prepended pointing at 'ops'.
+
+    Uses ``hint: true`` on every op so descriptions and examples stay in the
+    output — that's the realistic worst case where compaction can't trim more.
+    """
+    big_ops = {
+        f"op_{i}": {
+            "syntax": f"op_{i}:PATH:LIMIT[:CONTEXT][:MODE]",
+            "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+                           "sed do eiusmod tempor incididunt ut labore et dolore magna.",
+            "example": f"op_{i}:src/foo.py:50",
+            "hint": True,
+        }
+        for i in range(40)
+    }
+    _set_config(monkeypatch, tmp_path, {"builtin-ops": big_ops})
+    out = supertool.op_ops(compact=True)
+    assert "exceeds the" in out
+    assert "SessionStart hook cap" in out
+    assert "./supertool 'ops'" in out
+
+
+def test_ops_compact_dispatched_via_dispatch(tmp_path: Path, monkeypatch) -> None:
+    """`./supertool 'ops-compact'` routes through dispatch() to op_ops(compact=True)."""
+    _set_config(monkeypatch, tmp_path, {
+        "builtin-ops": {
+            "read": {
+                "syntax": "read:PATH",
+                "description": "Read",
+                "example": "read:foo",
+            },
+            "between": {
+                "syntax": "between:SYM:PATH",
+                "description": "Chunk",
+                "example": "between:foo:bar",
+                "hint": True,
+            },
+        }
+    })
+    out = supertool.dispatch("ops-compact")
+    # Hint op keeps example, non-hint op drops it.
+    assert "between:foo:bar" in out
+    assert "read:foo" not in out
+
+
+def test_hook_output_cap_constant_exists() -> None:
+    """The cap constant is a module-level int — tunable without code changes."""
+    assert isinstance(supertool._HOOK_OUTPUT_CAP_BYTES, int)
+    assert supertool._HOOK_OUTPUT_CAP_BYTES > 0


### PR DESCRIPTION
## Summary

Three related changes to make supertool play nicely with Claude Code's hook-stdout cap (output above ~7KB gets truncated to a 2KB preview + saved to disk):

- **`ops-compact` mode** — drops examples and descriptions for self-explanatory ops, keeps them only on ops marked `"hint": true`. SessionStart hook now calls `ops-compact` instead of `ops`. If the body still exceeds the cap, prepends a warning telling the model to fetch the full listing via `./supertool 'ops'`.
- **Hook cap threshold bump 2048 → 7168** — empirically observed in a live session: a 6.6KB ops listing landed inline in the model's context, while an 11.1KB output got truncated. Tightens descriptions across `.supertool.json`, `.supertool.example.json`, and the claude-log/git/gitlab presets so the compact listing models the right brevity.
- **`claude-log` preset** — three ops for inspecting `~/.claude/projects/<encoded-cwd>/*.jsonl` session logs without ad-hoc Python parsers (original PR scope, details below).

## claude-log preset

- **`claude-log-list[:N]`** — N most recent sessions for the current project. Columns: UUID, mtime, turn count, line count, first user-message excerpt.
- **`claude-log-tail:UUID[:N]`** — last N events in compact form: `[role] TOOL name(input...)` / `[result] output` / `[result/ERR] msg` / `[bootstrap] preview`. Default N=30.
- **`claude-log-summary:UUID`** — whole-session digest:
  - model, wall-clock duration, user/assistant turn counts
  - tool call total + per-tool counts with error tags (`Bash (1 err)`)
  - tokens: input / output / cache read / cache create / total + cache hit %
  - bootstrap chars, first user message, final assistant text

Built during a Kevin orchestrator optimization session to spot wasted round-trips and prove the fixes worked. Replaces ~50 lines of throwaway parsing code per session inspection.

### Windows compatibility

`encode_cwd()` handles `/`, `\`, and drive colons (`C:\Users\foo` → `-C--Users-foo`). `project_dir()` falls back to the closest-prefix sibling directory when the direct encoding doesn't match (versions of Claude Code may differ).

## Tests

- 510/510 pytest green, 93.8% coverage
- 23 tests in `tests/test_claude_log.py` (encode_cwd POSIX + Windows, project_dir matching, end-to-end subprocess tests for each script)
- New tests in `tests/test_meta_ops.py` cover `op_ops(compact=True)` paths and warning emission

## Test plan

- [x] `pytest tests/` — 510/510 green
- [x] Smoke test against real session in dvsi project (≈1300 sessions)
- [ ] CI green on merge

🤖 Generated by Max
