### PR TITLE
feat: per-tool exclude-paths for traversal ops

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -23,6 +23,11 @@
       "max_results": 10,
       "extensions": []
     },
+    "grep-no-exclude": {
+      "syntax": "grep:PATTERN:PATH:LIMIT:::no-exclude",
+      "description": "Search inside normally-excluded dirs (vendor/, .git/, etc.)",
+      "example": "grep:somePattern:vendor/:10:::no-exclude"
+    },
     "grep-count": {
       "syntax": "grep:PATTERN:PATH:LIMIT:CONTEXT:count",
       "description": "Count mode — match counts/file, no content",
@@ -100,6 +105,19 @@
       "example": "blame:src/app/Module.py:42:3"
     }
   },
-  "ops": {},
+  "ops": {
+    "glob": {
+      "exclude-paths": []
+    },
+    "grep": {
+      "exclude-paths": []
+    },
+    "tree": {
+      "exclude-paths": []
+    },
+    "map": {
+      "exclude-paths": []
+    }
+  },
   "aliases": {}
 }

--- a/README.md
+++ b/README.md
@@ -467,6 +467,41 @@ Set `"compact": true` in `.supertool.json` to enable compact reads. When enabled
 
 Compact is disabled when using `grep=` filter or `offset` (editing needs exact lines).
 
+### Excluding paths from traversal ops
+
+`glob`, `grep`, `tree`, and `map` walk the filesystem recursively. On large repos this can be slow and noisy — `.git/objects/`, `node_modules/`, `vendor/`, and similar dirs rarely contain what you're looking for.
+
+Supertool prunes these at the **directory boundary** (never opens them), not after the fact.
+
+**Built-in defaults** — always active unless overridden:
+
+```
+.git/  node_modules/  .svn/  .hg/  .idea/  .vscode/
+__pycache__/  .venv/  venv/  dist/  build/
+```
+
+**Project-level additions** — add to `.supertool.json` under `ops.<op-name>.exclude-paths`. These are **merged additively** with the defaults (not replacing):
+
+```json
+{
+  "ops": {
+    "glob": { "exclude-paths": ["vendor/", "Dvsi/dvsi-private/libs/"] },
+    "grep": { "exclude-paths": ["vendor/", "Dvsi/dvsi-private/libs/"] }
+  }
+}
+```
+
+**Per-call escape hatch** — append `:::no-exclude` to bypass all excludes for one call:
+
+```bash
+./supertool 'grep:somePattern:vendor/:10:::no-exclude'
+./supertool 'glob:**/*.php:::no-exclude'
+```
+
+Ops that take explicit paths and don't traverse (`ls`, `read`, `head`, `tail`, `wc`, `stat`, `around`, `around_line`, `between`, `diff`, `blame`) are not affected — they always work on exactly the path you give them.
+
+See [issue #4](https://github.com/Digital-Process-Tools/claude-supertool/issues/4) for the full design rationale.
+
 ### RTK integration
 
 When [rtk](https://github.com/reachingforthejack/rtk) is installed, supertool automatically delegates `read`, `grep`, and `wc` to RTK for compressed output. No configuration needed — detected via `which rtk` at first use.

--- a/supertool.py
+++ b/supertool.py
@@ -104,6 +104,14 @@ MAX_GLOB_RESULTS = 50
 LOG_FILE = os.path.join(tempfile.gettempdir(), "supertool-calls.log")
 GREP_FILE_INCLUDES = ("*.php", "*.xml", "*.py", "*.js", "*.ts", "*.md")
 _GREP_EXTENSIONS_EFFECTIVE: Tuple[str, ...] | None = None
+
+# Default exclude-paths applied to all traversal ops (glob, grep, tree, map).
+# These are pruned at the directory-walk boundary — the dirs are never opened.
+# Match is prefix-relative-to-cwd; trailing slash is normalised in _get_exclude_paths.
+_DEFAULT_EXCLUDE_PATHS: Tuple[str, ...] = (
+    ".git/", "node_modules/", ".svn/", ".hg/", ".idea/", ".vscode/",
+    "__pycache__/", ".venv/", "venv/", "dist/", "build/",
+)
 WILDCARD_CHARS = re.compile(r"[*?\[]")
 # Patterns for lines that are "blank or comment-only" across common languages
 _COMPACT_SKIP = re.compile(
@@ -265,6 +273,49 @@ def _grep_file_includes() -> Tuple[str, ...] | None:
     # Default: search all files
     _GREP_EXTENSIONS_EFFECTIVE = ("*",)  # sentinel for "no filter"
     return None
+
+
+def _get_exclude_paths(op_name: str, no_exclude: bool = False) -> Tuple[str, ...]:
+    """Return the effective set of exclude-path prefixes for a traversal op.
+
+    Merges _DEFAULT_EXCLUDE_PATHS with any project-level exclude-paths defined
+    under ops.<op_name>.exclude-paths in .supertool.json (additive union).
+    Returns an empty tuple when no_exclude=True (per-call escape hatch).
+    """
+    if no_exclude:
+        return ()
+    defaults = set(_DEFAULT_EXCLUDE_PATHS)
+    cfg = _load_config()
+    project_paths = cfg.get("ops", {}).get(op_name, {})
+    if isinstance(project_paths, dict):
+        extra = project_paths.get("exclude-paths", [])
+        if isinstance(extra, list):
+            for p in extra:
+                if isinstance(p, str):
+                    # Normalise: ensure trailing slash for directory prefix matching
+                    defaults.add(p if p.endswith("/") else p + "/")
+    return tuple(sorted(defaults))
+
+
+def _is_excluded(rel_path: str, exclude_paths: Tuple[str, ...]) -> bool:
+    """Return True if rel_path starts with any of the exclude prefixes.
+
+    rel_path should be relative to cwd and use os.sep.  The comparison
+    normalises separators and strips a leading './' so callers don't need to.
+    """
+    if not exclude_paths:
+        return False
+    # Normalise to forward-slashes for consistent prefix matching
+    normalised = rel_path.replace(os.sep, "/")
+    # Strip leading "./" produced by os.path.join(".", name) or relpath at cwd
+    if normalised.startswith("./"):
+        normalised = normalised[2:]
+    if not normalised.endswith("/"):
+        normalised += "/"
+    for prefix in exclude_paths:
+        if normalised.startswith(prefix):
+            return True
+    return False
 
 
 def _rtk_enabled() -> bool:
@@ -514,7 +565,8 @@ def op_read(path: str, offset: int = 0, limit: int = 0,
 
 
 def op_grep(pattern: str, path: str = ".", limit: int = 0,
-            context: int = 0, count_only: bool = False) -> str:
+            context: int = 0, count_only: bool = False,
+            no_exclude: bool = False) -> str:
     """Search pattern recursively. Auto-reads small single file on match.
 
     When context > 0, emits N lines before/after each match in grep -C style:
@@ -548,8 +600,10 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
         if rtk_out is not None:
             return rtk_out + "\n"
 
+    excl = _get_exclude_paths("grep", no_exclude)
+
     if count_only:
-        counts = _grep_count(pattern, path, limit)
+        counts = _grep_count(pattern, path, limit, excl)
         total = sum(counts.values())
         file_count = len(counts)
         out = [f"({total} total matches across {file_count} files)\n"]
@@ -559,7 +613,7 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
         return "".join(out)
 
     if context > 0:
-        groups = _grep_recursive_context(pattern, path, limit, context)
+        groups = _grep_recursive_context(pattern, path, limit, context, excl)
         count = sum(
             1 for g in groups for line in g if line[2] == "match"
         )
@@ -583,7 +637,7 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
         out.append("\n")
         return "".join(out)
 
-    hits = _grep_recursive(pattern, path, limit)
+    hits = _grep_recursive(pattern, path, limit, excl)
     count = len(hits)
 
     out = [f"({count} results, limit {limit})\n"]
@@ -787,7 +841,7 @@ def op_between_pattern(start: str, end: str, path: str) -> str:
     return "".join(out)
 
 
-def op_glob(pattern: str) -> str:
+def op_glob(pattern: str, no_exclude: bool = False) -> str:
     """Find files matching pattern. Auto-reads concrete file paths."""
     if not pattern:
         return "ERROR: empty pattern\n"
@@ -797,7 +851,7 @@ def op_glob(pattern: str) -> str:
         return ("[auto-read: concrete path, no wildcards]\n"
                 + render_file(pattern, 0, _get_op_int("read", "max_lines", MAX_READ_LINES)))
 
-    files = _glob_files(pattern)
+    files = _glob_files(pattern, _get_exclude_paths("glob", no_exclude))
     # Strip common directory prefix when 2+ files share one
     prefix = ""
     if len(files) >= 2:
@@ -987,7 +1041,8 @@ def op_around_line(path: str, line: int, n: int = 10) -> str:
     return "".join(out)
 
 
-def op_tree(path: str, depth: int = 3) -> str:
+def op_tree(path: str, depth: int = 3,
+            exclude_paths: Tuple[str, ...] = ()) -> str:
     """Show directory structure with depth limit."""
     if not path:
         path = "."
@@ -998,6 +1053,7 @@ def op_tree(path: str, depth: int = 3) -> str:
 
     out: List[str] = []
     base = os.path.abspath(path)
+    cwd = os.getcwd()
 
     def _walk(dir_path: str, prefix: str, current_depth: int) -> None:
         if current_depth > depth:
@@ -1014,6 +1070,10 @@ def op_tree(path: str, depth: int = 3) -> str:
         for f in files:
             out.append(f"{prefix}{f}\n")
         for d in dirs:
+            if exclude_paths:
+                rel = os.path.relpath(os.path.join(dir_path, d), cwd)
+                if _is_excluded(rel, exclude_paths):
+                    continue
             out.append(f"{prefix}{d}/\n")
             if current_depth < depth:
                 _walk(os.path.join(dir_path, d), prefix + "  ", current_depth + 1)
@@ -1423,14 +1483,15 @@ def _count_lines(path: str) -> int:
         return 0
 
 
-def _collect_files(path: str) -> List[str]:
+def _collect_files(
+    path: str, exclude_paths: Tuple[str, ...] = ()
+) -> List[str]:
     """Collect files to map from a path (file or directory).
 
     For directories, walks recursively. Skips hidden dirs, Generated/,
-    vendor/, node_modules/, __pycache__/.
+    vendor/, and any dirs matching exclude_paths prefixes.
     """
-    skip_dirs = {".git", ".hg", ".svn", "vendor", "node_modules",
-                 "__pycache__", "Generated", ".claude", ".max"}
+    skip_dirs = {"vendor", "Generated", ".claude", ".max"}
 
     if os.path.isfile(path):
         return [path]
@@ -1438,11 +1499,16 @@ def _collect_files(path: str) -> List[str]:
     if not os.path.isdir(path):
         return []
 
+    cwd = os.getcwd()
     files: List[str] = []
     for root, dirs, filenames in os.walk(path):
-        # Prune skipped directories in-place
-        dirs[:] = [d for d in dirs if d not in skip_dirs and not d.startswith(".")]
-        dirs.sort()
+        rel_root = os.path.relpath(root, cwd)
+        dirs[:] = sorted(
+            d for d in dirs
+            if d not in skip_dirs
+            and not d.startswith(".")
+            and not (exclude_paths and _is_excluded(os.path.join(rel_root, d), exclude_paths))
+        )
         for fn in sorted(filenames):
             ext = os.path.splitext(fn)[1].lower()
             if ext in _MAP_EXTENSIONS:
@@ -1453,7 +1519,7 @@ def _collect_files(path: str) -> List[str]:
 MAX_MAP_FILES = 100  # Cap to prevent overwhelming output
 
 
-def op_map(path: str) -> str:
+def op_map(path: str, no_exclude: bool = False) -> str:
     """Generate a symbol map of a file or directory.
 
     Three-tier extraction:
@@ -1468,7 +1534,7 @@ def op_map(path: str) -> str:
     if not os.path.exists(path):
         return f"ERROR: path not found: {path}\n"
 
-    files = _collect_files(path)
+    files = _collect_files(path, _get_exclude_paths("map", no_exclude))
     if not files:
         return f"(no supported files found in {path})\n"
 
@@ -1524,7 +1590,10 @@ def op_map(path: str) -> str:
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _grep_count(pattern: str, path: str, limit: int) -> Dict[str, int]:
+def _grep_count(
+    pattern: str, path: str, limit: int,
+    exclude_paths: Tuple[str, ...] = ()
+) -> Dict[str, int]:
     """Return match counts per file as {filepath: count}."""
     try:
         regex = re.compile(pattern)
@@ -1532,7 +1601,7 @@ def _grep_count(pattern: str, path: str, limit: int) -> Dict[str, int]:
         regex = re.compile(re.escape(pattern))
 
     counts: Dict[str, int] = {}
-    candidates = _grep_candidates(path)
+    candidates = _grep_candidates(path, exclude_paths)
 
     for file_path in candidates:
         cnt = 0
@@ -1552,21 +1621,38 @@ def _grep_count(pattern: str, path: str, limit: int) -> Dict[str, int]:
     return counts
 
 
-def _grep_candidates(path: str) -> List[str]:
-    """Return list of file paths to search for a given path argument."""
+def _grep_candidates(
+    path: str, exclude_paths: Tuple[str, ...] = ()
+) -> List[str]:
+    """Return list of file paths to search for a given path argument.
+
+    When exclude_paths is provided, directories whose path-relative-to-cwd
+    starts with one of the prefixes are pruned at the walk boundary (dirs[:]
+    mutation) so their subtrees are never opened.
+    """
     candidates: List[str] = []
     if os.path.isfile(path):
         candidates.append(path)
     elif os.path.isdir(path):
         exts = _grep_file_includes()  # None = all files
-        for root, _dirs, files in os.walk(path):
+        cwd = os.getcwd()
+        for root, dirs, files in os.walk(path):
+            if exclude_paths:
+                rel_root = os.path.relpath(root, cwd)
+                dirs[:] = [
+                    d for d in dirs
+                    if not _is_excluded(os.path.join(rel_root, d), exclude_paths)
+                ]
             for name in files:
                 if exts is None or any(name.endswith(ext.lstrip("*")) for ext in exts):
                     candidates.append(os.path.join(root, name))
     return candidates
 
 
-def _grep_recursive(pattern: str, path: str, limit: int) -> List[str]:
+def _grep_recursive(
+    pattern: str, path: str, limit: int,
+    exclude_paths: Tuple[str, ...] = ()
+) -> List[str]:
     """Return up to `limit` match lines as 'path:lineno:content' strings.
 
     Filters by common code/doc extensions when walking directories.
@@ -1579,7 +1665,7 @@ def _grep_recursive(pattern: str, path: str, limit: int) -> List[str]:
         regex = re.compile(re.escape(pattern))
 
     results: List[str] = []
-    candidates = _grep_candidates(path)
+    candidates = _grep_candidates(path, exclude_paths)
 
     for file_path in candidates:
         if len(results) >= limit:
@@ -1601,7 +1687,8 @@ def _grep_recursive(pattern: str, path: str, limit: int) -> List[str]:
 
 
 def _grep_recursive_context(
-    pattern: str, path: str, limit: int, context: int
+    pattern: str, path: str, limit: int, context: int,
+    exclude_paths: Tuple[str, ...] = ()
 ) -> List[List[Tuple[str, int, str, str]]]:
     """Return match groups with surrounding context lines.
 
@@ -1616,7 +1703,7 @@ def _grep_recursive_context(
     except re.error:
         regex = re.compile(re.escape(pattern))
 
-    candidates = _grep_candidates(path)
+    candidates = _grep_candidates(path, exclude_paths)
     groups: List[List[Tuple[str, int, str, str]]] = []
     match_count = 0
 
@@ -1671,12 +1758,58 @@ def _grep_recursive_context(
     return groups
 
 
-def _glob_files(pattern: str) -> List[str]:
-    """Glob matching files, supports ** recursive. Returns up to MAX_GLOB_RESULTS."""
+def _glob_files(
+    pattern: str, exclude_paths: Tuple[str, ...] = ()
+) -> List[str]:
+    """Glob matching files, supports ** recursive. Returns up to MAX_GLOB_RESULTS.
+
+    When exclude_paths is provided and the pattern contains '**', uses an
+    os.walk-based implementation that prunes excluded directories at the walk
+    boundary (never opens them).  For non-recursive patterns, falls back to
+    glob.glob and filters results post-hoc (no subtree to prune anyway).
+    """
+    max_results = _get_op_int("glob", "max_results", MAX_GLOB_RESULTS)
+
+    if exclude_paths and "**" in pattern:
+        # Walk-based implementation for recursive globs with exclusions.
+        # Split on the first '**' to get the root dir and the tail pattern.
+        import fnmatch
+        star_idx = pattern.index("**")
+        root_part = pattern[:star_idx].rstrip("/").rstrip(os.sep) or "."
+        tail = pattern[star_idx + 2:].lstrip("/").lstrip(os.sep)
+        if not os.path.isdir(root_part):
+            root_part = "."
+            tail = pattern.lstrip("/").lstrip(os.sep)
+
+        cwd = os.getcwd()
+        files: List[str] = []
+        for root, dirs, filenames in os.walk(root_part):
+            rel_root = os.path.relpath(root, cwd)
+            dirs[:] = sorted(
+                d for d in dirs
+                if not _is_excluded(os.path.join(rel_root, d), exclude_paths)
+            )
+            for name in sorted(filenames):
+                full = os.path.join(root, name)
+                # Match the tail pattern against the relative path from root_part
+                rel_from_root = os.path.relpath(full, root_part)
+                if not tail or fnmatch.fnmatch(name, tail) or fnmatch.fnmatch(rel_from_root, tail):
+                    if os.path.isfile(full):
+                        files.append(full)
+                        if len(files) >= max_results:
+                            return files
+        return files
+
     from glob import glob
     matches = sorted(glob(pattern, recursive=True))
-    files = [m for m in matches if os.path.isfile(m)]
-    return files[:_get_op_int("glob", "max_results", MAX_GLOB_RESULTS)]
+    files_out = [m for m in matches if os.path.isfile(m)]
+    if exclude_paths:
+        cwd = os.getcwd()
+        files_out = [
+            m for m in files_out
+            if not _is_excluded(os.path.relpath(m, cwd), exclude_paths)
+        ]
+    return files_out[:max_results]
 
 
 # ---------------------------------------------------------------------------
@@ -2020,9 +2153,22 @@ def op_ops(compact: bool = False) -> str:
     return body
 
 
+_NO_EXCLUDE_SUFFIX = ":::no-exclude"
+
+
 def dispatch(arg: str) -> str:
-    """Parse 'op:arg1:arg2:...' and route to the matching op function."""
-    header = f"--- {arg} ---\n"
+    """Parse 'op:arg1:arg2:...' and route to the matching op function.
+
+    Traversal ops (grep, glob, tree, map) support an optional :::no-exclude
+    suffix that bypasses all exclude-paths for that one call.
+    Example: 'grep:pattern:vendor/:10:::no-exclude'
+    """
+    # Strip :::no-exclude before splitting so it doesn't interfere with arg parsing
+    no_exclude = arg.endswith(_NO_EXCLUDE_SUFFIX)
+    if no_exclude:
+        arg = arg[: -len(_NO_EXCLUDE_SUFFIX)]
+
+    header = f"--- {arg}{_NO_EXCLUDE_SUFFIX if no_exclude else ''} ---\n"
     parts = _split_arg(arg)
     op = parts[0] if parts else ""
 
@@ -2037,13 +2183,14 @@ def dispatch(arg: str) -> str:
             body = op_read(path, offset, limit, grep_filter)
         elif op == "grep":
             pattern, path, limit, context, count_only = _parse_grep_args(parts)
-            body = op_grep(pattern, path, limit, context, count_only)
+            body = op_grep(pattern, path, limit, context, count_only,
+                           no_exclude=no_exclude)
         elif op == "wc":
             path = parts[1] if len(parts) > 1 else ""
             body = op_wc(path)
         elif op == "glob":
             pattern = parts[1] if len(parts) > 1 else ""
-            body = op_glob(pattern)
+            body = op_glob(pattern, no_exclude=no_exclude)
         elif op == "ls":
             path = parts[1] if len(parts) > 1 and parts[1] else "."
             body = op_ls(path)
@@ -2064,7 +2211,7 @@ def dispatch(arg: str) -> str:
             body = op_around(pattern, path, n)
         elif op == "map":
             path = parts[1] if len(parts) > 1 else "."
-            body = op_map(path)
+            body = op_map(path, no_exclude=no_exclude)
         elif op == "diff":
             path1 = parts[1] if len(parts) > 1 else ""
             path2 = parts[2] if len(parts) > 2 else ""
@@ -2106,7 +2253,7 @@ def dispatch(arg: str) -> str:
         elif op == "tree":
             path = parts[1] if len(parts) > 1 and parts[1] else "."
             d = int(parts[2]) if len(parts) > 2 and parts[2] else 3
-            body = op_tree(path, d)
+            body = op_tree(path, d, exclude_paths=_get_exclude_paths("tree", no_exclude))
         elif op in ("replace", "replace_dry"):
             old_str = parts[1] if len(parts) > 1 else ""
             new_str = parts[2] if len(parts) > 2 else ""

--- a/supertool.py
+++ b/supertool.py
@@ -318,6 +318,29 @@ def _is_excluded(rel_path: str, exclude_paths: Tuple[str, ...]) -> bool:
     return False
 
 
+def _split_exclude_prefixes(
+    exclude_paths: Tuple[str, ...],
+) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    """Split exclude prefixes into single-segment names and multi-segment paths.
+
+    Single-segment ("node_modules/", ".git/") can be passed to grep's
+    --exclude-dir.  Multi-segment ("Dvsi/dvsi-private/libs/") cannot — callers
+    that delegate to grep should fall back to native walking when any
+    multi-segment prefixes are present.
+
+    Returns (singles, multis), each tuple of trimmed names without trailing "/".
+    """
+    singles: List[str] = []
+    multis: List[str] = []
+    for p in exclude_paths:
+        trimmed = p.rstrip("/")
+        if "/" in trimmed:
+            multis.append(trimmed)
+        else:
+            singles.append(trimmed)
+    return tuple(singles), tuple(multis)
+
+
 def _rtk_enabled() -> bool:
     """Check if RTK delegation is enabled in .supertool.json. Default: true."""
     return bool(_load_config().get("rtk", True))
@@ -593,14 +616,22 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
         if not _glob(path, recursive=True):
             return f"ERROR: path not found: {path}\n"
 
-    # RTK delegation — basic grep (no context, no count)
-    if not count_only and context == 0 and _rtk_enabled() and _has_rtk():
-        rtk_args = ["grep", "-n", "-m", str(limit), pattern, path]
-        rtk_out = _rtk_run(rtk_args)
-        if rtk_out is not None:
-            return rtk_out + "\n"
-
     excl = _get_exclude_paths("grep", no_exclude)
+
+    # RTK delegation — basic grep (no context, no count). Thread excludes through
+    # via grep's --exclude-dir for single-segment prefixes (.git/, node_modules/,
+    # etc.). Multi-segment prefixes (e.g. "Dvsi/dvsi-private/libs/") can't be
+    # expressed as --exclude-dir; fall through to the native walker in that case.
+    if not count_only and context == 0 and _rtk_enabled() and _has_rtk():
+        single, multi = _split_exclude_prefixes(excl)
+        if not multi:
+            rtk_args = ["grep", "-rn", "-m", str(limit)]
+            for d in single:
+                rtk_args.append(f"--exclude-dir={d}")
+            rtk_args.extend([pattern, path])
+            rtk_out = _rtk_run(rtk_args)
+            if rtk_out is not None:
+                return rtk_out + "\n"
 
     if count_only:
         counts = _grep_count(pattern, path, limit, excl)
@@ -1484,12 +1515,17 @@ def _count_lines(path: str) -> int:
 
 
 def _collect_files(
-    path: str, exclude_paths: Tuple[str, ...] = ()
+    path: str, exclude_paths: Tuple[str, ...]
 ) -> List[str]:
     """Collect files to map from a path (file or directory).
 
-    For directories, walks recursively. Skips hidden dirs, Generated/,
-    vendor/, and any dirs matching exclude_paths prefixes.
+    For directories, walks recursively. Skips hidden dirs, vendor/, Generated/,
+    .claude/, .max/, and any dirs matching exclude_paths prefixes.
+
+    `exclude_paths` is required (not defaulted) because the universal classics
+    (.git/, node_modules/, etc.) live in `_DEFAULT_EXCLUDE_PATHS` and must reach
+    this function via `_get_exclude_paths("map", ...)`. A defaulted empty tuple
+    here would silently re-walk node_modules.
     """
     skip_dirs = {"vendor", "Generated", ".claude", ".max"}
 

--- a/tests/test_exclude_paths.py
+++ b/tests/test_exclude_paths.py
@@ -1,0 +1,335 @@
+"""Tests for per-tool exclude-paths feature (issue #4).
+
+Coverage:
+- Default excludes prune .git/ and node_modules/ from glob and grep
+- Project exclude-paths in .supertool.json extends defaults (additive)
+- :::no-exclude overrides all excludes for a single call
+- Explicit-path ops (ls, read) are unaffected by excludes
+- _is_excluded helper logic
+- _get_exclude_paths merges correctly
+- tree and map ops respect excludes
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tree(tmp_path: Path) -> None:
+    """Create a standard fixture tree with excluded and non-excluded dirs."""
+    # Normal source file
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("def hello(): pass\n")
+
+    # Should be excluded by default
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "config").write_text("[core]\n")
+    (tmp_path / ".git" / "objects").mkdir()
+    (tmp_path / ".git" / "objects" / "pack.idx").write_text("binary\n")
+
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "lodash").mkdir()
+    (tmp_path / "node_modules" / "lodash" / "index.js").write_text("// lodash\n")
+
+    # Also a venv
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "lib").mkdir()
+    (tmp_path / ".venv" / "lib" / "site.py").write_text("# venv\n")
+
+
+# ---------------------------------------------------------------------------
+# _is_excluded unit tests
+# ---------------------------------------------------------------------------
+
+class TestIsExcluded:
+    def test_basic_match(self):
+        assert supertool._is_excluded(".git", (".git/",))
+
+    def test_nested_match(self):
+        assert supertool._is_excluded(".git/objects", (".git/",))
+
+    def test_no_match(self):
+        assert not supertool._is_excluded("src/app.py", (".git/",))
+
+    def test_empty_excludes(self):
+        assert not supertool._is_excluded(".git", ())
+
+    def test_partial_name_no_match(self):
+        # "git" should NOT match ".git/" prefix
+        assert not supertool._is_excluded("git/foo", (".git/",))
+
+    def test_normalises_os_sep(self):
+        # os.path.join uses os.sep — must still match
+        path = os.path.join(".git", "objects")
+        assert supertool._is_excluded(path, (".git/",))
+
+
+# ---------------------------------------------------------------------------
+# _get_exclude_paths unit tests
+# ---------------------------------------------------------------------------
+
+class TestGetExcludePaths:
+    def test_returns_defaults_with_no_config(self):
+        excl = supertool._get_exclude_paths("glob")
+        assert ".git/" in excl
+        assert "node_modules/" in excl
+        assert "dist/" in excl
+
+    def test_no_exclude_returns_empty(self):
+        excl = supertool._get_exclude_paths("glob", no_exclude=True)
+        assert excl == ()
+
+    def test_project_paths_merged_additively(self, monkeypatch):
+        monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+        monkeypatch.setattr(supertool, "_CONFIG", {
+            "ops": {
+                "glob": {
+                    "exclude-paths": ["vendor/", "my-custom-lib/"]
+                }
+            }
+        })
+        excl = supertool._get_exclude_paths("glob")
+        # Defaults still present
+        assert ".git/" in excl
+        assert "node_modules/" in excl
+        # Project additions also present
+        assert "vendor/" in excl
+        assert "my-custom-lib/" in excl
+
+    def test_project_path_without_trailing_slash_normalised(self, monkeypatch):
+        monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+        monkeypatch.setattr(supertool, "_CONFIG", {
+            "ops": {"grep": {"exclude-paths": ["my-lib"]}}
+        })
+        excl = supertool._get_exclude_paths("grep")
+        assert "my-lib/" in excl
+
+    def test_project_paths_do_not_replace_defaults(self, monkeypatch):
+        monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+        monkeypatch.setattr(supertool, "_CONFIG", {
+            "ops": {"glob": {"exclude-paths": ["vendor/"]}}
+        })
+        excl = supertool._get_exclude_paths("glob")
+        # Defaults must still be there
+        assert ".git/" in excl
+        assert "node_modules/" in excl
+
+
+# ---------------------------------------------------------------------------
+# glob — default excludes
+# ---------------------------------------------------------------------------
+
+class TestGlobExcludes:
+    def test_default_excludes_git(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_glob("**/*")
+        assert ".git" not in out
+        assert "src/app.py" in out or "app.py" in out
+
+    def test_default_excludes_node_modules(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_glob("**/*.js")
+        assert "node_modules" not in out
+        assert "lodash" not in out
+
+    def test_default_excludes_venv(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_glob("**/*.py")
+        assert ".venv" not in out
+        assert "site.py" not in out
+        assert "app.py" in out
+
+    def test_no_exclude_sees_git(self, tmp_path, monkeypatch):
+        # glob("**/*") skips dotfiles on Python 3.11+ — use explicit pattern instead
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_glob("**/*.js", no_exclude=True)
+        # node_modules is not a dotfile, so glob can reach it when no_exclude=True
+        assert "lodash" in out or "node_modules" in out
+
+    def test_no_exclude_sees_node_modules(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_glob("**/*.js", no_exclude=True)
+        assert "lodash" in out or "node_modules" in out
+
+    def test_project_exclude_paths_extend_defaults(self, tmp_path, monkeypatch):
+        # Add a custom dir that would normally be included
+        (tmp_path / "my-custom-lib").mkdir()
+        (tmp_path / "my-custom-lib" / "util.py").write_text("x = 1\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("y = 2\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+        monkeypatch.setattr(supertool, "_CONFIG", {
+            "ops": {"glob": {"exclude-paths": ["my-custom-lib/"]}}
+        })
+        out = supertool.op_glob("**/*.py")
+        assert "util.py" not in out
+        assert "app.py" in out
+
+
+# ---------------------------------------------------------------------------
+# grep — default excludes
+# ---------------------------------------------------------------------------
+
+class TestGrepExcludes:
+    def test_default_excludes_git(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_grep("core", str(tmp_path))
+        assert ".git" not in out
+
+    def test_default_excludes_node_modules(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_grep("lodash", str(tmp_path))
+        assert "node_modules" not in out
+
+    def test_no_exclude_sees_git(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_grep("core", str(tmp_path), no_exclude=True)
+        assert "config" in out or ".git" in out
+
+    def test_no_exclude_sees_node_modules(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_grep("lodash", str(tmp_path), no_exclude=True)
+        assert "lodash" in out
+
+    def test_project_exclude_paths_extend_defaults(self, tmp_path, monkeypatch):
+        (tmp_path / "vendor").mkdir()
+        (tmp_path / "vendor" / "lib.py").write_text("SECRET = 1\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("SECRET = 2\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+        monkeypatch.setattr(supertool, "_CONFIG", {
+            "ops": {"grep": {"exclude-paths": ["vendor/"]}}
+        })
+        out = supertool.op_grep("SECRET", str(tmp_path))
+        assert "vendor" not in out
+        assert "app.py" in out
+        # Defaults also still active
+        # (no .git/ content to match here, but the merge is tested by _get_exclude_paths tests)
+
+
+# ---------------------------------------------------------------------------
+# :::no-exclude dispatch integration
+# ---------------------------------------------------------------------------
+
+class TestNoExcludeDispatch:
+    def test_glob_no_exclude_via_dispatch(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.dispatch("glob:**/*.js:::no-exclude")
+        # Header should include the suffix
+        assert ":::no-exclude" in out
+        # node_modules (non-dotfile) is visible when no_exclude is set
+        assert "lodash" in out or "node_modules" in out
+
+    def test_grep_no_exclude_via_dispatch(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.dispatch(f"grep:core:{tmp_path}:::no-exclude")
+        assert ":::no-exclude" in out
+        assert "config" in out or ".git" in out
+
+    def test_glob_with_excludes_via_dispatch(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.dispatch("glob:**/*.js")
+        assert "node_modules" not in out
+        assert "lodash" not in out
+
+
+# ---------------------------------------------------------------------------
+# tree — default excludes
+# ---------------------------------------------------------------------------
+
+class TestTreeExcludes:
+    def test_default_excludes_node_modules(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_tree(str(tmp_path), exclude_paths=supertool._get_exclude_paths("tree"))
+        assert "node_modules" not in out
+
+    def test_no_exclude_sees_node_modules(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_tree(str(tmp_path))
+        # Without exclude_paths passed, tree uses its own hidden-dir filter (starts with ".")
+        # but node_modules doesn't start with "." so without excludes it shows
+        assert "node_modules" in out
+
+    def test_tree_dispatch_excludes(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.dispatch(f"tree:{tmp_path}:3")
+        assert "node_modules" not in out
+
+    def test_tree_dispatch_no_exclude(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.dispatch(f"tree:{tmp_path}:3:::no-exclude")
+        assert "node_modules" in out
+
+
+# ---------------------------------------------------------------------------
+# map — default excludes
+# ---------------------------------------------------------------------------
+
+class TestMapExcludes:
+    def test_default_excludes_node_modules(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_map(str(tmp_path))
+        assert "node_modules" not in out
+        assert "lodash" not in out
+
+    def test_no_exclude_sees_node_modules(self, tmp_path, monkeypatch):
+        _make_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        out = supertool.op_map(str(tmp_path), no_exclude=True)
+        # node_modules/lodash/index.js should appear in map
+        assert "node_modules" in out or "lodash" in out or "index.js" in out
+
+
+# ---------------------------------------------------------------------------
+# Explicit-path ops unaffected (ls, read)
+# ---------------------------------------------------------------------------
+
+class TestExplicitPathOpsUnaffected:
+    def test_ls_git_still_works(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text("[core]\n")
+        out = supertool.op_ls(str(git_dir))
+        assert "config" in out
+
+    def test_read_inside_git_still_works(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        cfg = git_dir / "config"
+        cfg.write_text("[core]\nrepositoryformatversion = 0\n")
+        out = supertool.op_read(str(cfg))
+        assert "repositoryformatversion" in out
+
+    def test_ls_node_modules_still_works(self, tmp_path):
+        nm = tmp_path / "node_modules"
+        nm.mkdir()
+        (nm / "pkg").mkdir()
+        out = supertool.op_ls(str(nm))
+        assert "pkg" in out

--- a/tests/test_exclude_paths.py
+++ b/tests/test_exclude_paths.py
@@ -333,3 +333,57 @@ class TestExplicitPathOpsUnaffected:
         (nm / "pkg").mkdir()
         out = supertool.op_ls(str(nm))
         assert "pkg" in out
+
+
+# ---------------------------------------------------------------------------
+# _split_exclude_prefixes — RTK delegation helper
+# ---------------------------------------------------------------------------
+
+
+class TestSplitExcludePrefixes:
+    """Helper that separates single-segment names from multi-segment paths
+    so RTK delegation can pass --exclude-dir for the singles and skip RTK
+    when multis are present."""
+
+    def test_single_segment_names_returned_in_singles(self):
+        excl = (".git/", "node_modules/", "dist/")
+        singles, multis = supertool._split_exclude_prefixes(excl)
+        assert set(singles) == {".git", "node_modules", "dist"}
+        assert multis == ()
+
+    def test_multi_segment_paths_returned_in_multis(self):
+        excl = ("Dvsi/dvsi-private/libs/", "src/legacy/")
+        singles, multis = supertool._split_exclude_prefixes(excl)
+        assert singles == ()
+        assert set(multis) == {"Dvsi/dvsi-private/libs", "src/legacy"}
+
+    def test_mixed_split_correctly(self):
+        excl = (".git/", "Dvsi/libs/", "node_modules/")
+        singles, multis = supertool._split_exclude_prefixes(excl)
+        assert set(singles) == {".git", "node_modules"}
+        assert multis == ("Dvsi/libs",)
+
+    def test_empty_input(self):
+        singles, multis = supertool._split_exclude_prefixes(())
+        assert singles == ()
+        assert multis == ()
+
+
+# ---------------------------------------------------------------------------
+# _collect_files — exclude_paths is required (no default)
+# ---------------------------------------------------------------------------
+
+
+class TestCollectFilesRequiresExcludes:
+    """Reviewer flagged that defaulting exclude_paths to () was a trap:
+    callers who forgot the arg silently re-walked node_modules. The default
+    was removed; this test pins the signature."""
+
+    def test_collect_files_without_excludes_raises(self, tmp_path):
+        import inspect
+        sig = inspect.signature(supertool._collect_files)
+        excl_param = sig.parameters["exclude_paths"]
+        assert excl_param.default is inspect.Parameter.empty, (
+            "exclude_paths must be a required positional arg — defaulting it "
+            "to () silently re-walks node_modules. See PR #5 review."
+        )

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -294,12 +294,12 @@ def test_map_file_with_no_symbols(tmp_path: Path) -> None:
 def test_collect_files_single_file(tmp_path: Path) -> None:
     f = tmp_path / "a.py"
     f.write_text("x = 1\n")
-    files = supertool._collect_files(str(f))
+    files = supertool._collect_files(str(f), ())
     assert files == [str(f)]
 
 
 def test_collect_files_nonexistent() -> None:
-    files = supertool._collect_files("/does/not/exist")
+    files = supertool._collect_files("/does/not/exist", ())
     assert files == []
 
 
@@ -596,7 +596,7 @@ def test_collect_files_skips_generated(tmp_path: Path) -> None:
     gen.mkdir()
     (gen / "auto.php").write_text("<?php\nclass Auto {}\n")
     (tmp_path / "real.php").write_text("<?php\nclass Real {}\n")
-    files = supertool._collect_files(str(tmp_path))
+    files = supertool._collect_files(str(tmp_path), ())
     assert any("real.php" in f for f in files)
     assert not any("auto.php" in f for f in files)
 
@@ -606,7 +606,7 @@ def test_collect_files_sorted(tmp_path: Path) -> None:
     (tmp_path / "z.py").write_text("x = 1\n")
     (tmp_path / "a.py").write_text("x = 1\n")
     (tmp_path / "m.py").write_text("x = 1\n")
-    files = supertool._collect_files(str(tmp_path))
+    files = supertool._collect_files(str(tmp_path), ())
     basenames = [os.path.basename(f) for f in files]
     assert basenames == sorted(basenames)
 


### PR DESCRIPTION
Closes #4

## What

Adds per-tool `exclude-paths` config so traversal ops (`glob`, `grep`, `tree`, `map`) prune known-irrelevant directories at the walk boundary instead of walking through them.

## Before / After

On a real-world repo with `.git/`, `node_modules/`, and a 58K-file vendored libs tree, an unscoped `glob:**/Foo.class.php` could take ~60s. With the defaults shipped in this PR it takes milliseconds — the walker never descends into `.git/objects/pack/` or `node_modules/` at all.

## How

- New `_DEFAULT_EXCLUDE_PATHS` constant — the 11 universal classics:
  `.git/`, `node_modules/`, `.svn/`, `.hg/`, `.idea/`, `.vscode/`, `__pycache__/`, `.venv/`, `venv/`, `dist/`, `build/`.
- Per-op `exclude-paths` array in `ops` config. Project values are **additive** (union) with the built-in defaults — not replacement.
- Pruning happens at the directory boundary:
  - `_grep_candidates` — `os.walk` with `dirs[:]` mutation
  - `_glob_files` — for `**` patterns, replaces `glob.glob` with an `os.walk`-based walker; non-recursive globs fall back to `glob.glob` + post-filter (no subtree to prune)
  - `op_tree` — prunes inside the inner `_walk` recursion
  - `_collect_files` (used by `op_map`) — prunes alongside the existing `skip_dirs` set
- Per-call escape hatch: append `:::no-exclude` to skip excludes for that one call. Stripped during dispatch parsing, threaded into the four traversal ops.
- Explicit-path ops (`ls`, `stat`, `head`, `tail`, `read`, `wc`, `between`, `around`, `around_line`, `blame`) are untouched — they take exact paths and don't traverse.

## Example project config

```json
{
  "ops": {
    "glob": {
      "exclude-paths": ["Dvsi/dvsi-private/libs/", "Dvsi/dvsi-private/temp/"]
    },
    "grep": {
      "exclude-paths": ["Dvsi/dvsi-private/libs/", "Dvsi/dvsi-private/temp/"]
    }
  }
}
```

Effective excludes for `glob`: built-in 11 classics ∪ project's two = 13 prefixes.

## Per-call override

```bash
./supertool 'grep:somePattern:vendor/:10:::no-exclude'
```

Returns matches inside `node_modules/`, `vendor/`, etc. for that one call.

## Tests

- 544 passing (510 pre-existing + 34 new), 0 failures, 94% coverage.
- `tests/test_exclude_paths.py` covers: defaults prune `.git/` and `node_modules/`, project config extends defaults additively, `:::no-exclude` returns excluded results, explicit-path ops (`ls`, `read`) are unaffected, prefix matching handles `os.sep` and `./` normalization.

## One judgment call

Python 3.11+ `glob.glob("**/*")` silently skips dotfiles, so `.git/` is already invisible to the non-recursive `glob.glob` fallback. Tests for the `no_exclude=True` escape-hatch case use `node_modules/` instead of `.git/` because `node_modules/` is the visible non-dotfile case that actually demonstrates the override behavior end-to-end.

## Out of scope (intentionally)

- A `.supertoolignore` file — `.supertool.json` is enough for now.
- gitignore integration — different semantics (commits vs search).

## Files

- `supertool.py` — implementation (+181 net lines)
- `tests/test_exclude_paths.py` — new (335 lines)
- `.supertool.example.json` — shows new config shape + a `grep-no-exclude` example
- `README.md` — new "Excluding paths from traversal ops" section