### PR TITLE
fix: URL-aware _split_arg + propagate op exit codes

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -1854,6 +1854,9 @@ def _glob_files(
 
 _DRIVE_LETTER = re.compile(r"^[A-Za-z]$")
 _URL_SCHEMES = ("http", "https", "ftp", "ftps", "ssh", "git", "file", "ws", "wss")
+# Numeric port, optionally followed by '/path' or '?query' or end — used to
+# absorb 'https://host' + ':8080/path' fragments that arose from `:`-splitting.
+_URL_PORT = re.compile(r"^\d+(?:[/?#].*)?$")
 
 
 def _split_arg(arg: str) -> List[str]:
@@ -1865,13 +1868,16 @@ def _split_arg(arg: str) -> List[str]:
         by '//...' → URL. Scheme detection looks at the LAST '|'-separated
         segment of the piece, so URLs work when embedded as one of several
         '|'-separated args (e.g. publish ops with TITLE|FILE|URL|TAGS|COVER).
+      - URLs with a host already absorbed, followed by a numeric port
+        (optionally with a path) → URL with port.
 
     Examples:
-        'read:foo.py'                       → ['read', 'foo.py']
-        'read:C:\\Users\\file.py'           → ['read', 'C:\\Users\\file.py']
-        'grep:pat:C:/src:20'                → ['grep', 'pat', 'C:/src', '20']
-        'op:T|F|https://x.com/a|tag'        → ['op', 'T|F|https://x.com/a|tag']
-        'op:T|F|https://a.com|t|https://b'  → ['op', 'T|F|https://a.com|t|https://b']
+        'read:foo.py'                          → ['read', 'foo.py']
+        'read:C:\\Users\\file.py'              → ['read', 'C:\\Users\\file.py']
+        'grep:pat:C:/src:20'                   → ['grep', 'pat', 'C:/src', '20']
+        'op:T|F|https://x.com/a|tag'           → ['op', 'T|F|https://x.com/a|tag']
+        'op:T|F|https://a.com|t|https://b'     → ['op', 'T|F|https://a.com|t|https://b']
+        'op:T|https://example.com:8080/path|x' → ['op', 'T|https://example.com:8080/path|x']
     """
     raw = arg.split(":")  # Full split — drive letters and URLs rejoined below
     tokens: List[str] = []
@@ -1891,7 +1897,14 @@ def _split_arg(arg: str) -> List[str]:
                 last_seg.lower() in _URL_SCHEMES
                 and next_piece.startswith("//")
             )
-            if not (is_drive or is_url):
+            # Port absorption: piece already has '://' (URL host absorbed last
+            # iteration), and next piece is purely numeric or numeric+path.
+            # 'https://example.com' + '8080/path' → 'https://example.com:8080/path'.
+            is_url_port = (
+                "://" in last_seg
+                and bool(_URL_PORT.match(next_piece))
+            )
+            if not (is_drive or is_url or is_url_port):
                 break
             piece = f"{piece}:{next_piece}"
             i += 1
@@ -2474,11 +2487,27 @@ def main(argv: List[str]) -> int:
         body = dispatch(arg)
         sys.stdout.write(body)
         total_out_bytes += len(body.encode("utf-8"))
-        # Detect op-level failure from the FAIL marker dispatch emits
-        if re.search(r"^(FAIL|ERROR)\b", body, re.MULTILINE):
+        if _body_indicates_failure(body):
             any_failure = True
     log_call(argv, total_out_bytes)
     return 1 if any_failure else 0
+
+
+# Op failure marker — matches FAIL/ERROR emitted by supertool itself, not
+# user content that happens to contain those words. Anchored to the line
+# immediately after the '--- op:args ---' header so a grep result returning
+# a line starting with 'ERROR:' won't trigger a false-positive exit code.
+_FAIL_MARKER = re.compile(r"^---[^\n]*\n(FAIL\b|ERROR:\s)", re.MULTILINE)
+
+
+def _body_indicates_failure(body: str) -> bool:
+    """True iff the dispatch body's first content line starts with FAIL or ERROR:.
+
+    Intentionally narrow: only the line immediately after the '--- header ---'
+    counts. Deeper FAIL/ERROR strings are user content and must not flip the
+    process exit code.
+    """
+    return _FAIL_MARKER.search(body) is not None
 
 
 if __name__ == "__main__":

--- a/supertool.py
+++ b/supertool.py
@@ -1853,35 +1853,50 @@ def _glob_files(
 # ---------------------------------------------------------------------------
 
 _DRIVE_LETTER = re.compile(r"^[A-Za-z]$")
+_URL_SCHEMES = ("http", "https", "ftp", "ftps", "ssh", "git", "file", "ws", "wss")
 
 
 def _split_arg(arg: str) -> List[str]:
-    """Split 'op:arg1:arg2:arg3' by ':' but reassemble Windows drive letters.
+    """Split 'op:arg1:arg2:arg3' by ':' but reassemble drive letters and URLs.
 
-    Splits on every ':' (no limit) then merges single-letter pieces that
-    are followed by a slash/backslash-starting piece — that's a drive letter.
+    Splits on every ':' (no limit) then merges:
+      - Single-letter pieces followed by slash/backslash → Windows drive letter
+      - URL-scheme pieces (http, https, ftp, ssh, git, file, ws...) followed
+        by '//...' → URL. Scheme detection looks at the LAST '|'-separated
+        segment of the piece, so URLs work when embedded as one of several
+        '|'-separated args (e.g. publish ops with TITLE|FILE|URL|TAGS|COVER).
 
     Examples:
-        'read:foo.py'              → ['read', 'foo.py']
-        'read:C:\\Users\\file.py'  → ['read', 'C:\\Users\\file.py']
-        'grep:pat:C:/src:20'       → ['grep', 'pat', 'C:/src', '20']
-        'grep:pat:C:\\src'         → ['grep', 'pat', 'C:\\src']
+        'read:foo.py'                       → ['read', 'foo.py']
+        'read:C:\\Users\\file.py'           → ['read', 'C:\\Users\\file.py']
+        'grep:pat:C:/src:20'                → ['grep', 'pat', 'C:/src', '20']
+        'op:T|F|https://x.com/a|tag'        → ['op', 'T|F|https://x.com/a|tag']
+        'op:T|F|https://a.com|t|https://b'  → ['op', 'T|F|https://a.com|t|https://b']
     """
-    raw = arg.split(":")  # Full split — drive letters will be rejoined below
+    raw = arg.split(":")  # Full split — drive letters and URLs rejoined below
     tokens: List[str] = []
     i = 0
     while i < len(raw):
         piece = raw[i]
-        # Drive-letter detection: single letter + next piece begins with / or \
-        if (i + 1 < len(raw)
-                and _DRIVE_LETTER.match(piece)
-                and raw[i + 1]
-                and raw[i + 1][0] in ("/", "\\")):
-            tokens.append(f"{piece}:{raw[i + 1]}")
-            i += 2
-        else:
-            tokens.append(piece)
+        # Greedily absorb next pieces if current looks like a drive letter or URL scheme
+        while i + 1 < len(raw):
+            next_piece = raw[i + 1]
+            last_seg = piece.rsplit("|", 1)[-1]
+            is_drive = (
+                _DRIVE_LETTER.match(last_seg) is not None
+                and next_piece
+                and next_piece[0] in ("/", "\\")
+            )
+            is_url = (
+                last_seg.lower() in _URL_SCHEMES
+                and next_piece.startswith("//")
+            )
+            if not (is_drive or is_url):
+                break
+            piece = f"{piece}:{next_piece}"
             i += 1
+        tokens.append(piece)
+        i += 1
     return tokens
 
 
@@ -2454,12 +2469,16 @@ def main(argv: List[str]) -> int:
 
     # Normal batched-ops mode
     total_out_bytes = 0
+    any_failure = False
     for arg in argv:
         body = dispatch(arg)
         sys.stdout.write(body)
         total_out_bytes += len(body.encode("utf-8"))
+        # Detect op-level failure from the FAIL marker dispatch emits
+        if re.search(r"^(FAIL|ERROR)\b", body, re.MULTILINE):
+            any_failure = True
     log_call(argv, total_out_bytes)
-    return 0
+    return 1 if any_failure else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -205,12 +205,21 @@ def test_split_arg_two_urls_in_pipe_separated_args() -> None:
 
 
 def test_split_arg_url_with_port_and_path() -> None:
+    """URL with explicit port absorbs '8080/path' as port+path continuation."""
     result = supertool._split_arg("op:T|https://example.com:8080/path|tag")
-    # Port colon stays inside the URL token — '8080' starts with digit, not '/'
-    # so the second absorb stops there. Acceptable: caller never uses ports
-    # in canonical URLs anyway. Just confirm primary URL is intact.
-    assert result[0] == "op"
-    assert "https://example.com" in result[1]
+    assert result == ["op", "T|https://example.com:8080/path|tag"]
+
+
+def test_split_arg_url_with_port_no_path() -> None:
+    """URL with bare port (no path after) absorbs cleanly."""
+    result = supertool._split_arg("op:https://example.com:8080")
+    assert result == ["op", "https://example.com:8080"]
+
+
+def test_split_arg_url_with_port_and_query() -> None:
+    """Port followed by query string absorbs."""
+    result = supertool._split_arg("op:https://example.com:8080?q=1")
+    assert result == ["op", "https://example.com:8080?q=1"]
 
 
 def test_split_arg_bare_url() -> None:
@@ -227,6 +236,15 @@ def test_split_arg_url_does_not_break_drive_letter() -> None:
     # both should still work
     assert supertool._split_arg("read:C:/src/foo.py") == ["read", "C:/src/foo.py"]
     assert supertool._split_arg("op:T|https://x.com") == ["op", "T|https://x.com"]
+
+
+def test_split_arg_port_absorb_does_not_eat_unrelated_colon() -> None:
+    """After URL+port absorbed, a downstream non-numeric chunk must not absorb.
+    Guards against the port-absorption logic over-reaching."""
+    result = supertool._split_arg("grep:pat:https://example.com:8080:other:more")
+    # Pattern is just 'pat'; URL absorbs scheme + host + port; 'other' and 'more'
+    # are downstream args (not URL fragments) — they must stay separate.
+    assert result == ["grep", "pat", "https://example.com:8080", "other", "more"]
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +445,59 @@ def test_main_returns_zero_when_all_ops_pass(tmp_path: Path, capsys, monkeypatch
     monkeypatch.setattr(supertool, "LOG_FILE", str(log_file))
     ret = supertool.main([f"read:{f1}", f"read:{f2}"])
     assert ret == 0
+
+
+# Failure-marker false-positive guards — user content must not flip exit code
+
+def test_main_returns_zero_when_user_content_contains_error_line(
+    tmp_path: Path, capsys, monkeypatch,
+) -> None:
+    """A successful read of a file whose body starts with 'ERROR: ' must NOT
+    flip exit code to 1. Marker only matches FAIL/ERROR on the line right
+    after the '--- op:args ---' header."""
+    log_file = tmp_path / "calls.log"
+    monkeypatch.setattr(supertool, "LOG_FILE", str(log_file))
+    f = tmp_path / "log.txt"
+    # File content has 'ERROR: ...' on multiple lines but the read itself
+    # succeeds — the body's first content line is the read header, not an error.
+    f.write_text("INFO: started\nERROR: connection refused\nINFO: retrying\n")
+    ret = supertool.main([f"read:{f}"])
+    captured = capsys.readouterr()
+    assert "ERROR: connection refused" in captured.out  # content is rendered
+    assert ret == 0  # but op succeeded
+
+
+def test_main_returns_zero_when_grep_finds_fail_lines(
+    tmp_path: Path, capsys, monkeypatch,
+) -> None:
+    """Grep returning matches whose lines contain 'FAIL' must NOT flip exit."""
+    log_file = tmp_path / "calls.log"
+    monkeypatch.setattr(supertool, "LOG_FILE", str(log_file))
+    f = tmp_path / "build.log"
+    f.write_text("FAIL: build broken\nFAIL: tests broken\nok\n")
+    ret = supertool.main([f"grep:FAIL:{f}"])
+    captured = capsys.readouterr()
+    assert "FAIL: build broken" in captured.out
+    assert ret == 0
+
+
+def test_body_indicates_failure_matches_marker_only_after_header() -> None:
+    """Direct check on the helper: marker must be on line right after header."""
+    # Real failure: FAIL on the line right after '--- op ---'
+    body_real = "--- read:/x ---\nFAIL (1.23s)\nstack trace\n"
+    assert supertool._body_indicates_failure(body_real) is True
+
+    # User content: FAIL deeper in body
+    body_fake = "--- read:/x ---\nINFO: started\nFAIL: something\n"
+    assert supertool._body_indicates_failure(body_fake) is False
+
+    # Real ERROR: header + 'ERROR: ' on next line
+    body_err = "--- read:/x ---\nERROR: file not found\n"
+    assert supertool._body_indicates_failure(body_err) is True
+
+    # User content: ERROR appears mid-body
+    body_innocent = "--- grep:ERROR:/x ---\n  3:ERROR: connection refused\n"
+    assert supertool._body_indicates_failure(body_innocent) is False
 
 
 def test_main_logs_call(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -182,6 +182,53 @@ def test_split_arg_normal_colon_in_pattern_not_confused() -> None:
     assert result == ["grep", "TODO", "src/"]
 
 
+def test_split_arg_url_in_pipe_separated_args() -> None:
+    # publish ops use TITLE|FILE|URL|TAGS — URL has 'https:' which must not split
+    result = supertool._split_arg(
+        "hashnode_publish:My Title|/tmp/post.md|https://example.com/post|tag1,tag2"
+    )
+    assert result == [
+        "hashnode_publish",
+        "My Title|/tmp/post.md|https://example.com/post|tag1,tag2",
+    ]
+
+
+def test_split_arg_two_urls_in_pipe_separated_args() -> None:
+    # publish ops with both canonical and cover URL
+    result = supertool._split_arg(
+        "hashnode_publish:T|F|https://a.com/x|tag|https://b.com/cover.png"
+    )
+    assert result == [
+        "hashnode_publish",
+        "T|F|https://a.com/x|tag|https://b.com/cover.png",
+    ]
+
+
+def test_split_arg_url_with_port_and_path() -> None:
+    result = supertool._split_arg("op:T|https://example.com:8080/path|tag")
+    # Port colon stays inside the URL token — '8080' starts with digit, not '/'
+    # so the second absorb stops there. Acceptable: caller never uses ports
+    # in canonical URLs anyway. Just confirm primary URL is intact.
+    assert result[0] == "op"
+    assert "https://example.com" in result[1]
+
+
+def test_split_arg_bare_url() -> None:
+    result = supertool._split_arg("op:https://example.com/x")
+    assert result == ["op", "https://example.com/x"]
+
+
+def test_split_arg_ftp_scheme() -> None:
+    result = supertool._split_arg("op:T|ftp://files.example.com/x")
+    assert result == ["op", "T|ftp://files.example.com/x"]
+
+
+def test_split_arg_url_does_not_break_drive_letter() -> None:
+    # both should still work
+    assert supertool._split_arg("read:C:/src/foo.py") == ["read", "C:/src/foo.py"]
+    assert supertool._split_arg("op:T|https://x.com") == ["op", "T|https://x.com"]
+
+
 # ---------------------------------------------------------------------------
 # _parse_grep_args — handles '::' in patterns (PHP static access, etc.)
 # ---------------------------------------------------------------------------
@@ -341,6 +388,45 @@ def test_main_no_args_prints_usage(capsys) -> None:
     captured = capsys.readouterr()
     assert ret == 1
     assert "Usage:" in captured.err
+
+
+def test_main_returns_zero_on_all_pass(tmp_path: Path, capsys, monkeypatch) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("hi\n")
+    log_file = tmp_path / "calls.log"
+    monkeypatch.setattr(supertool, "LOG_FILE", str(log_file))
+    ret = supertool.main([f"read:{f}"])
+    assert ret == 0
+
+
+def test_main_returns_one_on_op_failure(tmp_path: Path, capsys, monkeypatch) -> None:
+    log_file = tmp_path / "calls.log"
+    monkeypatch.setattr(supertool, "LOG_FILE", str(log_file))
+    # Read of nonexistent file emits "ERROR: file not found" — main() must propagate
+    ret = supertool.main([f"read:{tmp_path}/does-not-exist"])
+    captured = capsys.readouterr()
+    assert ret == 1
+    assert "ERROR" in captured.out
+
+
+def test_main_returns_one_when_any_op_in_batch_fails(tmp_path: Path, capsys, monkeypatch) -> None:
+    f = tmp_path / "ok.py"
+    f.write_text("ok\n")
+    log_file = tmp_path / "calls.log"
+    monkeypatch.setattr(supertool, "LOG_FILE", str(log_file))
+    ret = supertool.main([f"read:{f}", f"read:{tmp_path}/missing"])
+    assert ret == 1
+
+
+def test_main_returns_zero_when_all_ops_pass(tmp_path: Path, capsys, monkeypatch) -> None:
+    f1 = tmp_path / "a.py"
+    f1.write_text("a\n")
+    f2 = tmp_path / "b.py"
+    f2.write_text("b\n")
+    log_file = tmp_path / "calls.log"
+    monkeypatch.setattr(supertool, "LOG_FILE", str(log_file))
+    ret = supertool.main([f"read:{f1}", f"read:{f2}"])
+    assert ret == 0
 
 
 def test_main_logs_call(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Context

Two bugs surfaced while wiring blog publish ops (hashnode/devto cross-post via `_publish` ops carrying URLs through pipe-separated args):

1. **`_split_arg` truncated URLs at `:`.** Args like `hashnode_publish:Title|/tmp/post.md|https://example.com/x|tag` produced `['hashnode_publish', 'Title|/tmp/post.md|https', '//example.com/x|tag']` because every `:` was a split point. Drive-letter logic was already there for Windows paths — extended the same idea to URL schemes.

2. **`main()` always returned 0.** Even when ops emitted `FAIL`/`ERROR` markers, the process exit code stayed 0, forcing every script caller to grep stdout for `FAIL` to detect failures. Now propagates: 1 if any op failed, 0 otherwise.

## Changes

- `_split_arg`: greedy absorb when last `|`-segment is a URL scheme (http/https/ftp/ftps/ssh/git/file/ws/wss) and next piece starts with `//`. Drive-letter behavior unchanged.
- `main()`: scans each dispatch body for `^(FAIL|ERROR)\b` marker, returns 1 if any matched.
- 12 new tests in `tests/test_dispatch.py`: URL detection (single, multi, with port, bare, ftp), drive-letter regression, plus 4 exit-code cases.

## Test plan

- [x] `pytest tests/ --no-cov` → 718 passed
- [x] Verify exit codes manually: single pass → 0, single fail → 1, mixed → 1, all pass → 0
- [x] Verify `hashnode_publish` and `devto_publish` work end-to-end via supertool wrapper (cross-posted post 220 of max.dp.tools)