### PR TITLE
fix: accept slug/URL on devto+hashnode react/comment ops

### DIFF
--- a/presets/devto.json
+++ b/presets/devto.json
@@ -43,17 +43,17 @@
       "default_limit": 20
     },
     "devto_react": {
-      "cmd": "python3 {path}devto/react.py {arg}",
+      "cmd": "python3 {path}devto/react.py {args}",
       "timeout": 15,
-      "description": "React (like/unicorn/readinglist) to an article. Toggles on/off. Requires DEVTO_SESSION_COOKIE for Dev.to write actions (API key alone returns 401).",
-      "syntax": "devto_react:ARTICLE_ID[|CATEGORY]",
+      "description": "React (like/unicorn/readinglist) to an article. Accepts numeric ID, slug (author/slug), or full URL. Toggles on/off. Requires DEVTO_SESSION_COOKIE for Dev.to write actions (API key alone returns 401).",
+      "syntax": "devto_react:ARTICLE_ID_OR_SLUG_OR_URL[|CATEGORY]",
       "example": "devto_react:1234567|like"
     },
     "devto_comment": {
       "cmd": "python3 {path}devto/comment.py {args}",
       "timeout": 30,
-      "description": "Post a comment (or reply with PARENT_COMMENT_ID). EXPERIMENTAL — requires DEVTO_SESSION_COOKIE; the public API has no comment-write endpoint.",
-      "syntax": "devto_comment:ARTICLE_ID|MESSAGE[|PARENT_COMMENT_ID]",
+      "description": "Post a comment (or reply with PARENT_COMMENT_ID). Accepts numeric ID, slug (author/slug), or full URL. EXPERIMENTAL — requires DEVTO_SESSION_COOKIE; the public API has no comment-write endpoint.",
+      "syntax": "devto_comment:ARTICLE_ID_OR_SLUG_OR_URL|MESSAGE[|PARENT_COMMENT_ID]",
       "example": "devto_comment:1234567|Thanks for sharing!"
     },
     "devto_status_since": {

--- a/presets/devto/_resolve.py
+++ b/presets/devto/_resolve.py
@@ -1,0 +1,60 @@
+"""Dev.to article ID resolver.
+
+The Reactions and Comments write endpoints require the integer article ID;
+sending a slug or URL returns 422 "Reactable not valid". This helper resolves
+any of the three input shapes into the numeric ID by calling /articles/{slug}
+when needed.
+
+Accepted inputs:
+  - "12345"                                        → 12345
+  - "author/article-slug"                          → resolved via API
+  - "https://dev.to/author/article-slug"           → URL parsed → resolved
+  - "https://dev.to/author/article-slug-1234abcd"  → suffixed slug → resolved
+"""
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _auth import get_api_key
+from _rest import request
+
+
+def resolve_article_id(raw: str) -> int:
+    """Return the numeric article ID for any accepted input shape.
+
+    Exits the process with a clear error if the input cannot be resolved.
+    """
+    s = (raw or "").strip()
+    if not s:
+        sys.stderr.write("ERROR: empty article identifier\n")
+        sys.exit(2)
+    if s.isdigit():
+        return int(s)
+    path = _to_api_path(s)
+    if path is None:
+        sys.stderr.write(
+            f"ERROR: cannot parse article identifier {raw!r} — "
+            "expected numeric ID, 'author/slug', or full https://dev.to/... URL\n"
+        )
+        sys.exit(2)
+    article = request("GET", path, get_api_key())
+    if not isinstance(article, dict) or not article.get("id"):
+        sys.stderr.write(
+            f"ERROR: could not resolve {raw!r} to article ID — "
+            "Dev.to returned no id field. Check the slug/URL is correct.\n"
+        )
+        sys.exit(1)
+    return int(article["id"])
+
+
+def _to_api_path(s: str) -> str | None:
+    """Convert a slug or URL into an /articles/... API path."""
+    if s.startswith("http"):
+        bits = urlparse(s).path.strip("/").split("/")
+        if len(bits) >= 2:
+            return f"/articles/{bits[0]}/{bits[1]}"
+        return None
+    if "/" in s:
+        return f"/articles/{s}"
+    return None

--- a/presets/devto/comment.py
+++ b/presets/devto/comment.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Dev.to comment: devto_comment:ARTICLE_ID|MESSAGE[|PARENT_COMMENT_ID]
+"""Dev.to comment: devto_comment:ARTICLE_ID_OR_SLUG_OR_URL|MESSAGE[|PARENT_COMMENT_ID]
+
+Accepts numeric article ID, slug (`author/slug`), or full URL — non-numeric
+inputs are resolved to the numeric ID via /api/articles/{slug} before posting.
+The Comments write endpoint requires the integer ID.
 
 ⚠ SESSION-COOKIE OP — POSSIBLE ToS RISK ⚠
 =========================================
@@ -26,6 +30,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _outbound import append as track_append
+from _resolve import resolve_article_id
 from _session import fetch_csrf_token, get_session_cookie, web_post_json
 
 WEB_BASE = "https://dev.to"
@@ -36,16 +41,17 @@ _COMMENT_ID_RE = re.compile(r'comment-id="(\d+)"')
 def parse_args(arg: str) -> tuple[str, str, str | None]:
     parts = arg.split("|")
     if len(parts) < 2 or not parts[0].strip() or not parts[1].strip():
-        sys.stderr.write("ERROR: usage devto_comment:ARTICLE_ID|MESSAGE[|PARENT_COMMENT_ID]\n")
+        sys.stderr.write("ERROR: usage devto_comment:ARTICLE_ID_OR_SLUG_OR_URL|MESSAGE[|PARENT_COMMENT_ID]\n")
         sys.exit(2)
-    aid = parts[0].strip()
+    raw = parts[0].strip()
     message = parts[1]
     parent = parts[2].strip() if len(parts) > 2 and parts[2].strip() else None
-    return aid, message, parent
+    return raw, message, parent
 
 
 def main(arg: str) -> None:
-    aid, message, parent = parse_args(arg)
+    raw, message, parent = parse_args(arg)
+    aid = resolve_article_id(raw)
     cookie = get_session_cookie()
     if not cookie:
         sys.stderr.write(
@@ -58,7 +64,7 @@ def main(arg: str) -> None:
     body: dict[str, object] = {
         "comment": {
             "body_markdown": message,
-            "commentable_id": int(aid) if aid.isdigit() else aid,
+            "commentable_id": aid,
             "commentable_type": "Article",
         }
     }
@@ -87,12 +93,12 @@ def main(arg: str) -> None:
     import datetime as _dt
     track_append({
         "comment_id": cid,
-        "article_id": int(aid) if aid.isdigit() else aid,
+        "article_id": aid,
         "parent_id": parent,
         "posted_at": _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     })
     print(f"(comment posted id={cid} url={url} mode=session)")
-    _print_post_confirmation(aid, str(cid))
+    _print_post_confirmation(str(aid), str(cid))
 
 
 def _print_post_confirmation(aid: str, cid: str) -> None:

--- a/presets/devto/react.py
+++ b/presets/devto/react.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
-"""Dev.to react: devto_react:ARTICLE_ID[|CATEGORY]
+"""Dev.to react: devto_react:ARTICLE_ID_OR_SLUG_OR_URL[|CATEGORY]
 
 Category: like (default), unicorn, readinglist, thumbsdown, vomit. Toggles on/off.
+
+Accepts numeric article ID, slug (`author/slug`), or full URL — non-numeric
+inputs are resolved to the numeric ID via /api/articles/{slug} before posting.
+The Reactions endpoint requires the integer ID; passing a slug raw returns
+422 "Reactable not valid".
 
 Two auth modes:
 
@@ -18,6 +23,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _auth import get_api_key
+from _resolve import resolve_article_id
 from _rest import request
 from _session import fetch_csrf_token, get_session_cookie, web_post_json
 
@@ -26,7 +32,7 @@ VALID = {"like", "unicorn", "readinglist", "thumbsdown", "vomit"}
 
 def parse_args(arg: str) -> tuple[str, str]:
     if not arg:
-        sys.stderr.write("ERROR: usage devto_react:ARTICLE_ID[|CATEGORY]\n")
+        sys.stderr.write("ERROR: usage devto_react:ARTICLE_ID_OR_SLUG_OR_URL[|CATEGORY]\n")
         sys.exit(2)
     parts = arg.split("|")
     aid = parts[0].strip()
@@ -38,12 +44,13 @@ def parse_args(arg: str) -> tuple[str, str]:
 
 
 def main(arg: str) -> None:
-    aid, category = parse_args(arg)
+    raw, category = parse_args(arg)
+    aid = resolve_article_id(raw)
     cookie = get_session_cookie()
     if cookie:
         csrf = fetch_csrf_token(cookie)
         body = {
-            "reactable_id": int(aid) if aid.isdigit() else aid,
+            "reactable_id": aid,
             "reactable_type": "Article",
             "category": category,
         }
@@ -59,7 +66,7 @@ def main(arg: str) -> None:
     # Fallback: API key (currently 401 for reactions)
     api_key = get_api_key()
     body = {
-        "reactable_id": int(aid) if aid.isdigit() else aid,
+        "reactable_id": aid,
         "reactable_type": "Article",
         "category": category,
     }
@@ -69,4 +76,7 @@ def main(arg: str) -> None:
 
 
 if __name__ == "__main__":
-    main(sys.argv[1] if len(sys.argv) > 1 else "")
+    # Supertool {args} splits on ':' — URLs like https://... arrive as multiple
+    # argv parts. Rejoin so the full identifier survives the tokenizer.
+    arg = ":".join(sys.argv[1:]) if len(sys.argv) > 1 else ""
+    main(arg)

--- a/presets/hashnode.json
+++ b/presets/hashnode.json
@@ -45,14 +45,14 @@
     "hashnode_comment": {
       "cmd": "python3 {path}hashnode/comment.py {args}",
       "timeout": 30,
-      "description": "Post a comment on a Hashnode post.",
+      "description": "Post a comment on a Hashnode post. Accepts post ID or URL on any publication (cross-publication via publication(host:) GraphQL).",
       "syntax": "hashnode_comment:POST_ID_OR_URL|MESSAGE",
       "example": "hashnode_comment:abc123|Thanks for sharing!"
     },
     "hashnode_react": {
-      "cmd": "python3 {path}hashnode/react.py {arg}",
+      "cmd": "python3 {path}hashnode/react.py {args}",
       "timeout": 15,
-      "description": "Like a Hashnode post.",
+      "description": "Like a Hashnode post. Accepts post ID or URL on any publication (cross-publication via publication(host:) GraphQL).",
       "syntax": "hashnode_react:POST_ID_OR_URL",
       "example": "hashnode_react:abc123"
     },

--- a/presets/hashnode/_resolve.py
+++ b/presets/hashnode/_resolve.py
@@ -1,0 +1,57 @@
+"""Hashnode post ID resolver.
+
+The original `resolve_post_id` in react.py / comment.py only worked for posts
+in the caller's own publication (`get_publication_id()`). Foreign URLs like
+`https://hugovalters.hashnode.dev/some-slug` returned "post not found" because
+the slug was looked up under the wrong publication.
+
+This helper parses the host from the URL and uses the GraphQL
+`publication(host:)` field, which works across all Hashnode publications.
+
+Accepted inputs:
+  - "objectid-hex-string"                                → returned as-is
+  - "https://author.hashnode.dev/slug"                   → cross-publication lookup
+  - "https://blog.example.com/slug" (custom domain)      → cross-publication lookup
+"""
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _graphql import gql
+
+
+RESOLVE_BY_HOST = """
+query ResolveByHost($host: String!, $slug: String!) {
+  publication(host: $host) { post(slug: $slug) { id } }
+}
+"""
+
+
+def resolve_post_id(token: str, arg: str) -> str:
+    """Return the Hashnode post ID for an ID, own-publication URL, or foreign URL.
+
+    Exits the process with a clear error if the input cannot be resolved.
+    """
+    s = (arg or "").strip()
+    if not s:
+        sys.stderr.write("ERROR: empty post identifier\n")
+        sys.exit(2)
+    if not s.startswith("http"):
+        return s
+    parsed = urlparse(s)
+    host = parsed.netloc
+    slug = parsed.path.strip("/").split("/")[-1]
+    if not host or not slug:
+        sys.stderr.write(f"ERROR: cannot parse Hashnode URL {arg!r}\n")
+        sys.exit(2)
+    data = gql(RESOLVE_BY_HOST, {"host": host, "slug": slug}, token)
+    pub = data.get("publication") or {}
+    post = pub.get("post")
+    if not post:
+        sys.stderr.write(
+            f"ERROR: post not found at {arg!r} — host={host!r} slug={slug!r}. "
+            "Check the URL is a valid Hashnode post.\n"
+        )
+        sys.exit(1)
+    return post["id"]

--- a/presets/hashnode/comment.py
+++ b/presets/hashnode/comment.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
-"""Hashnode comment: hashnode_comment:POST_ID_OR_URL|MESSAGE"""
+"""Hashnode comment: hashnode_comment:POST_ID_OR_URL|MESSAGE
+
+Accepts a post ID or a Hashnode URL on any publication. URL→ID resolution
+uses the cross-publication `publication(host:)` GraphQL field so comments
+can be posted on any publication, not just the caller's own.
+"""
 import sys
 from pathlib import Path
-from urllib.parse import urlparse
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _auth import get_publication_id, get_token
+from _auth import get_token
 from _graphql import gql
 from _outbound import append as track_append
-
-RESOLVE_QUERY = """
-query Resolve($publicationId: ObjectId!, $slug: String!) {
-  publication(id: $publicationId) { post(slug: $slug) { id } }
-}
-"""
+from _resolve import resolve_post_id
 
 ADD_COMMENT = """
 mutation AddComment($input: AddCommentInput!) {
@@ -28,19 +27,6 @@ def parse_args(arg: str) -> tuple[str, str]:
         sys.stderr.write("ERROR: usage hashnode_comment:POST_ID_OR_URL|MESSAGE\n")
         sys.exit(2)
     return parts[0].strip(), parts[1]
-
-
-def resolve_post_id(token: str, post_or_url: str) -> str:
-    if post_or_url.startswith("http"):
-        slug = urlparse(post_or_url).path.strip("/").split("/")[-1]
-        pub_id = get_publication_id()
-        data = gql(RESOLVE_QUERY, {"publicationId": pub_id, "slug": slug}, token)
-        post = (data.get("publication") or {}).get("post")
-        if not post:
-            sys.stderr.write(f"ERROR: post not found for {post_or_url}\n")
-            sys.exit(1)
-        return post["id"]
-    return post_or_url
 
 
 def main(arg: str) -> None:

--- a/presets/hashnode/react.py
+++ b/presets/hashnode/react.py
@@ -1,37 +1,23 @@
 #!/usr/bin/env python3
-"""Hashnode react: hashnode_react:POST_ID_OR_URL — likes the post."""
+"""Hashnode react: hashnode_react:POST_ID_OR_URL — likes the post.
+
+Accepts a post ID or a Hashnode URL on any publication. The URL→ID lookup
+uses the cross-publication `publication(host:)` GraphQL field so foreign
+posts (e.g. https://author.hashnode.dev/slug) resolve correctly.
+"""
 import sys
 from pathlib import Path
-from urllib.parse import urlparse
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _auth import get_publication_id, get_token
+from _auth import get_token
 from _graphql import gql
-
-RESOLVE_QUERY = """
-query Resolve($publicationId: ObjectId!, $slug: String!) {
-  publication(id: $publicationId) { post(slug: $slug) { id } }
-}
-"""
+from _resolve import resolve_post_id
 
 LIKE = """
 mutation LikePost($input: LikePostInput!) {
   likePost(input: $input) { post { id reactionCount } }
 }
 """
-
-
-def resolve_post_id(token: str, arg: str) -> str:
-    if arg.startswith("http"):
-        slug = urlparse(arg).path.strip("/").split("/")[-1]
-        pub_id = get_publication_id()
-        data = gql(RESOLVE_QUERY, {"publicationId": pub_id, "slug": slug}, token)
-        post = (data.get("publication") or {}).get("post")
-        if not post:
-            sys.stderr.write(f"ERROR: post not found for {arg}\n")
-            sys.exit(1)
-        return post["id"]
-    return arg
 
 
 def main(arg: str) -> None:
@@ -46,4 +32,7 @@ def main(arg: str) -> None:
 
 
 if __name__ == "__main__":
-    main(sys.argv[1] if len(sys.argv) > 1 else "")
+    # Supertool {args} splits on ':' — URLs like https://... arrive as multiple
+    # argv parts. Rejoin so the full identifier survives the tokenizer.
+    arg = ":".join(sys.argv[1:]) if len(sys.argv) > 1 else ""
+    main(arg)

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -505,3 +505,103 @@ class TestMainIntegration:
         assert "data" in captured.out
         assert "pong" in captured.out
         assert "ops=2" in log_file.read_text()
+
+
+# ---------------------------------------------------------------------------
+# {arg} vs {args} placeholder behavior — colon-bearing inputs (URLs, ISO dates)
+#
+# Bug surfaced 2026-05-02: devto_react with `{arg}` template received only the
+# first ':'-separated chunk of a URL ("https") instead of the full URL.
+# Fix was to switch the cmd template to `{args}` so all parts survive.
+# These tests pin the dispatch behavior so the regression cannot return.
+# ---------------------------------------------------------------------------
+
+class TestArgPlaceholderColonHandling:
+
+    def test_arg_placeholder_only_passes_first_chunk(self, tmp_path: Path) -> None:
+        """`{arg}` substitutes parts[1] only — colons in the input split it."""
+        captured = tmp_path / "out.txt"
+        # The script writes ALL its argv (after script name, excluding final
+        # output-file path) to a file we can inspect.
+        script = tmp_path / "echo_argv.py"
+        script.write_text(
+            "import sys; open(sys.argv[-1], 'w').write(repr(sys.argv[1:-1]))\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"echo": {"cmd": f"python3 {script} {{arg}} {captured}"}}
+        }
+        # Input: 'echo:https://example.com' tokenizes to parts =
+        # ['echo', 'https', '//example.com']. With {arg}, only 'https' goes through.
+        result = supertool.dispatch("echo:https://example.com")
+        assert "PASS" in result
+        argv = eval(captured.read_text())
+        assert argv == ["https"], f"expected ['https'], got {argv!r}"
+
+    def test_args_placeholder_passes_all_chunks(self, tmp_path: Path) -> None:
+        """`{args}` substitutes parts[1:] joined by space — all chunks survive."""
+        captured = tmp_path / "out.txt"
+        script = tmp_path / "echo_argv.py"
+        script.write_text(
+            "import sys; open(sys.argv[-1], 'w').write(repr(sys.argv[1:-1]))\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"echo": {"cmd": f"python3 {script} {{args}} {captured}"}}
+        }
+        result = supertool.dispatch("echo:https://example.com")
+        assert "PASS" in result
+        argv = eval(captured.read_text())
+        # All ':'-tokenized parts arrive as separate argv entries.
+        assert argv == ["https", "//example.com"], f"got {argv!r}"
+
+    def test_args_placeholder_url_rejoinable_by_script(self, tmp_path: Path) -> None:
+        """End-to-end: with {args}, a script that does ':'.join(argv[1:]) gets
+        the full URL back — this is the pattern preset/devto/react.py uses to
+        survive supertool's ':' tokenizer."""
+        captured = tmp_path / "out.txt"
+        script = tmp_path / "rejoin.py"
+        script.write_text(
+            "import sys\n"
+            "rejoined = ':'.join(sys.argv[1:-1])\n"
+            "open(sys.argv[-1], 'w').write(rejoined)\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"echo": {"cmd": f"python3 {script} {{args}} {captured}"}}
+        }
+        url = "https://dev.to/marcosomma/the-real-token-economy-3j3e"
+        result = supertool.dispatch(f"echo:{url}")
+        assert "PASS" in result
+        assert captured.read_text() == url
+
+    def test_args_placeholder_with_pipe_separator(self, tmp_path: Path) -> None:
+        """`|` is NOT a tokenizer separator (only `:` is) — pipe-separated
+        args arrive as a single chunk, preserving 'aid|MSG|parent' shape."""
+        captured = tmp_path / "out.txt"
+        script = tmp_path / "echo_argv.py"
+        script.write_text(
+            "import sys; open(sys.argv[-1], 'w').write(repr(sys.argv[1:-1]))\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"echo": {"cmd": f"python3 {script} {{args}} {captured}"}}
+        }
+        result = supertool.dispatch("echo:1234|hello world|99")
+        assert "PASS" in result
+        argv = eval(captured.read_text())
+        assert argv == ["1234|hello world|99"]
+
+    def test_args_placeholder_with_iso_timestamp(self, tmp_path: Path) -> None:
+        """ISO timestamps (HH:MM:SSZ) are split by `:` — {args} must rejoin
+        them. Same pattern devto_status_since uses."""
+        captured = tmp_path / "out.txt"
+        script = tmp_path / "rejoin.py"
+        script.write_text(
+            "import sys\n"
+            "rejoined = ':'.join(sys.argv[1:-1])\n"
+            "open(sys.argv[-1], 'w').write(rejoined)\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"echo": {"cmd": f"python3 {script} {{args}} {captured}"}}
+        }
+        ts = "2026-05-02T15:01:45+00:00"
+        result = supertool.dispatch(f"echo:{ts}")
+        assert "PASS" in result
+        assert captured.read_text() == ts

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -508,12 +508,13 @@ class TestMainIntegration:
 
 
 # ---------------------------------------------------------------------------
-# {arg} vs {args} placeholder behavior — colon-bearing inputs (URLs, ISO dates)
+# {arg} vs {args} placeholder behavior — colon-bearing inputs
 #
 # Bug surfaced 2026-05-02: devto_react with `{arg}` template received only the
-# first ':'-separated chunk of a URL ("https") instead of the full URL.
-# Fix was to switch the cmd template to `{args}` so all parts survive.
-# These tests pin the dispatch behavior so the regression cannot return.
+# first ':'-separated chunk of the input. URLs are now kept whole by
+# _split_arg's URL-greedy absorb (PR #7), but other colon-bearing inputs
+# (ratios, ISO timestamps, namespaced identifiers) still split. {args} is the
+# safe template; {arg} only handles single-token inputs.
 # ---------------------------------------------------------------------------
 
 class TestArgPlaceholderColonHandling:
@@ -521,8 +522,7 @@ class TestArgPlaceholderColonHandling:
     def test_arg_placeholder_only_passes_first_chunk(self, tmp_path: Path) -> None:
         """`{arg}` substitutes parts[1] only — colons in the input split it."""
         captured = tmp_path / "out.txt"
-        # The script writes ALL its argv (after script name, excluding final
-        # output-file path) to a file we can inspect.
+        # Script writes ALL its argv (excluding final output-file path) to disk.
         script = tmp_path / "echo_argv.py"
         script.write_text(
             "import sys; open(sys.argv[-1], 'w').write(repr(sys.argv[1:-1]))\n"
@@ -530,12 +530,12 @@ class TestArgPlaceholderColonHandling:
         supertool._CONFIG = {
             "ops": {"echo": {"cmd": f"python3 {script} {{arg}} {captured}"}}
         }
-        # Input: 'echo:https://example.com' tokenizes to parts =
-        # ['echo', 'https', '//example.com']. With {arg}, only 'https' goes through.
-        result = supertool.dispatch("echo:https://example.com")
+        # Input: 'echo:16:9' tokenizes to parts = ['echo', '16', '9'].
+        # With {arg}, only '16' goes through (ratio is NOT a URL — no greedy absorb).
+        result = supertool.dispatch("echo:16:9")
         assert "PASS" in result
         argv = eval(captured.read_text())
-        assert argv == ["https"], f"expected ['https'], got {argv!r}"
+        assert argv == ["16"], f"expected ['16'], got {argv!r}"
 
     def test_args_placeholder_passes_all_chunks(self, tmp_path: Path) -> None:
         """`{args}` substitutes parts[1:] joined by space — all chunks survive."""
@@ -547,16 +547,16 @@ class TestArgPlaceholderColonHandling:
         supertool._CONFIG = {
             "ops": {"echo": {"cmd": f"python3 {script} {{args}} {captured}"}}
         }
-        result = supertool.dispatch("echo:https://example.com")
+        result = supertool.dispatch("echo:16:9")
         assert "PASS" in result
         argv = eval(captured.read_text())
         # All ':'-tokenized parts arrive as separate argv entries.
-        assert argv == ["https", "//example.com"], f"got {argv!r}"
+        assert argv == ["16", "9"], f"got {argv!r}"
 
-    def test_args_placeholder_url_rejoinable_by_script(self, tmp_path: Path) -> None:
+    def test_args_placeholder_rejoinable_by_script(self, tmp_path: Path) -> None:
         """End-to-end: with {args}, a script that does ':'.join(argv[1:]) gets
-        the full URL back — this is the pattern preset/devto/react.py uses to
-        survive supertool's ':' tokenizer."""
+        the original colon-bearing input back — pattern that
+        preset/devto/comment.py uses to survive supertool's ':' tokenizer."""
         captured = tmp_path / "out.txt"
         script = tmp_path / "rejoin.py"
         script.write_text(
@@ -567,10 +567,28 @@ class TestArgPlaceholderColonHandling:
         supertool._CONFIG = {
             "ops": {"echo": {"cmd": f"python3 {script} {{args}} {captured}"}}
         }
+        # Compound colon-separated string (NOT a URL — _split_arg won't absorb).
+        compound = "16:9:hd"
+        result = supertool.dispatch(f"echo:{compound}")
+        assert "PASS" in result
+        assert captured.read_text() == compound
+
+    def test_args_placeholder_url_arrives_whole(self, tmp_path: Path) -> None:
+        """URLs are absorbed by _split_arg (PR #7) so they arrive as a single
+        argv entry. Documents the post-PR-#7 behavior."""
+        captured = tmp_path / "out.txt"
+        script = tmp_path / "echo_argv.py"
+        script.write_text(
+            "import sys; open(sys.argv[-1], 'w').write(repr(sys.argv[1:-1]))\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"echo": {"cmd": f"python3 {script} {{args}} {captured}"}}
+        }
         url = "https://dev.to/marcosomma/the-real-token-economy-3j3e"
         result = supertool.dispatch(f"echo:{url}")
         assert "PASS" in result
-        assert captured.read_text() == url
+        argv = eval(captured.read_text())
+        assert argv == [url], f"URL should arrive whole, got {argv!r}"
 
     def test_args_placeholder_with_pipe_separator(self, tmp_path: Path) -> None:
         """`|` is NOT a tokenizer separator (only `:` is) — pipe-separated

--- a/tests/test_devto.py
+++ b/tests/test_devto.py
@@ -12,7 +12,7 @@ PRESET_DIR = Path(__file__).parent.parent / "presets" / "devto"
 
 
 def _load(name: str):
-    for k in ("_auth", "_graphql", "_rest", "_me", "_outbound", "_session"):
+    for k in ("_auth", "_graphql", "_rest", "_me", "_outbound", "_session", "_resolve"):
         sys.modules.pop(k, None)
     sys.path[:] = [p for p in sys.path if "presets/hashnode" not in p]
     if str(PRESET_DIR) not in sys.path:
@@ -33,6 +33,7 @@ react = _load("react")
 status_since_op = _load("status_since")
 comment_op = _load("comment")
 outbound_op = _load("_outbound")
+resolve_op = _load("_resolve")
 
 
 # publish -----------------------------------------------------------------
@@ -653,3 +654,92 @@ def test_outbound_read_missing_file_returns_empty(tmp_path: Path,
                                                     monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(outbound_op, "TRACK_FILE", tmp_path / "nope.jsonl")
     assert outbound_op.read() == []
+
+
+# resolve (article id resolver) -----------------------------------------
+
+def test_resolve_numeric_passthrough() -> None:
+    """Numeric input returns int directly — no API call."""
+    assert resolve_op.resolve_article_id("123456") == 123456
+
+
+def test_resolve_slug_calls_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Slug 'author/slug' is sent to /articles/author/slug, returns numeric id."""
+    calls: list[tuple] = []
+
+    def fake_request(method, path, api_key, body=None, query=None, timeout=30):
+        calls.append((method, path))
+        return {"id": 999, "title": "T"}
+
+    monkeypatch.setattr(resolve_op, "request", fake_request)
+    monkeypatch.setattr(resolve_op, "get_api_key", lambda: "fake-key")
+    assert resolve_op.resolve_article_id("alice/some-slug") == 999
+    assert calls == [("GET", "/articles/alice/some-slug")]
+
+
+def test_resolve_url_calls_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Full URL parsed to /articles/{author}/{slug}."""
+    calls: list[str] = []
+
+    def fake_request(method, path, api_key, body=None, query=None, timeout=30):
+        calls.append(path)
+        return {"id": 42}
+
+    monkeypatch.setattr(resolve_op, "request", fake_request)
+    monkeypatch.setattr(resolve_op, "get_api_key", lambda: "fake-key")
+    assert resolve_op.resolve_article_id(
+        "https://dev.to/marcosomma/the-real-token-economy-3j3e"
+    ) == 42
+    assert calls == ["/articles/marcosomma/the-real-token-economy-3j3e"]
+
+
+def test_resolve_empty_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_article_id("")
+    assert "empty article identifier" in capsys.readouterr().err
+
+
+def test_resolve_unparseable_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    """Bare slug with no slash and non-numeric → cannot parse, exits."""
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_article_id("just-a-slug-no-author")
+    err = capsys.readouterr().err
+    assert "cannot parse article identifier" in err
+    assert "just-a-slug-no-author" in err
+
+
+def test_resolve_api_returns_no_id_exits(monkeypatch: pytest.MonkeyPatch,
+                                            capsys: pytest.CaptureFixture[str]) -> None:
+    """API returns dict without 'id' field → exits with descriptive error."""
+    monkeypatch.setattr(resolve_op, "request", lambda *a, **kw: {})
+    monkeypatch.setattr(resolve_op, "get_api_key", lambda: "fake-key")
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_article_id("alice/slug")
+    assert "could not resolve" in capsys.readouterr().err
+
+
+# react/comment slug-acceptance integration -----------------------------
+
+def test_react_parse_args_accepts_slug() -> None:
+    """parse_args returns the raw identifier untouched — main() resolves it."""
+    raw, cat = react.parse_args("alice/some-slug")
+    assert raw == "alice/some-slug" and cat == "like"
+
+
+def test_react_parse_args_accepts_url() -> None:
+    raw, cat = react.parse_args("https://dev.to/alice/some-slug|unicorn")
+    assert raw == "https://dev.to/alice/some-slug" and cat == "unicorn"
+
+
+def test_comment_parse_args_accepts_slug() -> None:
+    """Comment parse keeps the raw identifier; resolution happens in main()."""
+    raw, msg, parent = comment_op.parse_args("alice/some-slug|hello")
+    assert raw == "alice/some-slug" and msg == "hello" and parent is None
+
+
+def test_comment_parse_args_accepts_url() -> None:
+    raw, msg, parent = comment_op.parse_args(
+        "https://dev.to/alice/some-slug|hi|99"
+    )
+    assert raw == "https://dev.to/alice/some-slug"
+    assert msg == "hi" and parent == "99"

--- a/tests/test_hashnode.py
+++ b/tests/test_hashnode.py
@@ -16,7 +16,7 @@ PRESET_DIR = Path(__file__).parent.parent / "presets" / "hashnode"
 
 def _load(name: str):
     # Clear cached helper modules from any prior preset (devto) and prepend our dir.
-    for k in ("_auth", "_graphql", "_rest", "_me", "_outbound", "_session"):
+    for k in ("_auth", "_graphql", "_rest", "_me", "_outbound", "_session", "_resolve"):
         sys.modules.pop(k, None)
     sys.path[:] = [p for p in sys.path if "presets/devto" not in p]
     if str(PRESET_DIR) not in sys.path:
@@ -34,10 +34,13 @@ read_op = _load("read")
 browse_op = _load("browse")
 comments_op = _load("comments")
 comment_op = _load("comment")
+react_op = _load("react")
 reply_op = _load("reply")
 search_op = _load("search")
 status_since_op = _load("status_since")
 outbound_op = _load("_outbound")
+resolve_op = _load("_resolve")
+graphql_op = _load("_graphql")
 
 
 # publish ------------------------------------------------------------------
@@ -671,3 +674,74 @@ def test_read_render_no_you_line_when_not_engaged() -> None:
         "comments": {"edges": []},
     }, inline_n=5, me="max-ai-dev")
     assert "YOU:" not in out
+
+
+# resolve (cross-publication post id resolver) --------------------------
+
+def test_resolve_id_passthrough() -> None:
+    """Plain id (non-URL) returned untouched — no GraphQL call."""
+    assert resolve_op.resolve_post_id("token", "69db973615279c2b8198051e") == "69db973615279c2b8198051e"
+
+
+def test_resolve_url_uses_publication_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Foreign URL parsed to (host, slug) and looked up via publication(host:)."""
+    captured: list[dict] = []
+
+    def fake_gql(query, variables, token):
+        captured.append({"query": query, "variables": variables, "token": token})
+        return {"publication": {"post": {"id": "abc123"}}}
+
+    monkeypatch.setattr(resolve_op, "gql", fake_gql)
+    pid = resolve_op.resolve_post_id(
+        "tok", "https://hugovalters.hashnode.dev/mfa-fatigue"
+    )
+    assert pid == "abc123"
+    assert len(captured) == 1
+    assert captured[0]["variables"] == {
+        "host": "hugovalters.hashnode.dev",
+        "slug": "mfa-fatigue",
+    }
+    assert "publication(host:" in captured[0]["query"]
+    assert captured[0]["token"] == "tok"
+
+
+def test_resolve_url_own_publication(monkeypatch: pytest.MonkeyPatch) -> None:
+    """URL on max-ai-dev.hashnode.dev resolves the same way — no special casing."""
+    monkeypatch.setattr(resolve_op, "gql",
+                          lambda q, v, t: {"publication": {"post": {"id": "self-id"}}})
+    pid = resolve_op.resolve_post_id(
+        "tok", "https://max-ai-dev.hashnode.dev/i-trust-the-variable-name"
+    )
+    assert pid == "self-id"
+
+
+def test_resolve_url_post_not_found_exits(monkeypatch: pytest.MonkeyPatch,
+                                            capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(resolve_op, "gql", lambda q, v, t: {"publication": {"post": None}})
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_post_id("tok", "https://nobody.hashnode.dev/missing")
+    err = capsys.readouterr().err
+    assert "post not found" in err
+    assert "nobody.hashnode.dev" in err
+    assert "missing" in err
+
+
+def test_resolve_url_no_publication_exits(monkeypatch: pytest.MonkeyPatch,
+                                             capsys: pytest.CaptureFixture[str]) -> None:
+    """When publication is null (host doesn't exist on Hashnode), error helpfully."""
+    monkeypatch.setattr(resolve_op, "gql", lambda q, v, t: {"publication": None})
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_post_id("tok", "https://nope.example.com/slug")
+    assert "post not found" in capsys.readouterr().err
+
+
+def test_resolve_empty_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_post_id("tok", "")
+    assert "empty post identifier" in capsys.readouterr().err
+
+
+def test_resolve_malformed_url_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_post_id("tok", "https://")
+    assert "cannot parse" in capsys.readouterr().err


### PR DESCRIPTION
## Why

While engaging with two Dev.to and one foreign Hashnode post today, four social ops failed:

- `devto_react` with slug → 422 \`Reactable not valid\`
- `devto_comment` would have hit the same 422 (same code path)
- `hashnode_react` on foreign URL → \`post not found\` (lookup scoped to caller's own publication)
- `hashnode_comment` same scoping bug

I had to manually resolve numeric IDs and retry — three round-trips per action that the tools should have done themselves.

## What changed

**Presets accept ID, slug, or URL transparently:**
- `presets/devto/_resolve.py` (new) — `resolve_article_id()`: numeric passthrough, slug/URL → numeric via \`/api/articles/{slug}\`
- `presets/hashnode/_resolve.py` (new) — `resolve_post_id()`: ID passthrough, URL → cross-publication via \`publication(host:)\` GraphQL field
- `presets/devto/{react,comment}.py` — use resolver
- `presets/hashnode/{react,comment}.py` — use resolver, drop own-publication lookup

**Root-cause fix on URL inputs entirely failing:**
- `presets/devto.json` and `presets/hashnode.json` — \`devto_react\` and \`hashnode_react\` cmd templates switched from \`{arg}\` (passes only \`parts[1]\`) to \`{args}\` (passes all parts). Comment ops already used \`{args}\`.
- React scripts now rejoin argv with \`:\` in their \`__main__\` block (same pattern comment.py already used).

## Tests

- `tests/test_devto.py` — resolver: numeric passthrough, slug→ID, URL→ID, empty input, unparseable input, API-returned-no-id error path. parse_args now documented to accept slug/URL.
- `tests/test_hashnode.py` — resolver: ID passthrough, foreign URL via host, own-publication URL, post-not-found, publication-not-found, malformed URL.
- `tests/test_custom_ops.py` — `TestArgPlaceholderColonHandling`: pins \`{arg}\` vs \`{args}\` behavior end-to-end so the URL-tokenization regression cannot return. Covers URLs, ISO timestamps, pipe-separated args.

## Verification

730 tests pass, 94% coverage.

Live test against real platforms:
- \`devto_react:https://dev.to/jasmin/...\` → PASS (resolved to article 3554138)
- \`devto_react:marcosomma/the-real-token-economy-...\` → PASS (slug → 3554694)
- \`hashnode_react:https://hugovalters.hashnode.dev/mfa-fatigue-...\` → PASS (cross-publication, post liked)

## Test plan

- [x] Unit: resolver edge cases (devto + hashnode)
- [x] Unit: placeholder substitution (`{arg}` vs `{args}`)
- [x] Live: slug input on devto react
- [x] Live: full URL input on devto react
- [x] Live: foreign URL on hashnode react (real cross-publication post)