### PR TITLE
fix: pre-flight idempotency on all mutation ops

### DIFF
--- a/presets/bluesky/follow.py
+++ b/presets/bluesky/follow.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Bluesky follow: bluesky_follow:HANDLE_OR_DID"""
+"""Bluesky follow: bluesky_follow:HANDLE_OR_DID[|force]
+
+PRE-FLIGHT DUPLICATE CHECK: Before following, the op scans own follows via
+app.bsky.graph.getFollows and aborts if target DID is already followed.
+Pass |force as 2nd pipe-separated field to bypass: bluesky_follow:HANDLE|force
+If the pre-flight check fails, a warning is printed and the follow proceeds
+(graceful degrade — don't block on platform issues).
+"""
 import datetime as _dt
 import sys
 from pathlib import Path
@@ -9,11 +16,35 @@ from _atproto import get_session, xrpc
 from _auth import get_app_password, get_handle
 
 
-def main(arg: str) -> None:
-    target = arg.strip().lstrip("@")
+def parse_args(arg: str) -> tuple[str, bool]:
+    """Return (handle_or_did, force)."""
+    parts = arg.split("|", 1)
+    target = parts[0].strip().lstrip("@")
     if not target:
-        sys.stderr.write("ERROR: usage bluesky_follow:HANDLE_OR_DID\n")
+        sys.stderr.write("ERROR: usage bluesky_follow:HANDLE_OR_DID[|force]\n")
         sys.exit(2)
+    force = len(parts) > 1 and parts[1].strip().lower() == "force"
+    return target, force
+
+
+def preflight_follow(target_did: str, session: dict) -> bool:
+    """Return True if own DID already follows target_did.
+
+    Scans up to 100 own follows. Returns False on any API error (graceful degrade).
+    """
+    try:
+        resp = xrpc("app.bsky.graph.getFollows", session,
+                    params={"actor": session["did"], "limit": 100})
+        for follow in resp.get("follows") or []:
+            if follow.get("did") == target_did:
+                return True
+        return False
+    except Exception:
+        return False
+
+
+def main(arg: str) -> None:
+    target, force = parse_args(arg)
     handle = get_handle()
     session = get_session(handle, get_app_password())
     did = target if target.startswith("did:") else None
@@ -23,6 +54,15 @@ def main(arg: str) -> None:
         if not did:
             sys.stderr.write(f"ERROR: cannot resolve handle {target}\n")
             sys.exit(1)
+    if not force:
+        try:
+            if preflight_follow(did, session):
+                sys.stderr.write(
+                    f"ABORT — already following {target} (did={did}). Use |force to override.\n"
+                )
+                sys.exit(1)
+        except Exception as exc:
+            sys.stderr.write(f"WARNING: pre-flight check failed ({exc}) — proceeding anyway.\n")
     data = xrpc(
         "com.atproto.repo.createRecord", session, method="POST",
         body={

--- a/presets/bluesky/like.py
+++ b/presets/bluesky/like.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Bluesky like: bluesky_like:AT_URI_OR_WEB_URL"""
+"""Bluesky like: bluesky_like:AT_URI_OR_WEB_URL[|force]
+
+PRE-FLIGHT DUPLICATE CHECK: Before liking, the op scans own actor likes via
+app.bsky.feed.getActorLikes and aborts if the target URI is already liked.
+Pass |force as 2nd pipe-separated field to bypass: bluesky_like:URI|force
+If the pre-flight check fails, a warning is printed and the like proceeds
+(graceful degrade — don't block on platform issues).
+"""
 import datetime as _dt
 import sys
 from pathlib import Path
@@ -8,6 +15,17 @@ from urllib.parse import urlparse
 sys.path.insert(0, str(Path(__file__).parent))
 from _atproto import get_session, xrpc
 from _auth import get_app_password, get_handle
+
+
+def parse_args(arg: str) -> tuple[str, bool]:
+    """Return (raw_uri_or_url, force)."""
+    if not arg:
+        sys.stderr.write("ERROR: usage bluesky_like:AT_URI_OR_WEB_URL[|force]\n")
+        sys.exit(2)
+    parts = arg.split("|", 1)
+    raw = parts[0].strip()
+    force = len(parts) > 1 and parts[1].strip().lower() == "force"
+    return raw, force
 
 
 def to_at_uri(arg: str, session: dict) -> str:
@@ -24,14 +42,37 @@ def to_at_uri(arg: str, session: dict) -> str:
     sys.exit(2)
 
 
+def preflight_like(target_uri: str, session: dict) -> bool:
+    """Return True if own DID has already liked target_uri.
+
+    Scans up to 100 own likes. Returns False on any API error (graceful degrade).
+    """
+    try:
+        resp = xrpc("app.bsky.feed.getActorLikes", session,
+                    params={"actor": session["did"], "limit": 100})
+        for item in resp.get("feed") or []:
+            post = (item.get("post") or {})
+            if post.get("uri") == target_uri:
+                return True
+        return False
+    except Exception:
+        return False
+
+
 def main(arg: str) -> None:
-    if not arg:
-        sys.stderr.write("ERROR: usage bluesky_like:AT_URI_OR_WEB_URL\n")
-        sys.exit(2)
+    raw, force = parse_args(arg)
     handle = get_handle()
     session = get_session(handle, get_app_password())
-    uri = to_at_uri(arg, session)
-    # Need post cid for the like record subject
+    uri = to_at_uri(raw, session)
+    if not force:
+        try:
+            if preflight_like(uri, session):
+                sys.stderr.write(
+                    f"ABORT — already liked {uri}. Use |force to override.\n"
+                )
+                sys.exit(1)
+        except Exception as exc:
+            sys.stderr.write(f"WARNING: pre-flight check failed ({exc}) — proceeding anyway.\n")
     thread = xrpc("app.bsky.feed.getPostThread", session, params={"uri": uri, "depth": 0})
     post = (thread.get("thread") or {}).get("post") or {}
     cid = post.get("cid")

--- a/presets/bluesky/publish.py
+++ b/presets/bluesky/publish.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bluesky publish: bluesky_publish:TEXT_FILE_OR_TEXT[|REPLY_TO_AT_URI]
+"""Bluesky publish: bluesky_publish:TEXT_FILE_OR_TEXT[|REPLY_TO_AT_URI[|force]]
 
 If the first arg is a path to a file that exists, its contents become
 the post body. Otherwise the arg is treated as inline text. Bluesky
@@ -9,9 +9,14 @@ the body exceeds that, since the API will silently truncate otherwise.
 Optional second arg: AT URI of a post to reply to
 (at://DID/app.bsky.feed.post/POST_ID). Builds the reply ref correctly
 (parent + root via getPostThread).
+
+PRE-FLIGHT DUPLICATE CHECK (reply only): When reply_uri is set, the op scans
+own recent posts via app.bsky.feed.getAuthorFeed and aborts if a reply to the
+same root already exists. Pass |force as 3rd pipe-separated field to bypass.
+If the pre-flight check fails, a warning is printed and publish proceeds
+(graceful degrade — don't block on platform issues).
 """
 import datetime as _dt
-import json
 import sys
 from pathlib import Path
 
@@ -22,17 +27,17 @@ from _auth import get_app_password, get_handle
 MAX_LEN = 300
 
 
-def parse_args(arg: str) -> tuple[str, str | None]:
-    parts = arg.split("|", 1)
+def parse_args(arg: str) -> tuple[str, str | None, bool]:
+    """Return (body, reply_uri, force)."""
+    parts = arg.split("|", 2)
     if not parts[0].strip():
-        sys.stderr.write("ERROR: usage bluesky_publish:TEXT_OR_FILE[|REPLY_TO_AT_URI]\n")
+        sys.stderr.write("ERROR: usage bluesky_publish:TEXT_OR_FILE[|REPLY_TO_AT_URI[|force]]\n")
         sys.exit(2)
     body = parts[0]
     try:
         p = Path(body)
         is_file = p.is_file()
     except OSError:
-        # Path too long for filesystem — treat as inline text
         is_file = False
     if is_file:
         body = Path(body).read_text()
@@ -41,7 +46,8 @@ def parse_args(arg: str) -> tuple[str, str | None]:
         sys.stderr.write(f"ERROR: post is {len(body)} chars (max {MAX_LEN}). Trim or split.\n")
         sys.exit(2)
     reply_uri = parts[1].strip() if len(parts) > 1 and parts[1].strip() else None
-    return body, reply_uri
+    force = len(parts) > 2 and parts[2].strip().lower() == "force"
+    return body, reply_uri, force
 
 
 def resolve_reply_ref(session: dict, reply_to_uri: str) -> dict:
@@ -52,15 +58,61 @@ def resolve_reply_ref(session: dict, reply_to_uri: str) -> dict:
     parent_ref = {"uri": post.get("uri"), "cid": post.get("cid")}
     record = post.get("record") or {}
     parent_reply = record.get("reply") or {}
-    root_ref = parent_reply.get("root") or parent_ref  # if parent is itself the root
+    root_ref = parent_reply.get("root") or parent_ref
     return {"parent": parent_ref, "root": root_ref}
 
 
+def _get_root_uri(session: dict, reply_to_uri: str) -> str | None:
+    """Resolve the root URI of a reply chain. Returns None on failure."""
+    try:
+        thread = xrpc("app.bsky.feed.getPostThread", session,
+                       params={"uri": reply_to_uri, "depth": 0})
+        post = (thread.get("thread") or {}).get("post") or {}
+        record = post.get("record") or {}
+        root = (record.get("reply") or {}).get("root") or {}
+        return root.get("uri") or reply_to_uri
+    except Exception:
+        return None
+
+
+def preflight_publish(reply_uri: str, session: dict) -> bool:
+    """Return True if own feed already has a reply to the same root as reply_uri.
+
+    Scans up to 50 own recent posts. Returns False on any API error (graceful degrade).
+    """
+    try:
+        root_uri = _get_root_uri(session, reply_uri)
+        if not root_uri:
+            return False
+        resp = xrpc("app.bsky.feed.getAuthorFeed", session,
+                    params={"actor": session["did"], "limit": 50})
+        for item in resp.get("feed") or []:
+            post = item.get("post") or {}
+            record = post.get("record") or {}
+            reply = record.get("reply") or {}
+            item_root = (reply.get("root") or {}).get("uri")
+            if item_root and item_root == root_uri:
+                return True
+        return False
+    except Exception:
+        return False
+
+
 def main(arg: str) -> None:
-    body, reply_uri = parse_args(arg)
+    body, reply_uri, force = parse_args(arg)
     handle = get_handle()
     session = get_session(handle, get_app_password())
-    record = {
+    if reply_uri and not force:
+        try:
+            if preflight_publish(reply_uri, session):
+                sys.stderr.write(
+                    f"ABORT — already replied to thread root of {reply_uri}. "
+                    "Use |force to override.\n"
+                )
+                sys.exit(1)
+        except Exception as exc:
+            sys.stderr.write(f"WARNING: pre-flight check failed ({exc}) — proceeding anyway.\n")
+    record: dict = {
         "$type": "app.bsky.feed.post",
         "text": body,
         "createdAt": _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
@@ -77,7 +129,6 @@ def main(arg: str) -> None:
     )
     uri = data.get("uri", "?")
     cid = data.get("cid", "?")
-    # Convert AT URI → web URL: at://DID/app.bsky.feed.post/RKEY
     rkey = uri.split("/")[-1] if uri.startswith("at://") else "?"
     web = f"https://bsky.app/profile/{handle}/post/{rkey}"
     print(f"(published uri={uri} cid={cid})")

--- a/presets/devto/_resolve.py
+++ b/presets/devto/_resolve.py
@@ -2,15 +2,18 @@
 
 The Reactions and Comments write endpoints require the integer article ID;
 sending a slug or URL returns 422 "Reactable not valid". This helper resolves
-any of the three input shapes into the numeric ID by calling /articles/{slug}
-when needed.
+any of the four input shapes into the numeric ID by calling the appropriate
+Dev.to API endpoint when needed.
 
 Accepted inputs:
   - "12345"                                        → 12345
-  - "author/article-slug"                          → resolved via API
+  - "author/article-slug"                          → resolved via /articles/author/slug
   - "https://dev.to/author/article-slug"           → URL parsed → resolved
   - "https://dev.to/author/article-slug-1234abcd"  → suffixed slug → resolved
+  - "article-slug-with-suffix-3j3e"               → bare slug (no author, no scheme)
+                                                      → resolved via /articles?slug=...
 """
+import re
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
@@ -18,6 +21,8 @@ from urllib.parse import urlparse
 sys.path.insert(0, str(Path(__file__).parent))
 from _auth import get_api_key
 from _rest import request
+
+_BARE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*-[a-z0-9]{4,6}$")
 
 
 def resolve_article_id(raw: str) -> int:
@@ -31,30 +36,45 @@ def resolve_article_id(raw: str) -> int:
         sys.exit(2)
     if s.isdigit():
         return int(s)
-    path = _to_api_path(s)
+    path, query = _to_api_path_and_query(s)
     if path is None:
         sys.stderr.write(
             f"ERROR: cannot parse article identifier {raw!r} — "
-            "expected numeric ID, 'author/slug', or full https://dev.to/... URL\n"
+            "expected numeric ID, 'author/slug', bare slug (e.g. my-post-3j3e), "
+            "or full https://dev.to/... URL\n"
         )
         sys.exit(2)
-    article = request("GET", path, get_api_key())
-    if not isinstance(article, dict) or not article.get("id"):
+    result = request("GET", path, get_api_key(), query=query)
+    if isinstance(result, list):
+        if not result or not isinstance(result[0], dict) or not result[0].get("id"):
+            sys.stderr.write(
+                f"ERROR: could not resolve {raw!r} to article ID — "
+                "Dev.to returned no results. Check the slug is correct.\n"
+            )
+            sys.exit(1)
+        return int(result[0]["id"])
+    if not isinstance(result, dict) or not result.get("id"):
         sys.stderr.write(
             f"ERROR: could not resolve {raw!r} to article ID — "
             "Dev.to returned no id field. Check the slug/URL is correct.\n"
         )
         sys.exit(1)
-    return int(article["id"])
+    return int(result["id"])
 
 
-def _to_api_path(s: str) -> str | None:
-    """Convert a slug or URL into an /articles/... API path."""
+def _to_api_path_and_query(s: str) -> tuple[str | None, dict | None]:
+    """Convert a slug or URL into an /articles/... API path plus optional query params.
+
+    Returns (path, query) where query is None for author/slug and URL forms,
+    and {"per_page": 1, "slug": s} for bare-slug form.
+    """
     if s.startswith("http"):
         bits = urlparse(s).path.strip("/").split("/")
         if len(bits) >= 2:
-            return f"/articles/{bits[0]}/{bits[1]}"
-        return None
+            return f"/articles/{bits[0]}/{bits[1]}", None
+        return None, None
     if "/" in s:
-        return f"/articles/{s}"
-    return None
+        return f"/articles/{s}", None
+    if _BARE_SLUG_RE.match(s):
+        return "/articles", {"per_page": 1, "slug": s}
+    return None, None

--- a/presets/devto/comment.py
+++ b/presets/devto/comment.py
@@ -23,7 +23,7 @@ comment URL HTML on demand.
 
 PRE-FLIGHT DUPLICATE CHECK: Before posting, the op fetches existing
 comments on the article and aborts if the authenticated user has already
-commented (matched by username from DEVTO_API_KEY lookup). Pass `:force`
+commented (matched by username from DEVTO_API_KEY lookup). Pass `|force`
 as the 4th pipe-separated field to bypass: devto_comment:slug|MSG||force
 If the pre-flight API call fails, a warning is printed and the comment
 proceeds (graceful degrade — don't block on platform issues).

--- a/presets/devto/comment.py
+++ b/presets/devto/comment.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Dev.to comment: devto_comment:ARTICLE_ID_OR_SLUG_OR_URL|MESSAGE[|PARENT_COMMENT_ID]
+"""Dev.to comment: devto_comment:ARTICLE_ID_OR_SLUG_OR_URL|MESSAGE[|PARENT_COMMENT_ID[|force]]
 
 Accepts numeric article ID, slug (`author/slug`), or full URL — non-numeric
 inputs are resolved to the numeric ID via /api/articles/{slug} before posting.
@@ -20,6 +20,13 @@ devto_status_since output (e.g. "37d65"). Forem's CommentsController
 permits `parent_id` as the numeric DB id only; the public API does
 not expose it, so we resolve id_code → numeric id by scraping the
 comment URL HTML on demand.
+
+PRE-FLIGHT DUPLICATE CHECK: Before posting, the op fetches existing
+comments on the article and aborts if the authenticated user has already
+commented (matched by username from DEVTO_API_KEY lookup). Pass `:force`
+as the 4th pipe-separated field to bypass: devto_comment:slug|MSG||force
+If the pre-flight API call fails, a warning is printed and the comment
+proceeds (graceful degrade — don't block on platform issues).
 """
 import json
 import re
@@ -38,19 +45,48 @@ API_BASE = "https://dev.to/api"
 _COMMENT_ID_RE = re.compile(r'comment-id="(\d+)"')
 
 
-def parse_args(arg: str) -> tuple[str, str, str | None]:
+def parse_args(arg: str) -> tuple[str, str, str | None, bool]:
     parts = arg.split("|")
     if len(parts) < 2 or not parts[0].strip() or not parts[1].strip():
-        sys.stderr.write("ERROR: usage devto_comment:ARTICLE_ID_OR_SLUG_OR_URL|MESSAGE[|PARENT_COMMENT_ID]\n")
+        sys.stderr.write("ERROR: usage devto_comment:ARTICLE_ID_OR_SLUG_OR_URL|MESSAGE[|PARENT_COMMENT_ID[|force]]\n")
         sys.exit(2)
     raw = parts[0].strip()
     message = parts[1]
     parent = parts[2].strip() if len(parts) > 2 and parts[2].strip() else None
-    return raw, message, parent
+    force = len(parts) > 3 and parts[3].strip().lower() == "force"
+    return raw, message, parent, force
+
+
+def preflight_comment(aid: int, me: str) -> tuple[bool, list[str], str]:
+    """Check if `me` has already commented on article `aid`.
+
+    Returns (already_commented, existing_ids, last_date).
+    On API error returns (False, [], "") so the caller can degrade gracefully.
+    """
+    if not me:
+        return False, [], ""
+    try:
+        from _auth import get_api_key
+        from _rest import request
+        items = request("GET", "/comments", get_api_key(), query={"a_id": aid, "per_page": 1000})
+    except Exception:
+        return False, [], ""
+    if not isinstance(items, list):
+        return False, [], ""
+    flat: list[dict] = []
+    for c in items:
+        flat.append(c)
+        flat.extend(c.get("children") or [])
+    mine = [c for c in flat if (c.get("user") or {}).get("username") == me]
+    if not mine:
+        return False, [], ""
+    ids = [c.get("id_code") or str(c.get("id", "?")) for c in mine]
+    last = max((c.get("created_at") or "") for c in mine).split("T")[0]
+    return True, ids, last
 
 
 def main(arg: str) -> None:
-    raw, message, parent = parse_args(arg)
+    raw, message, parent, force = parse_args(arg)
     aid = resolve_article_id(raw)
     cookie = get_session_cookie()
     if not cookie:
@@ -60,6 +96,21 @@ def main(arg: str) -> None:
             "comment-write endpoint — see _session.py for opt-in instructions.\n"
         )
         sys.exit(2)
+    if not force:
+        try:
+            from _auth import get_api_key
+            from _me import get_username
+            me = get_username(get_api_key())
+            already, ids, last = preflight_comment(aid, me)
+            if already:
+                sys.stderr.write(
+                    f"ABORT — already commented {len(ids)}× on article {aid} "
+                    f"(ids: {', '.join(ids)}, last {last}). "
+                    "Use |force as 4th field to override.\n"
+                )
+                sys.exit(1)
+        except Exception as exc:
+            sys.stderr.write(f"WARNING: pre-flight check failed ({exc}) — proceeding anyway.\n")
     csrf = fetch_csrf_token(cookie)
     body: dict[str, object] = {
         "comment": {
@@ -178,4 +229,4 @@ if __name__ == "__main__":
     # Supertool {args} passes parts space-separated; rejoin with ':' so a body
     # containing ':' survives the supertool tokenizer.
     arg = ":".join(sys.argv[1:])
-    main(arg)
+    main(arg)  # parse_args now returns 4-tuple; main() unpacks it internally

--- a/presets/devto/publish.py
+++ b/presets/devto/publish.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-"""Dev.to publish: TITLE|MD_FILE|CANONICAL[|TAGS|COVER|PUBLISHED]
+"""Dev.to publish: TITLE|MD_FILE|CANONICAL[|TAGS|COVER|PUBLISHED[|force]]
 
 Tags: comma-separated, max 4. Cover: URL. Published: 'true'/'false', default true.
 Defaults from manifest: SUPERTOOL_DEFAULT_TAGS, SUPERTOOL_DEFAULT_COVER (env).
 Caller-supplied values win.
+
+PRE-FLIGHT DUPLICATE CHECK: Before publishing, the op fetches /articles/me and
+aborts if an article with the same canonical_url already exists. Pass `force` as
+the 7th pipe-separated field to bypass: TITLE|MD|CANONICAL|||||force
+If the pre-flight API call fails, a warning is printed and the publish proceeds.
 """
 import os
 import sys
@@ -17,7 +22,7 @@ from _rest import request
 def parse_args(arg: str) -> dict[str, object]:
     parts = arg.split("|")
     if len(parts) < 3:
-        sys.stderr.write("ERROR: usage devto_publish:TITLE|MD_FILE|CANONICAL[|TAGS|COVER|PUBLISHED]\n")
+        sys.stderr.write("ERROR: usage devto_publish:TITLE|MD_FILE|CANONICAL[|TAGS|COVER|PUBLISHED[|force]]\n")
         sys.exit(2)
     title = parts[0].strip()
     md_path = Path(parts[1].strip())
@@ -25,6 +30,7 @@ def parse_args(arg: str) -> dict[str, object]:
     tags_csv = parts[3].strip() if len(parts) > 3 and parts[3].strip() else os.environ.get("SUPERTOOL_DEFAULT_TAGS", "")
     cover = parts[4].strip() if len(parts) > 4 and parts[4].strip() else os.environ.get("SUPERTOOL_DEFAULT_COVER", "")
     published_raw = parts[5].strip().lower() if len(parts) > 5 and parts[5].strip() else "true"
+    force = len(parts) > 6 and parts[6].strip().lower() == "force"
     if not md_path.is_file():
         sys.stderr.write(f"ERROR: markdown file not found: {md_path}\n")
         sys.exit(2)
@@ -36,7 +42,28 @@ def parse_args(arg: str) -> dict[str, object]:
         "tags": tags,
         "cover": cover,
         "published": published_raw == "true",
+        "force": force,
     }
+
+
+def preflight_publish(canonical: str, api_key: str) -> tuple[bool, str, str]:
+    """Check if an article with this canonical_url already exists on the account.
+
+    Returns (already_exists, existing_url, existing_slug).
+    On API error returns (False, '', '') so the caller can degrade gracefully.
+    """
+    if not canonical:
+        return False, "", ""
+    try:
+        articles = request("GET", "/articles/me", api_key, query={"per_page": 1000})
+    except Exception:
+        return False, "", ""
+    if not isinstance(articles, list):
+        return False, "", ""
+    for a in articles:
+        if (a.get("canonical_url") or "").rstrip("/") == canonical.rstrip("/"):
+            return True, a.get("url", ""), a.get("slug", "")
+    return False, "", ""
 
 
 def build_body(parsed: dict[str, object]) -> dict[str, object]:
@@ -56,6 +83,18 @@ def build_body(parsed: dict[str, object]) -> dict[str, object]:
 def main(arg: str) -> None:
     parsed = parse_args(arg)
     api_key = get_api_key()
+    if not parsed["force"]:
+        try:
+            already, url, slug = preflight_publish(str(parsed["canonical"]), api_key)
+            if already:
+                sys.stderr.write(
+                    f"ABORT — already published with canonical_url={parsed['canonical']!r} "
+                    f"(slug={slug}, url={url}). "
+                    "Use |force as 7th field to override.\n"
+                )
+                sys.exit(1)
+        except Exception as exc:
+            sys.stderr.write(f"WARNING: pre-flight check failed ({exc}) — proceeding anyway.\n")
     data = request("POST", "/articles", api_key, body=build_body(parsed))
     print(f"(published id={data.get('id')} slug={data.get('slug')})")
     print(f"URL:   {data.get('url')}")

--- a/presets/devto/react.py
+++ b/presets/devto/react.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python3
-"""Dev.to react: devto_react:ARTICLE_ID_OR_SLUG_OR_URL[|CATEGORY]
+"""Dev.to react: devto_react:ARTICLE_ID_OR_SLUG_OR_URL[|CATEGORY[|toggle]]
 
-Category: like (default), unicorn, readinglist, thumbsdown, vomit. Toggles on/off.
+Category: like (default), unicorn, readinglist, thumbsdown, vomit.
 
-Accepts numeric article ID, slug (`author/slug`), or full URL — non-numeric
-inputs are resolved to the numeric ID via /api/articles/{slug} before posting.
-The Reactions endpoint requires the integer ID; passing a slug raw returns
-422 "Reactable not valid".
+By default the op is IDEMPOTENT — it always ends with the reaction present
+(result=create). If the first POST returns result=destroy (reaction was already
+set and got toggled off), a second POST is issued immediately to restore it,
+and the output line is annotated with "was_on=true".
+
+Pass `:toggle` as the third pipe-separated field to get the raw toggle
+behaviour (one POST, no correction):
+  devto_react:author/slug|like|toggle
+
+Accepts numeric article ID, bare slug (e.g. my-post-3j3e), author/slug, or
+full URL — non-numeric inputs are resolved to the numeric ID via the Dev.to
+API before posting. The Reactions endpoint requires the integer ID; passing a
+slug raw returns 422 "Reactable not valid".
 
 Two auth modes:
 
@@ -18,6 +27,7 @@ Two auth modes:
      401 because Dev.to API keys do not authorize reactions; kept as
      placeholder until the platform exposes a proper write scope.
 """
+import json as _json
 import sys
 from pathlib import Path
 
@@ -30,9 +40,15 @@ from _session import fetch_csrf_token, get_session_cookie, web_post_json
 VALID = {"like", "unicorn", "readinglist", "thumbsdown", "vomit"}
 
 
-def parse_args(arg: str) -> tuple[str, str]:
+def parse_args(arg: str) -> tuple[str, str, bool]:
+    """Return (raw_identifier, category, idempotent).
+
+    idempotent=True (default) means the op ensures the reaction ends as
+    'create'. idempotent=False (pass '|toggle' as third field) means one
+    raw POST with no correction.
+    """
     if not arg:
-        sys.stderr.write("ERROR: usage devto_react:ARTICLE_ID_OR_SLUG_OR_URL[|CATEGORY]\n")
+        sys.stderr.write("ERROR: usage devto_react:ARTICLE_ID_OR_SLUG_OR_URL[|CATEGORY[|toggle]]\n")
         sys.exit(2)
     parts = arg.split("|")
     aid = parts[0].strip()
@@ -40,39 +56,55 @@ def parse_args(arg: str) -> tuple[str, str]:
     if category not in VALID:
         sys.stderr.write(f"ERROR: category must be one of {sorted(VALID)}\n")
         sys.exit(2)
-    return aid, category
+    toggle_mode = len(parts) > 2 and parts[2].strip().lower() == "toggle"
+    return aid, category, not toggle_mode
+
+
+def _react_once_session(aid: int, category: str, cookie: str, csrf: str) -> str:
+    """POST one reaction via session cookie. Returns result string ('create'/'destroy'/'unknown')."""
+    body = {"reactable_id": aid, "reactable_type": "Article", "category": category}
+    text, _status = web_post_json("/reactions", cookie, csrf, body)
+    try:
+        data = _json.loads(text)
+    except _json.JSONDecodeError:
+        data = {}
+    return data.get("result", "unknown")
 
 
 def main(arg: str) -> None:
-    raw, category = parse_args(arg)
+    raw, category, idempotent = parse_args(arg)
     aid = resolve_article_id(raw)
     cookie = get_session_cookie()
     if cookie:
         csrf = fetch_csrf_token(cookie)
-        body = {
-            "reactable_id": aid,
-            "reactable_type": "Article",
-            "category": category,
-        }
-        text, status = web_post_json("/reactions", cookie, csrf, body)
-        import json as _json
-        try:
-            data = _json.loads(text)
-        except _json.JSONDecodeError:
-            data = {}
-        result = data.get("result", "unknown")
-        print(f"(react article={aid} category={category} result={result} mode=session)")
+        result = _react_once_session(aid, category, cookie, csrf)
+        was_on = False
+        if idempotent and result == "destroy":
+            was_on = True
+            sys.stderr.write(
+                f"NOTE: reaction was already set — toggled off then back on (idempotent mode). "
+                f"Use '|{category}|toggle' to suppress this.\n"
+            )
+            result = _react_once_session(aid, category, cookie, csrf)
+        suffix = " was_on=true" if was_on else ""
+        print(f"(react article={aid} category={category} result={result} mode=session{suffix})")
         return
     # Fallback: API key (currently 401 for reactions)
     api_key = get_api_key()
-    body = {
-        "reactable_id": aid,
-        "reactable_type": "Article",
-        "category": category,
-    }
+    body = {"reactable_id": aid, "reactable_type": "Article", "category": category}
     data = request("POST", "/reactions/toggle", api_key, body=body)
     result = data.get("result") if isinstance(data, dict) else None
-    print(f"(react article={aid} category={category} result={result or 'unknown'} mode=api)")
+    was_on = False
+    if idempotent and result == "destroy":
+        was_on = True
+        sys.stderr.write(
+            f"NOTE: reaction was already set — toggled off then back on (idempotent mode). "
+            f"Use '|{category}|toggle' to suppress this.\n"
+        )
+        data = request("POST", "/reactions/toggle", api_key, body=body)
+        result = data.get("result") if isinstance(data, dict) else None
+    suffix = " was_on=true" if was_on else ""
+    print(f"(react article={aid} category={category} result={result or 'unknown'} mode=api{suffix})")
 
 
 if __name__ == "__main__":

--- a/presets/hashnode/_graphql.py
+++ b/presets/hashnode/_graphql.py
@@ -44,6 +44,31 @@ def gql(query: str, variables: dict[str, Any], token: str, timeout: int = 30) ->
     return data.get("data", {})
 
 
+def gql_safe(query: str, variables: dict[str, Any], token: str, timeout: int = 30) -> dict[str, Any] | None:
+    """Like gql() but returns None on any error instead of exiting. For preflight
+    checks that must degrade gracefully — caller decides whether to abort, warn,
+    or proceed when the lookup itself fails."""
+    payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": token,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8")
+        data = json.loads(body)
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError, OSError):
+        return None
+    if "errors" in data:
+        return None
+    return data.get("data", {})
+
+
 def _format_http_error(e: urllib.error.HTTPError) -> str:
     body = e.read().decode("utf-8", errors="replace")
     if e.code == 401:

--- a/presets/hashnode/comment.py
+++ b/presets/hashnode/comment.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
-"""Hashnode comment: hashnode_comment:POST_ID_OR_URL|MESSAGE
+"""Hashnode comment: hashnode_comment:POST_ID_OR_URL|MESSAGE[|force]
 
 Accepts a post ID or a Hashnode URL on any publication. URL→ID resolution
 uses the cross-publication `publication(host:)` GraphQL field so comments
 can be posted on any publication, not just the caller's own.
+
+PRE-FLIGHT DUPLICATE CHECK: Before posting, the op fetches existing comments
+on the post and aborts if the authenticated user has already commented (matched
+by username from HASHNODE_USERNAME env / me query). Pass |force as the 3rd
+pipe-separated field to bypass: hashnode_comment:POST_ID|MSG|force
+If the pre-flight check fails, a warning is printed and the comment proceeds
+(graceful degrade — don't block on platform issues).
 """
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _auth import get_token
-from _graphql import gql
+from _graphql import gql, gql_safe
 from _outbound import append as track_append
 from _resolve import resolve_post_id
 
@@ -20,19 +27,80 @@ mutation AddComment($input: AddCommentInput!) {
 }
 """
 
+PREFLIGHT = """
+query PostComments($id: ID!) {
+  post(id: $id) {
+    comments(first: 50) {
+      edges { node { id author { username } dateAdded } }
+    }
+  }
+}
+"""
 
-def parse_args(arg: str) -> tuple[str, str]:
-    parts = arg.split("|", 1)
+
+def parse_args(arg: str) -> tuple[str, str, bool]:
+    """Return (post_or_url, message, force)."""
+    parts = arg.split("|", 2)
     if len(parts) < 2 or not parts[1].strip():
-        sys.stderr.write("ERROR: usage hashnode_comment:POST_ID_OR_URL|MESSAGE\n")
+        sys.stderr.write("ERROR: usage hashnode_comment:POST_ID_OR_URL|MESSAGE[|force]\n")
         sys.exit(2)
-    return parts[0].strip(), parts[1]
+    post_or_url = parts[0].strip()
+    message = parts[1]
+    force = len(parts) > 2 and parts[2].strip().lower() == "force"
+    return post_or_url, message, force
+
+
+def preflight_comment(post_id: str, me: str, token: str) -> tuple[bool | None, list[str], str]:
+    """Check if `me` has already commented on post_id.
+
+    Returns (already_commented, existing_ids, last_date) or (None, [], '')
+    when the lookup itself failed (caller should fail-closed).
+    """
+    if not me:
+        return None, [], ""
+    data = gql_safe(PREFLIGHT, {"id": post_id}, token)
+    if data is None:
+        return None, [], ""
+    post = data.get("post") or {}
+    edges = (post.get("comments") or {}).get("edges") or []
+    mine = [e["node"] for e in edges
+            if (e.get("node") or {}).get("author", {}).get("username") == me]
+    if not mine:
+        return False, [], ""
+    ids = [c["id"] for c in mine]
+    last = max(c.get("dateAdded") or "" for c in mine).split("T")[0]
+    return True, ids, last
 
 
 def main(arg: str) -> None:
-    post_or_url, message = parse_args(arg)
+    post_or_url, message, force = parse_args(arg)
     token = get_token()
     post_id = resolve_post_id(token, post_or_url)
+    if not force:
+        try:
+            from _me import get_username
+            me = get_username(token)
+        except Exception as exc:
+            sys.stderr.write(
+                f"ABORT — pre-flight failed (cannot identify user: {exc}). "
+                "Use |force as 3rd field to bypass and post anyway.\n"
+            )
+            sys.exit(1)
+        already, ids, last = preflight_comment(post_id, me, token)
+        if already is None:
+            sys.stderr.write(
+                f"ABORT — pre-flight lookup failed for post {post_id} "
+                "(cannot verify whether already commented). "
+                "Use |force as 3rd field to bypass and post anyway.\n"
+            )
+            sys.exit(1)
+        if already:
+            sys.stderr.write(
+                f"ABORT — already commented {len(ids)}× on post {post_id} "
+                f"(ids: {', '.join(ids)}, last {last}). "
+                "Use |force as 3rd field to override.\n"
+            )
+            sys.exit(1)
     data = gql(ADD_COMMENT, {"input": {"postId": post_id, "contentMarkdown": message}}, token)
     c = data["addComment"]["comment"]
     track_append({

--- a/presets/hashnode/publish.py
+++ b/presets/hashnode/publish.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Hashnode publish: TITLE|MD_FILE|CANONICAL[|TAGS|COVER]
+"""Hashnode publish: TITLE|MD_FILE|CANONICAL[|TAGS|COVER[|force]]
 
 Tags: comma-separated slugs. Cover: URL.
 Defaults from manifest: SUPERTOOL_DEFAULT_TAGS, SUPERTOOL_DEFAULT_COVER (env).
 Caller-supplied values win.
+
+PRE-FLIGHT DUPLICATE CHECK: Before publishing, the op queries
+me { posts(first:50) } and aborts if a post with the same canonical URL
+already exists. Pass |force as the 6th pipe-separated field to bypass:
+TITLE|MD|CANONICAL||||force
+If the pre-flight check fails, a warning is printed and publish proceeds.
 """
 import os
 import sys
@@ -11,7 +17,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _auth import get_publication_id, get_token
-from _graphql import gql
+from _graphql import gql, gql_safe
 
 QUERY = """
 mutation PublishPost($input: PublishPostInput!) {
@@ -21,17 +27,24 @@ mutation PublishPost($input: PublishPostInput!) {
 }
 """
 
+PREFLIGHT = """
+query MyPosts {
+  me { posts(first: 50) { edges { node { id slug url canonicalUrl } } } }
+}
+"""
+
 
 def parse_args(arg: str) -> dict[str, object]:
     parts = arg.split("|")
     if len(parts) < 3:
-        sys.stderr.write("ERROR: usage hashnode_publish:TITLE|MD_FILE|CANONICAL[|TAGS|COVER]\n")
+        sys.stderr.write("ERROR: usage hashnode_publish:TITLE|MD_FILE|CANONICAL[|TAGS|COVER[|force]]\n")
         sys.exit(2)
     title = parts[0].strip()
     md_path = Path(parts[1].strip())
     canonical = parts[2].strip()
     tags_csv = parts[3].strip() if len(parts) > 3 and parts[3].strip() else os.environ.get("SUPERTOOL_DEFAULT_TAGS", "")
     cover = parts[4].strip() if len(parts) > 4 and parts[4].strip() else os.environ.get("SUPERTOOL_DEFAULT_COVER", "")
+    force = len(parts) > 5 and parts[5].strip().lower() == "force"
     if not md_path.is_file():
         sys.stderr.write(f"ERROR: markdown file not found: {md_path}\n")
         sys.exit(2)
@@ -43,7 +56,29 @@ def parse_args(arg: str) -> dict[str, object]:
         "canonical": canonical,
         "tags": tags,
         "cover": cover,
+        "force": force,
     }
+
+
+def preflight_publish(canonical: str, token: str) -> tuple[bool | None, str, str]:
+    """Check if a post with this canonical URL already exists.
+
+    Returns (already_exists, existing_url, existing_slug) or (None, '', '')
+    when the lookup itself failed (caller should fail-closed).
+    """
+    if not canonical:
+        return False, "", ""
+    data = gql_safe(PREFLIGHT, {}, token)
+    if data is None:
+        return None, "", ""
+    me = data.get("me") or {}
+    edges = (me.get("posts") or {}).get("edges") or []
+    for e in edges:
+        node = e.get("node") or {}
+        node_canonical = (node.get("canonicalUrl") or "").rstrip("/")
+        if node_canonical == canonical.rstrip("/"):
+            return True, node.get("url", ""), node.get("slug", "")
+    return False, "", ""
 
 
 def build_input(parsed: dict[str, object], publication_id: str) -> dict[str, object]:
@@ -63,6 +98,22 @@ def build_input(parsed: dict[str, object], publication_id: str) -> dict[str, obj
 def main(arg: str) -> None:
     parsed = parse_args(arg)
     token = get_token()
+    if not parsed["force"]:
+        already, url, slug = preflight_publish(str(parsed["canonical"]), token)
+        if already is None:
+            sys.stderr.write(
+                f"ABORT — pre-flight lookup failed for canonical_url={parsed['canonical']!r} "
+                "(cannot verify whether already published). "
+                "Use |force as 6th field to bypass and publish anyway.\n"
+            )
+            sys.exit(1)
+        if already:
+            sys.stderr.write(
+                f"ABORT — already published with canonical_url={parsed['canonical']!r} "
+                f"(slug={slug}, url={url}). "
+                "Use |force as 6th field to override.\n"
+            )
+            sys.exit(1)
     pub_id = get_publication_id()
     data = gql(QUERY, {"input": build_input(parsed, pub_id)}, token)
     post = data["publishPost"]["post"]

--- a/presets/hashnode/publish.py
+++ b/presets/hashnode/publish.py
@@ -28,8 +28,12 @@ mutation PublishPost($input: PublishPostInput!) {
 """
 
 PREFLIGHT = """
-query MyPosts {
-  me { posts(first: 50) { edges { node { id slug url canonicalUrl } } } }
+query MyPublicationPosts {
+  me {
+    publications(first: 1) {
+      edges { node { posts(first: 50) { edges { node { id slug url canonicalUrl } } } } }
+    }
+  }
 }
 """
 
@@ -72,7 +76,11 @@ def preflight_publish(canonical: str, token: str) -> tuple[bool | None, str, str
     if data is None:
         return None, "", ""
     me = data.get("me") or {}
-    edges = (me.get("posts") or {}).get("edges") or []
+    pubs = (me.get("publications") or {}).get("edges") or []
+    edges = []
+    for pub in pubs:
+        pub_node = pub.get("node") or {}
+        edges.extend((pub_node.get("posts") or {}).get("edges") or [])
     for e in edges:
         node = e.get("node") or {}
         node_canonical = (node.get("canonicalUrl") or "").rstrip("/")

--- a/presets/hashnode/react.py
+++ b/presets/hashnode/react.py
@@ -25,12 +25,6 @@ mutation LikePost($input: LikePostInput!) {
 }
 """
 
-PREFLIGHT = """
-query PostReactions($id: ID!) {
-  post(id: $id) { myTotalReactions }
-}
-"""
-
 
 def parse_args(arg: str) -> tuple[str, bool]:
     """Return (raw_identifier, force)."""

--- a/presets/hashnode/react.py
+++ b/presets/hashnode/react.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Hashnode react: hashnode_react:POST_ID_OR_URL — likes the post.
+"""Hashnode react: hashnode_react:POST_ID_OR_URL[|force]
 
 Accepts a post ID or a Hashnode URL on any publication. The URL→ID lookup
 uses the cross-publication `publication(host:)` GraphQL field so foreign
 posts (e.g. https://author.hashnode.dev/slug) resolve correctly.
+
+PRE-FLIGHT DUPLICATE CHECK: Before liking, the op queries the post's
+myTotalReactions field and aborts if >0 (already reacted). Pass |force as a
+second pipe-separated field to bypass: hashnode_react:POST_ID_OR_URL|force
+If the pre-flight check fails, a warning is printed and the like proceeds
+(graceful degrade — don't block on platform issues).
 """
 import sys
 from pathlib import Path
@@ -19,13 +25,55 @@ mutation LikePost($input: LikePostInput!) {
 }
 """
 
+PREFLIGHT = """
+query PostReactions($id: ID!) {
+  post(id: $id) { myTotalReactions }
+}
+"""
+
+
+def parse_args(arg: str) -> tuple[str, bool]:
+    """Return (raw_identifier, force)."""
+    if not arg:
+        sys.stderr.write("ERROR: usage hashnode_react:POST_ID_OR_URL[|force]\n")
+        sys.exit(2)
+    parts = arg.split("|", 1)
+    raw = parts[0].strip()
+    force = len(parts) > 1 and parts[1].strip().lower() == "force"
+    return raw, force
+
+
+def preflight_react(post_id: str, token: str) -> tuple[bool | None, int]:
+    """Check if already reacted to post_id.
+
+    Returns (already_reacted, reaction_count) or (None, 0) when unknown.
+    Hashnode's GraphQL schema has no per-user reaction field, so we cannot
+    reliably tell whether *we* reacted — only the total. Returning None
+    signals the caller to fail-closed (likePost is additive on Hashnode,
+    so silently posting on every call would spam reactions).
+    """
+    return None, 0
+
 
 def main(arg: str) -> None:
-    if not arg:
-        sys.stderr.write("ERROR: usage hashnode_react:POST_ID_OR_URL\n")
-        sys.exit(2)
+    raw, force = parse_args(arg)
     token = get_token()
-    post_id = resolve_post_id(token, arg)
+    post_id = resolve_post_id(token, raw)
+    if not force:
+        already, count = preflight_react(post_id, token)
+        if already is None:
+            sys.stderr.write(
+                f"ABORT — cannot verify whether already reacted to post {post_id} "
+                "(Hashnode GraphQL exposes no per-user reaction field, and likePost "
+                "is additive — each call adds a reaction). Use |force to react anyway.\n"
+            )
+            sys.exit(1)
+        if already:
+            sys.stderr.write(
+                f"ABORT — already reacted to post {post_id} "
+                f"(reactions={count}). Use |force to override.\n"
+            )
+            sys.exit(1)
     data = gql(LIKE, {"input": {"postId": post_id, "likesCount": 1}}, token)
     p = data["likePost"]["post"]
     print(f"(liked id={p['id']} total_reactions={p.get('reactionCount', 0)})")

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -38,21 +38,23 @@ status_since_op = _load("status_since")
 # publish ---------------------------------------------------------------
 
 def test_publish_parse_args_inline_text() -> None:
-    body, reply = publish.parse_args("Hello, real humans.")
-    assert body == "Hello, real humans." and reply is None
+    body, reply, force = publish.parse_args("Hello, real humans.")
+    assert body == "Hello, real humans." and reply is None and force is False
 
 
 def test_publish_parse_args_with_reply(tmp_path: Path) -> None:
-    body, reply = publish.parse_args("Reply text|at://did:plc:abc/app.bsky.feed.post/3kxyz")
+    body, reply, force = publish.parse_args("Reply text|at://did:plc:abc/app.bsky.feed.post/3kxyz")
     assert body == "Reply text"
     assert reply == "at://did:plc:abc/app.bsky.feed.post/3kxyz"
+    assert force is False
 
 
 def test_publish_parse_args_text_file(tmp_path: Path) -> None:
     md = tmp_path / "post.txt"
     md.write_text("From a file")
-    body, _ = publish.parse_args(str(md))
+    body, _, force = publish.parse_args(str(md))
     assert body == "From a file"
+    assert force is False
 
 
 def test_publish_parse_args_too_long(capsys: pytest.CaptureFixture[str]) -> None:
@@ -175,3 +177,281 @@ def test_status_since_render_with_kinds() -> None:
     assert "@alice.bsky.social" in out and "@bob.bsky.social" in out
     assert "bluesky_publish:" in out  # reply NEXT
     assert "bluesky_follow:" in out  # follow back NEXT
+
+
+# pre-flight: like ----------------------------------------------------------
+
+like_op = _load("like")
+follow_op = _load("follow")
+
+
+def test_like_parse_args_no_force() -> None:
+    raw, force = like_op.parse_args("at://did:plc:abc/app.bsky.feed.post/xyz")
+    assert raw == "at://did:plc:abc/app.bsky.feed.post/xyz" and force is False
+
+
+def test_like_parse_args_force() -> None:
+    raw, force = like_op.parse_args("at://did:plc:abc/app.bsky.feed.post/xyz|force")
+    assert raw == "at://did:plc:abc/app.bsky.feed.post/xyz" and force is True
+
+
+def test_like_parse_args_empty_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        like_op.parse_args("")
+    assert "ERROR" in capsys.readouterr().err
+
+
+def test_like_preflight_already_liked(monkeypatch: pytest.MonkeyPatch) -> None:
+    target = "at://did:plc:abc/app.bsky.feed.post/xyz"
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    monkeypatch.setattr(like_op, "xrpc", lambda nsid, s, **kw: {
+        "feed": [{"post": {"uri": target}}, {"post": {"uri": "other"}}]
+    })
+    assert like_op.preflight_like(target, session) is True
+
+
+def test_like_preflight_not_liked(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    monkeypatch.setattr(like_op, "xrpc", lambda nsid, s, **kw: {
+        "feed": [{"post": {"uri": "at://other/post/1"}}]
+    })
+    assert like_op.preflight_like("at://target/post/x", session) is False
+
+
+def test_like_preflight_api_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    monkeypatch.setattr(like_op, "xrpc", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("down")))
+    assert like_op.preflight_like("at://x/y/z", session) is False
+
+
+def test_like_main_aborts_on_dupe(monkeypatch: pytest.MonkeyPatch,
+                                   capsys: pytest.CaptureFixture[str]) -> None:
+    target_uri = "at://did:plc:abc/app.bsky.feed.post/xyz"
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    monkeypatch.setattr(like_op, "get_handle", lambda: "me.bsky.social")
+    monkeypatch.setattr(like_op, "get_app_password", lambda: "pw")
+    monkeypatch.setattr(like_op, "get_session", lambda h, p: session)
+    monkeypatch.setattr(like_op, "to_at_uri", lambda arg, s: target_uri)
+    monkeypatch.setattr(like_op, "xrpc", lambda nsid, s, **kw: {
+        "feed": [{"post": {"uri": target_uri}}]
+    })
+    with pytest.raises(SystemExit) as exc:
+        like_op.main(target_uri)
+    assert exc.value.code == 1
+    assert "ABORT" in capsys.readouterr().err
+
+
+def test_like_main_force_bypasses_preflight(monkeypatch: pytest.MonkeyPatch,
+                                             capsys: pytest.CaptureFixture[str]) -> None:
+    target_uri = "at://did:plc:abc/app.bsky.feed.post/xyz"
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    calls: list[str] = []
+
+    def fake_xrpc(nsid, s, method="GET", params=None, body=None, **kw):
+        calls.append(nsid)
+        if nsid == "app.bsky.feed.getPostThread":
+            return {"thread": {"post": {"uri": target_uri, "cid": "cid123"}}}
+        if nsid == "com.atproto.repo.createRecord":
+            return {"uri": "at://me/like/1", "cid": "cid-like"}
+        return {}
+
+    monkeypatch.setattr(like_op, "get_handle", lambda: "me.bsky.social")
+    monkeypatch.setattr(like_op, "get_app_password", lambda: "pw")
+    monkeypatch.setattr(like_op, "get_session", lambda h, p: session)
+    monkeypatch.setattr(like_op, "to_at_uri", lambda arg, s: target_uri)
+    monkeypatch.setattr(like_op, "xrpc", fake_xrpc)
+    like_op.main(f"{target_uri}|force")
+    assert "liked" in capsys.readouterr().out
+    assert "getActorLikes" not in calls  # preflight skipped
+
+
+# pre-flight: follow --------------------------------------------------------
+
+def test_follow_parse_args_no_force() -> None:
+    target, force = follow_op.parse_args("alice.bsky.social")
+    assert target == "alice.bsky.social" and force is False
+
+
+def test_follow_parse_args_force() -> None:
+    target, force = follow_op.parse_args("alice.bsky.social|force")
+    assert target == "alice.bsky.social" and force is True
+
+
+def test_follow_parse_args_strips_at() -> None:
+    target, force = follow_op.parse_args("@alice.bsky.social")
+    assert target == "alice.bsky.social"
+
+
+def test_follow_parse_args_empty_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        follow_op.parse_args("")
+    assert "ERROR" in capsys.readouterr().err
+
+
+def test_follow_preflight_already_follows(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    target_did = "did:plc:alice"
+    monkeypatch.setattr(follow_op, "xrpc", lambda nsid, s, **kw: {
+        "follows": [{"did": target_did}, {"did": "did:plc:other"}]
+    })
+    assert follow_op.preflight_follow(target_did, session) is True
+
+
+def test_follow_preflight_not_following(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    monkeypatch.setattr(follow_op, "xrpc", lambda nsid, s, **kw: {
+        "follows": [{"did": "did:plc:other"}]
+    })
+    assert follow_op.preflight_follow("did:plc:alice", session) is False
+
+
+def test_follow_preflight_api_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    monkeypatch.setattr(follow_op, "xrpc", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("down")))
+    assert follow_op.preflight_follow("did:plc:alice", session) is False
+
+
+def test_follow_main_aborts_on_dupe(monkeypatch: pytest.MonkeyPatch,
+                                     capsys: pytest.CaptureFixture[str]) -> None:
+    target_did = "did:plc:alice"
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+
+    def fake_xrpc(nsid, s, method="GET", params=None, body=None, **kw):
+        if nsid == "app.bsky.actor.getProfile":
+            return {"did": target_did}
+        return {"follows": [{"did": target_did}]}
+
+    monkeypatch.setattr(follow_op, "get_handle", lambda: "me.bsky.social")
+    monkeypatch.setattr(follow_op, "get_app_password", lambda: "pw")
+    monkeypatch.setattr(follow_op, "get_session", lambda h, p: session)
+    monkeypatch.setattr(follow_op, "xrpc", fake_xrpc)
+    with pytest.raises(SystemExit) as exc:
+        follow_op.main("alice.bsky.social")
+    assert exc.value.code == 1
+    assert "ABORT" in capsys.readouterr().err
+
+
+def test_follow_main_force_bypasses_preflight(monkeypatch: pytest.MonkeyPatch,
+                                               capsys: pytest.CaptureFixture[str]) -> None:
+    target_did = "did:plc:alice"
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    calls: list[str] = []
+
+    def fake_xrpc(nsid, s, method="GET", params=None, body=None, **kw):
+        calls.append(nsid)
+        if nsid == "app.bsky.actor.getProfile":
+            return {"did": target_did}
+        return {"uri": "at://me/follow/1"}
+
+    monkeypatch.setattr(follow_op, "get_handle", lambda: "me.bsky.social")
+    monkeypatch.setattr(follow_op, "get_app_password", lambda: "pw")
+    monkeypatch.setattr(follow_op, "get_session", lambda h, p: session)
+    monkeypatch.setattr(follow_op, "xrpc", fake_xrpc)
+    follow_op.main("alice.bsky.social|force")
+    assert "followed" in capsys.readouterr().out
+    assert "getFollows" not in calls
+
+
+# pre-flight: publish --------------------------------------------------------
+
+def test_publish_parse_args_with_force() -> None:
+    body, reply, force = publish.parse_args("Hello world|at://x/y/z|force")
+    assert body == "Hello world" and reply == "at://x/y/z" and force is True
+
+
+def test_publish_parse_args_no_force() -> None:
+    body, reply, force = publish.parse_args("Hello world|at://x/y/z")
+    assert force is False
+
+
+def test_publish_parse_args_no_reply_no_force() -> None:
+    body, reply, force = publish.parse_args("Hello world")
+    assert reply is None and force is False
+
+
+def test_publish_preflight_already_replied(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    root_uri = "at://root/post/1"
+    reply_uri = "at://parent/post/2"
+
+    def fake_xrpc(nsid, s, **kw):
+        if nsid == "app.bsky.feed.getPostThread":
+            return {"thread": {"post": {"uri": reply_uri, "cid": "c",
+                                         "record": {"reply": {"root": {"uri": root_uri}}}}}}
+        return {"feed": [
+            {"post": {"uri": "at://me/post/9",
+                       "record": {"reply": {"root": {"uri": root_uri}}}}},
+        ]}
+
+    monkeypatch.setattr(publish, "xrpc", fake_xrpc)
+    assert publish.preflight_publish(reply_uri, session) is True
+
+
+def test_publish_preflight_not_replied(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    root_uri = "at://root/post/1"
+    reply_uri = "at://parent/post/2"
+
+    def fake_xrpc(nsid, s, **kw):
+        if nsid == "app.bsky.feed.getPostThread":
+            return {"thread": {"post": {"uri": reply_uri, "cid": "c",
+                                         "record": {"reply": {"root": {"uri": root_uri}}}}}}
+        return {"feed": [
+            {"post": {"uri": "at://me/post/9",
+                       "record": {"reply": {"root": {"uri": "at://other/root/1"}}}}},
+        ]}
+
+    monkeypatch.setattr(publish, "xrpc", fake_xrpc)
+    assert publish.preflight_publish(reply_uri, session) is False
+
+
+def test_publish_preflight_api_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    monkeypatch.setattr(publish, "xrpc", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("down")))
+    assert publish.preflight_publish("at://x/y/z", session) is False
+
+
+def test_publish_main_aborts_on_dupe_reply(monkeypatch: pytest.MonkeyPatch,
+                                            capsys: pytest.CaptureFixture[str]) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    root_uri = "at://root/post/1"
+    reply_uri = "at://parent/post/2"
+
+    def fake_xrpc(nsid, s, method="GET", params=None, body=None, **kw):
+        if nsid == "app.bsky.feed.getPostThread":
+            return {"thread": {"post": {"uri": reply_uri, "cid": "c",
+                                         "record": {"reply": {"root": {"uri": root_uri}}}}}}
+        return {"feed": [
+            {"post": {"uri": "at://me/post/9",
+                       "record": {"reply": {"root": {"uri": root_uri}}}}},
+        ]}
+
+    monkeypatch.setattr(publish, "get_handle", lambda: "me.bsky.social")
+    monkeypatch.setattr(publish, "get_app_password", lambda: "pw")
+    monkeypatch.setattr(publish, "get_session", lambda h, p: session)
+    monkeypatch.setattr(publish, "xrpc", fake_xrpc)
+    with pytest.raises(SystemExit) as exc:
+        publish.main(f"Hello|{reply_uri}")
+    assert exc.value.code == 1
+    assert "ABORT" in capsys.readouterr().err
+
+
+def test_publish_main_force_bypasses_preflight(monkeypatch: pytest.MonkeyPatch,
+                                                capsys: pytest.CaptureFixture[str]) -> None:
+    session = {"did": "did:plc:me", "accessJwt": "tok"}
+    reply_uri = "at://parent/post/2"
+    calls: list[str] = []
+
+    def fake_xrpc(nsid, s, method="GET", params=None, body=None, **kw):
+        calls.append(nsid)
+        if nsid == "app.bsky.feed.getPostThread":
+            return {"thread": {"post": {"uri": reply_uri, "cid": "c", "record": {}}}}
+        return {"uri": "at://me/post/new", "cid": "cid-new"}
+
+    monkeypatch.setattr(publish, "get_handle", lambda: "me.bsky.social")
+    monkeypatch.setattr(publish, "get_app_password", lambda: "pw")
+    monkeypatch.setattr(publish, "get_session", lambda h, p: session)
+    monkeypatch.setattr(publish, "xrpc", fake_xrpc)
+    publish.main(f"Hello|{reply_uri}|force")
+    assert "published" in capsys.readouterr().out
+    assert "getAuthorFeed" not in calls

--- a/tests/test_devto.py
+++ b/tests/test_devto.py
@@ -922,3 +922,161 @@ def test_comment_parse_args_accepts_url() -> None:
     assert raw == "https://dev.to/alice/some-slug"
     assert msg == "hi" and parent == "99"
     assert force is False
+
+
+# preflight tests — comment -----------------------------------------------
+# preflight_comment does `from _rest import request` and `from _auth import get_api_key`
+# inside the function body, so we patch via sys.modules (already populated when
+# comment_op was loaded at module-import time) rather than importing directly.
+
+def _ensure_devto_module(name: str):
+    """Return the named module from the devto preset, (re)loading if evicted."""
+    if name not in sys.modules:
+        if str(PRESET_DIR) not in sys.path:
+            sys.path.insert(0, str(PRESET_DIR))
+        spec = importlib.util.spec_from_file_location(name, PRESET_DIR / f"{name}.py")
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+    return sys.modules[name]
+
+
+def _patch_rest_auth(fake_items):
+    """Stub request/get_api_key on the devto _rest/_auth modules in sys.modules."""
+    _rest_mod = _ensure_devto_module("_rest")
+    _auth_mod = _ensure_devto_module("_auth")
+    _rest_mod.request = lambda *a, **kw: fake_items() if callable(fake_items) else fake_items
+    _auth_mod.get_api_key = lambda: "fake"
+    return _rest_mod, _auth_mod
+
+
+def test_comment_preflight_already_commented(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = [{"id": 1, "id_code": "abc12", "created_at": "2026-05-01T10:00:00Z",
+              "user": {"username": "max-ai-dev"}, "children": []}]
+    _patch_rest_auth(items)
+    already, ids, last = comment_op.preflight_comment(999, "max-ai-dev")
+    assert already is True and "abc12" in ids and last == "2026-05-01"
+
+
+def test_comment_preflight_already_commented_nested_children(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = [{"id": 1, "id_code": "top01", "created_at": "2026-04-01T00:00:00Z",
+              "user": {"username": "other"}, "children": [
+                  {"id": 2, "id_code": "child2", "created_at": "2026-05-02T00:00:00Z",
+                   "user": {"username": "max-ai-dev"}},
+              ]}]
+    _patch_rest_auth(items)
+    already, ids, last = comment_op.preflight_comment(999, "max-ai-dev")
+    assert already is True and "child2" in ids and last == "2026-05-02"
+
+
+def test_comment_preflight_not_commented(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = [{"id": 1, "id_code": "xyz99", "created_at": "2026-05-01T10:00:00Z",
+              "user": {"username": "alice"}, "children": []}]
+    _patch_rest_auth(items)
+    already, ids, last = comment_op.preflight_comment(999, "max-ai-dev")
+    assert already is False and ids == []
+
+
+def test_comment_preflight_api_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*a, **kw): raise Exception("timeout")
+    _patch_rest_auth(_raise)
+    already, ids, last = comment_op.preflight_comment(999, "max-ai-dev")
+    assert already is False and ids == [] and last == ""
+
+
+def test_comment_main_aborts_on_dupe(monkeypatch: pytest.MonkeyPatch,
+                                      capsys: pytest.CaptureFixture[str]) -> None:
+    items = [{"id": 1, "id_code": "abc12", "created_at": "2026-05-01T10:00:00Z",
+              "user": {"username": "max-ai-dev"}, "children": []}]
+    _patch_rest_auth(items)
+    # inject _me into sys.modules so the local import inside main() resolves
+    import types
+    _me_mod = types.ModuleType("_me")
+    _me_mod.get_username = lambda key: "max-ai-dev"  # type: ignore[attr-defined]
+    sys.modules["_me"] = _me_mod
+    monkeypatch.setattr(comment_op, "resolve_article_id", lambda raw: 999)
+    monkeypatch.setattr(comment_op, "get_session_cookie", lambda: "cookie-val")
+    with pytest.raises(SystemExit) as exc:
+        comment_op.main("999|Hello world")
+    assert exc.value.code == 1
+    assert "ABORT" in capsys.readouterr().err
+
+
+def test_comment_main_force_bypasses_preflight(monkeypatch: pytest.MonkeyPatch,
+                                                capsys: pytest.CaptureFixture[str]) -> None:
+    # With |force the preflight block is skipped entirely — _rest.request must
+    # NOT be called before the post. Stub _print_post_confirmation to suppress
+    # the post-confirmation fetch (a separate concern, not preflight).
+    called: list[str] = []
+    def _track(*a, **kw): called.append("preflight"); return []
+    _patch_rest_auth(_track)
+    monkeypatch.setattr(comment_op, "resolve_article_id", lambda raw: 999)
+    monkeypatch.setattr(comment_op, "get_session_cookie", lambda: "cookie-val")
+    monkeypatch.setattr(comment_op, "fetch_csrf_token", lambda c: "csrf-tok")
+    monkeypatch.setattr(comment_op, "web_post_json",
+                        lambda path, cookie, csrf, body: ('{"id": 42}', 200))
+    monkeypatch.setattr(comment_op, "_print_post_confirmation", lambda aid, cid: None)
+    comment_op.main("999|Hello world||force")
+    assert "preflight" not in called
+
+
+# preflight tests — publish -----------------------------------------------
+
+def test_publish_preflight_dupe_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(publish, "request",
+                        lambda *a, **kw: [{"canonical_url": "https://x.io",
+                                           "url": "https://dev.to/u/s", "slug": "u-s"}])
+    monkeypatch.setattr(publish, "get_api_key", lambda: "fake")
+    already, url, slug = publish.preflight_publish("https://x.io", "fake")
+    assert already is True and slug == "u-s"
+
+
+def test_publish_preflight_no_dupe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(publish, "request",
+                        lambda *a, **kw: [{"canonical_url": "https://other.io",
+                                           "url": "https://dev.to/u/o", "slug": "u-o"}])
+    monkeypatch.setattr(publish, "get_api_key", lambda: "fake")
+    already, url, slug = publish.preflight_publish("https://x.io", "fake")
+    assert already is False
+
+
+def test_publish_preflight_api_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(publish, "request",
+                        lambda *a, **kw: (_ for _ in ()).throw(Exception("500")))
+    monkeypatch.setattr(publish, "get_api_key", lambda: "fake")
+    already, url, slug = publish.preflight_publish("https://x.io", "fake")
+    assert already is False and url == "" and slug == ""
+
+
+def test_publish_main_aborts_on_dupe(monkeypatch: pytest.MonkeyPatch,
+                                      capsys: pytest.CaptureFixture[str],
+                                      tmp_path: Path) -> None:
+    md = tmp_path / "p.md"
+    md.write_text("body")
+    monkeypatch.setattr(publish, "get_api_key", lambda: "fake")
+    monkeypatch.setattr(publish, "request",
+                        lambda *a, **kw: [{"canonical_url": "https://x.io",
+                                           "url": "https://dev.to/u/s", "slug": "u-s"}])
+    with pytest.raises(SystemExit) as exc:
+        publish.main(f"T|{md}|https://x.io")
+    assert exc.value.code == 1
+    assert "ABORT" in capsys.readouterr().err
+
+
+def test_publish_main_force_bypasses_preflight(monkeypatch: pytest.MonkeyPatch,
+                                                capsys: pytest.CaptureFixture[str],
+                                                tmp_path: Path) -> None:
+    md = tmp_path / "p.md"
+    md.write_text("body")
+    calls: list[str] = []
+    def fake_request(method: str, path: str, *a, **kw):
+        calls.append(method)
+        if method == "GET":
+            return [{"canonical_url": "https://x.io", "url": "https://dev.to/u/s", "slug": "u-s"}]
+        return {"id": 99, "slug": "new-slug", "url": "https://dev.to/u/new-slug", "title": "T"}
+    monkeypatch.setattr(publish, "get_api_key", lambda: "fake")
+    monkeypatch.setattr(publish, "request", fake_request)
+    publish.main(f"T|{md}|https://x.io||||force")
+    assert "GET" not in calls
+    assert "published" in capsys.readouterr().out

--- a/tests/test_devto.py
+++ b/tests/test_devto.py
@@ -80,6 +80,22 @@ def test_publish_parse_args_md_missing(tmp_path: Path, capsys: pytest.CaptureFix
     assert "not found" in capsys.readouterr().err
 
 
+def test_publish_parse_args_force_flag(tmp_path: Path) -> None:
+    """7th pipe field 'force' sets force=True."""
+    md = tmp_path / "p.md"
+    md.write_text("body")
+    parsed = publish.parse_args(f"T|{md}|https://x.io||||force")
+    assert parsed["force"] is True
+
+
+def test_publish_parse_args_no_force_by_default(tmp_path: Path) -> None:
+    """Omitting 7th field → force=False."""
+    md = tmp_path / "p.md"
+    md.write_text("body")
+    parsed = publish.parse_args(f"T|{md}|https://x.io")
+    assert parsed["force"] is False
+
+
 def test_publish_build_body_minimal() -> None:
     parsed: dict[str, Any] = {
         "title": "T", "markdown": "body", "canonical": "https://x.io",
@@ -256,19 +272,105 @@ def test_comments_render_marks_you() -> None:
 # react -------------------------------------------------------------------
 
 def test_react_parse_args_default() -> None:
-    aid, cat = react.parse_args("123")
-    assert aid == "123" and cat == "like"
+    aid, cat, idempotent = react.parse_args("123")
+    assert aid == "123" and cat == "like" and idempotent is True
 
 
 def test_react_parse_args_with_category() -> None:
-    aid, cat = react.parse_args("123|unicorn")
-    assert aid == "123" and cat == "unicorn"
+    aid, cat, idempotent = react.parse_args("123|unicorn")
+    assert aid == "123" and cat == "unicorn" and idempotent is True
 
 
 def test_react_parse_args_invalid_category(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit):
         react.parse_args("123|nope")
     assert "category" in capsys.readouterr().err
+
+
+def test_react_parse_args_idempotent_default() -> None:
+    """No third field → idempotent=True (ensure-create semantics)."""
+    aid, cat, idempotent = react.parse_args("123|like")
+    assert idempotent is True
+
+
+def test_react_parse_args_toggle_modifier() -> None:
+    """|toggle as third field → idempotent=False (raw toggle, one POST)."""
+    aid, cat, idempotent = react.parse_args("123|like|toggle")
+    assert aid == "123" and cat == "like" and idempotent is False
+
+
+def test_react_parse_args_toggle_modifier_default_category() -> None:
+    """Toggle modifier works even when category is omitted (empty second field)."""
+    aid, cat, idempotent = react.parse_args("123||toggle")
+    assert cat == "like" and idempotent is False
+
+
+def test_react_idempotent_create_no_double_post(monkeypatch: pytest.MonkeyPatch,
+                                                 capsys: pytest.CaptureFixture[str]) -> None:
+    """result=create on first POST → no second POST needed."""
+    posts: list[dict] = []
+
+    def fake_web_post(path, cookie, csrf, body, **kw):
+        posts.append(body)
+        return ('{"result": "create"}', 200)
+
+    monkeypatch.setattr(react, "get_session_cookie", lambda: "cookie-val")
+    monkeypatch.setattr(react, "fetch_csrf_token", lambda c: "csrf-tok")
+    monkeypatch.setattr(react, "web_post_json", fake_web_post)
+    monkeypatch.setattr(react, "resolve_article_id", lambda raw: 42)
+
+    react.main("42|like")
+
+    assert len(posts) == 1
+    out = capsys.readouterr()
+    assert "result=create" in out.out
+    assert "was_on=true" not in out.out
+
+
+def test_react_idempotent_destroy_corrects(monkeypatch: pytest.MonkeyPatch,
+                                            capsys: pytest.CaptureFixture[str]) -> None:
+    """result=destroy on first POST → second POST issued to restore; output shows was_on=true."""
+    responses = iter(['{"result": "destroy"}', '{"result": "create"}'])
+    posts: list[dict] = []
+
+    def fake_web_post(path, cookie, csrf, body, **kw):
+        posts.append(body)
+        return (next(responses), 200)
+
+    monkeypatch.setattr(react, "get_session_cookie", lambda: "cookie-val")
+    monkeypatch.setattr(react, "fetch_csrf_token", lambda c: "csrf-tok")
+    monkeypatch.setattr(react, "web_post_json", fake_web_post)
+    monkeypatch.setattr(react, "resolve_article_id", lambda raw: 42)
+
+    react.main("42|like")
+
+    assert len(posts) == 2
+    out = capsys.readouterr()
+    assert "result=create" in out.out
+    assert "was_on=true" in out.out
+    assert "NOTE:" in out.err
+
+
+def test_react_toggle_mode_no_correction(monkeypatch: pytest.MonkeyPatch,
+                                          capsys: pytest.CaptureFixture[str]) -> None:
+    """With |toggle, destroy result is NOT corrected — raw one-shot behaviour."""
+    posts: list[dict] = []
+
+    def fake_web_post(path, cookie, csrf, body, **kw):
+        posts.append(body)
+        return ('{"result": "destroy"}', 200)
+
+    monkeypatch.setattr(react, "get_session_cookie", lambda: "cookie-val")
+    monkeypatch.setattr(react, "fetch_csrf_token", lambda c: "csrf-tok")
+    monkeypatch.setattr(react, "web_post_json", fake_web_post)
+    monkeypatch.setattr(react, "resolve_article_id", lambda raw: 42)
+
+    react.main("42|like|toggle")
+
+    assert len(posts) == 1
+    out = capsys.readouterr()
+    assert "result=destroy" in out.out
+    assert "was_on" not in out.out
 
 
 # status_since -----------------------------------------------------------
@@ -401,22 +503,23 @@ def test_read_own_engagement_flat_and_nested() -> None:
 # comment ----------------------------------------------------------------
 
 def test_comment_parse_args_minimal() -> None:
-    aid, msg, parent = comment_op.parse_args("1234|Hello")
-    assert aid == "1234" and msg == "Hello" and parent is None
+    aid, msg, parent, force = comment_op.parse_args("1234|Hello")
+    assert aid == "1234" and msg == "Hello" and parent is None and force is False
 
 
 def test_comment_parse_args_reply() -> None:
-    aid, msg, parent = comment_op.parse_args("1234|Hello|99")
-    assert aid == "1234" and parent == "99"
+    aid, msg, parent, force = comment_op.parse_args("1234|Hello|99")
+    assert aid == "1234" and parent == "99" and force is False
 
 
 def test_comment_parse_args_message_keeps_pipes() -> None:
-    aid, msg, parent = comment_op.parse_args("1234|hi | there | mate")
+    aid, msg, parent, force = comment_op.parse_args("1234|hi | there | mate")
     assert aid == "1234"
     # implementation splits on '|' so message is just first piece — but parent may capture "mate"
     # this asserts the actual behavior so we don't accidentally regress it
     assert msg == "hi "  # arg parser splits liberally; document the limit
     assert parent == "there"
+    assert force is False
 
 
 def test_comment_parse_args_missing_msg(capsys: pytest.CaptureFixture[str]) -> None:
@@ -435,12 +538,25 @@ def test_comment_parse_args_message_keeps_colons() -> None:
     """When supertool {args} parts are colon-rejoined in main(), parse_args
     must preserve a colon-bearing body intact (no truncation at first ':').
     """
-    aid, msg, parent = comment_op.parse_args(
+    aid, msg, parent, force = comment_op.parse_args(
         "1234|Boundary prediction is the right name. Worth saying: it's learnable.|99"
     )
     assert aid == "1234"
     assert msg == "Boundary prediction is the right name. Worth saying: it's learnable."
     assert parent == "99"
+    assert force is False
+
+
+def test_comment_parse_args_force_flag() -> None:
+    """4th pipe field 'force' sets force=True."""
+    aid, msg, parent, force = comment_op.parse_args("1234|Hello|99|force")
+    assert aid == "1234" and msg == "Hello" and parent == "99" and force is True
+
+
+def test_comment_parse_args_force_no_parent() -> None:
+    """force can appear in 4th slot even with empty parent."""
+    aid, msg, parent, force = comment_op.parse_args("1234|Hello||force")
+    assert parent is None and force is True
 
 
 def test_resolve_parent_numeric_id_happy(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -526,7 +642,7 @@ def _run_comment_dryrun(*argv_parts: str) -> tuple[str, str, str | None]:
         "import sys; sys.path.insert(0, %r);\n"
         "import comment as c\n"
         "arg = ':'.join(sys.argv[1:])\n"
-        "aid, msg, parent = c.parse_args(arg)\n"
+        "aid, msg, parent, force = c.parse_args(arg)\n"
         "print(repr((aid, msg, parent)))\n"
     ) % str(repo / "presets" / "devto")
     proc = subprocess.run(
@@ -700,12 +816,73 @@ def test_resolve_empty_exits(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_resolve_unparseable_exits(capsys: pytest.CaptureFixture[str]) -> None:
-    """Bare slug with no slash and non-numeric → cannot parse, exits."""
+    """Input that matches no known form (too-short suffix, no slash, no scheme) → exits."""
     with pytest.raises(SystemExit):
-        resolve_op.resolve_article_id("just-a-slug-no-author")
+        resolve_op.resolve_article_id("just-a-slug-x")  # suffix only 1 char → no match
     err = capsys.readouterr().err
     assert "cannot parse article identifier" in err
-    assert "just-a-slug-no-author" in err
+    assert "just-a-slug-x" in err
+
+
+def test_resolve_bare_slug_calls_list_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare slug matching ^[a-z0-9][a-z0-9-]*-[a-z0-9]{4,6}$ → GET /articles?slug=... → returns id."""
+    calls: list[tuple] = []
+
+    def fake_request(method, path, api_key, body=None, query=None, timeout=30):
+        calls.append((method, path, query))
+        return [{"id": 777, "title": "T"}]
+
+    monkeypatch.setattr(resolve_op, "request", fake_request)
+    monkeypatch.setattr(resolve_op, "get_api_key", lambda: "fake-key")
+
+    slug = "the-real-token-economy-is-not-about-spending-less-3j3e"
+    result = resolve_op.resolve_article_id(slug)
+
+    assert result == 777
+    assert len(calls) == 1
+    method, path, query = calls[0]
+    assert method == "GET"
+    assert path == "/articles"
+    assert query == {"per_page": 1, "slug": slug}
+
+
+def test_resolve_bare_slug_not_found_exits(monkeypatch: pytest.MonkeyPatch,
+                                            capsys: pytest.CaptureFixture[str]) -> None:
+    """Bare slug → API returns empty list → exits with descriptive error."""
+    monkeypatch.setattr(resolve_op, "request", lambda *a, **kw: [])
+    monkeypatch.setattr(resolve_op, "get_api_key", lambda: "fake-key")
+
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_article_id("my-article-3j3e")
+    assert "could not resolve" in capsys.readouterr().err
+
+
+def test_resolve_bare_slug_short_suffix_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    """Suffix of 3 chars or fewer doesn't match the pattern → falls through to unparseable error."""
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_article_id("my-article-abc")  # 3-char suffix → no match
+    assert "cannot parse article identifier" in capsys.readouterr().err
+
+
+def test_resolve_bare_slug_min_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """4-char suffix is the minimum accepted (boundary)."""
+    monkeypatch.setattr(resolve_op, "request", lambda *a, **kw: [{"id": 1}])
+    monkeypatch.setattr(resolve_op, "get_api_key", lambda: "fake-key")
+    assert resolve_op.resolve_article_id("post-abcd") == 1
+
+
+def test_resolve_bare_slug_max_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """6-char suffix is the maximum accepted (boundary)."""
+    monkeypatch.setattr(resolve_op, "request", lambda *a, **kw: [{"id": 2}])
+    monkeypatch.setattr(resolve_op, "get_api_key", lambda: "fake-key")
+    assert resolve_op.resolve_article_id("post-abcdef") == 2
+
+
+def test_resolve_bare_slug_seven_char_suffix_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    """7-char suffix exceeds the pattern → falls through to unparseable error."""
+    with pytest.raises(SystemExit):
+        resolve_op.resolve_article_id("post-abcdefg")
+    assert "cannot parse article identifier" in capsys.readouterr().err
 
 
 def test_resolve_api_returns_no_id_exits(monkeypatch: pytest.MonkeyPatch,
@@ -722,24 +899,26 @@ def test_resolve_api_returns_no_id_exits(monkeypatch: pytest.MonkeyPatch,
 
 def test_react_parse_args_accepts_slug() -> None:
     """parse_args returns the raw identifier untouched — main() resolves it."""
-    raw, cat = react.parse_args("alice/some-slug")
-    assert raw == "alice/some-slug" and cat == "like"
+    raw, cat, idempotent = react.parse_args("alice/some-slug")
+    assert raw == "alice/some-slug" and cat == "like" and idempotent is True
 
 
 def test_react_parse_args_accepts_url() -> None:
-    raw, cat = react.parse_args("https://dev.to/alice/some-slug|unicorn")
-    assert raw == "https://dev.to/alice/some-slug" and cat == "unicorn"
+    raw, cat, idempotent = react.parse_args("https://dev.to/alice/some-slug|unicorn")
+    assert raw == "https://dev.to/alice/some-slug" and cat == "unicorn" and idempotent is True
 
 
 def test_comment_parse_args_accepts_slug() -> None:
     """Comment parse keeps the raw identifier; resolution happens in main()."""
-    raw, msg, parent = comment_op.parse_args("alice/some-slug|hello")
+    raw, msg, parent, force = comment_op.parse_args("alice/some-slug|hello")
     assert raw == "alice/some-slug" and msg == "hello" and parent is None
+    assert force is False
 
 
 def test_comment_parse_args_accepts_url() -> None:
-    raw, msg, parent = comment_op.parse_args(
+    raw, msg, parent, force = comment_op.parse_args(
         "https://dev.to/alice/some-slug|hi|99"
     )
     assert raw == "https://dev.to/alice/some-slug"
     assert msg == "hi" and parent == "99"
+    assert force is False

--- a/tests/test_hashnode.py
+++ b/tests/test_hashnode.py
@@ -917,10 +917,13 @@ def test_publish_parse_args_no_force(tmp_path: Path) -> None:
 
 def test_publish_preflight_dupe_found(monkeypatch: pytest.MonkeyPatch) -> None:
     # preflight_publish calls gql_safe (not gql) — monkeypatch the right name.
+    # Shape: me.publications.edges[].node.posts.edges (updated PREFLIGHT query).
     monkeypatch.setattr(publish_op, "gql_safe", lambda q, v, t: {
-        "me": {"posts": {"edges": [
-            {"node": {"id": "p1", "slug": "my-slug", "url": "https://x.io/my-slug",
-                      "canonicalUrl": "https://x.io"}},
+        "me": {"publications": {"edges": [
+            {"node": {"posts": {"edges": [
+                {"node": {"id": "p1", "slug": "my-slug", "url": "https://x.io/my-slug",
+                          "canonicalUrl": "https://x.io"}},
+            ]}}},
         ]}}
     })
     already, url, slug = publish_op.preflight_publish("https://x.io", "tok")
@@ -930,9 +933,11 @@ def test_publish_preflight_dupe_found(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_publish_preflight_no_dupe(monkeypatch: pytest.MonkeyPatch) -> None:
     # preflight_publish calls gql_safe (not gql) — monkeypatch the right name.
     monkeypatch.setattr(publish_op, "gql_safe", lambda q, v, t: {
-        "me": {"posts": {"edges": [
-            {"node": {"id": "p1", "slug": "other", "url": "https://other.io",
-                      "canonicalUrl": "https://other.io"}},
+        "me": {"publications": {"edges": [
+            {"node": {"posts": {"edges": [
+                {"node": {"id": "p1", "slug": "other", "url": "https://other.io",
+                          "canonicalUrl": "https://other.io"}},
+            ]}}},
         ]}}
     })
     already, url, slug = publish_op.preflight_publish("https://x.io", "tok")
@@ -952,10 +957,12 @@ def test_publish_main_aborts_on_dupe(monkeypatch: pytest.MonkeyPatch,
     md = tmp_path / "p.md"
     md.write_text("body")
     monkeypatch.setattr(publish_op, "get_token", lambda: "tok")
-    monkeypatch.setattr(publish_op, "gql", lambda q, v, t: {
-        "me": {"posts": {"edges": [
-            {"node": {"id": "p1", "slug": "my-slug", "url": "https://x.io",
-                      "canonicalUrl": "https://x.io"}},
+    monkeypatch.setattr(publish_op, "gql_safe", lambda q, v, t: {
+        "me": {"publications": {"edges": [
+            {"node": {"posts": {"edges": [
+                {"node": {"id": "p1", "slug": "my-slug", "url": "https://x.io",
+                          "canonicalUrl": "https://x.io"}},
+            ]}}},
         ]}}
     })
     with pytest.raises(SystemExit) as exc:

--- a/tests/test_hashnode.py
+++ b/tests/test_hashnode.py
@@ -322,8 +322,8 @@ def test_comments_render_marks_you() -> None:
 # comment ------------------------------------------------------------------
 
 def test_comment_parse_args_ok() -> None:
-    post, msg = comment_op.parse_args("abc123|Hello world")
-    assert post == "abc123" and msg == "Hello world"
+    post, msg, force = comment_op.parse_args("abc123|Hello world")
+    assert post == "abc123" and msg == "Hello world" and force is False
 
 
 def test_comment_parse_args_missing_msg(capsys: pytest.CaptureFixture[str]) -> None:
@@ -353,9 +353,10 @@ def test_reply_parse_args_missing_msg(capsys: pytest.CaptureFixture[str]) -> Non
 
 def test_comment_parse_args_keeps_colons() -> None:
     """Body with ':' must survive when arg comes from main()'s ':'-rejoin of argv."""
-    post, msg = comment_op.parse_args("abc123|Worth saying: it's learnable. Really: it is.")
+    post, msg, force = comment_op.parse_args("abc123|Worth saying: it's learnable. Really: it is.")
     assert post == "abc123"
     assert msg == "Worth saying: it's learnable. Really: it is."
+    assert force is False
 
 
 def test_reply_parse_args_keeps_colons() -> None:
@@ -387,18 +388,18 @@ def _run_hn_dryrun(script: str, *argv_parts: str) -> tuple[str, str]:
 
 
 def test_argv_rejoin_hn_comment_simple() -> None:
-    post, msg = _run_hn_dryrun("comment", "abc|hi")
-    assert post == "abc" and msg == "hi"
+    post, msg, force = _run_hn_dryrun("comment", "abc|hi")
+    assert post == "abc" and msg == "hi" and force is False
 
 
 def test_argv_rejoin_hn_comment_with_colons() -> None:
-    post, msg = _run_hn_dryrun("comment", "abc|Worth saying", "it's learnable")
-    assert post == "abc" and msg == "Worth saying:it's learnable"
+    post, msg, force = _run_hn_dryrun("comment", "abc|Worth saying", "it's learnable")
+    assert post == "abc" and msg == "Worth saying:it's learnable" and force is False
 
 
 def test_argv_rejoin_hn_comment_multiple_colons() -> None:
-    post, msg = _run_hn_dryrun("comment", "abc|first", "second", "third")
-    assert post == "abc" and msg == "first:second:third"
+    post, msg, force = _run_hn_dryrun("comment", "abc|first", "second", "third")
+    assert post == "abc" and msg == "first:second:third" and force is False
 
 
 def test_argv_rejoin_hn_reply_simple() -> None:
@@ -745,3 +746,235 @@ def test_resolve_malformed_url_exits(capsys: pytest.CaptureFixture[str]) -> None
     with pytest.raises(SystemExit):
         resolve_op.resolve_post_id("tok", "https://")
     assert "cannot parse" in capsys.readouterr().err
+
+
+# pre-flight: react --------------------------------------------------------
+
+def test_react_parse_args_no_force() -> None:
+    raw, force = react_op.parse_args("abc123")
+    assert raw == "abc123" and force is False
+
+
+def test_react_parse_args_force_flag() -> None:
+    raw, force = react_op.parse_args("abc123|force")
+    assert raw == "abc123" and force is True
+
+
+def test_react_parse_args_empty_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        react_op.parse_args("")
+    assert "ERROR" in capsys.readouterr().err
+
+
+def test_react_preflight_already_reacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    # preflight_react always returns (None, 0) — Hashnode exposes no per-user
+    # reaction field, so react.py is fail-closed: caller must use |force.
+    already, count = react_op.preflight_react("post-id", "tok")
+    assert already is None and count == 0
+
+
+def test_react_preflight_not_reacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same: preflight always returns (None, 0) regardless of API state.
+    already, count = react_op.preflight_react("post-id", "tok")
+    assert already is None and count == 0
+
+
+def test_react_preflight_api_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    # preflight_react never calls gql; always returns (None, 0).
+    already, count = react_op.preflight_react("post-id", "tok")
+    assert already is None and count == 0
+
+
+def test_react_main_aborts_on_dupe(monkeypatch: pytest.MonkeyPatch,
+                                    capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(react_op, "get_token", lambda: "tok")
+    monkeypatch.setattr(react_op, "resolve_post_id", lambda t, r: "post-id")
+    monkeypatch.setattr(react_op, "gql",
+                        lambda q, v, t: {"post": {"myTotalReactions": 1}})
+    with pytest.raises(SystemExit) as exc:
+        react_op.main("abc123")
+    assert exc.value.code == 1
+    assert "ABORT" in capsys.readouterr().err
+
+
+def test_react_main_force_bypasses_preflight(monkeypatch: pytest.MonkeyPatch,
+                                              capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(react_op, "get_token", lambda: "tok")
+    monkeypatch.setattr(react_op, "resolve_post_id", lambda t, r: "post-id")
+    monkeypatch.setattr(react_op, "gql", lambda q, v, t: (
+        calls.append("like") or {"likePost": {"post": {"id": "post-id", "reactionCount": 1}}}
+    ))
+    react_op.main("abc123|force")
+    assert "liked" in capsys.readouterr().out
+    assert len(calls) == 1  # only the like mutation, no preflight query
+
+
+def test_react_main_api_error_degrades(monkeypatch: pytest.MonkeyPatch,
+                                        capsys: pytest.CaptureFixture[str]) -> None:
+    # preflight always returns (None, 0) → main aborts unless |force is passed.
+    # Use |force to exercise the mutation path directly.
+    monkeypatch.setattr(react_op, "get_token", lambda: "tok")
+    monkeypatch.setattr(react_op, "resolve_post_id", lambda t, r: "post-id")
+    monkeypatch.setattr(react_op, "gql",
+                        lambda q, v, t: {"likePost": {"post": {"id": "post-id", "reactionCount": 1}}})
+    react_op.main("abc123|force")
+    out = capsys.readouterr()
+    assert "liked" in out.out
+
+
+# pre-flight: comment -------------------------------------------------------
+
+def test_comment_parse_args_force() -> None:
+    post, msg, force = comment_op.parse_args("abc|Hello|force")
+    assert post == "abc" and msg == "Hello" and force is True
+
+
+def test_comment_parse_args_no_force() -> None:
+    post, msg, force = comment_op.parse_args("abc|Hello")
+    assert force is False
+
+
+def test_comment_preflight_already_commented(monkeypatch: pytest.MonkeyPatch) -> None:
+    # preflight_comment calls gql_safe (not gql) — monkeypatch the right name.
+    monkeypatch.setattr(comment_op, "gql_safe", lambda q, v, t: {
+        "post": {"comments": {"edges": [
+            {"node": {"id": "c1", "author": {"username": "max-ai-dev"},
+                      "dateAdded": "2026-05-01T00:00:00Z"}},
+        ]}}
+    })
+    already, ids, last = comment_op.preflight_comment("post-id", "max-ai-dev", "tok")
+    assert already is True and "c1" in ids and last == "2026-05-01"
+
+
+def test_comment_preflight_not_commented(monkeypatch: pytest.MonkeyPatch) -> None:
+    # preflight_comment calls gql_safe (not gql) — monkeypatch the right name.
+    monkeypatch.setattr(comment_op, "gql_safe", lambda q, v, t: {
+        "post": {"comments": {"edges": [
+            {"node": {"id": "c1", "author": {"username": "alice"},
+                      "dateAdded": "2026-05-01T00:00:00Z"}},
+        ]}}
+    })
+    already, ids, last = comment_op.preflight_comment("post-id", "max-ai-dev", "tok")
+    assert already is False and ids == []
+
+
+def test_comment_preflight_api_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    # gql_safe returns None on error → preflight returns (None, [], '') → fail-closed.
+    monkeypatch.setattr(comment_op, "gql_safe", lambda q, v, t: None)
+    already, ids, last = comment_op.preflight_comment("post-id", "max-ai-dev", "tok")
+    assert already is None
+
+
+def test_comment_main_aborts_on_dupe(monkeypatch: pytest.MonkeyPatch,
+                                      capsys: pytest.CaptureFixture[str]) -> None:
+    import sys as _sys
+    monkeypatch.setattr(comment_op, "get_token", lambda: "tok")
+    monkeypatch.setattr(comment_op, "resolve_post_id", lambda t, r: "post-id")
+    import types
+    fake_me = types.ModuleType("_me")
+    fake_me.get_username = lambda token: "max-ai-dev"
+    monkeypatch.setitem(_sys.modules, "_me", fake_me)
+    monkeypatch.setattr(comment_op, "gql", lambda q, v, t: {
+        "post": {"comments": {"edges": [
+            {"node": {"id": "c1", "author": {"username": "max-ai-dev"},
+                      "dateAdded": "2026-05-01T00:00:00Z"}},
+        ]}}
+    })
+    with pytest.raises(SystemExit) as exc:
+        comment_op.main("abc|Hello")
+    assert exc.value.code == 1
+    assert "ABORT" in capsys.readouterr().err
+
+
+def test_comment_main_force_bypasses_preflight(monkeypatch: pytest.MonkeyPatch,
+                                                capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(comment_op, "get_token", lambda: "tok")
+    monkeypatch.setattr(comment_op, "resolve_post_id", lambda t, r: "post-id")
+    monkeypatch.setattr(comment_op, "gql",
+                        lambda q, v, t: {"addComment": {"comment": {"id": "new-c",
+                                                                      "dateAdded": "2026-05-01T00:00:00Z"}}})
+    monkeypatch.setattr(comment_op, "track_append", lambda x: None)
+    comment_op.main("abc|Hello|force")
+    assert "comment posted" in capsys.readouterr().out
+
+
+# pre-flight: publish -------------------------------------------------------
+
+def test_publish_parse_args_force(tmp_path: Path) -> None:
+    md = tmp_path / "p.md"
+    md.write_text("body")
+    parsed = publish_op.parse_args(f"T|{md}|https://x.io|||force")
+    assert parsed["force"] is True
+
+
+def test_publish_parse_args_no_force(tmp_path: Path) -> None:
+    md = tmp_path / "p.md"
+    md.write_text("body")
+    parsed = publish_op.parse_args(f"T|{md}|https://x.io")
+    assert parsed["force"] is False
+
+
+def test_publish_preflight_dupe_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    # preflight_publish calls gql_safe (not gql) — monkeypatch the right name.
+    monkeypatch.setattr(publish_op, "gql_safe", lambda q, v, t: {
+        "me": {"posts": {"edges": [
+            {"node": {"id": "p1", "slug": "my-slug", "url": "https://x.io/my-slug",
+                      "canonicalUrl": "https://x.io"}},
+        ]}}
+    })
+    already, url, slug = publish_op.preflight_publish("https://x.io", "tok")
+    assert already is True and slug == "my-slug"
+
+
+def test_publish_preflight_no_dupe(monkeypatch: pytest.MonkeyPatch) -> None:
+    # preflight_publish calls gql_safe (not gql) — monkeypatch the right name.
+    monkeypatch.setattr(publish_op, "gql_safe", lambda q, v, t: {
+        "me": {"posts": {"edges": [
+            {"node": {"id": "p1", "slug": "other", "url": "https://other.io",
+                      "canonicalUrl": "https://other.io"}},
+        ]}}
+    })
+    already, url, slug = publish_op.preflight_publish("https://x.io", "tok")
+    assert already is False
+
+
+def test_publish_preflight_api_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    # gql_safe returns None on error → preflight returns (None, '', '') → fail-closed.
+    monkeypatch.setattr(publish_op, "gql_safe", lambda q, v, t: None)
+    already, url, slug = publish_op.preflight_publish("https://x.io", "tok")
+    assert already is None
+
+
+def test_publish_main_aborts_on_dupe(monkeypatch: pytest.MonkeyPatch,
+                                      capsys: pytest.CaptureFixture[str],
+                                      tmp_path: Path) -> None:
+    md = tmp_path / "p.md"
+    md.write_text("body")
+    monkeypatch.setattr(publish_op, "get_token", lambda: "tok")
+    monkeypatch.setattr(publish_op, "gql", lambda q, v, t: {
+        "me": {"posts": {"edges": [
+            {"node": {"id": "p1", "slug": "my-slug", "url": "https://x.io",
+                      "canonicalUrl": "https://x.io"}},
+        ]}}
+    })
+    with pytest.raises(SystemExit) as exc:
+        publish_op.main(f"T|{md}|https://x.io")
+    assert exc.value.code == 1
+    assert "ABORT" in capsys.readouterr().err
+
+
+def test_publish_main_force_bypasses_preflight(monkeypatch: pytest.MonkeyPatch,
+                                                capsys: pytest.CaptureFixture[str],
+                                                tmp_path: Path) -> None:
+    md = tmp_path / "p.md"
+    md.write_text("body")
+    monkeypatch.setattr(publish_op, "get_token", lambda: "tok")
+    monkeypatch.setattr(publish_op, "get_publication_id", lambda: "pub-id")
+    monkeypatch.setattr(publish_op, "gql",
+                        lambda q, v, t: {"publishPost": {"post": {
+                            "id": "new-p", "slug": "new-slug",
+                            "url": "https://x.io/new-slug", "title": "T",
+                        }}})
+    publish_op.main(f"T|{md}|https://x.io|||force")
+    assert "published" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Real incident 2026-05-03: `devto_comment` posted a duplicate comment (ids 37e3e + 37edf) on marcosomma's article. The platform itself already detected it — `devto_read` output included `"YOU: already commented 2× ..."` — but the write op never consulted the platform before posting.

This PR adds pre-flight checks before every mutation across all 3 platform presets, with `:force`/`|force` to bypass.

## Changes

**hashnode** — fail-closed where the schema can't verify (no per-user reaction field on `Post`, so `myTotalReactions` doesn't exist). New `gql_safe()` returns `None` on error so preflights degrade without `sys.exit`.

- `react`: always fail-closed (schema limit, `likePost` is additive — silent dupes would spam reactions)
- `comment`: GraphQL post comments paginated, filter `author.username == me`
- `publish`: `me { posts(first:50) { canonicalUrl } }` match — falls back to fail-closed when query shape doesn't resolve

**devto**
- `react`: idempotent by default (POST + auto-correct `destroy` → re-POST); `:toggle` modifier for old behavior
- `comment`: GET `/comments?a_id=N`, scan for own user_id (reuses `_me.get_username`)
- `publish`: GET `/articles/me`, match canonical_url
- `_resolve`: bare slug-with-id suffix now accepted (e.g. `the-real-token-...-3j3e`) via `/articles?slug=` lookup

**bluesky**
- `like`: `getActorLikes` for own DID, scan for matching URI
- `follow`: `getFollows` for own DID, scan for target DID
- `publish` (reply only): scan author feed for reply to same root

## Live test results (9 ops on already-done targets from this morning)

| Op | Result |
|---|---|
| devto_comment | ABORT — names existing ids + date |
| bluesky_publish (reply) | ABORT — same root |
| bluesky_like | ABORT — URI matched |
| bluesky_follow | ABORT — already following |
| hashnode_react | ABORT fail-closed (schema limit) |
| devto_react | auto-correct, ends in liked state |
| hashnode_comment | ABORT — names existing comment id |
| hashnode_publish | ABORT fail-closed (lookup query needs schema fix — separate bug, fail-closed catches it) |
| devto_publish | ABORT — names existing slug + URL |

All paths safe: no duplicate fires without explicit `|force`.

## Test plan

- [x] `pytest tests/ -q` — 811 passed, 0 failed, 94% coverage
- [x] Live test all 9 mutation ops against already-done targets
- [x] `:force` / `|force` modifier verified on each op
- [ ] Reviewer: confirm Hashnode publish preflight schema query (`me { posts { canonicalUrl } }`) — currently fail-closes on lookup error; happy-path detection unverified because the test target's lookup itself failed

## Known limitations

- Hashnode reactions cannot be verified (no per-user field exposed by Hashnode GraphQL); `react` always fail-closes unless `|force`
- Hashnode publish preflight query may need schema adjustment — falls back to fail-closed which is safe but blocks all publishes pending fix or `|force`
- Idempotency is best-effort, not atomic (TOCTOU window between check and mutation) — cosmetic risk for social actions, not a real concern