### PR TITLE
feat: parallel exec, edit/replace_lines, ::: dispatch, raw job mode

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -1,15 +1,17 @@
 {
   "compact": false,
   "rtk": false,
+  "parallel": 0,
   "introduction": "supertool batches multiple file operations into one Bash call.\n\nInvoke via Bash:\n./supertool \\\n    'read:src/app/Module.py' \\\n    'read:src/app/Config.py' \\\n    'grep:class:src/app/:20' \\\n    'glob:src/app/**/*.py'\n\nRules:\n- One call, many ops. 6-7 per call is normal. Each separate call wastes money.\n- Paths are relative to project root.\n- Single quotes around each op.\n- Use Read tool ONLY for the file you're about to Edit — supertool for everything else.",
   "output-format": "Each operation returns a header followed by its output:\n\n```\n--- read:src/app/Module.py ---\n(45 lines, 1230 bytes)\n     1→import os\n     2→import sys\n     3→\n     4→class Module:\n\n--- grep:class:src/app/:5 ---\n(2 results, limit 5)\nsrc/app/Module.py\n  4:class Module:\nsrc/app/Config.py\n  8:class Config:\n\n--- glob:src/app/**/*.py ---\n(3 files)\nsrc/app/Module.py\nsrc/app/Config.py\nsrc/app/Utils.py\n```",
   "builtin-ops": {
     "read": {
-      "syntax": "read:PATH[:OFFSET:LIMIT]",
-      "description": "Read file (300 lines, 20KB cap)",
-      "example": "read:src/app/Module.py:10:50",
+      "syntax": "read:PATH[:OFFSET:LIMIT|:full]",
+      "description": "Read file (300 lines, 20KB cap). Set php_abstract:1 to return tree-sitter symbol maps for PHP files larger than max_bytes — saves tokens on big classes. Use :full to force raw. Threshold override: SUPERTOOL_READ_ABSTRACT_THRESHOLD_BYTES=N",
+      "example": "read:src/app/Module.py:full",
       "max_lines": 300,
-      "max_bytes": 20000
+      "max_bytes": 20000,
+      "php_abstract": 0
     },
     "read-grep": {
       "syntax": "read:PATH:::grep=PATTERN",
@@ -103,6 +105,16 @@
       "syntax": "blame:PATH:LINE[:N]",
       "description": "Git blame N lines around LINE (def 5)",
       "example": "blame:src/app/Module.py:42:3"
+    },
+    "edit": {
+      "syntax": "edit:::OLD:::NEW:::PATH",
+      "description": "Single-file edit, OLD must match exactly once. Bypasses native Edit must-Read state — saves a round-trip. Use ::: separator so content with ':' works (single ':' also accepted when content has no colons).",
+      "example": "edit:::return false;:::return true;:::src/app/Foo.py"
+    },
+    "replace_lines": {
+      "syntax": "replace_lines:::PATH:::START:::END:::CONTENT",
+      "description": "Swap lines [START,END] (1-indexed inclusive) with CONTENT. END<START = insert before START. Empty CONTENT = delete.",
+      "example": "replace_lines:::src/app/Foo.py:::42:::45:::    return x"
     }
   },
   "ops": {

--- a/.supertool.json
+++ b/.supertool.json
@@ -99,16 +99,30 @@
       "example": "tree:tests/:2"
     },
     "replace_dry": {
-      "syntax": "replace_dry:OLD:NEW:PATH",
-      "description": "Preview replace. -old/+new per match",
-      "example": "replace_dry:TYPE_CUSTOMER:TYPE_ENUM_CUSTOMER:src/",
+      "syntax": "replace_dry:::OLD:::NEW:::PATH",
+      "description": "Preview replace. -old/+new per match. Use ::: when content has ':'",
+      "example": "replace_dry:::TYPE_CUSTOMER:::TYPE_ENUM_CUSTOMER:::src/",
       "status": 1,
       "hint": true
     },
     "replace": {
-      "syntax": "replace:OLD:NEW:PATH",
-      "description": "Replace OLD→NEW in PATH. Returns receipt",
-      "example": "replace:TYPE_CUSTOMER:TYPE_ENUM_CUSTOMER:src/",
+      "syntax": "replace:::OLD:::NEW:::PATH",
+      "description": "Replace OLD→NEW in PATH. Returns receipt. Use ::: when content has ':'",
+      "example": "replace:::TYPE_CUSTOMER:::TYPE_ENUM_CUSTOMER:::src/",
+      "status": 1,
+      "hint": true
+    },
+    "edit": {
+      "syntax": "edit:::OLD:::NEW:::PATH",
+      "description": "Single-file, single-occurrence edit (mirrors native Edit). Errors if 0 or >1 matches. Bypasses Edit's must-Read-first state — saves a round-trip. Use ::: separator (single ':' also accepted when content has no colons)",
+      "example": "edit:::return False:::return True:::supertool.py",
+      "status": 1,
+      "hint": true
+    },
+    "replace_lines": {
+      "syntax": "replace_lines:::PATH:::START:::END:::CONTENT",
+      "description": "Swap lines [START,END] (1-indexed inclusive) with CONTENT. END<START = insert before START. Empty CONTENT = delete. Receipt shows new line numbers",
+      "example": "replace_lines:::supertool.py:::42:::45:::    return x",
       "status": 1,
       "hint": true
     }

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ claude -p "..." --permission-mode bypassPermissions \
 | `tree` | `tree:PATH` or `tree:PATH:DEPTH` | Directory structure with depth limit (default 3). Hides dotfiles. Files listed before subdirectories. |
 | `blame` | `blame:PATH:LINE` or `blame:PATH:LINE:N` | Git blame for N lines (default 5) around a specific line number. Requires git repo. |
 | `version` | `version` | Show supertool version. |
+| `edit` | `edit:::OLD:::NEW:::PATH` | Single-file, single-occurrence edit (mirrors native Edit). Errors if 0 or >1 matches. **Bypasses native Edit must-Read state** — saves a round-trip when you already know the unique snippet. Use `:::` separator so content with `:` works. |
+| `replace_lines` | `replace_lines:::PATH:::START:::END:::CONTENT` | Swap lines `[START, END]` (1-indexed, inclusive) with CONTENT. `END < START` = pure insert before line START. Empty CONTENT = delete. Receipt shows new line numbers + ±2 context. |
+| `replace` / `replace_dry` | `replace:::OLD:::NEW:::PATH` | Recursive find/replace across PATH (`replace_dry` = preview). Use `:::` separator when content has `:`. |
 
 **LLM onboarding in one call:** `./supertool 'introduction' 'output-format' 'ops'` — outputs everything an LLM needs to use supertool.
 
@@ -466,6 +469,26 @@ Without either, regex fallback works for all supported languages — just no nes
 Set `"compact": true` in `.supertool.json` to enable compact reads. When enabled, `read` ops skip blank lines and comment-only lines (`//`, `#`, `/* */`, `<!-- -->`, PHPDoc `*` lines), preserving original line numbers. Reduces token cost for exploration without losing structure.
 
 Compact is disabled when using `grep=` filter or `offset` (editing needs exact lines).
+
+### Parallel execution
+
+Read-only ops in a batch can run concurrently. Output order is preserved (matches input order, not completion order).
+
+Enable in `.supertool.json`:
+
+```json
+{ "parallel": 4 }
+```
+
+`parallel: N` runs up to N ops concurrently via a thread pool. `0` (default) = sequential. Boolean `true` is accepted as `4` for back-compat.
+
+Override via env: `SUPERTOOL_PARALLEL=4 ./supertool 'read:a' 'grep:x:b/' 'glob:c/**'`. Env wins over JSON. Set `0` to force off for one call.
+
+**Safe ops** (parallelized): `read`, `grep`, `glob`, `ls`, `head`, `tail`, `wc`, `stat`, `map`, `tree`, `around`, `around_line`, `between`, `diff`, `blame`, `version`.
+
+**Unsafe** — batch falls back to sequential whenever any op is mutating (`edit`, `replace`, `replace_dry`, `replace_lines`) or custom (anything in `ops:` — could shell out to anything). All-or-nothing per call: no partial parallelism.
+
+Speedup: I/O-bound ops on different files. ~3-5× faster on cold filesystem; modest gain on warm cache.
 
 ### Excluding paths from traversal ops
 

--- a/presets/github.json
+++ b/presets/github.json
@@ -21,10 +21,10 @@
       "syntax": "gh-run:NUMBER"
     },
     "gh-job": {
-      "cmd": "python3 {path}github/job.py {arg}",
+      "cmd": "python3 {path}github/job.py {args}",
       "timeout": 30,
-      "description": "Why did this job fail? PR context + error pattern search + log tail — the actual error, not setup noise.",
-      "syntax": "gh-job:NUMBER",
+      "description": "Why did this job fail? PR context + error pattern search + log tail. :raw dumps full trace; :raw:START[:END] slices lines (1-indexed, inclusive)",
+      "syntax": "gh-job:NUMBER[:raw[:START[:END]]]",
       "lines": 80,
       "error_patterns": "ERROR,FAILED,Error:,Failed,fatal:,##[error]",
       "error_context": 5

--- a/presets/github/job.py
+++ b/presets/github/job.py
@@ -72,10 +72,22 @@ def _find_error_sections(lines: list[str], patterns: list[str], context: int) ->
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("ERROR: usage: job.py JOB_ID")
+        print("ERROR: usage: job.py JOB_ID [raw [START [END]]]")
         return 1
 
     job_id = sys.argv[1]
+    raw_mode = len(sys.argv) > 2 and sys.argv[2] == "raw"
+    raw_start: int | None = None
+    raw_end: int | None = None
+    if raw_mode:
+        try:
+            if len(sys.argv) > 3 and sys.argv[3]:
+                raw_start = max(1, int(sys.argv[3]))
+            if len(sys.argv) > 4 and sys.argv[4]:
+                raw_end = int(sys.argv[4])
+        except ValueError:
+            print("ERROR: raw START/END must be integers")
+            return 1
     config = _get_config()
     tail_lines = config["lines"]
 
@@ -177,7 +189,21 @@ def main() -> int:
 
     print(f"Log: {total} lines total")
 
-    # 3. Error pattern search
+    # 3. Raw mode — dump (sliced) trace, skip filters
+    if raw_mode:
+        start = raw_start if raw_start is not None else 1
+        end = raw_end if raw_end is not None else total
+        end = min(end, total)
+        if start > total:
+            print(f"\n## Raw — start ({start}) > total ({total}); nothing to show")
+            return 0
+        shown = lines[start - 1:end]
+        print(f"\n## Raw lines {start}-{start + len(shown) - 1} of {total}")
+        for i, line in enumerate(shown):
+            print(f"  {start + i:>5} | {line}")
+        return 0
+
+    # 4. Error pattern search
     error_sections = _find_error_sections(
         lines, config["error_patterns"], config["error_context"]
     )

--- a/presets/gitlab.json
+++ b/presets/gitlab.json
@@ -21,12 +21,12 @@
       "syntax": "gl-pipeline:NUMBER"
     },
     "gl-job": {
-      "cmd": "python3 {path}gitlab/job.py {arg}",
+      "cmd": "python3 {path}gitlab/job.py {args}",
       "timeout": 30,
-      "description": "Why job failed: MR ctx + error patterns + log tail",
-      "syntax": "gl-job:NUMBER",
+      "description": "Why job failed: MR ctx + error patterns + log tail. :raw dumps full trace; :raw:START[:END] slices lines (1-indexed, inclusive)",
+      "syntax": "gl-job:NUMBER[:raw[:START[:END]]]",
       "lines": 80,
-      "error_patterns": "ERROR,FAILURES!,Fatal,Failed asserting",
+      "error_patterns": "ERROR,FAILURES!,Fatal,Failed asserting,PHP Warning,PHP Notice,PHP Deprecated",
       "error_context": 5
     }
   }

--- a/presets/gitlab/job.py
+++ b/presets/gitlab/job.py
@@ -74,10 +74,22 @@ def _find_error_sections(lines: list[str], patterns: list[str], context: int) ->
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("ERROR: usage: job.py JOB_ID")
+        print("ERROR: usage: job.py JOB_ID [raw [START [END]]]")
         return 1
 
     job_id = sys.argv[1]
+    raw_mode = len(sys.argv) > 2 and sys.argv[2] == "raw"
+    raw_start: int | None = None
+    raw_end: int | None = None
+    if raw_mode:
+        try:
+            if len(sys.argv) > 3 and sys.argv[3]:
+                raw_start = max(1, int(sys.argv[3]))
+            if len(sys.argv) > 4 and sys.argv[4]:
+                raw_end = int(sys.argv[4])
+        except ValueError:
+            print("ERROR: raw START/END must be integers")
+            return 1
     config = _get_config()
     tail_lines = config["lines"]
 
@@ -189,7 +201,21 @@ def main() -> int:
         print(f"URL: {web_url}")
     print(f"Log: {total} lines total")
 
-    # 3. Try error pattern search first
+    # 3. Raw mode — dump (sliced) trace, skip filters
+    if raw_mode:
+        start = raw_start if raw_start is not None else 1
+        end = raw_end if raw_end is not None else total
+        end = min(end, total)
+        if start > total:
+            print(f"\n## Raw — start ({start}) > total ({total}); nothing to show")
+            return 0
+        shown = lines[start - 1:end]
+        print(f"\n## Raw lines {start}-{start + len(shown) - 1} of {total}")
+        for i, line in enumerate(shown):
+            print(f"  {start + i:>5} | {line}")
+        return 0
+
+    # 4. Try error pattern search first
     error_sections = _find_error_sections(
         lines, config["error_patterns"], config["error_context"]
     )

--- a/supertool.py
+++ b/supertool.py
@@ -582,6 +582,14 @@ def render_file(path: str, offset: int = 0, limit: int = 0,
 
 def op_read(path: str, offset: int = 0, limit: int = 0,
             grep_filter: str = "") -> str:
+    # PHP abstract mode — when enabled, read:PATH on a PHP file with no
+    # offset/limit/grep returns the symbol map (~10x smaller). Use
+    # read:PATH:0:N or read:PATH:OFFSET:LIMIT to bypass.
+    if (offset == 0 and limit == 0 and not grep_filter
+            and path.endswith(".php")
+            and _get_op_int("read", "php_abstract", 0)):
+        return (op_map(path)
+                + "\n[php abstract — use read:PATH:0:N or read:PATH:OFFSET:LIMIT for content]\n")
     if limit <= 0:
         limit = _get_op_int("read", "max_lines", MAX_READ_LINES)
     return render_file(path, offset, limit, grep_filter)
@@ -1240,7 +1248,7 @@ def _ts_extract(path: str, lang_name: str) -> List[Tuple[str, str, int, int]]:
         return []
 
     def_nodes = _TS_DEF_NODES.get(lang_name, _TS_DEF_NODES_DEFAULT)
-    symbols: List[Tuple[str, str, int, int]] = []
+    symbols: List[Tuple[str, str, int, int, int]] = []
 
     def _walk(node: Any, depth: int = 0) -> None:
         node_type = node.type
@@ -1248,7 +1256,8 @@ def _ts_extract(path: str, lang_name: str) -> List[Tuple[str, str, int, int]]:
             kind = def_nodes[node_type]
             name = _ts_node_name(node, lang_name)
             line = node.start_point[0] + 1  # 0-indexed → 1-indexed
-            symbols.append((kind, name, line, depth))
+            end_line = node.end_point[0] + 1
+            symbols.append((kind, name, line, end_line, depth))
             # Recurse into class/struct/impl bodies for methods
             for child in node.children:
                 _walk(child, depth + 1)
@@ -1474,13 +1483,13 @@ def _regex_extract(path: str) -> List[Tuple[str, str, int, int]]:
 
 
 def _format_map_symbols(
-    symbols: List[Tuple[str, str, int, int]], path: str, line_count: int
+    symbols: List[Tuple[str, str, int, int, int]], path: str, line_count: int
 ) -> str:
     """Format extracted symbols as an indented tree string."""
     out = [f"{path} ({line_count} lines)\n"]
-    for kind, name, line, depth in symbols:
+    for kind, name, line, end_line, depth in symbols:
         indent = "  " * (depth + 1)
-        out.append(f"{indent}{kind} {name}  [{line}]\n")
+        out.append(f"{indent}{kind} {name}  [{line}-{end_line}]\n")
     return "".join(out)
 
 
@@ -2240,7 +2249,7 @@ def dispatch(arg: str) -> str:
         if op == "read":
             path = parts[1] if len(parts) > 1 else ""
             offset = int(parts[2]) if len(parts) > 2 and parts[2] else 0
-            limit = int(parts[3]) if len(parts) > 3 and parts[3] else _get_op_int("read", "max_lines", MAX_READ_LINES)
+            limit = int(parts[3]) if len(parts) > 3 and parts[3] else 0
             grep_filter = ""
             if len(parts) > 4 and parts[4].startswith("grep="):
                 grep_filter = parts[4][5:]

--- a/supertool.py
+++ b/supertool.py
@@ -1443,12 +1443,12 @@ _REGEX_PATTERNS[".tsx"] = _REGEX_PATTERNS[".ts"]
 _REGEX_PATTERNS[".jsx"] = _REGEX_PATTERNS[".js"]
 
 
-def _regex_extract(path: str) -> List[Tuple[str, str, int, int]]:
+def _regex_extract(path: str) -> List[Tuple[str, str, int, int, int]]:
     """Extract symbols from a file using regex patterns.
 
-    Returns list of (kind, name, line, depth) tuples.
-    depth is always 0 (regex can't reliably detect nesting).
-    Python is the exception: indented `def` gets depth 1.
+    Returns list of (kind, name, line, end_line, depth) tuples.
+    Regex can't reliably detect span; end_line == line.
+    depth is always 0 except indented Python `def` → depth 1.
     """
     ext = os.path.splitext(path)[1].lower()
     patterns = _REGEX_PATTERNS.get(ext)
@@ -1461,7 +1461,7 @@ def _regex_extract(path: str) -> List[Tuple[str, str, int, int]]:
     except OSError:
         return []
 
-    symbols: List[Tuple[str, str, int, int]] = []
+    symbols: List[Tuple[str, str, int, int, int]] = []
     lines = content.split("\n")
 
     for kind, regex in patterns:
@@ -1475,7 +1475,7 @@ def _regex_extract(path: str) -> List[Tuple[str, str, int, int]]:
             else:
                 name = m.group(1)
                 depth = 0
-            symbols.append((kind, name, line_num, depth))
+            symbols.append((kind, name, line_num, line_num, depth))
 
     # Sort by line number
     symbols.sort(key=lambda s: s[2])

--- a/supertool.py
+++ b/supertool.py
@@ -241,8 +241,48 @@ def _is_compact() -> bool:
     return bool(_load_config().get("compact", False))
 
 
+def _parallel_workers() -> int:
+    """Max worker count for parallel batched ops. 0 = sequential.
+
+    Env `SUPERTOOL_PARALLEL` wins over JSON. Accepts:
+      int N      → up to N workers (0 disables)
+      true/false → 4 / 0 (back-compat with bool config)
+    Default: 0 (off).
+    """
+    env = os.environ.get("SUPERTOOL_PARALLEL")
+    raw: object = env if env is not None else _load_config().get("parallel", 0)
+    if isinstance(raw, bool):
+        return 4 if raw else 0
+    if isinstance(raw, int):
+        return max(0, raw)
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in ("true", "yes", "on"):
+            return 4
+        if s in ("false", "no", "off", ""):
+            return 0
+        try:
+            return max(0, int(s))
+        except ValueError:
+            return 0
+    return 0
+
+
 def _get_op_int(op_name: str, key: str, default: int) -> int:
-    """Read an integer setting from builtin-ops.<op_name>.<key>, with fallback."""
+    """Read an integer setting from builtin-ops.<op_name>.<key>, with fallback.
+
+    Env var SUPERTOOL_<OP>_<KEY> takes precedence over JSON config.
+    Example: SUPERTOOL_READ_ABSTRACT_THRESHOLD_BYTES=12000
+    """
+    env_key = f"SUPERTOOL_{op_name.upper()}_{key.upper()}"
+    env_val = os.environ.get(env_key)
+    if env_val:
+        try:
+            n = int(env_val)
+            if n > 0:
+                return n
+        except ValueError:
+            pass
     cfg = _load_config()
     op_cfg = cfg.get("builtin-ops", {}).get(op_name, {})
     val = op_cfg.get(key)
@@ -384,7 +424,28 @@ BLOCKED_TOOLS = {"Grep", "Glob", "LS"}
 BLOCKED_BASH_COMMANDS = {"cat", "find", "grep", "ls", "sed", "awk", "tail", "head"}
 
 # Built-in op names — custom ops/aliases with these names are ignored
-_BUILTIN_OPS = {"read", "grep", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry"}
+_BUILTIN_OPS = {"read", "grep", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines"}
+
+# Read-only built-in ops — safe to run in parallel across a batch.
+# Excludes mutating ops (replace, edit, replace_lines) and custom ops
+# (could shell out to anything). `between` is included — pure file read.
+_PARALLEL_SAFE_OPS = {
+    "read", "grep", "glob", "ls", "head", "tail", "wc", "stat",
+    "map", "tree", "around", "around_line", "between", "diff", "blame",
+    "version",
+}
+
+
+def _is_parallel_safe(arg: str) -> bool:
+    """Return True if the op name is in the read-only safe set.
+
+    Detects op name from `op:...` or `op:::...` prefix. Anything else —
+    custom ops, mutating ops, malformed args — is treated as unsafe.
+    """
+    m = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*)(:::|:|$)", arg)
+    if not m:
+        return False
+    return m.group(1) in _PARALLEL_SAFE_OPS
 
 
 # ---------------------------------------------------------------------------
@@ -581,15 +642,35 @@ def render_file(path: str, offset: int = 0, limit: int = 0,
 
 
 def op_read(path: str, offset: int = 0, limit: int = 0,
-            grep_filter: str = "") -> str:
+            grep_filter: str = "", force_full: bool = False) -> str:
     # PHP abstract mode — when enabled, read:PATH on a PHP file with no
-    # offset/limit/grep returns the symbol map (~10x smaller). Use
-    # read:PATH:0:N or read:PATH:OFFSET:LIMIT to bypass.
+    # offset/limit/grep returns the symbol map (~10x smaller). Skipped when:
+    #   - file size <= threshold (small files fit raw in the cap, abstract
+    #     buys nothing)
+    #   - caller passes :full / :raw (force_full)
+    #   - explicit offset/limit/grep
     if (offset == 0 and limit == 0 and not grep_filter
+            and not force_full
             and path.endswith(".php")
             and _get_op_int("read", "php_abstract", 0)):
-        return (op_map(path)
-                + "\n[php abstract — use read:PATH:0:N or read:PATH:OFFSET:LIMIT for content]\n")
+        threshold = _get_op_int("read", "abstract_threshold_bytes",
+                                _get_op_int("read", "max_bytes", MAX_READ_BYTES))
+        try:
+            size_bytes = os.path.getsize(path)
+        except OSError:
+            size_bytes = 0
+        if size_bytes > threshold:
+            line_count = 0
+            try:
+                with open(path, "rb") as f:
+                    for line_count, _ in enumerate(f, 1):
+                        pass
+            except OSError:
+                pass
+            return (op_map(path)
+                    + f"\n[php abstract — {line_count} lines, {size_bytes} bytes raw — "
+                      f"use read:{path}:full for content "
+                      f"or read:{path}:::grep=PATTERN to filter]\n")
     if limit <= 0:
         limit = _get_op_int("read", "max_lines", MAX_READ_LINES)
     return render_file(path, offset, limit, grep_filter)
@@ -2083,6 +2164,138 @@ def op_replace(old: str, new: str, path: str = ".", dry: bool = False) -> str:
         return "".join(out)
 
 
+def op_edit(old: str, new: str, path: str) -> str:
+    """Single-file, single-occurrence edit — mirrors native Edit semantics.
+
+    Errors on 0 or >1 matches. For replace_all, use the `replace` op.
+    Returns a receipt with ±2 lines of context around the change.
+    """
+    if not old:
+        return "ERROR: empty old string\n"
+    if old == new:
+        return "ERROR: old and new strings are identical\n"
+    if not path:
+        return "ERROR: empty path\n"
+    if not os.path.isfile(path):
+        return f"ERROR: file not found: {path}\n"
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except OSError as e:
+        return f"ERROR: failed to read {path}: {e}\n"
+
+    count = content.count(old)
+    if count == 0:
+        return f"ERROR: old string not found in {path}\n"
+    if count > 1:
+        return (
+            f"ERROR: old string found {count} times in {path} — ambiguous. "
+            f"Use a larger snippet to make it unique, or use replace for "
+            f"replace_all semantics.\n"
+        )
+
+    new_content = content.replace(old, new, 1)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(new_content)
+    except OSError as e:
+        return f"ERROR: failed to write {path}: {e}\n"
+
+    # Receipt — locate the change and show ±2 lines context
+    pre = content[: content.index(old)]
+    start_line = pre.count("\n") + 1
+    new_lines = new_content.splitlines()
+    new_block_line_count = new.count("\n") + 1
+    end_line = start_line + new_block_line_count - 1
+    ctx_start = max(1, start_line - 2)
+    ctx_end = min(len(new_lines), end_line + 2)
+
+    out = [f"edited {path} (line {start_line}"]
+    if end_line != start_line:
+        out.append(f"-{end_line}")
+    out.append(")\n")
+    for ln in range(ctx_start, ctx_end + 1):
+        marker = "→" if start_line <= ln <= end_line else " "
+        out.append(f"  {ln:>5} {marker} {new_lines[ln - 1]}\n")
+    return "".join(out)
+
+
+def op_replace_lines(path: str, start: int, end: int, content: str) -> str:
+    """Replace lines [start, end] (1-indexed, inclusive) with content.
+
+    Modes (all via the same op):
+      insert  — end < start (e.g. 42:41) inserts CONTENT before line `start`
+      replace — end >= start, swap range with CONTENT
+      delete  — empty CONTENT, removes lines in range
+
+    Returns receipt with new line numbers + ±2 context.
+    """
+    if not path:
+        return "ERROR: empty path\n"
+    if not os.path.isfile(path):
+        return f"ERROR: file not found: {path}\n"
+    if start < 1:
+        return f"ERROR: start ({start}) must be >= 1\n"
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            orig = f.read()
+    except OSError as e:
+        return f"ERROR: failed to read {path}: {e}\n"
+
+    orig_lines = orig.splitlines(keepends=True)
+    total = len(orig_lines)
+
+    if start > total + 1:
+        return f"ERROR: start ({start}) > file length ({total}) + 1\n"
+
+    insert_only = end < start
+    if not insert_only and end > total:
+        return f"ERROR: end ({end}) > file length ({total})\n"
+
+    new_block = content
+    if new_block and not new_block.endswith("\n"):
+        new_block += "\n"
+    new_block_lines = new_block.splitlines(keepends=True) if new_block else []
+
+    if insert_only:
+        before = orig_lines[: start - 1]
+        after = orig_lines[start - 1:]
+        removed = 0
+    else:
+        before = orig_lines[: start - 1]
+        after = orig_lines[end:]
+        removed = end - start + 1
+
+    new_lines = before + new_block_lines + after
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(new_lines)
+    except OSError as e:
+        return f"ERROR: failed to write {path}: {e}\n"
+
+    added = len(new_block_lines)
+    new_start = start
+    new_end = start + added - 1 if added > 0 else start - 1
+
+    if added == 0:
+        verb = f"deleted lines {start}-{end}"
+    elif insert_only:
+        verb = f"inserted {added} lines before line {start}"
+    else:
+        verb = f"replaced lines {start}-{end} with lines {new_start}-{new_end}"
+    out = [f"{verb} in {path} (Δ {added - removed:+d})\n"]
+
+    ctx_start = max(1, new_start - 2)
+    ctx_end = min(len(new_lines), max(new_end, new_start) + 2)
+    for ln in range(ctx_start, ctx_end + 1):
+        marker = "→" if added > 0 and new_start <= ln <= new_end else " "
+        text = new_lines[ln - 1].rstrip("\n")
+        out.append(f"  {ln:>5} {marker} {text}\n")
+    return "".join(out)
+
+
 def op_introduction() -> str:
     """Output the project-specific introduction text from .supertool.json."""
     config = _load_config()
@@ -2242,18 +2455,39 @@ def dispatch(arg: str) -> str:
         arg = arg[: -len(_NO_EXCLUDE_SUFFIX)]
 
     header = f"--- {arg}{_NO_EXCLUDE_SUFFIX if no_exclude else ''} ---\n"
-    parts = _split_arg(arg)
+
+    # `op:::FIELD:::FIELD:::...` — triple-colon mode for write ops with
+    # arbitrary `:` in content. Only triggers when the op name is followed
+    # immediately by `:::`. Existing `:::no-exclude` (suffix, stripped above)
+    # and `read:PATH:::grep=` (mid-arg) keep working under single-colon parsing.
+    import re as _re
+    triple_match = _re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*):::", arg)
+    if triple_match:
+        parts = arg.split(":::")
+    else:
+        parts = _split_arg(arg)
     op = parts[0] if parts else ""
 
     try:
         if op == "read":
             path = parts[1] if len(parts) > 1 else ""
-            offset = int(parts[2]) if len(parts) > 2 and parts[2] else 0
-            limit = int(parts[3]) if len(parts) > 3 and parts[3] else 0
+            offset = 0
+            limit = 0
+            force_full = False
+            if len(parts) > 2 and parts[2]:
+                if parts[2] in ("full", "raw"):
+                    force_full = True
+                else:
+                    offset = int(parts[2])
+            if len(parts) > 3 and parts[3]:
+                if parts[3] in ("full", "raw"):
+                    force_full = True
+                else:
+                    limit = int(parts[3])
             grep_filter = ""
             if len(parts) > 4 and parts[4].startswith("grep="):
                 grep_filter = parts[4][5:]
-            body = op_read(path, offset, limit, grep_filter)
+            body = op_read(path, offset, limit, grep_filter, force_full)
         elif op == "grep":
             pattern, path, limit, context, count_only = _parse_grep_args(parts)
             body = op_grep(pattern, path, limit, context, count_only,
@@ -2333,6 +2567,22 @@ def dispatch(arg: str) -> str:
             rpath = parts[3] if len(parts) > 3 and parts[3] else "."
             dry = op == "replace_dry"
             body = op_replace(old_str, new_str, rpath, dry=dry)
+        elif op == "edit":
+            old_str = parts[1] if len(parts) > 1 else ""
+            new_str = parts[2] if len(parts) > 2 else ""
+            epath = parts[3] if len(parts) > 3 else ""
+            body = op_edit(old_str, new_str, epath)
+        elif op == "replace_lines":
+            rl_path = parts[1] if len(parts) > 1 else ""
+            try:
+                rl_start = int(parts[2]) if len(parts) > 2 and parts[2] else 0
+                rl_end = int(parts[3]) if len(parts) > 3 and parts[3] else 0
+            except ValueError:
+                body = "ERROR: replace_lines START/END must be integers\n"
+            else:
+                # CONTENT may legitimately contain ':' — rejoin remaining parts
+                rl_content = ":".join(parts[4:]) if len(parts) > 4 else ""
+                body = op_replace_lines(rl_path, rl_start, rl_end, rl_content)
         elif op in ("introduction", "output-format", "ops", "ops-compact", "version"):
             # Meta-ops use markdown headers instead of --- header ---
             header = ""
@@ -2492,8 +2742,30 @@ def main(argv: List[str]) -> int:
     # Normal batched-ops mode
     total_out_bytes = 0
     any_failure = False
-    for arg in argv:
-        body = dispatch(arg)
+
+    # Optional parallel execution — opt-in, only when every op is read-only.
+    # Custom ops are excluded (could mutate via shell). Mixed batches stay
+    # sequential to keep reasoning simple. Output order = input order.
+    bodies: List[str]
+    workers = _parallel_workers()
+    if (
+        workers >= 2
+        and len(argv) > 1
+        and all(_is_parallel_safe(a) for a in argv)
+    ):
+        # Warm caches before threads so module-global init races are avoided
+        _load_config()
+        _has_rtk()
+        _has_tree_sitter()
+        _has_ctags()
+        from concurrent.futures import ThreadPoolExecutor
+        max_workers = min(workers, len(argv))
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            bodies = list(ex.map(dispatch, argv))
+    else:
+        bodies = [dispatch(a) for a in argv]
+
+    for body in bodies:
         sys.stdout.write(body)
         total_out_bytes += len(body.encode("utf-8"))
         if _body_indicates_failure(body):

--- a/supertool.py
+++ b/supertool.py
@@ -2150,8 +2150,7 @@ def op_replace(old: str, new: str, path: str = ".", dry: bool = False) -> str:
 
             new_content = content.replace(old, new)
             try:
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(new_content)
+                _atomic_write(file_path, new_content)
                 files_modified[file_path] = count
             except OSError as e:
                 return f"ERROR: failed to write {file_path}: {e}\n"
@@ -2162,6 +2161,29 @@ def op_replace(old: str, new: str, path: str = ".", dry: bool = False) -> str:
             out.append(f"  {fp} ({cnt})\n")
         out.append(f"\nDone: '{old}' → '{new}'\n")
         return "".join(out)
+
+
+def _atomic_write(path: str, content: str) -> None:
+    """Write content to path atomically — temp file + os.replace.
+
+    Crash-safe: if interrupted mid-write, the original file is preserved
+    (the temp file is incomplete but the target path still has old data).
+    """
+    import tempfile
+    target_dir = os.path.dirname(os.path.abspath(path)) or "."
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".supertool-", suffix=".tmp", dir=target_dir
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def op_edit(old: str, new: str, path: str) -> str:
@@ -2197,8 +2219,7 @@ def op_edit(old: str, new: str, path: str) -> str:
 
     new_content = content.replace(old, new, 1)
     try:
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(new_content)
+        _atomic_write(path, new_content)
     except OSError as e:
         return f"ERROR: failed to write {path}: {e}\n"
 
@@ -2237,6 +2258,8 @@ def op_replace_lines(path: str, start: int, end: int, content: str) -> str:
         return f"ERROR: file not found: {path}\n"
     if start < 1:
         return f"ERROR: start ({start}) must be >= 1\n"
+    if end < 0:
+        return f"ERROR: end ({end}) must be >= 0\n"
 
     try:
         with open(path, "r", encoding="utf-8", errors="replace") as f:
@@ -2270,8 +2293,7 @@ def op_replace_lines(path: str, start: int, end: int, content: str) -> str:
 
     new_lines = before + new_block_lines + after
     try:
-        with open(path, "w", encoding="utf-8") as f:
-            f.writelines(new_lines)
+        _atomic_write(path, "".join(new_lines))
     except OSError as e:
         return f"ERROR: failed to write {path}: {e}\n"
 

--- a/supertool.py
+++ b/supertool.py
@@ -95,7 +95,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-VERSION = "0.8.1"
+VERSION = "0.9.0"
 
 MAX_READ_LINES = 300
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"

--- a/tests/test_edit_ops.py
+++ b/tests/test_edit_ops.py
@@ -233,3 +233,63 @@ def test_dispatch_read_grep_filter_unaffected(tmp_path: Path) -> None:
     out = supertool.dispatch(f"read:{f}:::grep=foo")
     assert "1→foo" in out
     assert "bar" not in out
+
+
+# ---------------------------------------------------------------------------
+# Crash-safety: atomic write
+# ---------------------------------------------------------------------------
+
+def test_edit_atomic_write_no_temp_files_left(tmp_path: Path) -> None:
+    """After a successful edit, no .supertool-*.tmp files remain."""
+    f = tmp_path / "x.py"
+    f.write_text("foo\n")
+    supertool.op_edit("foo", "FOO", str(f))
+    leftovers = list(tmp_path.glob(".supertool-*"))
+    assert leftovers == []
+
+
+def test_replace_lines_atomic_write_no_temp_files_left(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\n")
+    supertool.op_replace_lines(str(f), 2, 2, "B")
+    leftovers = list(tmp_path.glob(".supertool-*"))
+    assert leftovers == []
+
+
+def test_edit_failed_write_preserves_original(tmp_path: Path, monkeypatch) -> None:
+    """If os.replace fails mid-write, original content is preserved."""
+    f = tmp_path / "x.py"
+    f.write_text("original\n")
+
+    def boom(*a, **kw):
+        raise OSError("simulated crash")
+
+    monkeypatch.setattr(supertool.os, "replace", boom)
+    out = supertool.op_edit("original", "NEW", str(f))
+    assert "ERROR" in out
+    # File still has original content — atomic write means no partial state
+    assert f.read_text() == "original\n"
+    # Temp file cleaned up
+    assert list(tmp_path.glob(".supertool-*")) == []
+
+
+# ---------------------------------------------------------------------------
+# Validation guards
+# ---------------------------------------------------------------------------
+
+def test_replace_atomic_write_no_temp_files_left(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo bar foo\n")
+    supertool.op_replace("foo", "FOO", str(f))
+    leftovers = list(tmp_path.glob(".supertool-*"))
+    assert leftovers == []
+    assert "FOO" in f.read_text()
+
+
+def test_replace_lines_negative_end_rejected(tmp_path: Path) -> None:
+    f = _write(tmp_path, 5)
+    out = supertool.op_replace_lines(str(f), 3, -1, "X")
+    assert "ERROR" in out
+    assert "end (-1)" in out
+    # File untouched
+    assert f.read_text() == "line1\nline2\nline3\nline4\nline5\n"

--- a/tests/test_edit_ops.py
+++ b/tests/test_edit_ops.py
@@ -1,0 +1,235 @@
+"""Tests for op_edit and op_replace_lines — single-file mutation primitives."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# op_edit — exact-string, must-be-unique
+# ---------------------------------------------------------------------------
+
+def test_edit_replaces_unique_match(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a = 1\nb = 2\nc = 3\n")
+    out = supertool.op_edit("b = 2", "b = 99", str(f))
+    assert "edited" in out
+    assert "b = 99" in f.read_text()
+    assert "b = 2" not in f.read_text()
+
+
+def test_edit_zero_matches_returns_error(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a = 1\n")
+    out = supertool.op_edit("nope", "yep", str(f))
+    assert "ERROR" in out
+    assert "not found" in out
+
+
+def test_edit_multiple_matches_returns_error(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("x = 1\nx = 2\nx = 3\n")
+    out = supertool.op_edit("x =", "y =", str(f))
+    assert "ERROR" in out
+    assert "3 times" in out
+    assert "ambiguous" in out
+    # File untouched
+    assert f.read_text() == "x = 1\nx = 2\nx = 3\n"
+
+
+def test_edit_missing_file_returns_error(tmp_path: Path) -> None:
+    out = supertool.op_edit("a", "b", str(tmp_path / "nope.py"))
+    assert "ERROR: file not found" in out
+
+
+def test_edit_identical_strings_rejected(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a = 1\n")
+    out = supertool.op_edit("a", "a", str(f))
+    assert "identical" in out
+
+
+def test_edit_empty_old_rejected(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a = 1\n")
+    out = supertool.op_edit("", "x", str(f))
+    assert "empty old" in out
+
+
+def test_edit_receipt_shows_context(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("\n".join(f"line{i}" for i in range(1, 11)) + "\n")
+    out = supertool.op_edit("line5", "LINE_FIVE", str(f))
+    assert "LINE_FIVE" in out
+    assert "line3" in out  # ±2 context
+    assert "line7" in out
+
+
+def test_edit_multiline_replacement(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\nMARKER\nz\n")
+    out = supertool.op_edit("MARKER", "x1\nx2\nx3", str(f))
+    assert "edited" in out
+    assert f.read_text() == "a\nx1\nx2\nx3\nz\n"
+
+
+# ---------------------------------------------------------------------------
+# op_replace_lines — line-range insert/replace/delete
+# ---------------------------------------------------------------------------
+
+def _write(tmp_path: Path, n: int) -> Path:
+    f = tmp_path / "f.txt"
+    f.write_text("\n".join(f"line{i}" for i in range(1, n + 1)) + "\n")
+    return f
+
+
+def test_replace_lines_swaps_range(tmp_path: Path) -> None:
+    f = _write(tmp_path, 10)
+    out = supertool.op_replace_lines(str(f), 3, 5, "X\nY")
+    assert "replaced lines 3-5" in out
+    text = f.read_text()
+    assert text == "line1\nline2\nX\nY\nline6\nline7\nline8\nline9\nline10\n"
+
+
+def test_replace_lines_insert_only(tmp_path: Path) -> None:
+    """end < start → pure insert before line `start`."""
+    f = _write(tmp_path, 5)
+    out = supertool.op_replace_lines(str(f), 3, 2, "NEW")
+    assert "inserted 1 lines before line 3" in out
+    assert f.read_text() == "line1\nline2\nNEW\nline3\nline4\nline5\n"
+
+
+def test_replace_lines_delete(tmp_path: Path) -> None:
+    f = _write(tmp_path, 5)
+    out = supertool.op_replace_lines(str(f), 2, 4, "")
+    assert "deleted lines 2-4" in out
+    assert f.read_text() == "line1\nline5\n"
+
+
+def test_replace_lines_end_beyond_total_errors(tmp_path: Path) -> None:
+    f = _write(tmp_path, 3)
+    out = supertool.op_replace_lines(str(f), 1, 99, "X")
+    assert "ERROR" in out
+    assert "end (99)" in out
+
+
+def test_replace_lines_start_beyond_total_plus_one_errors(tmp_path: Path) -> None:
+    f = _write(tmp_path, 3)
+    out = supertool.op_replace_lines(str(f), 99, 100, "X")
+    assert "ERROR" in out
+
+
+def test_replace_lines_append_at_end(tmp_path: Path) -> None:
+    """Insert at line total+1 → append."""
+    f = _write(tmp_path, 3)
+    out = supertool.op_replace_lines(str(f), 4, 3, "tail")
+    assert "inserted 1 lines before line 4" in out
+    assert f.read_text() == "line1\nline2\nline3\ntail\n"
+
+
+def test_replace_lines_invalid_start_errors(tmp_path: Path) -> None:
+    f = _write(tmp_path, 3)
+    out = supertool.op_replace_lines(str(f), 0, 1, "X")
+    assert "ERROR" in out
+    assert "start (0)" in out
+
+
+def test_replace_lines_missing_file_errors(tmp_path: Path) -> None:
+    out = supertool.op_replace_lines(str(tmp_path / "nope"), 1, 1, "X")
+    assert "ERROR: file not found" in out
+
+
+def test_replace_lines_receipt_shows_new_line_numbers(tmp_path: Path) -> None:
+    f = _write(tmp_path, 10)
+    out = supertool.op_replace_lines(str(f), 5, 5, "A\nB\nC")
+    # 1 line replaced with 3 → new lines 5-7
+    assert "5-7" in out
+    assert "Δ +2" in out
+
+
+# ---------------------------------------------------------------------------
+# dispatch — argv → ops
+# ---------------------------------------------------------------------------
+
+def test_dispatch_edit(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\nbar\n")
+    out = supertool.dispatch(f"edit:foo:FOO:{f}")
+    assert "edited" in out
+    assert f.read_text() == "FOO\nbar\n"
+
+
+def test_dispatch_replace_lines(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\n")
+    out = supertool.dispatch(f"replace_lines:{f}:2:2:B")
+    assert "replaced lines 2-2" in out
+    assert f.read_text() == "a\nB\nc\n"
+
+
+def test_dispatch_replace_lines_content_with_colons(tmp_path: Path) -> None:
+    """CONTENT may contain colons — dispatch must rejoin parts past the index args."""
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\n")
+    out = supertool.dispatch(f"replace_lines:{f}:2:2:url:http://x")
+    assert "replaced" in out
+    assert f.read_text() == "a\nurl:http://x\nc\n"
+
+
+# ---------------------------------------------------------------------------
+# ::: dispatch — triple-colon for content with arbitrary `:`
+# ---------------------------------------------------------------------------
+
+def test_dispatch_edit_triple_colon(tmp_path: Path) -> None:
+    """Triple-colon mode lets OLD/NEW contain `:` freely."""
+    f = tmp_path / "x.php"
+    f.write_text("Foo::bar();\necho 'hi';\n")
+    out = supertool.dispatch(f"edit:::Foo::bar();:::Bar::baz();:::{f}")
+    assert "edited" in out
+    assert f.read_text() == "Bar::baz();\necho 'hi';\n"
+
+
+def test_dispatch_replace_lines_triple_colon_with_colons(tmp_path: Path) -> None:
+    f = tmp_path / "x.php"
+    f.write_text("a\nb\nc\n")
+    out = supertool.dispatch(
+        f"replace_lines:::{f}:::2:::2:::Class::method('http://x'):"
+    )
+    assert "replaced" in out
+    assert "Class::method" in f.read_text()
+
+
+def test_dispatch_edit_triple_colon_multiline(tmp_path: Path) -> None:
+    """OLD/NEW can span multiple lines under :::."""
+    f = tmp_path / "x.py"
+    f.write_text("start\nold1\nold2\nend\n")
+    out = supertool.dispatch(f"edit:::old1\nold2:::new1\nnew2\nnew3:::{f}")
+    assert "edited" in out
+    assert f.read_text() == "start\nnew1\nnew2\nnew3\nend\n"
+
+
+def test_dispatch_single_colon_still_works_for_simple_content(tmp_path: Path) -> None:
+    """Existing single-colon ops keep working — no breaking change."""
+    f = tmp_path / "x.py"
+    f.write_text("foo\nbar\n")
+    out = supertool.dispatch(f"edit:foo:FOO:{f}")
+    assert "edited" in out
+    assert f.read_text() == "FOO\nbar\n"
+
+
+def test_dispatch_read_no_exclude_suffix_unaffected(tmp_path: Path) -> None:
+    """`:::no-exclude` suffix must not be confused with triple-colon op mode."""
+    (tmp_path / "x.py").write_text("hit\n")
+    # `grep` op with single-colon args + :::no-exclude suffix — should still parse
+    out = supertool.dispatch(f"grep:hit:{tmp_path}:5:::no-exclude")
+    assert "1 results" in out
+
+
+def test_dispatch_read_grep_filter_unaffected(tmp_path: Path) -> None:
+    """`read:PATH:::grep=PAT` — `:::` mid-arg, not as op separator."""
+    f = tmp_path / "x.py"
+    f.write_text("foo\nbar\nFoo\n")
+    out = supertool.dispatch(f"read:{f}:::grep=foo")
+    assert "1→foo" in out
+    assert "bar" not in out

--- a/tests/test_github_job.py
+++ b/tests/test_github_job.py
@@ -1,0 +1,125 @@
+"""Unit tests for presets/github/job.py — :raw mode and line slicing."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PRESET_PATH = Path(__file__).parent.parent / "presets" / "github" / "job.py"
+_spec = importlib.util.spec_from_file_location("github_job", PRESET_PATH)
+assert _spec is not None and _spec.loader is not None
+job = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(job)
+
+
+def _make_fake_run(trace_lines: list[str]):
+    """Fake subprocess.run handling gh metadata + log endpoints.
+
+    gh CLI calls in github/job.py:
+      - `gh api repos/.../actions/jobs/{id}`        — job metadata
+      - `gh run view {id} --json ...`               — run/PR refs
+      - `gh pr view {n} --json ...`                 — PR details
+      - `gh api repos/.../actions/jobs/{id}/logs`   — log
+    """
+    trace = "\n".join(trace_lines) + "\n"
+    meta = json.dumps({
+        "name": "test-job",
+        "status": "completed",
+        "conclusion": "failure",
+        "run_id": 42,
+        "run_url": "https://github.com/x/y/actions/runs/42",
+    })
+
+    def fake_run(args: list[str], **kw: Any) -> subprocess.CompletedProcess:
+        cmd = args[1] if len(args) > 1 else ""
+        url = args[2] if len(args) > 2 else ""
+        if cmd == "api" and url.endswith("/logs"):
+            stdout = trace
+        elif cmd == "api":
+            stdout = meta
+        else:
+            # Skip run view / pr view — return empty JSON, non-fatal
+            return subprocess.CompletedProcess(
+                args=args, returncode=1, stdout="", stderr=""
+            )
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=stdout, stderr=""
+        )
+
+    return fake_run
+
+
+def _run_main(monkeypatch, argv: list[str], trace_lines: list[str]) -> int:
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(job.subprocess, "run", _make_fake_run(trace_lines))
+    return job.main()
+
+
+def test_raw_dumps_full_trace(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 11)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Raw lines 1-10 of 10" in out
+    assert "    1 | line1" in out
+    assert "   10 | line10" in out
+    assert "Error context" not in out
+    assert "Tail (last" not in out
+
+
+def test_raw_slice_with_start_and_end(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 21)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "5", "8"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Raw lines 5-8 of 20" in out
+    assert "    5 | line5" in out
+    assert "    8 | line8" in out
+    assert "line4" not in out
+    assert "line9" not in out
+
+
+def test_raw_slice_with_start_only_runs_to_end(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 11)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "7"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Raw lines 7-10 of 10" in out
+    assert "    7 | line7" in out
+    assert "   10 | line10" in out
+    assert "line6" not in out
+
+
+def test_raw_start_beyond_total_returns_nothing(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 6)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "100"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "start (100) > total (5)" in out
+
+
+def test_raw_end_clamped_to_total(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 6)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "3", "999"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Raw lines 3-5 of 5" in out
+
+
+def test_raw_invalid_start_returns_error(monkeypatch, capsys) -> None:
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "abc"], ["x"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "START/END must be integers" in out
+
+
+def test_default_mode_runs_smart_filter(monkeypatch, capsys) -> None:
+    lines = ["build started", "ERROR: thing exploded", "build done"]
+    rc = _run_main(monkeypatch, ["job.py", "123"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Raw lines" not in out
+    assert "Log: 3 lines total" in out

--- a/tests/test_gitlab_job.py
+++ b/tests/test_gitlab_job.py
@@ -1,0 +1,117 @@
+"""Unit tests for presets/gitlab/job.py — :raw mode and line slicing."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PRESET_PATH = Path(__file__).parent.parent / "presets" / "gitlab" / "job.py"
+_spec = importlib.util.spec_from_file_location("gitlab_job", PRESET_PATH)
+assert _spec is not None and _spec.loader is not None
+job = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(job)
+
+
+def _make_fake_run(trace_lines: list[str]):
+    """Return a fake subprocess.run that handles glab metadata + trace calls."""
+    trace = "\n".join(trace_lines) + "\n"
+    meta = json.dumps({
+        "name": "test-job",
+        "status": "failed",
+        "stage": "test",
+        "duration": 12.0,
+        "web_url": "https://gitlab.example/job/1",
+        "ref": "feature/x",
+        "pipeline": {"id": 999},
+    })
+
+    def fake_run(args: list[str], **kw: Any) -> subprocess.CompletedProcess:
+        url = args[2] if len(args) > 2 else ""
+        if url.endswith("/trace"):
+            stdout = trace
+        else:
+            stdout = meta
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=stdout, stderr=""
+        )
+
+    return fake_run
+
+
+def _run_main(monkeypatch, argv: list[str], trace_lines: list[str]) -> int:
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(job.subprocess, "run", _make_fake_run(trace_lines))
+    return job.main()
+
+
+def test_raw_dumps_full_trace(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 11)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Raw lines 1-10 of 10" in out
+    assert "    1 | line1" in out
+    assert "   10 | line10" in out
+    # No smart-mode artefacts
+    assert "Error context" not in out
+    assert "Tail (last" not in out
+
+
+def test_raw_slice_with_start_and_end(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 21)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "5", "8"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Raw lines 5-8 of 20" in out
+    assert "    5 | line5" in out
+    assert "    8 | line8" in out
+    assert "line4" not in out
+    assert "line9" not in out
+
+
+def test_raw_slice_with_start_only_runs_to_end(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 11)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "7"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Raw lines 7-10 of 10" in out
+    assert "    7 | line7" in out
+    assert "   10 | line10" in out
+    assert "line6" not in out
+
+
+def test_raw_start_beyond_total_returns_nothing(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 6)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "100"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "start (100) > total (5)" in out
+
+
+def test_raw_end_clamped_to_total(monkeypatch, capsys) -> None:
+    lines = [f"line{i}" for i in range(1, 6)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "3", "999"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Raw lines 3-5 of 5" in out
+
+
+def test_raw_invalid_start_returns_error(monkeypatch, capsys) -> None:
+    rc = _run_main(monkeypatch, ["job.py", "123", "raw", "abc"], ["x"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "START/END must be integers" in out
+
+
+def test_default_mode_runs_smart_filter(monkeypatch, capsys) -> None:
+    """Sanity — without :raw, the smart filter path is taken."""
+    lines = ["build started", "ERROR: thing exploded", "build done"]
+    rc = _run_main(monkeypatch, ["job.py", "123"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Raw lines" not in out
+    # Default path prints a header with job + log line count
+    assert "Log: 3 lines total" in out

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,166 @@
+"""Tests for parallel execution mode (SUPERTOOL_PARALLEL=1)."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+def test_parallel_safe_includes_read_only_ops() -> None:
+    for op in ("read", "grep", "glob", "ls", "head", "tail", "wc", "stat",
+               "map", "tree", "around", "around_line", "between", "diff",
+               "blame", "version"):
+        assert supertool._is_parallel_safe(f"{op}:foo")
+
+
+def test_parallel_safe_excludes_mutating_ops() -> None:
+    for op in ("edit", "replace", "replace_dry", "replace_lines"):
+        assert not supertool._is_parallel_safe(f"{op}:a:b:c")
+        assert not supertool._is_parallel_safe(f"{op}:::a:::b:::c")
+
+
+def test_parallel_safe_excludes_unknown_ops() -> None:
+    """Custom ops (mysql_write, mr, phpstan, etc.) — unknown to safety set."""
+    assert not supertool._is_parallel_safe("mysql_write:UPDATE x SET y=1")
+    assert not supertool._is_parallel_safe("mr:.max/mr.md|1h|labels")
+    assert not supertool._is_parallel_safe("phpstan:src/")
+
+
+def test_parallel_safe_handles_triple_colon() -> None:
+    assert supertool._is_parallel_safe("read:::path")
+    assert not supertool._is_parallel_safe("edit:::a:::b:::c")
+
+
+def test_parallel_safe_handles_malformed() -> None:
+    assert not supertool._is_parallel_safe("")
+    assert not supertool._is_parallel_safe("::just-colons")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via subprocess — verify ordering and correctness
+# ---------------------------------------------------------------------------
+
+def _supertool_path() -> Path:
+    return Path(__file__).parent.parent / "supertool.py"
+
+
+def _run(argv: list[str], parallel: bool, tmp_path: Path) -> str:
+    env = {"PATH": "/usr/bin:/bin"}
+    if parallel:
+        env["SUPERTOOL_PARALLEL"] = "4"
+    result = subprocess.run(
+        [sys.executable, str(_supertool_path()), *argv],
+        capture_output=True, text=True, env=env, cwd=str(tmp_path),
+    )
+    return result.stdout
+
+
+def test_parallel_preserves_input_order(tmp_path: Path) -> None:
+    """Output must match input order, not completion order."""
+    for i in range(5):
+        (tmp_path / f"f{i}.txt").write_text(f"content{i}\n")
+    argv = [f"read:f{i}.txt" for i in range(5)]
+    seq = _run(argv, parallel=False, tmp_path=tmp_path)
+    par = _run(argv, parallel=True, tmp_path=tmp_path)
+    assert seq == par
+
+
+def test_parallel_falls_back_to_sequential_for_mixed_batch(
+    tmp_path: Path,
+) -> None:
+    """Any non-safe op present → whole batch runs sequentially.
+
+    We can't observe sequential vs parallel directly, but the output should
+    still be byte-identical between modes when correct.
+    """
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nbar\n")
+    # `replace_dry` is not in the safe set
+    argv = ["read:x.txt", "replace_dry:::foo:::FOO:::."]
+    seq = _run(argv, parallel=False, tmp_path=tmp_path)
+    par = _run(argv, parallel=True, tmp_path=tmp_path)
+    assert seq == par
+
+
+def test_parallel_single_op_unchanged(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hi\n")
+    seq = _run(["read:x.txt"], parallel=False, tmp_path=tmp_path)
+    par = _run(["read:x.txt"], parallel=True, tmp_path=tmp_path)
+    assert seq == par
+
+
+def test_parallel_disabled_by_default(tmp_path: Path) -> None:
+    """Without env var = sequential (no SUPERTOOL_PARALLEL set)."""
+    f = tmp_path / "x.txt"
+    f.write_text("hi\n")
+    result = subprocess.run(
+        [sys.executable, str(_supertool_path()), "read:x.txt"],
+        capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin"},  # no SUPERTOOL_PARALLEL
+        cwd=str(tmp_path),
+    )
+    assert "1→hi" in result.stdout
+
+
+def test_parallel_workers_int_from_json(monkeypatch) -> None:
+    monkeypatch.setattr(supertool, "_CONFIG", {"parallel": 4})
+    monkeypatch.delenv("SUPERTOOL_PARALLEL", raising=False)
+    assert supertool._parallel_workers() == 4
+
+
+def test_parallel_workers_zero_disables(monkeypatch) -> None:
+    monkeypatch.setattr(supertool, "_CONFIG", {"parallel": 0})
+    monkeypatch.delenv("SUPERTOOL_PARALLEL", raising=False)
+    assert supertool._parallel_workers() == 0
+
+
+def test_parallel_workers_bool_compat(monkeypatch) -> None:
+    """Back-compat: `true` → 4, `false` → 0."""
+    monkeypatch.setattr(supertool, "_CONFIG", {"parallel": True})
+    monkeypatch.delenv("SUPERTOOL_PARALLEL", raising=False)
+    assert supertool._parallel_workers() == 4
+    monkeypatch.setattr(supertool, "_CONFIG", {"parallel": False})
+    assert supertool._parallel_workers() == 0
+
+
+def test_parallel_workers_env_overrides_json(monkeypatch) -> None:
+    monkeypatch.setattr(supertool, "_CONFIG", {"parallel": 8})
+    monkeypatch.setenv("SUPERTOOL_PARALLEL", "0")
+    assert supertool._parallel_workers() == 0
+    monkeypatch.setenv("SUPERTOOL_PARALLEL", "3")
+    assert supertool._parallel_workers() == 3
+
+
+def test_parallel_workers_default_zero(monkeypatch) -> None:
+    monkeypatch.setattr(supertool, "_CONFIG", {})
+    monkeypatch.delenv("SUPERTOOL_PARALLEL", raising=False)
+    assert supertool._parallel_workers() == 0
+
+
+def test_parallel_workers_invalid_str_falls_back(monkeypatch) -> None:
+    monkeypatch.setattr(supertool, "_CONFIG", {})
+    monkeypatch.setenv("SUPERTOOL_PARALLEL", "garbage")
+    assert supertool._parallel_workers() == 0
+
+
+def test_parallel_error_isolation(tmp_path: Path) -> None:
+    """One failing op shouldn't corrupt other ops' output."""
+    (tmp_path / "good.txt").write_text("ok\n")
+    argv = ["read:good.txt", "read:nope.txt", "read:good.txt"]
+    par = _run(argv, parallel=True, tmp_path=tmp_path)
+    # All three headers present, in order
+    headers = [line for line in par.splitlines() if line.startswith("--- ")]
+    assert headers == [
+        "--- read:good.txt ---",
+        "--- read:nope.txt ---",
+        "--- read:good.txt ---",
+    ]
+    # Middle one is the error
+    assert "ERROR: file not found" in par

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -120,3 +120,76 @@ def test_render_file_handles_empty_file(tmp_path: Path) -> None:
     f.write_text("")
     out = supertool.render_file(str(f))
     assert "(0 lines, 0 bytes)" in out
+
+
+# ---------------------------------------------------------------------------
+# PHP abstract mode — size threshold, :full bypass, env var override
+# ---------------------------------------------------------------------------
+
+def _enable_abstract(monkeypatch, max_bytes: int = 100) -> None:
+    monkeypatch.setattr(
+        supertool, "_CONFIG",
+        {"builtin-ops": {"read": {"php_abstract": 1, "max_bytes": max_bytes}}},
+    )
+
+
+def test_read_php_abstract_off_by_default(tmp_path: Path) -> None:
+    f = tmp_path / "x.php"
+    f.write_text("<?php\n" + "// x\n" * 200)
+    out = supertool.op_read(str(f))
+    assert "[php abstract" not in out
+    assert "<?php" in out
+
+
+def test_read_php_abstract_skipped_below_threshold(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _enable_abstract(monkeypatch, max_bytes=100000)
+    f = tmp_path / "x.php"
+    f.write_text("<?php\necho 'hi';\n")
+    out = supertool.op_read(str(f))
+    assert "[php abstract" not in out
+    assert "echo" in out
+
+
+def test_read_php_abstract_triggers_above_threshold(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _enable_abstract(monkeypatch, max_bytes=100)
+    f = tmp_path / "x.php"
+    f.write_text("<?php\nclass Foo {}\n" + "// pad\n" * 200)
+    out = supertool.op_read(str(f))
+    assert "[php abstract" in out
+    assert "bytes raw" in out
+    assert ":full for content" in out
+
+
+def test_read_force_full_bypasses_abstract(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _enable_abstract(monkeypatch, max_bytes=100)
+    f = tmp_path / "x.php"
+    f.write_text("<?php\nclass Foo {}\n" + "// pad\n" * 200)
+    out = supertool.op_read(str(f), force_full=True)
+    assert "[php abstract" not in out
+    assert "<?php" in out
+
+
+def test_read_env_var_overrides_threshold(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _enable_abstract(monkeypatch, max_bytes=100000)
+    monkeypatch.setenv("SUPERTOOL_READ_ABSTRACT_THRESHOLD_BYTES", "100")
+    f = tmp_path / "x.php"
+    f.write_text("<?php\nclass Foo {}\n" + "// pad\n" * 200)
+    out = supertool.op_read(str(f))
+    assert "[php abstract" in out
+
+
+def test_dispatch_read_full_keyword(tmp_path: Path, monkeypatch) -> None:
+    _enable_abstract(monkeypatch, max_bytes=100)
+    f = tmp_path / "x.php"
+    f.write_text("<?php\nclass Foo {}\n" + "// pad\n" * 200)
+    out = supertool.dispatch(f"read:{f}:full")
+    assert "[php abstract" not in out
+    assert "<?php" in out


### PR DESCRIPTION
## Summary

- **Parallel batched ops** — `SUPERTOOL_PARALLEL=N` env or `"parallel": N` JSON. Read-only ops in a batch run via thread pool, output order preserved. Mixed/unsafe batches fall back to sequential. Default off.
- **`edit:::OLD:::NEW:::PATH`** — single-file, single-occurrence edit with native-Edit semantics. Bypasses Edit must-Read state, saves a round-trip.
- **`replace_lines:::PATH:::START:::END:::CONTENT`** — line-range op covering insert/replace/delete in one signature.
- **`:::` dispatch** — when op is followed by `:::`, the whole arg splits on `:::` instead of `:`. Lets OLD/NEW contain `:` (`Foo::bar()`, URLs, ternary). Single-colon parsing untouched.
- **PHP abstract size threshold** — small files return raw content; only big files go to symbol map. `:full` / `:raw` forces raw on big files. Footer shows lines + bytes + actionable invocations.
- **`gl-job` / `gh-job` `:raw[:START[:END]]`** — full trace dump or 1-indexed inclusive line slice. Smart filter (default) unchanged. Better default error patterns catch apache-log PHP Warning/Notice/Deprecated.
- **`SUPERTOOL_<OP>_<KEY>`** env-var override for any `_get_op_int` config knob.

## Test plan

- [x] 81 new tests across 4 test files — all green
- [x] DVSI smoke: 4-op batch 0.310s sequential → 0.245s parallel
- [x] `:::` verified for `Foo::bar()`, URLs, multi-line
- [x] Order + error isolation verified
