### PR TITLE
feat: gl-issue/gh-issue :full + glob :no-auto-read (#14)

### DIFF
--- a/presets/github.json
+++ b/presets/github.json
@@ -3,10 +3,10 @@
   "requires": "gh",
   "ops": {
     "gh-issue": {
-      "cmd": "python3 {path}github/issue.py {arg}",
+      "cmd": "python3 {path}github/issue.py {args}",
       "timeout": 30,
-      "description": "Pick up a GitHub issue: description, comments, images downloaded locally, linked PRs — everything to start working.",
-      "syntax": "gh-issue:NUMBER"
+      "description": "GitHub issue: desc, comments, images, linked PRs. :full = no truncation, all comments",
+      "syntax": "gh-issue:NUMBER[:full]"
     },
     "gh-pr": {
       "cmd": "python3 {path}github/pr.py {args}",

--- a/presets/github/issue.py
+++ b/presets/github/issue.py
@@ -72,10 +72,13 @@ def _download_images(image_urls: list[str], issue_number: str) -> list[str]:
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("ERROR: usage: issue.py NUMBER")
+        print("ERROR: usage: issue.py NUMBER [full]")
         return 1
 
     number = sys.argv[1]
+    full = len(sys.argv) > 2 and sys.argv[2] == "full"
+    desc_max = None if full else DESCRIPTION_MAX
+    comment_max = None if full else COMMENT_MAX
 
     # Fetch issue with all needed fields
     try:
@@ -108,7 +111,9 @@ def main() -> int:
     author = (d.get("author") or {}).get("login", "?")
     iid = d.get("number", number)
     web_url = d.get("url", "")
-    body = (d.get("body") or "")[:DESCRIPTION_MAX]
+    body = d.get("body") or ""
+    if desc_max is not None:
+        body = body[:desc_max]
 
     # Header
     print(f"# #{iid} {title}")
@@ -149,10 +154,19 @@ def main() -> int:
     # Comments — gh gives them directly in the issue JSON
     comments = d.get("comments", [])
     if comments:
-        print(f"\n## Comments ({len(comments)})")
-        for comment in comments[-10:]:
+        if full:
+            shown = comments
+            print(f"\n## Comments ({len(comments)})")
+        else:
+            shown = comments[-10:]
+            truncated = len(comments) - len(shown)
+            suffix = f", {truncated} earlier truncated — use :full to fetch all" if truncated else ""
+            print(f"\n## Comments ({len(shown)} of {len(comments)} shown{suffix})")
+        for comment in shown:
             c_author = (comment.get("author") or {}).get("login", "?")
-            c_body = (comment.get("body") or "")[:COMMENT_MAX]
+            c_body = comment.get("body") or ""
+            if comment_max is not None and len(c_body) > comment_max:
+                c_body = c_body[:comment_max] + f"\n…[truncated at {comment_max} chars — use :full]"
             c_created = (comment.get("createdAt") or "")[:10]
             print(f"\n**{c_author}** ({c_created}):")
             print(c_body)

--- a/presets/gitlab.json
+++ b/presets/gitlab.json
@@ -3,10 +3,10 @@
   "requires": "glab",
   "ops": {
     "gl-issue": {
-      "cmd": "python3 {path}gitlab/issue.py {arg}",
+      "cmd": "python3 {path}gitlab/issue.py {args}",
       "timeout": 30,
-      "description": "GitLab issue: desc, comments, images downloaded, related MRs",
-      "syntax": "gl-issue:NUMBER"
+      "description": "GitLab issue: desc, comments, images, related MRs. :full = no truncation, all comments",
+      "syntax": "gl-issue:NUMBER[:full]"
     },
     "gl-mr": {
       "cmd": "python3 {path}gitlab/mr.py {args}",

--- a/presets/gitlab/issue.py
+++ b/presets/gitlab/issue.py
@@ -106,10 +106,13 @@ def _download_images(image_urls: list[str], issue_number: str) -> list[str]:
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("ERROR: usage: issue.py NUMBER")
+        print("ERROR: usage: issue.py NUMBER [full]")
         return 1
 
     number = sys.argv[1]
+    full = len(sys.argv) > 2 and sys.argv[2] == "full"
+    desc_max = None if full else DESCRIPTION_MAX
+    comment_max = None if full else COMMENT_MAX
 
     # 1. Fetch issue metadata
     try:
@@ -139,7 +142,9 @@ def main() -> int:
     author = (d.get("author") or {}).get("username", "?")
     iid = d.get("iid", number)
     web_url = d.get("web_url", "")
-    description = (d.get("description") or "")[:DESCRIPTION_MAX]
+    description = d.get("description") or ""
+    if desc_max is not None:
+        description = description[:desc_max]
     project_id = d.get("project_id", "")
 
     # Header
@@ -189,10 +194,19 @@ def main() -> int:
                 human_notes = [n for n in notes if not n.get("system", False)]
                 system_count = len(notes) - len(human_notes)
                 if human_notes:
-                    print(f"\n## Comments ({len(human_notes)} human, {system_count} system skipped)")
-                    for note in human_notes[-10:]:  # last 10 human comments
+                    if full:
+                        shown_notes = human_notes
+                        print(f"\n## Comments ({len(human_notes)} human, {system_count} system skipped)")
+                    else:
+                        shown_notes = human_notes[-10:]
+                        truncated = len(human_notes) - len(shown_notes)
+                        suffix = f", {truncated} earlier truncated — use :full to fetch all" if truncated else ""
+                        print(f"\n## Comments ({len(shown_notes)} of {len(human_notes)} human shown{suffix}, {system_count} system skipped)")
+                    for note in shown_notes:
                         note_author = (note.get("author") or {}).get("username", "?")
-                        body = (note.get("body") or "")[:COMMENT_MAX]
+                        body = note.get("body") or ""
+                        if comment_max is not None and len(body) > comment_max:
+                            body = body[:comment_max] + f"\n…[truncated at {comment_max} chars — use :full]"
                         created = (note.get("created_at") or "")[:10]
                         print(f"\n**{note_author}** ({created}):")
                         print(body)

--- a/supertool.py
+++ b/supertool.py
@@ -961,13 +961,15 @@ def op_between_pattern(start: str, end: str, path: str) -> str:
     return "".join(out)
 
 
-def op_glob(pattern: str, no_exclude: bool = False) -> str:
-    """Find files matching pattern. Auto-reads concrete file paths."""
+def op_glob(pattern: str, no_exclude: bool = False, no_auto_read: bool = False) -> str:
+    """Find files matching pattern. Auto-reads concrete file paths unless no_auto_read."""
     if not pattern:
         return "ERROR: empty pattern\n"
 
     # Auto-promote: concrete path with no wildcards that points to a file
     if not WILDCARD_CHARS.search(pattern) and os.path.isfile(pattern):
+        if no_auto_read:
+            return f"{pattern}\n"
         return ("[auto-read: concrete path, no wildcards]\n"
                 + render_file(pattern, 0, _get_op_int("read", "max_lines", MAX_READ_LINES)))
 
@@ -992,7 +994,7 @@ def op_glob(pattern: str, no_exclude: bool = False) -> str:
     out.append("\n")
 
     # Auto-read: glob returned exactly 1 file — save the follow-up read round-trip
-    if len(files) == 1 and os.path.getsize(files[0]) < _get_op_int("read", "max_bytes", MAX_READ_BYTES):
+    if not no_auto_read and len(files) == 1 and os.path.getsize(files[0]) < _get_op_int("read", "max_bytes", MAX_READ_BYTES):
         out.append(f"[auto-read: glob returned 1 file]\n")
         out.append(render_file(files[0], 0, _get_op_int("read", "max_lines", MAX_READ_LINES)))
 
@@ -2519,7 +2521,8 @@ def dispatch(arg: str) -> str:
             body = op_wc(path)
         elif op == "glob":
             pattern = parts[1] if len(parts) > 1 else ""
-            body = op_glob(pattern, no_exclude=no_exclude)
+            no_auto_read = len(parts) > 2 and parts[2] == "no-auto-read"
+            body = op_glob(pattern, no_exclude=no_exclude, no_auto_read=no_auto_read)
         elif op == "ls":
             path = parts[1] if len(parts) > 1 and parts[1] else "."
             body = op_ls(path)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -626,6 +626,16 @@ def test_dispatch_glob_branch(tmp_path: Path) -> None:
     assert "hello.txt" in result
 
 
+def test_dispatch_glob_no_auto_read_flag(tmp_path: Path) -> None:
+    """glob:PATTERN:no-auto-read suppresses auto-read of single matches."""
+    f = tmp_path / "only.txt"
+    f.write_text("secret content\n")
+    result = supertool.dispatch(f"glob:{tmp_path}/*.txt:no-auto-read")
+    assert "only.txt" in result
+    assert "[auto-read:" not in result
+    assert "secret content" not in result
+
+
 def test_dispatch_grep_path_not_found() -> None:
     """Grep on nonexistent path should say 'not found', not '0 results'."""
     result = supertool.dispatch("grep:TODO:/nonexistent/path/file.php")

--- a/tests/test_github_issue.py
+++ b/tests/test_github_issue.py
@@ -1,0 +1,113 @@
+"""Tests for presets/github/issue.py — :full flag fetches untruncated body+comments."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PRESET_PATH = Path(__file__).parent.parent / "presets" / "github" / "issue.py"
+_spec = importlib.util.spec_from_file_location("github_issue", PRESET_PATH)
+assert _spec is not None and _spec.loader is not None
+issue = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(issue)
+
+
+def _fake_run(stdout: str, returncode: int = 0) -> Any:
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def _install_fakes(monkeypatch, *, body: str, comments: list[dict]) -> None:
+    issue_payload = json.dumps({
+        "number": 42,
+        "title": "Plan",
+        "state": "OPEN",
+        "labels": [],
+        "milestone": None,
+        "assignees": [],
+        "author": {"login": "florian"},
+        "url": "",
+        "body": body,
+        "comments": comments,
+    })
+    pr_payload = json.dumps([])
+
+    def fake_gh(args, timeout=10):
+        if args and args[0] == "pr":
+            return _fake_run(pr_payload)
+        return _fake_run(issue_payload)
+
+    monkeypatch.setattr(issue, "_gh", fake_gh)
+    monkeypatch.setattr(issue, "_download_images", lambda urls, n: [])
+
+
+def _comment(login: str, body: str) -> dict:
+    return {
+        "author": {"login": login},
+        "body": body,
+        "createdAt": "2026-05-07T20:00:00Z",
+    }
+
+
+def test_default_truncates_long_body(monkeypatch, capsys) -> None:
+    long_body = "x" * (issue.DESCRIPTION_MAX + 500)
+    _install_fakes(monkeypatch, body=long_body, comments=[])
+    monkeypatch.setattr(sys, "argv", ["issue.py", "42"])
+    rc = issue.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert ("x" * (issue.DESCRIPTION_MAX + 500)) not in out
+
+
+def test_full_flag_keeps_full_body(monkeypatch, capsys) -> None:
+    long_body = "x" * (issue.DESCRIPTION_MAX + 500)
+    _install_fakes(monkeypatch, body=long_body, comments=[])
+    monkeypatch.setattr(sys, "argv", ["issue.py", "42", "full"])
+    rc = issue.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "x" * (issue.DESCRIPTION_MAX + 500) in out
+
+
+def test_default_caps_at_10_comments(monkeypatch, capsys) -> None:
+    comments = [_comment(f"u{i}", f"msg-{i}") for i in range(15)]
+    _install_fakes(monkeypatch, body="d", comments=comments)
+    monkeypatch.setattr(sys, "argv", ["issue.py", "42"])
+    issue.main()
+    out = capsys.readouterr().out
+    assert "msg-14" in out
+    assert "msg-0" not in out
+    assert "use :full" in out
+
+
+def test_full_flag_shows_all_comments(monkeypatch, capsys) -> None:
+    comments = [_comment(f"u{i}", f"msg-{i}") for i in range(15)]
+    _install_fakes(monkeypatch, body="d", comments=comments)
+    monkeypatch.setattr(sys, "argv", ["issue.py", "42", "full"])
+    issue.main()
+    out = capsys.readouterr().out
+    assert "msg-0" in out
+    assert "msg-14" in out
+
+
+def test_full_flag_keeps_long_comment_body(monkeypatch, capsys) -> None:
+    long_body = "y" * (issue.COMMENT_MAX + 500)
+    _install_fakes(monkeypatch, body="d", comments=[_comment("florian", long_body)])
+    monkeypatch.setattr(sys, "argv", ["issue.py", "42", "full"])
+    issue.main()
+    out = capsys.readouterr().out
+    assert long_body in out
+    assert "truncated" not in out
+
+
+def test_default_truncates_long_comment_body(monkeypatch, capsys) -> None:
+    long_body = "y" * (issue.COMMENT_MAX + 500)
+    _install_fakes(monkeypatch, body="d", comments=[_comment("florian", long_body)])
+    monkeypatch.setattr(sys, "argv", ["issue.py", "42"])
+    issue.main()
+    out = capsys.readouterr().out
+    assert "truncated" in out

--- a/tests/test_gitlab_issue.py
+++ b/tests/test_gitlab_issue.py
@@ -1,0 +1,125 @@
+"""Tests for presets/gitlab/issue.py — :full flag fetches untruncated body+comments."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PRESET_PATH = Path(__file__).parent.parent / "presets" / "gitlab" / "issue.py"
+_spec = importlib.util.spec_from_file_location("gitlab_issue", PRESET_PATH)
+assert _spec is not None and _spec.loader is not None
+issue = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(issue)
+
+
+def _fake_run(stdout: str, returncode: int = 0) -> Any:
+    return subprocess.CompletedProcess(
+        args=["glab"], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def _install_fakes(monkeypatch, *, description: str, comments: list[dict]) -> None:
+    """Stub glab calls: issue view, related MRs (empty), notes."""
+    issue_payload = json.dumps({
+        "title": "Plan",
+        "state": "opened",
+        "labels": [],
+        "milestone": None,
+        "assignees": [],
+        "author": {"username": "florian"},
+        "iid": 12345,
+        "web_url": "",
+        "description": description,
+        "project_id": 1,
+    })
+    notes_payload = json.dumps(comments)
+    related_payload = json.dumps([])
+
+    def fake_glab(args, timeout=10):
+        return _fake_run(issue_payload)
+
+    def fake_glab_api(endpoint, timeout=10):
+        if "related_merge_requests" in endpoint:
+            return _fake_run(related_payload)
+        if "/notes" in endpoint:
+            return _fake_run(notes_payload)
+        return _fake_run("[]")
+
+    monkeypatch.setattr(issue, "_glab", fake_glab)
+    monkeypatch.setattr(issue, "_glab_api", fake_glab_api)
+    monkeypatch.setattr(issue, "_download_images", lambda urls, n: [])
+
+
+def test_default_truncates_long_description(monkeypatch, capsys) -> None:
+    long_desc = "x" * (issue.DESCRIPTION_MAX + 500)
+    _install_fakes(monkeypatch, description=long_desc, comments=[])
+    monkeypatch.setattr(sys, "argv", ["issue.py", "12345"])
+    rc = issue.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    body = out.split("## Description")[1] if "## Description" in out else ""
+    assert len(body.strip()) <= issue.DESCRIPTION_MAX + 50  # trailing whitespace
+
+
+def test_full_flag_keeps_full_description(monkeypatch, capsys) -> None:
+    long_desc = "x" * (issue.DESCRIPTION_MAX + 500)
+    _install_fakes(monkeypatch, description=long_desc, comments=[])
+    monkeypatch.setattr(sys, "argv", ["issue.py", "12345", "full"])
+    rc = issue.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "x" * (issue.DESCRIPTION_MAX + 500) in out
+
+
+def _comment(author: str, body: str) -> dict:
+    return {
+        "system": False,
+        "author": {"username": author},
+        "body": body,
+        "created_at": "2026-05-07T20:00:00Z",
+    }
+
+
+def test_default_caps_at_10_comments(monkeypatch, capsys) -> None:
+    comments = [_comment(f"u{i}", f"msg-{i}") for i in range(15)]
+    _install_fakes(monkeypatch, description="d", comments=comments)
+    monkeypatch.setattr(sys, "argv", ["issue.py", "12345"])
+    issue.main()
+    out = capsys.readouterr().out
+    assert "msg-14" in out  # last
+    assert "msg-0" not in out  # earliest dropped
+    assert "use :full" in out  # nudge
+
+
+def test_full_flag_shows_all_comments(monkeypatch, capsys) -> None:
+    comments = [_comment(f"u{i}", f"msg-{i}") for i in range(15)]
+    _install_fakes(monkeypatch, description="d", comments=comments)
+    monkeypatch.setattr(sys, "argv", ["issue.py", "12345", "full"])
+    issue.main()
+    out = capsys.readouterr().out
+    assert "msg-0" in out
+    assert "msg-14" in out
+
+
+def test_full_flag_keeps_long_comment_body(monkeypatch, capsys) -> None:
+    long_body = "y" * (issue.COMMENT_MAX + 500)
+    comments = [_comment("florian", long_body)]
+    _install_fakes(monkeypatch, description="d", comments=comments)
+    monkeypatch.setattr(sys, "argv", ["issue.py", "12345", "full"])
+    issue.main()
+    out = capsys.readouterr().out
+    assert long_body in out
+    assert "truncated" not in out
+
+
+def test_default_truncates_long_comment_body(monkeypatch, capsys) -> None:
+    long_body = "y" * (issue.COMMENT_MAX + 500)
+    comments = [_comment("florian", long_body)]
+    _install_fakes(monkeypatch, description="d", comments=comments)
+    monkeypatch.setattr(sys, "argv", ["issue.py", "12345"])
+    issue.main()
+    out = capsys.readouterr().out
+    assert "truncated" in out

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -65,6 +65,23 @@ def test_glob_no_auto_read_when_multiple_results(tmp_path: Path, monkeypatch) ->
     assert "[auto-read:" not in out
 
 
+def test_glob_no_auto_read_flag_on_concrete_file(tmp_path: Path) -> None:
+    f = tmp_path / "specific.py"
+    f.write_text("content = 42\n")
+    out = supertool.op_glob(str(f), no_auto_read=True)
+    assert "[auto-read:" not in out
+    assert str(f) in out
+
+
+def test_glob_no_auto_read_flag_on_single_result(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n")
+    monkeypatch.chdir(tmp_path)
+    out = supertool.op_glob("*.py", no_auto_read=True)
+    assert "[auto-read:" not in out
+    assert "a.py" in out
+    assert "x = 1" not in out
+
+
 def test_glob_no_auto_read_on_concrete_directory(tmp_path: Path) -> None:
     # Directory path with no wildcards — glob() returns the dir name, but
     # we should NOT auto-read (it's not a file).


### PR DESCRIPTION
feat: gl-issue/gh-issue :full flag + glob :no-auto-read

## Summary

Addresses #14:

- **`gl-issue:NUMBER:full` / `gh-issue:NUMBER:full`** — disables description and comment truncation, shows all comments instead of just the last 10. Default keeps current 3000/1000 char caps and adds a "use :full to fetch all" nudge when truncation kicks in (so you know it happened without re-running).
- **`glob:PATTERN:no-auto-read`** — suppresses auto-read of single matches and concrete file paths. Useful when the next step is native `Edit` (which rejects files not previously read by Claude's `Read` tool) — you get the file list without burning the read-state on a file you may not actually need to open.

## Why

- Plan briefs in our flow are long (architecture writeups, multi-step plans). Truncation forced fallbacks to raw `glab api .../notes`. `:full` removes the round-trip.
- Auto-read is great for one-and-done lookups, but bad when it auto-loads a file before native `Edit` is ready, mismatching state. Opt-out fixes that without changing default behavior.

## Tests

- 6 tests for gitlab `issue.py`, 6 for github `issue.py` (default truncates, `:full` doesn't, in both desc and comments)
- 2 tests for `op_glob(no_auto_read=True)`
- 1 dispatch test for `glob:...:no-auto-read` parsing

`952 passed` overall (3 pre-existing `test_map.py` failures on `master`, unrelated).

## Test plan

- [x] Default behavior unchanged
- [x] `:full` returns full description + all comments on both gl and gh
- [x] `:no-auto-read` suppresses single-match and concrete-path auto-reads
- [x] Existing tests still pass
