### PR TITLE
chore: release 0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/supertool.py
+++ b/supertool.py
@@ -95,7 +95,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-VERSION = "0.9.0"
+VERSION = "0.10.0"
 
 MAX_READ_LINES = 300
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"


### PR DESCRIPTION
Version bump after #15 merge.

- plugin.json: 0.9.0 → 0.10.0
- supertool.py VERSION: 0.9.0 → 0.10.0

Tag pushed after merge.