### PR TITLE
feat(git-status): base divergence + MR diff size

### DIFF
--- a/presets/git.json
+++ b/presets/git.json
@@ -4,8 +4,8 @@
   "ops": {
     "git-status": {
       "cmd": "python3 {path}git/status.py",
-      "timeout": 5,
-      "description": "Branch, commits, changes, stashes, open MR/PR",
+      "timeout": 10,
+      "description": "Branch, commits + base divergence, changes, stashes, open MR/PR with diff size",
       "syntax": "git-status"
     },
     "git-investigate": {

--- a/presets/git/status.py
+++ b/presets/git/status.py
@@ -156,24 +156,27 @@ def main() -> int:
             print(f"\n## MR !{mr_iid} — {mr_title}")
             print(f"State: {mr_state} | Target: {mr_target} | Pipeline: {pipe_status}")
 
-            # MR diff size — guards against an "empty" MR that has no commits
-            try:
-                changes_result = subprocess.run(
-                    ["glab", "api",
-                     f"projects/:id/merge_requests/{mr_iid}/changes"],
-                    capture_output=True, text=True, timeout=5,
-                )
-                if changes_result.returncode == 0:
-                    changes_data = _json.loads(changes_result.stdout)
-                    changes = changes_data.get("changes", [])
-                    if not changes:
-                        print("Diff: EMPTY — branch has no commits ahead of target!")
-                    else:
-                        adds = sum(c.get("diff", "").count("\n+") for c in changes)
-                        dels = sum(c.get("diff", "").count("\n-") for c in changes)
-                        print(f"Diff: {len(changes)} files (+{adds} -{dels})")
-            except (subprocess.TimeoutExpired, _json.JSONDecodeError):
-                pass
+            # MR diff size — file count from existing JSON (no extra network).
+            # +/- line counts via local git diff against target branch (also no
+            # network; falls back silently if target ref isn't present locally).
+            changes_count = mr.get("changes_count")
+            if changes_count is None or changes_count == "" or changes_count == "0":
+                print("Diff: EMPTY — branch has no commits ahead of target!")
+            else:
+                diff_line = f"Diff: {changes_count} files"
+                target_ref = f"origin/{mr_target}" if mr_target != "?" else ""
+                if target_ref:
+                    shortstat = _git(["diff", "--shortstat",
+                                      f"{target_ref}...HEAD"], timeout=3)
+                    if shortstat.returncode == 0 and shortstat.stdout.strip():
+                        # e.g. " 5 files changed, 126 insertions(+), 72 deletions(-)"
+                        text = shortstat.stdout.strip()
+                        adds = _re.search(r"(\d+) insertions?", text)
+                        dels = _re.search(r"(\d+) deletions?", text)
+                        a = adds.group(1) if adds else "0"
+                        d = dels.group(1) if dels else "0"
+                        diff_line += f" (+{a} -{d})"
+                print(diff_line)
 
             # Extract linked issue from description
             desc = mr.get("description") or ""

--- a/presets/git/status.py
+++ b/presets/git/status.py
@@ -54,8 +54,35 @@ def main() -> int:
             else:
                 ahead_behind = "up to date"
 
+    # Divergence from base branch (master/main) — distinct from upstream tracking
+    base_divergence = ""
+    base_branch = ""
+    for candidate in ("master", "main"):
+        check = _git(["rev-parse", "--verify", "--quiet", candidate])
+        if check.returncode == 0:
+            base_branch = candidate
+            break
+    if base_branch and branch_name != base_branch:
+        base_ab = _git(["rev-list", "--left-right", "--count",
+                        f"{base_branch}...HEAD"])
+        if base_ab.returncode == 0:
+            parts = base_ab.stdout.strip().split()
+            if len(parts) == 2:
+                behind_base, ahead_base = int(parts[0]), int(parts[1])
+                if ahead_base == 0:
+                    suffix = f", {behind_base} behind" if behind_base else ""
+                    base_divergence = (f"vs {base_branch}: 0 ahead{suffix} "
+                                       f"— branch has no own commits!")
+                else:
+                    parts_str = f"{ahead_base} ahead"
+                    if behind_base:
+                        parts_str += f", {behind_base} behind"
+                    base_divergence = f"vs {base_branch}: {parts_str}"
+
     print(f"# git-status")
     print(f"Branch: {branch_name}" + (f" ({ahead_behind})" if ahead_behind else ""))
+    if base_divergence:
+        print(base_divergence)
 
     # 2. Last 5 commits
     log_result = _git(["log", "-5", "--format=%h %ad %an | %s", "--date=short"])
@@ -129,6 +156,25 @@ def main() -> int:
             print(f"\n## MR !{mr_iid} — {mr_title}")
             print(f"State: {mr_state} | Target: {mr_target} | Pipeline: {pipe_status}")
 
+            # MR diff size — guards against an "empty" MR that has no commits
+            try:
+                changes_result = subprocess.run(
+                    ["glab", "api",
+                     f"projects/:id/merge_requests/{mr_iid}/changes"],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if changes_result.returncode == 0:
+                    changes_data = _json.loads(changes_result.stdout)
+                    changes = changes_data.get("changes", [])
+                    if not changes:
+                        print("Diff: EMPTY — branch has no commits ahead of target!")
+                    else:
+                        adds = sum(c.get("diff", "").count("\n+") for c in changes)
+                        dels = sum(c.get("diff", "").count("\n-") for c in changes)
+                        print(f"Diff: {len(changes)} files (+{adds} -{dels})")
+            except (subprocess.TimeoutExpired, _json.JSONDecodeError):
+                pass
+
             # Extract linked issue from description
             desc = mr.get("description") or ""
             issue_match = _re.search(r'#(\d{4,})', desc)
@@ -143,7 +189,8 @@ def main() -> int:
         try:
             gh_result = subprocess.run(
                 ["gh", "pr", "view", branch_name, "--json",
-                 "number,title,state,baseRefName,statusCheckRollup,body"],
+                 "number,title,state,baseRefName,statusCheckRollup,body,"
+                 "additions,deletions,changedFiles"],
                 capture_output=True, text=True, timeout=5,
             )
             if gh_result.returncode == 0:
@@ -161,6 +208,12 @@ def main() -> int:
 
                 print(f"\n## PR #{pr_num} — {pr_title}")
                 print(f"State: {pr_state} | Target: {pr_target} | Checks: {check_summary}")
+
+                changed_files = pr.get("changedFiles", 0)
+                if changed_files == 0:
+                    print("Diff: EMPTY — branch has no commits ahead of target!")
+                else:
+                    print(f"Diff: {changed_files} files (+{pr.get('additions', 0)} -{pr.get('deletions', 0)})")
 
                 # Extract linked issue
                 body = pr.get("body") or ""

--- a/tests/test_git_status.py
+++ b/tests/test_git_status.py
@@ -1,0 +1,116 @@
+"""Tests for presets/git/status.py — base-branch divergence + MR diff size.
+
+Uses real git in tmp_path because status.py calls many subprocess endpoints.
+Stubs out glab/gh (network).
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any
+
+PRESET_PATH = Path(__file__).parent.parent / "presets" / "git" / "status.py"
+_spec = importlib.util.spec_from_file_location("git_status", PRESET_PATH)
+assert _spec is not None and _spec.loader is not None
+status = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(status)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True,
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "master")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "f").write_text("x\n")
+    _git(repo, "add", "f")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _stub_no_mr(monkeypatch) -> None:
+    """Block glab/gh subprocess calls — no MR found."""
+    real_run = subprocess.run
+
+    def fake_run(args, *a, **kw):
+        if args and args[0] in ("glab", "gh"):
+            return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="")
+        return real_run(args, *a, **kw)
+
+    monkeypatch.setattr(status.subprocess, "run", fake_run)
+
+
+def _run_main(repo: Path, monkeypatch) -> str:
+    monkeypatch.chdir(repo)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        status.main()
+    return buf.getvalue()
+
+
+def test_branch_with_zero_commits_warns(tmp_path: Path, monkeypatch) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")  # branched at master tip, no commits
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "0 ahead" in out
+    assert "no own commits" in out
+
+
+def test_branch_with_commits_shows_count(tmp_path: Path, monkeypatch) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "g").write_text("y\n")
+    _git(repo, "add", "g")
+    _git(repo, "commit", "-m", "feature work")
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "vs master: 1 ahead" in out
+    assert "no own commits" not in out
+
+
+def test_branch_behind_master_shows_behind_count(tmp_path: Path, monkeypatch) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+    _git(repo, "checkout", "master")
+    (repo / "h").write_text("z\n")
+    _git(repo, "add", "h")
+    _git(repo, "commit", "-m", "advance master")
+    _git(repo, "checkout", "feature")
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "0 ahead" in out
+    assert "1 behind" in out
+
+
+def test_on_master_no_divergence_line(tmp_path: Path, monkeypatch) -> None:
+    repo = _init_repo(tmp_path)
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "vs master" not in out  # comparing master to itself: skip
+
+
+def test_main_branch_used_when_master_missing(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "main_repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "t@t.com")
+    _git(repo, "config", "user.name", "T")
+    (repo / "f").write_text("x\n")
+    _git(repo, "add", "f")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "checkout", "-b", "feature")
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "vs main: 0 ahead" in out


### PR DESCRIPTION
feat(git-status): base divergence + MR diff size — make empty branches scream

## Why

In a real session today, I had:
- A branch `max/foo` with no commits (a stash/checkout dance lost the commit)
- An MR opened against that branch with no diff

`git-status` said:
```
Branch: max/foo (up to date)
## MR !20962 — feat: ...
State: opened | Target: master | Pipeline: failed
```

Both lines were technically true. "up to date" referred to upstream sync; the MR section reported state but not size. The visible output didn't contradict the working-tree state, so I went off and wasted ~6 round-trips on `git log`, `git rev-parse`, `glab api`, `reflog` to re-derive what the output should have told me at a glance: this branch has zero content and the MR is empty.

## What changes

Two signals, both opt-in to the existing dashboard:

1. **`vs master: N ahead, M behind`** — explicit divergence vs base branch (auto-detects master/main). When `N=0`, prints `vs master: 0 ahead — branch has no own commits!` so the contradiction can't hide.
2. **`Diff: N files (+adds -dels)`** under the MR/PR section. An empty MR prints `Diff: EMPTY — branch has no commits ahead of target!`.

On-master users get no `vs master` line (no contradiction possible).

## Sample output

Before:
```
Branch: max/foo (up to date)

## MR !20962 — feat: ...
State: opened | Target: master | Pipeline: failed
```

After (same scenario):
```
Branch: max/foo (up to date)
vs master: 0 ahead — branch has no own commits!

## MR !20962 — feat: ...
State: opened | Target: master | Pipeline: failed
Diff: EMPTY — branch has no commits ahead of target!
```

## Tests

5 new in `test_git_status.py`: zero-ahead, N-ahead, behind-master, on-master skip, main-branch fallback. All 957 prior tests still pass (3 pre-existing `test_map.py` failures on master, unrelated).

## Test plan

- [x] zero-ahead branch shows the warning
- [x] branch with commits shows `N ahead`
- [x] branch behind master shows `M behind`
- [x] on master itself: no `vs master` line (would be self-comparison)
- [x] repos using `main` instead of `master` work
- [x] MR/PR diff size displayed for both glab and gh
