### PR TITLE
fix(replace): support multi-line patterns + map line label

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -1572,7 +1572,8 @@ def _format_map_symbols(
     out = [f"{path} ({line_count} lines)\n"]
     for kind, name, line, end_line, depth in symbols:
         indent = "  " * (depth + 1)
-        out.append(f"{indent}{kind} {name}  [{line}-{end_line}]\n")
+        label = f"[{line}]" if line == end_line else f"[{line}-{end_line}]"
+        out.append(f"{indent}{kind} {name}  {label}\n")
     return "".join(out)
 
 
@@ -2105,64 +2106,75 @@ def op_replace(old: str, new: str, path: str = ".", dry: bool = False) -> str:
     if not candidates:
         return "(0 files to search)\n"
 
-    # Collect matches
-    matches: List[Tuple[str, int, str]] = []  # (filepath, lineno, line_content)
+    # Collect matches via whole-file scan so multi-line `old` patterns work.
+    # Line-by-line matching would silently miss any pattern containing '\n'.
+    file_matches: List[Tuple[str, List[int]]] = []  # (filepath, [match_start_offsets])
+    total_count = 0
     for file_path in candidates:
         try:
             with open(file_path, "r", encoding="utf-8", errors="replace") as f:
-                for lineno, line in enumerate(f, start=1):
-                    if old in line:
-                        matches.append((file_path, lineno, line.rstrip()))
+                content = f.read()
         except OSError:
             continue
+        positions: List[int] = []
+        start = 0
+        while True:
+            idx = content.find(old, start)
+            if idx == -1:
+                break
+            positions.append(idx)
+            start = idx + len(old)
+        if positions:
+            file_matches.append((file_path, positions))
+            total_count += len(positions)
 
-    if not matches:
+    if total_count == 0:
         return f"(0 occurrences of '{old}' found)\n"
 
     if dry:
-        # Diff preview mode
-        out: List[str] = []
-        current_file = ""
-        file_count = 0
-        for filepath, lineno, content in matches:
-            if filepath != current_file:
-                current_file = filepath
-                file_count += 1
-                out.append(f"\n{filepath}\n")
-            replaced = content.replace(old, new)
-            out.append(f"  {lineno}:  - {content}\n")
-            out.append(f"  {lineno}:  + {replaced}\n")
-
-        out.insert(0, f"({len(matches)} occurrences in {file_count} files)\n")
-        out.append(f"\nSummary: {len(matches)} replacements in {file_count} files (DRY RUN — no files modified)\n")
-        return "".join(out)
-    else:
-        # Execute mode — perform replacements file by file
-        files_modified: Dict[str, int] = {}  # filepath -> count
-        for file_path in candidates:
+        out: List[str] = [f"({total_count} occurrences in {len(file_matches)} files)\n"]
+        old_lines = old.split("\n")
+        new_lines = new.split("\n")
+        for filepath, positions in file_matches:
+            out.append(f"\n{filepath}\n")
             try:
-                with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                with open(filepath, "r", encoding="utf-8", errors="replace") as f:
                     content = f.read()
             except OSError:
                 continue
-
-            count = content.count(old)
-            if count == 0:
-                continue
-
-            new_content = content.replace(old, new)
-            try:
-                _atomic_write(file_path, new_content)
-                files_modified[file_path] = count
-            except OSError as e:
-                return f"ERROR: failed to write {file_path}: {e}\n"
-
-        total = sum(files_modified.values())
-        out = [f"({total} replacements in {len(files_modified)} files)\n"]
-        for fp, cnt in sorted(files_modified.items()):
-            out.append(f"  {fp} ({cnt})\n")
-        out.append(f"\nDone: '{old}' → '{new}'\n")
+            for pos in positions:
+                start_line = content.count("\n", 0, pos) + 1
+                end_line = start_line + len(old_lines) - 1
+                label = f"L{start_line}" if start_line == end_line else f"L{start_line}-L{end_line}"
+                out.append(f"  {label}:\n")
+                for ol in old_lines:
+                    out.append(f"    - {ol}\n")
+                for nl in new_lines:
+                    out.append(f"    + {nl}\n")
+        out.append(f"\nSummary: {total_count} replacements in {len(file_matches)} files (DRY RUN — no files modified)\n")
         return "".join(out)
+
+    # Execute mode
+    files_modified: Dict[str, int] = {}
+    for file_path, positions in file_matches:
+        try:
+            with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                content = f.read()
+        except OSError:
+            continue
+        new_content = content.replace(old, new)
+        try:
+            _atomic_write(file_path, new_content)
+            files_modified[file_path] = len(positions)
+        except OSError as e:
+            return f"ERROR: failed to write {file_path}: {e}\n"
+
+    total = sum(files_modified.values())
+    out = [f"({total} replacements in {len(files_modified)} files)\n"]
+    for fp, cnt in sorted(files_modified.items()):
+        out.append(f"  {fp} ({cnt})\n")
+    out.append(f"\nDone: '{old}' → '{new}'\n")
+    return "".join(out)
 
 
 def _atomic_write(path: str, content: str) -> None:

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -319,13 +319,13 @@ def test_regex_extract_unsupported() -> None:
 
 def test_format_map_symbols() -> None:
     symbols = [
-        ("class", "Foo", 1, 0),
-        ("method", "bar", 5, 1),
+        ("class", "Foo", 1, 1, 0),
+        ("method", "bar", 5, 7, 1),
     ]
     out = supertool._format_map_symbols(symbols, "test.py", 10)
     assert "test.py (10 lines)" in out
     assert "class Foo  [1]" in out
-    assert "method bar  [5]" in out
+    assert "method bar  [5-7]" in out
 
 
 def test_format_ctags_symbols() -> None:
@@ -635,7 +635,7 @@ def test_ts_extract_python(tmp_path: Path) -> None:
     # bar should have depth > Foo
     foo_sym = [s for s in symbols if s[1] == "Foo"][0]
     bar_sym = [s for s in symbols if s[1] == "bar"][0]
-    assert bar_sym[3] > foo_sym[3]
+    assert bar_sym[4] > foo_sym[4]
 
 
 @pytest.mark.skipif(not _has_any_tree_sitter(), reason="no tree-sitter")

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -149,3 +149,48 @@ class TestReplaceDispatch:
     def test_dispatch_replace_no_path_defaults_to_cwd(self, tmp_files):
         result = dispatch(f"replace_dry:XYZNONEXIST99:NEWVAL:{tmp_files}")
         assert "0 occurrences" in result
+
+
+@pytest.fixture
+def multiline_files(tmp_path):
+    """Files with multi-line patterns (e.g. duplicated INI sections)."""
+    f1 = tmp_path / "a.ini"
+    f1.write_text("[fr_all]\n[es_all]\n[es_all]\n")
+    f2 = tmp_path / "b.ini"
+    f2.write_text("[fr_all]\n[en_all]\n[es_all]\n[es_all]\n")
+    f3 = tmp_path / "c.ini"
+    f3.write_text("[fr_all]\n[es_all]\n")
+    return tmp_path
+
+
+class TestReplaceMultiline:
+    """Multi-line `old` patterns must match across line boundaries."""
+
+    def test_dry_finds_multiline_pattern(self, multiline_files):
+        result = op_replace("[es_all]\n[es_all]", "[es_all]", str(multiline_files), dry=True)
+        assert "(2 occurrences in 2 files)" in result
+        assert "DRY RUN" in result
+
+    def test_dry_shows_line_range_for_multiline(self, multiline_files):
+        result = op_replace("[es_all]\n[es_all]", "[es_all]", str(multiline_files), dry=True)
+        assert "L2-L3" in result or "L3-L4" in result
+
+    def test_execute_collapses_duplicate_blocks(self, multiline_files):
+        op_replace("[es_all]\n[es_all]", "[es_all]", str(multiline_files), dry=False)
+        assert (multiline_files / "a.ini").read_text() == "[fr_all]\n[es_all]\n"
+        assert (multiline_files / "b.ini").read_text() == "[fr_all]\n[en_all]\n[es_all]\n"
+        # File without duplicate stays untouched
+        assert (multiline_files / "c.ini").read_text() == "[fr_all]\n[es_all]\n"
+
+    def test_execute_receipt_counts_files(self, multiline_files):
+        result = op_replace("[es_all]\n[es_all]", "[es_all]", str(multiline_files), dry=False)
+        assert "2 replacements in 2 files" in result
+
+    def test_dry_does_not_modify_multiline(self, multiline_files):
+        original_a = (multiline_files / "a.ini").read_text()
+        op_replace("[es_all]\n[es_all]", "[es_all]", str(multiline_files), dry=True)
+        assert (multiline_files / "a.ini").read_text() == original_a
+
+    def test_replacement_can_be_multiline(self, multiline_files):
+        op_replace("[fr_all]\n[es_all]", "[fr_all]\n[de_all]\n[es_all]", str(multiline_files / "c.ini"), dry=False)
+        assert (multiline_files / "c.ini").read_text() == "[fr_all]\n[de_all]\n[es_all]\n"


### PR DESCRIPTION
## Summary
- `op_replace` scanned matches line-by-line, so any `old` containing `\n` silently returned "0 occurrences" — both dry and execute modes broken. Switched to whole-file `content.find()` loop.
- Dry preview now shows `Lstart-Lend` range with per-line `-`/`+` blocks.
- `_format_map_symbols` aligned to the 5-tuple shape (kind, name, line, end_line, depth): `[line]` for single-line, `[line-end_line]` otherwise.
- Stale tests pinned to 4-tuples / depth at index 3 updated.

## Test plan
- [x] 6 new `TestReplaceMultiline` cases (dry detection, line range, collapse, receipt counts, dry no-modify, multi-line replacement)
- [x] 27/27 replace tests green
- [x] 980 total pass on full suite
- [x] Verified end-to-end against a real DVSI dedup task (43 then 631 i18n-all.ini files)