### PR TITLE
feat: around dir fan-out + git-commit --no-edit

### DIFF
--- a/presets/git.json
+++ b/presets/git.json
@@ -59,7 +59,7 @@
     "git-commit": {
       "cmd": "python3 {path}git/commit.py {args}",
       "timeout": 60,
-      "description": "Commit MSG (stages PATHS) — HEAD before/after, hook errors surfaced",
+      "description": "Commit MSG (stages PATHS) — HEAD before/after, hook errors surfaced. MSG=--no-edit reuses MERGE_MSG/CHERRY_PICK msg (merge or cherry-pick must be in progress)",
       "syntax": "git-commit:::MSG[:::PATH...]"
     }
   }

--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -8,7 +8,12 @@ Receipt always shows:
 
 Surfaces silent rollbacks: if HEAD is unchanged after the call,
 that's printed loudly. Replaces the add/commit/log-1 cycle.
+
+Special MSG values:
+  --no-edit   Use prepared commit message (MERGE_MSG / CHERRY_PICK_HEAD).
+              Only valid when a merge or cherry-pick is in progress.
 """
+import os
 import subprocess
 import sys
 
@@ -49,8 +54,9 @@ def main() -> int:
 
     msg = sys.argv[1]
     paths = sys.argv[2:]
+    no_edit = msg.strip() == "--no-edit"
 
-    if not msg.strip():
+    if not no_edit and not msg.strip():
         print("ERROR: commit message is empty.")
         return 1
 
@@ -60,6 +66,17 @@ def main() -> int:
 
     head_before = _head_sha()
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+
+    if no_edit:
+        gd = _git(["rev-parse", "--git-dir"]).stdout.strip()
+        in_merge = bool(gd) and (
+            os.path.exists(os.path.join(gd, "MERGE_HEAD"))
+            or os.path.exists(os.path.join(gd, "CHERRY_PICK_HEAD"))
+        )
+        if not in_merge:
+            print("ERROR: --no-edit requires a merge or cherry-pick in progress "
+                  "(no MERGE_HEAD/CHERRY_PICK_HEAD found).")
+            return 1
 
     print(f"# git-commit on {branch}")
     print(f"HEAD before: {head_before}")
@@ -80,7 +97,10 @@ def main() -> int:
     staged_files = [l for l in staged.stdout.splitlines() if l.strip()]
 
     # Commit
-    result = _git(["commit", "-m", msg])
+    if no_edit:
+        result = _git(["commit", "--no-edit"])
+    else:
+        result = _git(["commit", "-m", msg])
     head_after = _head_sha()
 
     if result.returncode == 0 and head_after and head_after != head_before:

--- a/supertool.py
+++ b/supertool.py
@@ -786,24 +786,16 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
     return "".join(out)
 
 
-def op_around(pattern: str, path: str, n: int = 10) -> str:
-    """Show N lines before and after the first match of PATTERN in file at PATH."""
-    if not pattern:
-        return "ERROR: empty pattern\n"
-    if "\\|" in pattern:
-        pattern = pattern.replace("\\|", "|")
-    if not path:
-        return "ERROR: empty path\n"
-    if os.path.isdir(path):
-        return f"ERROR: around only works on single files, not directories: {path}\n"
-    if not os.path.isfile(path):
-        return f"ERROR: file not found: {path}\n"
+_AROUND_DIR_SKIP = {".git", "node_modules", "__pycache__", ".venv", "venv", ".tox", "vendor"}
+_AROUND_DIR_MAX_FILES = 20
 
-    try:
-        regex = re.compile(pattern)
-    except re.error:
-        regex = re.compile(re.escape(pattern))
 
+def _around_one_file(regex: "re.Pattern[str]", path: str, n: int) -> str:
+    """Render the first match of regex in file at path with n lines context.
+
+    Returns an empty string when the file has no match (caller filters these
+    out so dir fan-out only shows hits).
+    """
     try:
         with open(path, "rb") as f:
             raw_lines = f.read().splitlines(keepends=True)
@@ -824,7 +816,7 @@ def op_around(pattern: str, path: str, n: int = 10) -> str:
             break
 
     if match_lineno is None:
-        return f"(no match for {pattern!r} in {path})\n\n"
+        return ""
 
     total = len(lines)
     start = max(0, match_lineno - n)
@@ -837,6 +829,65 @@ def op_around(pattern: str, path: str, n: int = 10) -> str:
         out.append(f"{i + 1:>6}{marker}{lines[i]}")
     out.append("\n")
     return "".join(out)
+
+
+def op_around(pattern: str, path: str, n: int = 10) -> str:
+    """Show N lines before and after the first match of PATTERN in PATH.
+
+    PATH can be a file (first match in that file) or a directory (first
+    match per file, skipping files with no match, capped at
+    _AROUND_DIR_MAX_FILES). Hidden and heavy dirs (.git, node_modules,
+    vendor, …) are skipped during dir walk.
+    """
+    if not pattern:
+        return "ERROR: empty pattern\n"
+    if "\\|" in pattern:
+        pattern = pattern.replace("\\|", "|")
+    if not path:
+        return "ERROR: empty path\n"
+
+    try:
+        regex = re.compile(pattern)
+    except re.error:
+        regex = re.compile(re.escape(pattern))
+
+    if os.path.isdir(path):
+        hits: List[str] = []
+        scanned = 0
+        for root, dirs, files in os.walk(path):
+            dirs[:] = [d for d in dirs
+                       if not d.startswith(".") and d not in _AROUND_DIR_SKIP]
+            for name in sorted(files):
+                if name.startswith("."):
+                    continue
+                fpath = os.path.join(root, name)
+                scanned += 1
+                rendered = _around_one_file(regex, fpath, n)
+                if rendered and rendered.startswith("ERROR:"):
+                    continue
+                if not rendered:
+                    continue
+                rel = os.path.relpath(fpath, path)
+                hits.append(f"=== {rel} ===\n{rendered}")
+                if len(hits) >= _AROUND_DIR_MAX_FILES:
+                    break
+            if len(hits) >= _AROUND_DIR_MAX_FILES:
+                break
+        if not hits:
+            return f"(no match for {pattern!r} in {path}, scanned {scanned} file(s))\n\n"
+        header = f"(matched {len(hits)} file(s) under {path}"
+        if len(hits) >= _AROUND_DIR_MAX_FILES:
+            header += f", capped at {_AROUND_DIR_MAX_FILES}"
+        header += f", scanned {scanned})\n"
+        return header + "".join(hits)
+
+    if not os.path.isfile(path):
+        return f"ERROR: file not found: {path}\n"
+
+    rendered = _around_one_file(regex, path, n)
+    if not rendered:
+        return f"(no match for {pattern!r} in {path})\n\n"
+    return rendered
 
 
 def op_between_symbol(symbol: str, path: str) -> str:

--- a/tests/test_around.py
+++ b/tests/test_around.py
@@ -43,10 +43,43 @@ def test_around_no_match(tmp_path: Path) -> None:
     assert "no match" in out
 
 
-def test_around_directory_returns_error(tmp_path: Path) -> None:
-    out = supertool.op_around("pattern", str(tmp_path))
-    assert "ERROR" in out
-    assert "directories" in out or "directory" in out
+def test_around_directory_fans_out_to_files_with_match(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("alpha\nNEEDLE\nbeta\n")
+    (tmp_path / "b.py").write_text("nothing\nhere\n")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.py").write_text("hit NEEDLE again\n")
+
+    out = supertool.op_around("NEEDLE", str(tmp_path), n=1)
+    assert "matched 2 file(s)" in out
+    assert "=== a.py ===" in out
+    assert "=== sub/c.py" in out or "=== sub\\c.py" in out
+    assert "b.py" not in out  # files without match are skipped
+    assert "NEEDLE" in out
+
+
+def test_around_directory_no_match(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("nothing\n")
+    (tmp_path / "b.py").write_text("zilch\n")
+    out = supertool.op_around("XYZZY_NOMATCH", str(tmp_path))
+    assert "no match" in out
+    assert "scanned 2 file(s)" in out
+
+
+def test_around_directory_skips_heavy_dirs(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("NEEDLE here\n")
+    skip = tmp_path / ".git"
+    skip.mkdir()
+    (skip / "config").write_text("NEEDLE in git\n")
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / "x.js").write_text("NEEDLE in deps\n")
+
+    out = supertool.op_around("NEEDLE", str(tmp_path), n=0)
+    assert "matched 1 file(s)" in out
+    assert "=== a.py ===" in out
+    assert ".git" not in out
+    assert "node_modules" not in out
 
 
 def test_around_missing_file_returns_error(tmp_path: Path) -> None:

--- a/tests/test_git_commit.py
+++ b/tests/test_git_commit.py
@@ -45,3 +45,58 @@ def test_no_args_prints_usage(monkeypatch, capsys) -> None:
     out = capsys.readouterr().out
     assert rc == 1
     assert "usage" in out
+
+
+def test_no_edit_outside_merge_rejected(monkeypatch, capsys, tmp_path) -> None:
+    """--no-edit needs MERGE_HEAD or CHERRY_PICK_HEAD; reject otherwise."""
+    import subprocess
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(commit.sys, "argv", ["commit.py", "--no-edit"])
+    rc = commit.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "--no-edit" in out
+    assert "MERGE_HEAD" in out or "merge" in out.lower()
+
+
+def test_no_edit_during_merge_uses_prepared_message(monkeypatch, capsys, tmp_path) -> None:
+    """With MERGE_HEAD present, --no-edit calls `git commit --no-edit`."""
+    import subprocess
+    subprocess.run(["git", "init", "-q", "-b", "main", str(tmp_path)], check=True)
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "config", "user.name", "t"], check=True)
+    (tmp_path / "a.txt").write_text("hi\n")
+    subprocess.run(["git", "add", "a.txt"], check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], check=True)
+    # Fake a merge state: MERGE_HEAD + MERGE_MSG + a staged change
+    gd = subprocess.run(["git", "rev-parse", "--git-dir"],
+                        capture_output=True, text=True, check=True).stdout.strip()
+    Path(gd, "MERGE_HEAD").write_text("0" * 40 + "\n")
+    Path(gd, "MERGE_MSG").write_text("Merge fake\n")
+    (tmp_path / "a.txt").write_text("hi\nmerged\n")
+    subprocess.run(["git", "add", "a.txt"], check=True)
+
+    calls: list[list[str]] = []
+    real_run = commit._git
+
+    def spy(args, timeout=30):
+        calls.append(list(args))
+        # Short-circuit the actual commit so we don't depend on a clean merge:
+        # we only want to verify --no-edit reaches git.
+        if list(args)[:2] == ["commit", "--no-edit"]:
+            class R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+            return R()
+        return real_run(args, timeout=timeout)
+    monkeypatch.setattr(commit, "_git", spy)
+    monkeypatch.setattr(commit.sys, "argv", ["commit.py", "--no-edit"])
+
+    rc = commit.main()
+    capsys.readouterr()  # drain
+    assert ["commit", "--no-edit"] in calls
+    # No -m was passed for any commit invocation
+    assert all("-m" not in c for c in calls if c[:1] == ["commit"])


### PR DESCRIPTION
## Summary
- `around:PATTERN:DIR` now fans out across files (skips heavy dirs, caps 20 hits)
- `git-commit:::--no-edit` reuses MERGE_MSG / CHERRY_PICK_HEAD msg
- Tests: 3 around dir cases + 2 commit --no-edit cases

## Why
Hit during a real merge resolution today: had to drop to raw \`git commit --no-edit\` because supertool's git-commit required a MSG. Also wanted \`around\` against a directory without writing a one-shot script.

## Test plan
- [x] \`pytest tests/test_around.py tests/test_git_commit.py\` — 18/18 pass