### PR TITLE
feat(git-checkout): surface worktree path on locked-ref error

### DIFF
--- a/presets/git/checkout.py
+++ b/presets/git/checkout.py
@@ -39,6 +39,15 @@ def main() -> int:
         s = stderr.lower()
         if "not a git repository" in s:
             print("ERROR: not inside a git repository.")
+        elif "is already used by worktree" in s or "already checked out at" in s:
+            import re
+            m = re.search(r"worktree at ['\"]?([^'\"\n]+?)['\"]?$", stderr, re.MULTILINE) \
+                or re.search(r"checked out at ['\"]?([^'\"\n]+?)['\"]?$", stderr, re.MULTILINE)
+            path = m.group(1) if m else None
+            print(f"ERROR: ref {ref!r} is checked out in another worktree.")
+            if path:
+                print(f"Switch with: cd {path}")
+                print(f"Or remove it: git worktree remove {path}")
         elif "did not match any" in s or "pathspec" in s:
             print(f"ERROR: ref {ref!r} not found. Try `git fetch` first.")
         elif "would be overwritten" in s or "local changes" in s:

--- a/tests/test_git_checkout.py
+++ b/tests/test_git_checkout.py
@@ -51,3 +51,30 @@ def test_unknown_ref_returns_actionable_error(monkeypatch, capsys) -> None:
     assert rc == 1
     assert "not found" in out
     assert "git fetch" in out
+
+
+def test_checkout_worktree_locked_suggests_path(monkeypatch, capsys) -> None:
+    """When ref is checked out in another worktree, suggest cd <path>."""
+    err = (
+        "fatal: 'feature/x' is already used by worktree at "
+        "'/private/tmp/dvsi-google-tests'"
+    )
+
+    def fake(args, timeout=10):
+        if args[:2] == ["rev-parse", "--abbrev-ref"]:
+            return _fake_run("master\n")
+        if args[:2] == ["rev-parse", "--short"]:
+            return _fake_run("abc1234\n")
+        if args[0] == "checkout":
+            return _fake_run("", err, 128)
+        return _fake_run()
+
+    monkeypatch.setattr(checkout, "_git", fake)
+    monkeypatch.setattr(checkout.sys, "argv", ["checkout.py", "feature/x"])
+    rc = checkout.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "another worktree" in out
+    assert "/private/tmp/dvsi-google-tests" in out
+    assert "cd /private/tmp/dvsi-google-tests" in out
+    assert "git worktree remove" in out


### PR DESCRIPTION
## Summary
When `git checkout REF` fails with "already used by worktree at /path", we now parse the path and tell the user to `cd /path` (or `git worktree remove /path`). Saves a turn figuring out where the branch lives.

## Test plan
- [x] `pytest tests/test_git_checkout.py` — 3/3 pass
