### PR TITLE
feat(git-resolve): accept comma-separated PATH list

### DIFF
--- a/presets/git.json
+++ b/presets/git.json
@@ -52,9 +52,9 @@
     },
     "git-resolve": {
       "cmd": "python3 {path}git/resolve.py {args}",
-      "timeout": 15,
-      "description": "Pick ours/theirs for PATH (or all) + stage + continue cmd",
-      "syntax": "git-resolve:::SIDE:::PATH"
+      "timeout": 30,
+      "description": "Pick ours/theirs for PATH (single, comma-separated list, or 'all') + stage + continue cmd",
+      "syntax": "git-resolve:::SIDE:::PATH[,PATH...]"
     },
     "git-commit": {
       "cmd": "python3 {path}git/commit.py {args}",

--- a/presets/git/resolve.py
+++ b/presets/git/resolve.py
@@ -24,9 +24,9 @@ def _list_conflicts() -> list[str]:
 
 def main() -> int:
     if len(sys.argv) < 3:
-        print("ERROR: usage: resolve.py SIDE PATH")
+        print("ERROR: usage: resolve.py SIDE PATH[,PATH...]")
         print("  SIDE — 'ours' or 'theirs'")
-        print("  PATH — conflicted file path, or 'all' for every UU file")
+        print("  PATH — conflicted file path, comma-separated list, or 'all' for every UU file")
         return 1
 
     side = sys.argv[1].lower()
@@ -49,11 +49,14 @@ def main() -> int:
     if target == "all":
         targets = all_conflicts
     else:
-        if target not in all_conflicts:
-            print(f"ERROR: {target!r} is not a conflicted file.")
+        # Comma-separated list supported — multi-file resolves in one call
+        requested = [p.strip() for p in target.split(",") if p.strip()]
+        unknown = [p for p in requested if p not in all_conflicts]
+        if unknown:
+            print(f"ERROR: not conflicted: {', '.join(repr(p) for p in unknown)}")
             print(f"Conflicts: {', '.join(all_conflicts) or '(none)'}")
             return 1
-        targets = [target]
+        targets = requested
 
     print(f"# git-resolve: {side} ({len(targets)} file(s))")
 

--- a/tests/test_git_resolve.py
+++ b/tests/test_git_resolve.py
@@ -39,3 +39,60 @@ def test_side_case_insensitive(monkeypatch, capsys) -> None:
     out = capsys.readouterr().out
     assert "not inside a git repository" in out
     assert rc == 1
+
+
+def test_comma_separated_paths(monkeypatch, capsys) -> None:
+    """PATH accepts comma-separated list — resolves each in one call."""
+    import subprocess
+    calls: list[list[str]] = []
+
+    def fake_git(args, timeout=10):
+        calls.append(args)
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=".git\n", stderr="")
+        if args[:3] == ["diff", "--name-only", "--diff-filter=U"]:
+            # First call lists conflicts; subsequent (after resolves) returns empty
+            stdout = "a.php\nb.php\nc.php\n" if len([c for c in calls if c[:3] == ["diff", "--name-only", "--diff-filter=U"]]) == 1 else ""
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+        # checkout / add — succeed silently
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(resolve, "_git", fake_git)
+    monkeypatch.setattr(resolve.sys, "argv", ["resolve.py", "theirs", "a.php,b.php"])
+    rc = resolve.main()
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "git-resolve: theirs (2 file(s))" in out
+    assert "✓ a.php" in out
+    assert "✓ b.php" in out
+    # Both files received `checkout --theirs --` and `add --`
+    checkouts = [c for c in calls if c[:2] == ["checkout", "--theirs"]]
+    adds = [c for c in calls if c[:2] == ["add", "--"]]
+    assert len(checkouts) == 2
+    assert len(adds) == 2
+
+
+def test_comma_separated_unknown_path_rejected(monkeypatch, capsys) -> None:
+    """Unknown path in CSV list is rejected before any checkout runs."""
+    import subprocess
+    calls: list[list[str]] = []
+
+    def fake_git(args, timeout=10):
+        calls.append(args)
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=".git\n", stderr="")
+        if args[:3] == ["diff", "--name-only", "--diff-filter=U"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="a.php\nb.php\n", stderr="")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(resolve, "_git", fake_git)
+    monkeypatch.setattr(resolve.sys, "argv", ["resolve.py", "ours", "a.php,zzz.php"])
+    rc = resolve.main()
+    out = capsys.readouterr().out
+
+    assert rc == 1
+    assert "not conflicted" in out
+    assert "'zzz.php'" in out
+    # No checkout/add happened — atomic validation
+    assert not any(c[:2] == ["checkout", "--ours"] for c in calls)


### PR DESCRIPTION
## Summary

- `git-resolve:::SIDE:::PATH` now accepts `PATH1,PATH2,...` as well as a single path or `all`
- Atomic validation — if any path in the list isn't conflicted, the whole batch rejects before any `checkout`/`add` runs
- Tests added: happy path (CSV resolves both files) + unknown-path rejection

## Why

Single-path API forced N round-trips for N conflicts. Hit this resolving 20 conflicts during a fwk-wide variable rename merge — 20 separate calls. CSV cuts that to 1.