### PR TITLE
feat(grep): include file count in header summary

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -737,7 +737,9 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
         count = sum(
             1 for g in groups for line in g if line[2] == "match"
         )
-        out = [f"({count} results, limit {limit}, context {context})\n"]
+        file_count = len({g[0][0] for g in groups if g})
+        out = [f"({count} results in {file_count} files, "
+               f"limit {limit}, context {context})\n"]
         current_file: str = ""
         first_group = True
         for group in groups:
@@ -759,8 +761,9 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
 
     hits = _grep_recursive(pattern, path, limit, excl)
     count = len(hits)
+    file_count = len({h.split(":", 1)[0] for h in hits if ":" in h})
 
-    out = [f"({count} results, limit {limit})\n"]
+    out = [f"({count} results in {file_count} files, limit {limit})\n"]
     current_file = ""
     for hit in hits:
         # hits are "path:lineno:content" — split on first two colons

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -343,3 +343,18 @@ def test_grep_recursive_context_limit_across_files(tmp_path: Path) -> None:
     groups = supertool._grep_recursive_context("MATCH", str(tmp_path), 3, 0)
     match_count = sum(1 for g in groups for line in g if line[2] == "match")
     assert match_count == 3
+
+
+def test_grep_header_includes_file_count(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("MATCH\nMATCH\n")
+    (tmp_path / "b.txt").write_text("MATCH\n")
+    out = supertool.op_grep("MATCH", str(tmp_path))
+    assert "(3 results in 2 files," in out
+
+
+def test_grep_header_file_count_with_context(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("hello\nMATCH\nworld\n")
+    (tmp_path / "b.txt").write_text("MATCH\n")
+    out = supertool.op_grep("MATCH", str(tmp_path), context=1)
+    assert "results in 2 files" in out
+    assert "context 1" in out


### PR DESCRIPTION
## Summary
Default and context modes now show \`(N results in M files, limit L)\` instead of \`(N results, limit L)\`. Saves a separate \`wc\` round-trip when the agent needs to know how widespread a pattern is — total + spread in one read.

\`count_only\` mode already showed both numbers. This brings the regular modes to parity.

## Test plan
- [x] 2 new tests in test_grep.py
- [x] No existing tests assert on old header format
- [x] All tests pass