### PR TITLE
feat(grep_around): alias for grep with bulk-context defaults

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -41,6 +41,11 @@
       "description": "First match + N lines ctx (def 10). 1-shot grep+read",
       "example": "around:def main:src/app/Module.py:15"
     },
+    "grep_around": {
+      "syntax": "grep_around:PATTERN:PATH[:N[:LIMIT]]",
+      "description": "Every match + N ctx lines (def 3, limit 10). Bulk usage scan",
+      "example": "grep_around:CommandDriveCreateFile:src/:5"
+    },
     "glob": {
       "syntax": "glob:PATTERN",
       "description": "Find files (**). Auto-reads concrete paths",

--- a/.supertool.json
+++ b/.supertool.json
@@ -36,6 +36,12 @@
       "example": "around:def dispatch:supertool.py:15",
       "hint": true
     },
+    "grep_around": {
+      "syntax": "grep_around:PATTERN:PATH[:N[:LIMIT]]",
+      "description": "Every match + N ctx lines (def 3, limit 10). Bulk usage scan",
+      "example": "grep_around:def dispatch:supertool.py:5",
+      "hint": true
+    },
     "glob": {
       "syntax": "glob:PATTERN",
       "description": "Find files (**). Auto-reads concrete paths",

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ claude -p "..." --permission-mode bypassPermissions \
 | `head` | `head:PATH:N` | First N lines (default 20) |
 | `wc` | `wc:PATH` | Line/word/char count (like unix `wc`). Output: `LINES WORDS CHARS PATH`. |
 | `around` | `around:PATTERN:PATH` or `around:PATTERN:PATH:N` | Show N lines (default 10) before and after the **first** match of PATTERN in a single file. Uses line-numbered output like `read`. |
+| `grep_around` | `grep_around:PATTERN:PATH` or `grep_around:PATTERN:PATH:N:LIMIT` | Every match across files with N lines context (default N=3, LIMIT=10). Alias for `grep:PATTERN:PATH:LIMIT:CONTEXT` with sane defaults — useful for "show me how everyone uses this". |
 | `map` | `map:PATH` | Symbol map of a file or directory. Shows classes, functions, methods, constants as an indented tree with line numbers. Three-tier: tree-sitter → ctags → regex. Supports PHP, Python, JS, TS, Go, Rust, Java, Ruby. |
 | `introduction` | `introduction` | Output the project introduction text from `.supertool.json`. No `---` dispatch header — clean markdown. |
 | `output-format` | `output-format` | Output format examples from `.supertool.json`. Shows what responses look like. |

--- a/supertool.py
+++ b/supertool.py
@@ -65,6 +65,10 @@ OPERATIONS
                                 Config maps preset names to shell commands with {file}.
     around:PATTERN:PATH        Show 10 lines around the first match in FILE
     around:PATTERN:PATH:N      Show N lines around the first match in FILE
+    grep_around:PATTERN:PATH   Every match + 3 ctx lines, limit 10 (alias for
+                                grep with sane defaults — bulk usage scan)
+    grep_around:PATTERN:PATH:N:LIMIT
+                               Every match + N ctx lines, custom limit
     map:PATH                   Symbol map of a file or directory. Shows
                                 classes, functions, methods, constants as an
                                 indented tree with line numbers.
@@ -424,7 +428,7 @@ BLOCKED_TOOLS = {"Grep", "Glob", "LS"}
 BLOCKED_BASH_COMMANDS = {"cat", "find", "grep", "ls", "sed", "awk", "tail", "head"}
 
 # Built-in op names — custom ops/aliases with these names are ignored
-_BUILTIN_OPS = {"read", "grep", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines"}
+_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines"}
 
 # Read-only built-in ops — safe to run in parallel across a batch.
 # Excludes mutating ops (replace, edit, replace_lines) and custom ops
@@ -2604,6 +2608,15 @@ def dispatch(arg: str) -> str:
             pattern, path, limit, context, count_only = _parse_grep_args(parts)
             body = op_grep(pattern, path, limit, context, count_only,
                            no_exclude=no_exclude)
+        elif op == "grep_around":
+            # grep_around:PATTERN:PATH[:N[:LIMIT]] — every match with N lines
+            # context. Sane defaults for "show me how everyone uses this".
+            ga_pattern = parts[1] if len(parts) > 1 else ""
+            ga_path = parts[2] if len(parts) > 2 and parts[2] else "."
+            ga_context = int(parts[3]) if len(parts) > 3 and parts[3] else 3
+            ga_limit = int(parts[4]) if len(parts) > 4 and parts[4] else 10
+            body = op_grep(ga_pattern, ga_path, ga_limit, ga_context,
+                           count_only=False, no_exclude=no_exclude)
         elif op == "wc":
             path = parts[1] if len(parts) > 1 else ""
             body = op_wc(path)

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -358,3 +358,31 @@ def test_grep_header_file_count_with_context(tmp_path: Path) -> None:
     out = supertool.op_grep("MATCH", str(tmp_path), context=1)
     assert "results in 2 files" in out
     assert "context 1" in out
+
+
+# ---------------------------------------------------------------------------
+# grep_around dispatch — alias to grep with default context
+# ---------------------------------------------------------------------------
+
+def test_dispatch_grep_around_default_context(tmp_path: Path) -> None:
+    f = tmp_path / "src.py"
+    f.write_text("a\nb\nc\nMATCH\nd\ne\nf\n")
+    out = supertool.dispatch(f"grep_around:MATCH:{f}")
+    # Default context=3 → lines 1-7 all visible around match at 4
+    assert "context 3" in out
+    assert "  4:MATCH" in out
+    assert "  1-a" in out
+    assert "  7-f" in out
+
+
+def test_dispatch_grep_around_custom_n(tmp_path: Path) -> None:
+    f = tmp_path / "src.py"
+    f.write_text("a\nb\nMATCH\nd\ne\n")
+    out = supertool.dispatch(f"grep_around:MATCH:{f}:1")
+    assert "context 1" in out
+    assert "  3:MATCH" in out
+    assert "  2-b" in out
+    assert "  4-d" in out
+    # Beyond context not shown
+    assert "  1-a" not in out
+    assert "  5-e" not in out


### PR DESCRIPTION
## Summary
\`grep_around:PATTERN:PATH[:N[:LIMIT]]\` runs grep with context=N (def 3) and limit=L (def 10). Equivalent to \`grep:PATTERN:PATH:LIMIT:CONTEXT\` but with the right defaults for "show me how everyone uses this".

Discoverability fix — grep already supported context as 4th arg, but the alias makes the bulk-usage-scan use case obvious from the op name.

Updates: \`_BUILTIN_OPS\` set, dispatcher, op-list docstring, README ops table, both \`.supertool.json\` files.

## Test plan
- [x] 2 new tests in test_grep.py
- [x] All tests pass
- [x] All 3 .json configs valid