### PR TITLE
feat(gl-mr,gh-pr): always-print sections + assignees + age + threads

### DIFF
--- a/presets/github/pr.py
+++ b/presets/github/pr.py
@@ -9,6 +9,27 @@ DESCRIPTION_MAX = 2000
 COMMENT_MAX = 500
 
 
+def _relative_age(iso: str) -> str:
+    """Format an ISO timestamp as 'Nd ago', 'Nh ago', or 'Nm ago'."""
+    if not iso:
+        return "?"
+    try:
+        from datetime import datetime, timezone
+        s = iso.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(s)
+        delta = datetime.now(timezone.utc) - dt
+        secs = int(delta.total_seconds())
+        if secs < 60:
+            return f"{secs}s ago"
+        if secs < 3600:
+            return f"{secs // 60}m ago"
+        if secs < 86400:
+            return f"{secs // 3600}h ago"
+        return f"{secs // 86400}d ago"
+    except (ValueError, ImportError):
+        return "?"
+
+
 def _gh(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
     """Run a gh command and return the result."""
     return subprocess.run(
@@ -98,7 +119,7 @@ def main() -> int:
             "number,title,state,author,headRefName,baseRefName,labels,"
             "milestone,reviewDecision,reviews,mergeCommit,mergeable,"
             "isDraft,url,body,comments,additions,deletions,changedFiles,"
-            "statusCheckRollup"
+            "statusCheckRollup,assignees,createdAt,updatedAt,reviewThreads"
         ])
     except FileNotFoundError:
         print("ERROR: gh not found — install from https://cli.github.com")
@@ -166,7 +187,27 @@ def main() -> int:
     print(f"Labels: {labels}")
     print(f"Milestone: {milestone}")
 
-    # Reviews
+    # Assignees (distinct from reviewers)
+    assignees = d.get("assignees") or []
+    assignee_names = [a.get("login", "?") for a in assignees]
+    print(f"Assignees: {', '.join(assignee_names) if assignee_names else 'none'}")
+
+    # Age — created/updated, for stale-PR signal
+    created_at = d.get("createdAt") or ""
+    updated_at = d.get("updatedAt") or ""
+    if created_at:
+        age_str = f"Created: {_relative_age(created_at)}"
+        if updated_at and updated_at != created_at:
+            age_str += f" | Updated: {_relative_age(updated_at)}"
+        print(age_str)
+
+    # Unresolved review threads — distinct blocker from comments
+    review_threads = d.get("reviewThreads") or []
+    if review_threads:
+        unresolved = sum(1 for t in review_threads if not t.get("isResolved"))
+        print(f"Unresolved threads: {unresolved} / {len(review_threads)}")
+
+    # Reviews — always print so absence is signal, not silence
     reviews = d.get("reviews", [])
     if reviews:
         reviewers = {}
@@ -176,6 +217,8 @@ def main() -> int:
             reviewers[login] = r_state  # latest review state per reviewer
         parts = [f"{login} ({state})" for login, state in reviewers.items()]
         print(f"Reviews: {', '.join(parts)}")
+    else:
+        print("Reviews: none")
     print(f"Review decision: {review_decision}")
 
     # Checks (CI status)
@@ -236,6 +279,8 @@ def main() -> int:
     body = (d.get("body") or "")[:DESCRIPTION_MAX]
     if body:
         print(f"\n## Description\n{body}")
+    else:
+        print("\n## Description\n_(empty)_")
 
     # Comments
     comments = d.get("comments", [])

--- a/presets/gitlab/mr.py
+++ b/presets/gitlab/mr.py
@@ -13,6 +13,32 @@ DESCRIPTION_MAX = 2000
 COMMENT_MAX = 500
 
 
+def _relative_age(iso: str) -> str:
+    """Format an ISO timestamp as 'Nd ago', 'Nh ago', or 'Nm ago'.
+
+    Returns '?' on parse failure. Used for MR created/updated lines so the
+    agent gets stale-MR signal in one round-trip.
+    """
+    if not iso:
+        return "?"
+    try:
+        from datetime import datetime, timezone
+        # GitLab ISO format: 2026-05-08T10:00:00.000Z
+        s = iso.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(s)
+        delta = datetime.now(timezone.utc) - dt
+        secs = int(delta.total_seconds())
+        if secs < 60:
+            return f"{secs}s ago"
+        if secs < 3600:
+            return f"{secs // 60}m ago"
+        if secs < 86400:
+            return f"{secs // 3600}h ago"
+        return f"{secs // 86400}d ago"
+    except (ValueError, ImportError):
+        return "?"
+
+
 def _glab_api(endpoint: str, timeout: int = 10) -> subprocess.CompletedProcess[str]:
     """Run a glab api call."""
     return subprocess.run(
@@ -286,9 +312,22 @@ def main() -> int:
     print(f"Labels: {labels}")
     print(f"Milestone: {milestone}")
 
-    # Reviewers + approvals
-    if reviewer_names:
-        print(f"Reviewers: {', '.join(reviewer_names)}")
+    # Assignees (distinct from reviewers on GitLab)
+    assignees = d.get("assignees") or []
+    assignee_names = [a.get("username", "?") for a in assignees]
+    print(f"Assignees: {', '.join(assignee_names) if assignee_names else 'none'}")
+
+    # Reviewers + approvals — always print so absence is signal, not silence
+    print(f"Reviewers: {', '.join(reviewer_names) if reviewer_names else 'none'}")
+
+    # Age — created/updated, for stale-MR signal
+    created_at = d.get("created_at") or ""
+    updated_at = d.get("updated_at") or ""
+    if created_at:
+        age_str = f"Created: {_relative_age(created_at)}"
+        if updated_at and updated_at != created_at:
+            age_str += f" | Updated: {_relative_age(updated_at)}"
+        print(age_str)
 
     # Fetch approvals via API (glab mr view doesn't include this)
     try:
@@ -304,6 +343,22 @@ def main() -> int:
                 print(f"Approved by: {', '.join(approver_names)}")
             else:
                 print("Approved by: none")
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        pass
+
+    # Unresolved discussion threads — distinct blocker from comments
+    try:
+        disc_result = _glab_api(
+            f"projects/:id/merge_requests/{iid}/discussions?per_page=100"
+        )
+        if disc_result.returncode == 0:
+            discussions = json.loads(disc_result.stdout)
+            if isinstance(discussions, list):
+                resolvable = [dd for dd in discussions
+                              if any(n.get("resolvable") for n in (dd.get("notes") or []))]
+                unresolved = [dd for dd in resolvable
+                              if not all(n.get("resolved") for n in (dd.get("notes") or []) if n.get("resolvable"))]
+                print(f"Unresolved threads: {len(unresolved)} / {len(resolvable)}")
     except (subprocess.TimeoutExpired, json.JSONDecodeError):
         pass
 
@@ -405,8 +460,12 @@ def main() -> int:
     description = description_raw[:DESCRIPTION_MAX]
     if description:
         print(f"\n## Description\n{description}")
+    else:
+        print("\n## Description\n_(empty)_")
 
-    # Human comments (notes)
+    # Human comments (notes) — always print header so absence is signal,
+    # not silence. Mirrors gh-pr behavior.
+    human_notes: list = []
     try:
         notes_result = _glab_api(
             f"projects/:id/merge_requests/{iid}/notes?per_page=50&sort=asc"
@@ -415,16 +474,16 @@ def main() -> int:
             notes = json.loads(notes_result.stdout)
             if isinstance(notes, list):
                 human_notes = [n for n in notes if not n.get("system", False)]
-                if human_notes:
-                    print(f"\n## Comments ({len(human_notes)})")
-                    for note in human_notes[-10:]:
-                        note_author = (note.get("author") or {}).get("username", "?")
-                        body = (note.get("body") or "")[:COMMENT_MAX]
-                        created = (note.get("created_at") or "")[:10]
-                        print(f"\n**{note_author}** ({created}):")
-                        print(body)
     except (subprocess.TimeoutExpired, json.JSONDecodeError):
         pass
+
+    print(f"\n## Comments ({len(human_notes)})")
+    for note in human_notes[-10:]:
+        note_author = (note.get("author") or {}).get("username", "?")
+        body = (note.get("body") or "")[:COMMENT_MAX]
+        created = (note.get("created_at") or "")[:10]
+        print(f"\n**{note_author}** ({created}):")
+        print(body)
 
     return 0
 

--- a/tests/test_github_pr.py
+++ b/tests/test_github_pr.py
@@ -131,4 +131,65 @@ def test_main_slim_ignores_unknown_second_arg(monkeypatch, capsys) -> None:
     rc = pr.main()
     out = capsys.readouterr().out
     assert rc == 0
-    assert "Branch:" in out
+
+
+# ---------------------------------------------------------------------------
+# Always-print sections — empty case must show explicit marker
+# ---------------------------------------------------------------------------
+
+def test_main_full_mode_empty_sections_always_printed(monkeypatch, capsys) -> None:
+    payload = _pr_json_payload(
+        body="",
+        comments=[],
+        reviews=[],
+        assignees=[],
+        createdAt="2026-05-08T10:00:00Z",
+        reviewThreads=[],
+    )
+    monkeypatch.setattr(
+        pr.subprocess, "run",
+        lambda *a, **kw: _fake_run(payload, returncode=0),
+    )
+    monkeypatch.setattr(sys, "argv", ["pr.py", "12"])
+    rc = pr.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Description\n_(empty)_" in out
+    assert "## Comments (0)" in out
+    assert "Reviews: none" in out
+    assert "Assignees: none" in out
+    assert "Created:" in out
+
+
+def test_main_full_mode_with_assignees_age_threads(monkeypatch, capsys) -> None:
+    payload = _pr_json_payload(
+        assignees=[{"login": "alice"}, {"login": "bob"}],
+        createdAt="2026-05-01T10:00:00Z",
+        updatedAt="2026-05-08T10:00:00Z",
+        reviewThreads=[
+            {"isResolved": True},
+            {"isResolved": False},
+            {"isResolved": False},
+        ],
+    )
+    monkeypatch.setattr(
+        pr.subprocess, "run",
+        lambda *a, **kw: _fake_run(payload, returncode=0),
+    )
+    monkeypatch.setattr(sys, "argv", ["pr.py", "12"])
+    rc = pr.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Assignees: alice, bob" in out
+    assert "Created:" in out
+    assert "Updated:" in out
+    assert "Unresolved threads: 2 / 3" in out
+
+
+def test_relative_age_formats() -> None:
+    from datetime import datetime, timezone, timedelta
+    now = datetime.now(timezone.utc)
+    assert pr._relative_age((now - timedelta(minutes=5)).isoformat().replace("+00:00", "Z")).endswith("m ago")
+    assert pr._relative_age((now - timedelta(hours=2)).isoformat().replace("+00:00", "Z")).endswith("h ago")
+    assert pr._relative_age((now - timedelta(days=3)).isoformat().replace("+00:00", "Z")).endswith("d ago")
+    assert pr._relative_age("") == "?"

--- a/tests/test_gitlab_mr.py
+++ b/tests/test_gitlab_mr.py
@@ -305,4 +305,61 @@ def test_main_slim_ignores_unknown_second_arg(monkeypatch, capsys) -> None:
     rc = mr.main()
     out = capsys.readouterr().out
     assert rc == 0
-    assert "Branch:" in out  # full dashboard ran
+
+
+# ---------------------------------------------------------------------------
+# Always-print sections — empty case must show explicit marker
+# ---------------------------------------------------------------------------
+
+def test_main_full_mode_empty_sections_always_printed(monkeypatch, capsys) -> None:
+    """Empty description / comments / reviewers / assignees print explicit markers."""
+    payload = _mr_json_payload(
+        description="",
+        reviewers=[],
+        assignees=[],
+        created_at="2026-05-08T10:00:00.000Z",
+    )
+    monkeypatch.setattr(
+        mr.subprocess, "run",
+        lambda *a, **kw: _fake_run(payload, returncode=0),
+    )
+    monkeypatch.setattr(sys, "argv", ["mr.py", "20881"])
+    rc = mr.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Description\n_(empty)_" in out
+    assert "## Comments (0)" in out
+    assert "Reviewers: none" in out
+    assert "Assignees: none" in out
+    assert "Created:" in out
+
+
+def test_main_full_mode_with_assignees_and_age(monkeypatch, capsys) -> None:
+    payload = _mr_json_payload(
+        assignees=[{"username": "alice"}, {"username": "bob"}],
+        created_at="2026-05-01T10:00:00.000Z",
+        updated_at="2026-05-08T10:00:00.000Z",
+    )
+    monkeypatch.setattr(
+        mr.subprocess, "run",
+        lambda *a, **kw: _fake_run(payload, returncode=0),
+    )
+    monkeypatch.setattr(sys, "argv", ["mr.py", "20881"])
+    rc = mr.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Assignees: alice, bob" in out
+    assert "Created:" in out
+    assert "Updated:" in out
+
+
+def test_relative_age_formats() -> None:
+    """Helper formats produces 'd', 'h', 'm', 's' suffixes."""
+    from datetime import datetime, timezone, timedelta
+    now = datetime.now(timezone.utc)
+    assert mr._relative_age((now - timedelta(seconds=30)).isoformat().replace("+00:00", "Z")).endswith("s ago")
+    assert mr._relative_age((now - timedelta(minutes=5)).isoformat().replace("+00:00", "Z")).endswith("m ago")
+    assert mr._relative_age((now - timedelta(hours=2)).isoformat().replace("+00:00", "Z")).endswith("h ago")
+    assert mr._relative_age((now - timedelta(days=3)).isoformat().replace("+00:00", "Z")).endswith("d ago")
+    assert mr._relative_age("") == "?"
+    assert mr._relative_age("not-a-date") == "?"


### PR DESCRIPTION
## Summary
Empty sections silently skipped meant the agent couldn't tell whether the field was checked. Saves a follow-up roundtrip when a section turns out to legitimately be empty.

**Always print:**
- Description: prints \`_(empty)_\` when blank
- Comments: prints \`(0)\` when none (gl-mr now matches gh-pr)
- Reviewers / Reviews: prints \`none\` when empty

**New fields** (1 line of payload each, except threads = 1 API call):
- Assignees: distinct from reviewers on both sides
- Created/Updated: relative age (\`3d ago\`) for stale-MR signal
- Unresolved threads: gl-mr fetches discussions API; gh-pr uses \`reviewThreads\` (added to \`--json\` field list)

## Test plan
- [x] 6 new tests across test_gitlab_mr.py + test_github_pr.py
- [x] 1003 tests pass