### PR TITLE
feat(edit_session): cursor-based multi-action edit op

### DIFF
--- a/.supertool.json
+++ b/.supertool.json
@@ -131,6 +131,13 @@
       "example": "replace_lines:::supertool.py:::42:::45:::    return x",
       "status": 1,
       "hint": true
+    },
+    "edit_session": {
+      "syntax": "edit_session:::PATH:::SCRIPT",
+      "description": "Cursor-based multi-action edit. Actions (split by newline or ';'): @L:C goto, /PAT find, ^/$ BOL/EOL, ^^/$$ BOF/EOF, <N/>N left/right, kN/jN up/down, +TEXT insert, -N delete. Self-contained — no prior Read needed",
+      "example": "edit_session:::foo.py:::/def foo;$;+ # marker",
+      "status": 1,
+      "hint": true
     }
   },
   "ops": {},

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ claude -p "..." --permission-mode bypassPermissions \
 | `version` | `version` | Show supertool version. |
 | `edit` | `edit:::OLD:::NEW:::PATH` | Single-file, single-occurrence edit (mirrors native Edit). Errors if 0 or >1 matches. **Bypasses native Edit must-Read state** — saves a round-trip when you already know the unique snippet. Use `:::` separator so content with `:` works. |
 | `replace_lines` | `replace_lines:::PATH:::START:::END:::CONTENT` | Swap lines `[START, END]` (1-indexed, inclusive) with CONTENT. `END < START` = pure insert before line START. Empty CONTENT = delete. Receipt shows new line numbers + ±2 context. |
+| `edit_session` | `edit_session:::PATH:::SCRIPT` | Cursor-based multi-action edit in one op. SCRIPT actions (separated by `;` or newline): `@L:C` goto, `/PATTERN` find next match, `^`/`$` BOL/EOL, `^^`/`$$` BOF/EOF, `<N`/`>N` left/right, `kN`/`jN` up/down rows, `+TEXT` insert (escapes decoded), `-N` delete N chars. **Self-contained** — `/PATTERN` removes the need for a prior Read to know coordinates. Token-cheap for many small edits. Example: `edit_session:::foo.py:::/def foo;$;+ # marker`. |
 | `replace` / `replace_dry` | `replace:::OLD:::NEW:::PATH` | Recursive find/replace across PATH (`replace_dry` = preview). Use `:::` separator when content has `:`. |
 
 **LLM onboarding in one call:** `./supertool 'introduction' 'output-format' 'ops'` — outputs everything an LLM needs to use supertool.
@@ -657,6 +658,7 @@ The hook is in `.githooks/pre-push`, committed to the repo. Bypass with `git pus
 - **Python 3.9+.** macOS ships 3.9 via CommandLineTools; we don't force upgrades.
 - **No MCP server.** MCP is server-process-and-JSON-RPC ceremony for what's literally "run a script, get output." A Bash-invoked binary is simpler, faster, and plugs into Claude Code's existing `--allowedTools`/`--disallowedTools` flow.
 - **Enforcement via PreToolUse hook, not config mutation.** The plugin doesn't edit your `settings.json`. Toggling is a state file (`~/.claude/supertool-enforced`) read by the hook. Your config stays yours.
+- **Trade Python work for LLM tokens.** LLM compute is expensive; local CPU is cheap. Any time the model would spend tokens computing, parsing, formatting, or finding — supertool should spend milliseconds instead. Richer op output (state hints, guards, semantic anchors, auto-formatting, syntax checks) is not feature creep — it's the whole thesis. Heavy Python is fine if it shaves tokens off the model side.
 
 ---
 

--- a/supertool.py
+++ b/supertool.py
@@ -428,7 +428,7 @@ BLOCKED_TOOLS = {"Grep", "Glob", "LS"}
 BLOCKED_BASH_COMMANDS = {"cat", "find", "grep", "ls", "sed", "awk", "tail", "head"}
 
 # Built-in op names — custom ops/aliases with these names are ignored
-_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines"}
+_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines", "edit_session"}
 
 # Read-only built-in ops — safe to run in parallel across a batch.
 # Excludes mutating ops (replace, edit, replace_lines) and custom ops
@@ -2412,6 +2412,210 @@ def op_replace_lines(path: str, start: int, end: int, content: str) -> str:
     return "".join(out)
 
 
+def op_edit_session(path: str, script: str) -> str:
+    """Cursor-based multi-action edit session in a single op.
+
+    Mimics how humans edit: place cursor, insert/delete, move cursor, repeat.
+    Coordinates stay valid across actions because the engine tracks offsets
+    internally — N small edits in 1 round-trip instead of N replace ops.
+
+    Script syntax (actions separated by newlines OR semicolons):
+        @LINE:COL   — set cursor (1-indexed)
+        /PATTERN    — move cursor to first char of next literal match from
+                      cursor (errors if not found)
+        $           — move cursor to end of current line (before the \\n)
+        ^           — move cursor to start of current line (col 1)
+        $$          — move cursor to end of file
+        ^^          — move cursor to start of file
+        <N          — move cursor left by N chars (clamps to 0)
+        >N          — move cursor right by N chars (clamps to EOF)
+        kN          — move cursor up N rows (preserves column, clamps)
+        jN          — move cursor down N rows (preserves column, clamps)
+        +TEXT       — insert at cursor (\\n / \\t decoded), cursor advances past
+        -N          — delete N chars from cursor
+
+    Example:
+        edit_session:::foo.py:::/def foo;<3;+# annotated\\n
+    """
+    if not path:
+        return "ERROR: empty path\n"
+    if not os.path.isfile(path):
+        return f"ERROR: file not found: {path}\n"
+    if not script.strip():
+        return "ERROR: empty script\n"
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except OSError as e:
+        return f"ERROR: failed to read {path}: {e}\n"
+
+    raw_actions: List[str] = []
+    for line in script.split("\n"):
+        for seg in line.split(";"):
+            seg = seg.strip()
+            if seg:
+                raw_actions.append(seg)
+    if not raw_actions:
+        return "ERROR: no actions in script\n"
+
+    def _line_col_to_offset(text: str, line: int, col: int) -> int:
+        if line < 1 or col < 1:
+            raise ValueError(f"line/col must be >=1, got {line}:{col}")
+        lines = text.split("\n")
+        if line > len(lines):
+            raise ValueError(
+                f"line {line} beyond EOF (file has {len(lines)} lines)"
+            )
+        target = lines[line - 1]
+        if col - 1 > len(target):
+            col = len(target) + 1  # clamp to line end
+        return sum(len(l) + 1 for l in lines[: line - 1]) + (col - 1)
+
+    def _line_start_offset(text: str, offset: int) -> int:
+        nl = text.rfind("\n", 0, offset)
+        return nl + 1  # nl=-1 → 0, nl>=0 → after that \n
+
+    def _line_end_offset(text: str, offset: int) -> int:
+        nl = text.find("\n", offset)
+        return nl if nl != -1 else len(text)
+
+    def _offset_to_line_col(text: str, offset: int) -> tuple:
+        pre = text[:offset]
+        line = pre.count("\n") + 1
+        last_nl = pre.rfind("\n")
+        col = offset - last_nl  # last_nl=-1 → col=offset+1
+        return line, col
+
+    cursor = 0
+    log: List[str] = []
+    for i, action in enumerate(raw_actions, 1):
+        if action.startswith("@"):
+            ln_col = action[1:].split(":")
+            if len(ln_col) != 2:
+                return f"ERROR: action {i} '{action}': expected @LINE:COL\n"
+            try:
+                ln, col = int(ln_col[0]), int(ln_col[1])
+                cursor = _line_col_to_offset(content, ln, col)
+            except ValueError as e:
+                return f"ERROR: action {i} '{action}': {e}\n"
+            log.append(f"  {i}. @{ln}:{col} (cursor={cursor})")
+        elif action.startswith("/"):
+            pattern = _decode_escapes(action[1:])
+            if not pattern:
+                return f"ERROR: action {i} '{action}': empty search pattern\n"
+            idx = content.find(pattern, cursor)
+            if idx == -1:
+                return (f"ERROR: action {i} '{action}': "
+                        f"pattern not found from cursor={cursor}\n")
+            cursor = idx
+            log.append(f"  {i}. /{pattern!r} → cursor={cursor}")
+        elif action == "$$":
+            cursor = len(content)
+            log.append(f"  {i}. $$ (cursor={cursor}, EOF)")
+        elif action == "^^":
+            cursor = 0
+            log.append(f"  {i}. ^^ (cursor=0, BOF)")
+        elif action == "$":
+            cursor = _line_end_offset(content, cursor)
+            log.append(f"  {i}. $ (cursor={cursor})")
+        elif action == "^":
+            cursor = _line_start_offset(content, cursor)
+            log.append(f"  {i}. ^ (cursor={cursor})")
+        elif action.startswith("<"):
+            try:
+                n = int(action[1:])
+            except ValueError:
+                return (f"ERROR: action {i} '{action}': "
+                        f"left-move count must be integer\n")
+            if n < 0:
+                return (f"ERROR: action {i} '{action}': "
+                        f"left-move count must be >=0\n")
+            cursor = max(0, cursor - n)
+            log.append(f"  {i}. <{n} (cursor={cursor})")
+        elif action.startswith(">"):
+            try:
+                n = int(action[1:])
+            except ValueError:
+                return (f"ERROR: action {i} '{action}': "
+                        f"right-move count must be integer\n")
+            if n < 0:
+                return (f"ERROR: action {i} '{action}': "
+                        f"right-move count must be >=0\n")
+            cursor = min(len(content), cursor + n)
+            log.append(f"  {i}. >{n} (cursor={cursor})")
+        elif action.startswith("k") or action.startswith("j"):
+            direction = action[0]
+            try:
+                n = int(action[1:])
+            except ValueError:
+                return (f"ERROR: action {i} '{action}': "
+                        f"row-move count must be integer\n")
+            if n < 0:
+                return (f"ERROR: action {i} '{action}': "
+                        f"row-move count must be >=0\n")
+            cur_line, cur_col = _offset_to_line_col(content, cursor)
+            total_lines = content.count("\n") + 1
+            if direction == "k":
+                target_line = max(1, cur_line - n)
+            else:  # 'j'
+                target_line = min(total_lines, cur_line + n)
+            try:
+                cursor = _line_col_to_offset(content, target_line, cur_col)
+            except ValueError as e:
+                return f"ERROR: action {i} '{action}': {e}\n"
+            log.append(f"  {i}. {direction}{n} (cursor={cursor})")
+        elif action.startswith("+"):
+            text = _decode_escapes(action[1:])
+            content = content[:cursor] + text + content[cursor:]
+            cursor += len(text)
+            preview = text if len(text) <= 30 else text[:27] + "..."
+            log.append(f"  {i}. +{preview!r} (len={len(text)})")
+        elif action.startswith("-"):
+            try:
+                n = int(action[1:])
+            except ValueError:
+                return (f"ERROR: action {i} '{action}': "
+                        f"delete count must be integer\n")
+            if n < 0:
+                return (f"ERROR: action {i} '{action}': "
+                        f"delete count must be >=0\n")
+            if cursor + n > len(content):
+                return (f"ERROR: action {i} '{action}': "
+                        f"delete past EOF (cursor={cursor}, "
+                        f"file={len(content)})\n")
+            content = content[:cursor] + content[cursor + n:]
+            log.append(f"  {i}. -{n} chars")
+        else:
+            return (f"ERROR: action {i} '{action}': "
+                    f"unknown action (expected @, +, -, /, ^, $, <, >, k, or j)\n")
+
+    try:
+        _atomic_write(path, content)
+    except OSError as e:
+        return f"ERROR: failed to write {path}: {e}\n"
+
+    pre = content[:cursor]
+    final_line = pre.count("\n") + 1
+    last_nl = pre.rfind("\n")
+    final_col = cursor - last_nl  # last_nl=-1 → cursor+1 (col 1 at offset 0)
+    new_lines = content.split("\n")
+    ctx_start = max(1, final_line - 2)
+    ctx_end = min(len(new_lines), final_line + 2)
+
+    out = [
+        f"edit_session {path} ({len(raw_actions)} actions, "
+        f"cursor at {final_line}:{final_col})\n"
+    ]
+    out.extend(line + "\n" for line in log)
+    out.append("--- context ---\n")
+    for ln in range(ctx_start, ctx_end + 1):
+        marker = "→" if ln == final_line else " "
+        text = new_lines[ln - 1] if ln - 1 < len(new_lines) else ""
+        out.append(f"  {ln:>5} {marker} {text}\n")
+    return "".join(out)
+
+
 def op_introduction() -> str:
     """Output the project-specific introduction text from .supertool.json."""
     config = _load_config()
@@ -2709,6 +2913,10 @@ def dispatch(arg: str) -> str:
                 # CONTENT may legitimately contain ':' — rejoin remaining parts
                 rl_content = _decode_escapes(":".join(parts[4:]) if len(parts) > 4 else "")
                 body = op_replace_lines(rl_path, rl_start, rl_end, rl_content)
+        elif op == "edit_session":
+            es_path = parts[1] if len(parts) > 1 else ""
+            es_script = ":".join(parts[2:]) if len(parts) > 2 else ""
+            body = op_edit_session(es_path, es_script)
         elif op in ("introduction", "output-format", "ops", "ops-compact", "version"):
             # Meta-ops use markdown headers instead of --- header ---
             header = ""

--- a/tests/test_edit_session.py
+++ b/tests/test_edit_session.py
@@ -1,0 +1,559 @@
+"""Tests for op_edit_session — cursor-based multi-action edit op."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Single-action sanity
+# ---------------------------------------------------------------------------
+
+def test_insert_at_line_col(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("hello\nworld\n")
+    out = supertool.op_edit_session(str(f), "@1:6;+!")
+    assert "edit_session" in out
+    assert f.read_text() == "hello!\nworld\n"
+
+
+def test_delete_chars(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("abcdef\n")
+    out = supertool.op_edit_session(str(f), "@1:2;-3")
+    assert "edit_session" in out
+    assert f.read_text() == "aef\n"
+
+
+# ---------------------------------------------------------------------------
+# Multi-action — coordinate stability
+# ---------------------------------------------------------------------------
+
+def test_multiple_inserts_keep_coordinates_valid(tmp_path: Path) -> None:
+    """After inserting ZZZ\\n at top, the original line 5 ('e') is now at
+    line 6 in the live buffer — coordinates address the live buffer, the
+    caller sequences accordingly."""
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\nd\ne\n")
+    # \\n is a literal backslash-n in the script — decoded to a real newline
+    # by op_edit_session, so it doesn't terminate the +TEXT action.
+    out = supertool.op_edit_session(str(f), "@1:1;+ZZZ\\n;@6:1;+!")
+    assert f.read_text() == "ZZZ\na\nb\nc\nd\n!e\n"
+
+
+def test_semicolon_and_newline_separators(tmp_path: Path) -> None:
+    """Both ';' and real '\\n' split actions in the script."""
+    f = tmp_path / "x.py"
+    f.write_text("x\n")
+    out = supertool.op_edit_session(str(f), "@1:1;+a\n@1:3;+b")
+    # Buffer: "x\n" → @1:1+a → "ax\n" → @1:3 (col 3 of "ax\n" = before \n) +b → "axb\n"
+    assert f.read_text() == "axb\n"
+
+
+def test_three_actions(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\n")
+    out = supertool.op_edit_session(str(f), "@1:1;+(;@1:5;+)")
+    # @1:1 → insert "(" → "(foo\n", cursor at 1
+    # @1:5 → in updated buffer "(foo\n", line 1 col 5 = position of '\n' (after o)
+    # Insert ")" → "(foo)\n"
+    assert f.read_text() == "(foo)\n"
+
+
+# ---------------------------------------------------------------------------
+# Escapes
+# ---------------------------------------------------------------------------
+
+def test_insert_with_newline_escape(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("ab\n")
+    out = supertool.op_edit_session(str(f), "@1:2;+\\n")
+    assert f.read_text() == "a\nb\n"
+
+
+def test_insert_with_tab_escape(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("ab\n")
+    out = supertool.op_edit_session(str(f), "@1:2;+\\t")
+    assert f.read_text() == "a\tb\n"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+def test_missing_file(tmp_path: Path) -> None:
+    out = supertool.op_edit_session(str(tmp_path / "nope.py"), "@1:1;+x")
+    assert "ERROR: file not found" in out
+
+
+def test_empty_script(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\n")
+    out = supertool.op_edit_session(str(f), "")
+    assert "ERROR: empty script" in out
+
+
+def test_empty_path(tmp_path: Path) -> None:
+    out = supertool.op_edit_session("", "@1:1;+x")
+    assert "ERROR: empty path" in out
+
+
+def test_unknown_action(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\n")
+    out = supertool.op_edit_session(str(f), "?bogus")
+    assert "ERROR" in out and "unknown action" in out
+    # File untouched
+    assert f.read_text() == "a\n"
+
+
+def test_goto_beyond_eof(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\n")
+    out = supertool.op_edit_session(str(f), "@99:1;+x")
+    assert "ERROR" in out and "beyond EOF" in out
+
+
+def test_delete_past_eof(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("ab\n")
+    out = supertool.op_edit_session(str(f), "@1:1;-99")
+    assert "ERROR" in out and "delete past EOF" in out
+
+
+def test_negative_delete_count(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("ab\n")
+    out = supertool.op_edit_session(str(f), "@1:1;--5")
+    assert "ERROR" in out
+
+
+def test_non_integer_delete_count(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("ab\n")
+    out = supertool.op_edit_session(str(f), "@1:1;-xx")
+    assert "ERROR" in out and "integer" in out
+
+
+def test_malformed_goto(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("ab\n")
+    out = supertool.op_edit_session(str(f), "@5")
+    assert "ERROR" in out and "@LINE:COL" in out
+
+
+# ---------------------------------------------------------------------------
+# Dispatch (triple-colon)
+# ---------------------------------------------------------------------------
+
+def test_dispatch_triple_colon(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\n")
+    arg = f"edit_session:::{f}:::@1:1;+(;@1:5;+)"
+    out = supertool.dispatch(arg)
+    assert "edit_session" in out
+    assert f.read_text() == "(foo)\n"
+
+
+def test_dispatch_missing_script(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\n")
+    out = supertool.dispatch(f"edit_session:::{f}:::")
+    assert "ERROR: empty script" in out
+
+
+# ---------------------------------------------------------------------------
+# Receipt
+# ---------------------------------------------------------------------------
+
+def test_receipt_shows_cursor_and_context(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\nd\ne\n")
+    out = supertool.op_edit_session(str(f), "@3:1;+X")
+    assert "cursor at 3:" in out
+    assert "--- context ---" in out
+    assert "→" in out  # marker for cursor line
+
+
+# ---------------------------------------------------------------------------
+# Weird chars — UTF-8, emoji, escapes, regex meta
+# ---------------------------------------------------------------------------
+
+def test_insert_emoji(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("hello\n")
+    out = supertool.op_edit_session(str(f), "@1:6;+ 🦫")
+    assert "edit_session" in out
+    assert f.read_text() == "hello 🦫\n"
+
+
+def test_insert_accented_chars(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("cafe\n")
+    out = supertool.op_edit_session(str(f), "@1:4;-1;+é")
+    assert f.read_text() == "café\n"
+
+
+def test_cursor_position_after_multibyte(tmp_path: Path) -> None:
+    """Col is char-indexed, not byte-indexed. After 'café' (4 chars, 5 bytes
+    in UTF-8), col 5 is the position right after the 'é'."""
+    f = tmp_path / "x.py"
+    f.write_text("café\n")
+    out = supertool.op_edit_session(str(f), "@1:5;+!")
+    assert f.read_text() == "café!\n"
+
+
+def test_insert_chinese(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("hi\n")
+    out = supertool.op_edit_session(str(f), "@1:3;+ 你好")
+    assert f.read_text() == "hi 你好\n"
+
+
+def test_insert_zero_width_joiner(tmp_path: Path) -> None:
+    """ZWJ-composed emoji (e.g., 👨‍💻 = man + ZWJ + laptop) — multiple code
+    points, but Python str treats each code point as one char."""
+    f = tmp_path / "x.py"
+    f.write_text("dev:\n")
+    zwj_emoji = "👨‍💻"
+    out = supertool.op_edit_session(str(f), f"@1:5;+ {zwj_emoji}")
+    assert zwj_emoji in f.read_text()
+
+
+def test_insert_with_quotes_and_backslash(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("x\n")
+    out = supertool.op_edit_session(str(f), "@1:1;+\"a'b\\\\c")
+    # The +TEXT goes through _decode_escapes: \\\\ → \\ → actual single backslash
+    assert f.read_text() == "\"a'b\\cx\n"
+
+
+def test_insert_regex_meta_chars(tmp_path: Path) -> None:
+    """edit_session is char-based, not regex — meta chars are inserted literally."""
+    f = tmp_path / "x.py"
+    f.write_text("x\n")
+    out = supertool.op_edit_session(str(f), "@1:1;+.*+?[]()$^")
+    assert f.read_text() == ".*+?[]()$^x\n"
+
+
+def test_insert_explicit_newline_escape(tmp_path: Path) -> None:
+    """\\n in +TEXT decodes to a real newline — splits the line in two."""
+    f = tmp_path / "x.py"
+    f.write_text("ab\n")
+    out = supertool.op_edit_session(str(f), "@1:2;+\\n")
+    assert f.read_text() == "a\nb\n"
+
+
+def test_insert_explicit_carriage_return_escape(tmp_path: Path) -> None:
+    """Path.read_text() does universal-newline translation (\\r → \\n) — use
+    read_bytes() to verify the actual byte hit disk."""
+    f = tmp_path / "x.py"
+    f.write_text("ab\n")
+    out = supertool.op_edit_session(str(f), "@1:2;+\\r")
+    assert f.read_bytes() == b"a\rb\n"
+
+
+def test_delete_multibyte_chars(tmp_path: Path) -> None:
+    """Delete count is char-indexed: 'café' → delete 2 from col 3 removes 'fé'."""
+    f = tmp_path / "x.py"
+    f.write_text("café\n")
+    out = supertool.op_edit_session(str(f), "@1:3;-2")
+    assert f.read_text() == "ca\n"
+
+
+def test_insert_preserves_existing_utf8(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("café\nzürich\n")
+    out = supertool.op_edit_session(str(f), "@2:1;+!")
+    assert f.read_text() == "café\n!zürich\n"
+
+
+def test_dispatch_with_emoji_in_script(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("test\n")
+    out = supertool.dispatch(f"edit_session:::{f}:::@1:5;+ 🚀")
+    assert "edit_session" in out
+    assert f.read_text() == "test 🚀\n"
+
+
+# ---------------------------------------------------------------------------
+# /PATTERN — find from cursor
+# ---------------------------------------------------------------------------
+
+def test_find_pattern_moves_cursor(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo bar baz\n")
+    out = supertool.op_edit_session(str(f), "/bar;+!")
+    assert f.read_text() == "foo !bar baz\n"
+
+
+def test_find_lands_at_match_start_not_end(tmp_path: Path) -> None:
+    """/ lands at the FIRST char of the match (vim-like). To advance past
+    the match, compose with insert/delete or anchors. Successive /X without
+    advance will find the SAME match — by design."""
+    f = tmp_path / "x.py"
+    f.write_text("xx yy xx\n")
+    out = supertool.op_edit_session(str(f), "/xx;+a;/xx;+b")
+    # /xx → cursor=0; +a → "axx yy xx\n", cursor=1
+    # /xx from cursor=1 → finds "xx" at idx=1 (still there); +b → "abxx yy xx\n"
+    assert f.read_text() == "abxx yy xx\n"
+
+
+def test_find_skip_via_pattern_length_advance(tmp_path: Path) -> None:
+    """To skip past the current match: insert+delete or use anchors. Here:
+    after first /xx;+!, cursor sits between '!' and 'xx', so next /xx finds
+    the same match. Use $ to jump to EOL between finds for true skip."""
+    f = tmp_path / "x.py"
+    f.write_text("xx yy xx\n")
+    out = supertool.op_edit_session(str(f), "/xx;$;/xx;+!")
+    # /xx → cursor=0; $ → EOL=8; /xx from 8 → not found
+    assert "ERROR" in out and "not found" in out
+
+
+def test_find_pattern_not_found(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\n")
+    out = supertool.op_edit_session(str(f), "/missing;+!")
+    assert "ERROR" in out and "not found" in out
+    assert f.read_text() == "foo\n"
+
+
+def test_find_empty_pattern(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\n")
+    out = supertool.op_edit_session(str(f), "/")
+    assert "ERROR" in out and "empty search pattern" in out
+
+
+def test_find_pattern_with_escaped_newline(tmp_path: Path) -> None:
+    """Escaped \\n in pattern matches a real newline."""
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\n")
+    out = supertool.op_edit_session(str(f), "/a\\nb;+X")
+    # Cursor at start of "a\nb", insert X before
+    assert f.read_text() == "Xa\nb\n"
+
+
+def test_find_pattern_unicode(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("hello café world\n")
+    out = supertool.op_edit_session(str(f), "/café;+ tasty")
+    assert f.read_text() == "hello  tastycafé world\n"
+
+
+# ---------------------------------------------------------------------------
+# $ / ^ — line anchors
+# ---------------------------------------------------------------------------
+
+def test_dollar_jumps_to_eol(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\nbar\n")
+    out = supertool.op_edit_session(str(f), "@1:1;$;+!")
+    assert f.read_text() == "foo!\nbar\n"
+
+
+def test_caret_jumps_to_bol(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\nbar\n")
+    out = supertool.op_edit_session(str(f), "@2:3;^;+!")
+    assert f.read_text() == "foo\n!bar\n"
+
+
+def test_dollar_on_last_line_no_trailing_newline(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo")
+    out = supertool.op_edit_session(str(f), "$;+!")
+    assert f.read_text() == "foo!"
+
+
+def test_caret_at_offset_zero(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("foo\n")
+    out = supertool.op_edit_session(str(f), "^;+!")
+    assert f.read_text() == "!foo\n"
+
+
+def test_combined_find_eol_append(tmp_path: Path) -> None:
+    """The killer pattern: find function, append at end of that line."""
+    f = tmp_path / "x.py"
+    f.write_text("def foo():\n    pass\n")
+    out = supertool.op_edit_session(str(f), "/def foo();$;+  # marker")
+    assert f.read_text() == "def foo():  # marker\n    pass\n"
+
+
+# ---------------------------------------------------------------------------
+# < / > — relative cursor moves
+# ---------------------------------------------------------------------------
+
+def test_left_move_basic(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("abcdef\n")
+    out = supertool.op_edit_session(str(f), "@1:5;<2;+!")
+    # @1:5 → cursor=4 (between 'd' and 'e'); <2 → cursor=2; +! → "ab!cdef\n"
+    assert f.read_text() == "ab!cdef\n"
+
+
+def test_right_move_basic(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("abcdef\n")
+    out = supertool.op_edit_session(str(f), "@1:1;>3;+!")
+    # cursor=0; >3 → cursor=3; +! → "abc!def\n"
+    assert f.read_text() == "abc!def\n"
+
+
+def test_left_clamps_to_zero(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("abc\n")
+    out = supertool.op_edit_session(str(f), "@1:2;<99;+!")
+    # cursor=1; <99 → clamps to 0; +! → "!abc\n"
+    assert f.read_text() == "!abc\n"
+
+
+def test_right_clamps_to_eof(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("abc")  # no trailing newline
+    out = supertool.op_edit_session(str(f), "@1:1;>99;+!")
+    assert f.read_text() == "abc!"
+
+
+def test_find_then_left_then_insert(tmp_path: Path) -> None:
+    """The exact case asked for: /def, then 3 left, then append."""
+    f = tmp_path / "x.py"
+    f.write_text("xxxdef foo():\n")
+    out = supertool.op_edit_session(str(f), "/def;<3;+!")
+    # /def → cursor=3; <3 → cursor=0; +! → "!xxxdef foo():\n"
+    assert f.read_text() == "!xxxdef foo():\n"
+
+
+def test_left_non_integer(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("abc\n")
+    out = supertool.op_edit_session(str(f), "<xx")
+    assert "ERROR" in out and "integer" in out
+
+
+def test_right_negative(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("abc\n")
+    out = supertool.op_edit_session(str(f), ">-3")
+    assert "ERROR" in out
+
+
+def test_bof_anchor(tmp_path: Path) -> None:
+    """^^ jumps to start of file regardless of current cursor."""
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\n")
+    out = supertool.op_edit_session(str(f), "@3:1;^^;+!")
+    assert f.read_text() == "!a\nb\nc\n"
+
+
+def test_eof_anchor(tmp_path: Path) -> None:
+    """$$ jumps to end of file (after the last char)."""
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\n")
+    out = supertool.op_edit_session(str(f), "$$;+END")
+    assert f.read_text() == "a\nb\nc\nEND"
+
+
+def test_eof_then_append_block(tmp_path: Path) -> None:
+    """Append a multi-line block at end of file via $$ + escaped \\n."""
+    f = tmp_path / "x.py"
+    f.write_text("first\n")
+    out = supertool.op_edit_session(str(f), "$$;+second\\nthird\\n")
+    assert f.read_text() == "first\nsecond\nthird\n"
+
+
+def test_bof_anchor_on_empty_file(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("")
+    out = supertool.op_edit_session(str(f), "^^;+hello")
+    assert f.read_text() == "hello"
+
+
+def test_double_anchor_distinct_from_single(tmp_path: Path) -> None:
+    """^^ ≠ ^: ^ goes to start of CURRENT line, ^^ goes to start of FILE."""
+    f = tmp_path / "x.py"
+    f.write_text("aaa\nbbb\nccc\n")
+    out_single = supertool.op_edit_session(str(f), "@2:3;^;+X")
+    assert f.read_text() == "aaa\nXbbb\nccc\n"
+
+    f.write_text("aaa\nbbb\nccc\n")
+    out_double = supertool.op_edit_session(str(f), "@2:3;^^;+X")
+    assert f.read_text() == "Xaaa\nbbb\nccc\n"
+
+
+def test_row_up_basic(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("aaa\nbbb\nccc\n")
+    out = supertool.op_edit_session(str(f), "@3:2;k1;+!")
+    # @3:2 → cursor on 'b' of bbb? No — line 3 col 2 = pos in "ccc"
+    # Wait line 3 = "ccc", col 2 = between c[0] and c[1]
+    # k1 → up 1 row, line 2 col 2 = between b[0] and b[1]
+    # +! → "aaa\nb!bb\nccc\n"
+    assert f.read_text() == "aaa\nb!bb\nccc\n"
+
+
+def test_row_down_basic(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("aaa\nbbb\nccc\n")
+    out = supertool.op_edit_session(str(f), "@1:2;j1;+!")
+    assert f.read_text() == "aaa\nb!bb\nccc\n"
+
+
+def test_row_up_clamps_to_first_line(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("aaa\nbbb\nccc\n")
+    out = supertool.op_edit_session(str(f), "@3:1;k99;+!")
+    assert f.read_text() == "!aaa\nbbb\nccc\n"
+
+
+def test_row_down_clamps_to_last_line(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("aaa\nbbb\nccc\n")
+    out = supertool.op_edit_session(str(f), "@1:1;j99;+!")
+    # Last line in "aaa\nbbb\nccc\n" is 4 (the empty line after final \n)
+    # col 1 of empty line = offset at end of file
+    assert f.read_text() == "aaa\nbbb\nccc\n!"
+
+
+def test_row_move_preserves_column(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("aaaaa\nbbbbb\nccccc\n")
+    out = supertool.op_edit_session(str(f), "@1:4;j2;+!")
+    # Col 4 preserved across rows; line 3 col 4 → "ccc!cc\n"
+    assert f.read_text() == "aaaaa\nbbbbb\nccc!cc\n"
+
+
+def test_row_move_column_clamps_on_short_line(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("aaaaaaaa\nbb\ncccccccc\n")
+    out = supertool.op_edit_session(str(f), "@1:8;j1;+!")
+    # Col 8 on a 2-char line → clamps to end of line "bb" (col 3)
+    assert f.read_text() == "aaaaaaaa\nbb!\ncccccccc\n"
+
+
+def test_row_combined_with_dollar(tmp_path: Path) -> None:
+    """Common combo: jump down N rows then to end of line."""
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\nc\nd\n")
+    out = supertool.op_edit_session(str(f), "j2;$;+!")
+    # cursor=0; j2 → line 3 (preserves col 1, "c\n", offset 4); $ → eol of line 3 (offset 5); +!
+    assert f.read_text() == "a\nb\nc!\nd\n"
+
+
+def test_row_non_integer(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("a\nb\n")
+    out = supertool.op_edit_session(str(f), "kxx")
+    assert "ERROR" in out and "integer" in out
+
+
+def test_left_unicode_chars(tmp_path: Path) -> None:
+    """Move counts in chars, not bytes — multi-byte UTF-8 stays consistent."""
+    f = tmp_path / "x.py"
+    f.write_text("café_end\n")
+    # @1:5 lands cursor right after 'é' (4 chars in). <2 → between 'a' and 'f'.
+    out = supertool.op_edit_session(str(f), "@1:5;<2;+!")
+    assert f.read_text() == "ca!fé_end\n"


### PR DESCRIPTION
## Summary

Adds `edit_session:::PATH:::SCRIPT` — a single op that runs N small edits with an internal cursor. Coordinates stay valid across actions; the whole session is one round-trip.

**Why:** small edits via `edit:::OLD:::NEW:::PATH` ship surrounding context twice (~60 tokens). Cursor-based actions ship the move + delta (~15 tokens). `/PATTERN` lets callers skip a prior `Read` to locate coordinates — the op is self-contained.

**Action set** (separated by `;` or newline):

| Action | Effect |
|---|---|
| `@LINE:COL` | absolute cursor (1-indexed) |
| `/PATTERN` | find next literal match from cursor |
| `^` / `$` | start / end of current line |
| `^^` / `$$` | start / end of file |
| `<N` / `>N` | relative left / right |
| `kN` / `jN` | up / down rows (preserves column, clamps) |
| `+TEXT` | insert (`\n`/`\t`/`\r`/`\\` decoded) |
| `-N` | delete N chars |

Receipt shows the action log and ±2 lines around final cursor.

**Example** — annotate a function with no prior Read:
```
edit_session:::foo.py:::/def bar();$;+  # the answer
```

**Design principle:** trade Python work for LLM tokens. Heavier op-side parsing is fine; it shaves tokens off every call.

## Test plan
- [x] 64 unit tests covering each action, UTF-8 / emoji / multi-byte cursor positioning, escape decoding, BOF/EOF anchors, clamping, all error paths
- [x] Full suite green: 1073/1073
- [x] End-to-end smoke via the binary (`./supertool 'edit_session:::...'`)