### PR TITLE
feat(gl-job): errors mode + phpstan-aware default patterns

### DIFF
--- a/presets/gitlab/job.py
+++ b/presets/gitlab/job.py
@@ -59,9 +59,12 @@ def _get_config() -> dict:
     return {
         "lines": int(os.environ.get("SUPERTOOL_LINES", "80")),
         "error_patterns": os.environ.get(
-            "SUPERTOOL_ERROR_PATTERNS", "ERROR,FAILURES!,Fatal,Failed asserting"
+            "SUPERTOOL_ERROR_PATTERNS",
+            # ERROR/FAIL: generic. 🪪: phpstan identifier marker (every phpstan error).
+            # notSubtype/argument.type/return.type: phpstan identifiers as text fallback.
+            "ERROR,FAILURES!,Fatal,Failed asserting,🪪,notSubtype,argument.type,return.type"
         ).split(","),
-        "error_context": int(os.environ.get("SUPERTOOL_ERROR_CONTEXT", "5")),
+        "error_context": int(os.environ.get("SUPERTOOL_ERROR_CONTEXT", "8")),
     }
 
 
@@ -104,6 +107,7 @@ def main() -> int:
 
     job_id = sys.argv[1]
     raw_mode = len(sys.argv) > 2 and sys.argv[2] == "raw"
+    errors_mode = len(sys.argv) > 2 and sys.argv[2] == "errors"
     raw_start: int | None = None
     raw_end: int | None = None
     if raw_mode:
@@ -250,6 +254,20 @@ def main() -> int:
     error_sections = _find_error_sections(
         lines, config["error_patterns"], config["error_context"]
     )
+
+    # errors mode — dump ALL matched blocks, no tail cap
+    if errors_mode:
+        if not error_sections:
+            print("\n## No error patterns matched")
+            return 0
+        matched_count = len([e for e in error_sections if e[0] > 0])
+        print(f"\n## All error blocks ({matched_count} lines matched, no tail truncation)")
+        for line_num, text in error_sections:
+            if line_num == -1:
+                print(text)
+            else:
+                print(f"  {line_num:>5} | {text}")
+        return 0
 
     if error_sections and job_status == "failed":
         print(f"\n## Error context ({len([e for e in error_sections if e[0] > 0])} lines matched)")

--- a/tests/test_gitlab_job.py
+++ b/tests/test_gitlab_job.py
@@ -115,3 +115,48 @@ def test_default_mode_runs_smart_filter(monkeypatch, capsys) -> None:
     assert "Raw lines" not in out
     # Default path prints a header with job + log line count
     assert "Log: 3 lines total" in out
+
+
+def test_errors_mode_shows_all_matched_blocks(monkeypatch, capsys) -> None:
+    """errors mode shows every error block with no tail truncation."""
+    # Simulate phpstan output: 200 lines with errors scattered
+    lines = ["build start"] + [f"line {i}" for i in range(150)] + [
+        " ------ ---- ",
+        " Line   Dvsi/foo/Bar.class.php ",
+        " 42     Type mismatch ",
+        "    🪪  generics.notSubtype ",
+        " ------ ---- ",
+    ] + [f"trail {i}" for i in range(40)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "errors"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "All error blocks" in out
+    # Should include the early-in-log error block, not just tail
+    assert "generics.notSubtype" in out
+    assert "Line   Dvsi/foo/Bar" in out
+
+
+def test_errors_mode_no_matches(monkeypatch, capsys) -> None:
+    """errors mode prints clear message when nothing matched."""
+    lines = ["build started", "all good", "build done"]
+    rc = _run_main(monkeypatch, ["job.py", "123", "errors"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "No error patterns matched" in out
+
+
+def test_phpstan_identifier_marker_matches_default(monkeypatch, capsys) -> None:
+    """🪪 marker (phpstan identifier) is in default patterns."""
+    lines = [
+        "noise",
+        "noise",
+        " 12  some phpstan error ",
+        "    🪪  generics.notSubtype ",
+        "noise",
+    ]
+    rc = _run_main(monkeypatch, ["job.py", "123"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    # The phpstan error should appear in error context section
+    assert "generics.notSubtype" in out
+    assert "Error context" in out


### PR DESCRIPTION
## Context

`gl-job:JOB_ID` shows error context + tail (default 80 lines). When the log has many errors spread across 1000+ lines (e.g. a phpstan run with 17 errors), the tail captures only the last few — earlier errors get truncated and require manual `raw:START:END` paging to find.

Two fixes:

## 1. New `errors` mode

`gl-job:JOB_ID:errors` dumps ALL matched error blocks with no tail truncation cap. Use when the default smart filter misses errors due to size.

```bash
./supertool 'gl-job:5651861:errors'  # all 17 phpstan errors, full context
```

Prints `## No error patterns matched` when the log is clean.

## 2. PHPStan-aware default patterns

Default `SUPERTOOL_ERROR_PATTERNS` now includes:
- `🪪` — phpstan identifier marker (appears on every phpstan error)
- `notSubtype`, `argument.type`, `return.type` — common phpstan identifiers

Default `SUPERTOOL_ERROR_CONTEXT` bumped 5 → 8 lines to cover multi-line wrapped phpstan error descriptions (typical phpstan error spans 6-8 wrapped lines).

## Tests

3 new tests + 7 existing = 10 passing:
- `test_errors_mode_shows_all_matched_blocks`
- `test_errors_mode_no_matches`
- `test_phpstan_identifier_marker_matches_default`

🤖 Generated by Max — Every error visible, every time.