### PR TITLE
fix(xml): use {argjoin} placeholder so multi-colon args reach the script

### DIFF
--- a/presets/xml.json
+++ b/presets/xml.json
@@ -3,21 +3,21 @@
   "requires": "python3",
   "ops": {
     "xml": {
-      "cmd": "python3 {path}xml/query.py {arg}",
+      "cmd": "python3 {path}xml/query.py {argjoin}",
       "timeout": 30,
       "description": "XPath query over an XML file. Default: one match per line as 'LINE:TAG @attr=val …'. Add :full to dump matched subtrees as XML. Memory scales with file size.",
       "syntax": "xml:PATH:XPATH[:full]",
       "example": "xml:clover.xml://file[contains(@name,'CommandX')]/line[@count='0']:full"
     },
     "xml_attr": {
-      "cmd": "python3 {path}xml/attr.py {arg}",
+      "cmd": "python3 {path}xml/attr.py {argjoin}",
       "timeout": 30,
       "description": "Extract a single attribute value for each XPath match. One value per line. Skips elements missing the attribute. Use triple-colon (:::) as separator to escape colons inside XPath expressions.",
       "syntax": "xml_attr:PATH:XPATH:ATTR",
       "example": "xml_attr:clover.xml:.//file[contains(@name,'CommandX')]:::line[@count='0']:num"
     },
     "xml_count": {
-      "cmd": "python3 {path}xml/count.py {arg}",
+      "cmd": "python3 {path}xml/count.py {argjoin}",
       "timeout": 30,
       "description": "Count XPath matches. Returns one integer. Returns 0 (not error) when nothing matches. Faster than xml: for big files — avoids materializing result text.",
       "syntax": "xml_count:PATH:XPATH",

--- a/supertool.py
+++ b/supertool.py
@@ -479,7 +479,7 @@ def _resolve_custom_op(op: str, parts: List[str]) -> str | None:
     if not cmd_template:
         return f"ERROR: empty command for custom op {op!r}\n"
 
-    # Build the command — replace {file}, {dir}, {arg}, and {args} placeholders
+    # Build the command — replace {file}, {dir}, {arg}, {args}, {argjoin} placeholders
     file_arg = parts[1] if len(parts) > 1 else ""
     cmd = cmd_template.replace("{file}", shlex.quote(file_arg))
     dir_arg = os.path.dirname(file_arg) if file_arg else "."
@@ -487,6 +487,11 @@ def _resolve_custom_op(op: str, parts: List[str]) -> str | None:
     cmd = cmd.replace("{arg}", shlex.quote(file_arg))
     all_args = " ".join(shlex.quote(p) for p in parts[1:]) if len(parts) > 1 else ""
     cmd = cmd.replace("{args}", all_args)
+    # {argjoin}: parts[1:] rejoined with ':::' as a single shell-quoted arg.
+    # Lets the receiving script split fields itself when they contain colons
+    # (e.g. XPath like .//ns:tag or [position()=1]).
+    arg_join = ":::".join(parts[1:]) if len(parts) > 1 else ""
+    cmd = cmd.replace("{argjoin}", shlex.quote(arg_join))
 
     # Pass extra config keys as SUPERTOOL_ env vars
     _RESERVED_KEYS = {"cmd", "timeout", "description", "syntax", "example", "status"}

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -186,6 +186,36 @@ class TestResolveCustomOp:
         assert result is not None
         assert "start  end" in result or "start end" in result
 
+    def test_argjoin_placeholder_rejoins_with_triple_colon(self) -> None:
+        """The {argjoin} placeholder rejoins all parts with ':::' as one shell-quoted arg."""
+        supertool._CONFIG = {
+            "ops": {"echo3": {"cmd": "echo {argjoin}"}}
+        }
+        result = supertool._resolve_custom_op("echo3", ["echo3", "A", "B", "C"])
+        assert result is not None
+        assert "PASS" in result
+        assert "A:::B:::C" in result
+
+    def test_argjoin_placeholder_single_part(self) -> None:
+        """The {argjoin} placeholder works with a single part (no ':::' inserted)."""
+        supertool._CONFIG = {
+            "ops": {"echo1": {"cmd": "echo {argjoin}"}}
+        }
+        result = supertool._resolve_custom_op("echo1", ["echo1", "solo"])
+        assert result is not None
+        assert "solo" in result
+        assert ":::" not in result
+
+    def test_argjoin_placeholder_empty(self) -> None:
+        """The {argjoin} placeholder is empty when no arguments given."""
+        supertool._CONFIG = {
+            "ops": {"emptyargjoin": {"cmd": "echo start{argjoin}end"}}
+        }
+        result = supertool._resolve_custom_op("emptyargjoin", ["emptyargjoin"])
+        assert result is not None
+        # Empty argjoin shell-quotes to '' — between start and end we get start''end
+        assert "startend" in result or "start''end" in result
+
     def test_extra_config_keys_as_env_vars(self) -> None:
         """Extra keys in op config are passed as SUPERTOOL_ env vars."""
         supertool._CONFIG = {

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -501,3 +501,64 @@ class TestRealCloverBenchmarks:
         assert peak < 400 * 1024 * 1024, (
             f"peak memory {peak / 1024 / 1024:.1f} MB exceeded 400 MB cap"
         )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch (end-to-end via supertool subprocess)
+# ---------------------------------------------------------------------------
+
+class TestDispatchEndToEnd:
+    """Exercise the supertool binary with preset ops loaded from presets/xml.json.
+
+    This catches regressions in the {argjoin} substitution that bypassing main()
+    misses — main()-only tests can't tell whether supertool passes args correctly.
+    """
+
+    def _supertool(self) -> Path:
+        return Path(__file__).parent.parent / "supertool"
+
+    def test_dispatch_xml_attr_triple_colon(self) -> None:
+        """xml_attr via dispatch with ::: form returns uncovered line numbers."""
+        import subprocess
+        result = subprocess.run(
+            [
+                str(self._supertool()),
+                f"xml_attr:::{CLOVER_SAMPLE}:::"
+                ".//file[contains(@name,'CommandX')]/line[@count='0']:::num",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "PASS" in result.stdout
+        nums = [line for line in result.stdout.splitlines() if line.strip().isdigit()]
+        assert set(nums) == {"32", "34", "40", "50", "52"}
+
+    def test_dispatch_xml_attr_single_colon(self) -> None:
+        """xml_attr via dispatch with single-colon form also works (no colons in XPath)."""
+        import subprocess
+        result = subprocess.run(
+            [
+                str(self._supertool()),
+                f"xml_attr:{CLOVER_SAMPLE}:"
+                ".//file[contains(@name,'CommandX')]/line[@count='0']:num",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        nums = [line for line in result.stdout.splitlines() if line.strip().isdigit()]
+        assert set(nums) == {"32", "34", "40", "50", "52"}
+
+    def test_dispatch_xml_count(self) -> None:
+        """xml_count via dispatch returns single integer."""
+        import subprocess
+        result = subprocess.run(
+            [
+                str(self._supertool()),
+                f"xml_count:::{CLOVER_SAMPLE}:::.//file",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        # Output contains "PASS" header + integer count
+        ints = [line for line in result.stdout.splitlines() if line.strip().isdigit()]
+        assert len(ints) >= 1


### PR DESCRIPTION
## Context

The xml preset shipped in #33 was broken when invoked via the supertool dispatcher.

`xml_attr:PATH:XPATH:ATTR` only delivered `PATH` to the python script because the cmd template used `{arg}` (which substitutes `parts[1]` only). Tests passed because they called `attr_mod.main()` directly, bypassing dispatch.

## Fix

Add new `{argjoin}` placeholder to `_resolve_custom_op`: rejoins `parts[1:]` with `:::` as a single shell-quoted arg. The receiving script then runs its own `split_arg` which already handles `:::` as field separator.

Switch all three xml ops (`xml`, `xml_attr`, `xml_count`) to use `{argjoin}` instead of `{arg}`.

## Tests

- **3 unit tests** in `test_custom_ops.py` covering the new `{argjoin}` placeholder (rejoin, single part, empty)
- **3 dispatch end-to-end tests** in `test_xml.py` that actually spawn `./supertool` as a subprocess and verify args flow through. These catch this exact regression — the original tests didn't because they bypassed the dispatcher

Verified locally against the real 25 MB DVSI clover.xml — 1.47s, returns expected uncovered line numbers.

🤖 Generated by Max
Tests at the wrong abstraction hide the bug they exist to catch.