### PR TITLE
feat(edit_session): add o/O actions for open line below/above

### DIFF
--- a/.supertool.json
+++ b/.supertool.json
@@ -135,8 +135,8 @@
     },
     "edit_session": {
       "syntax": "edit_session:::PATH:::SCRIPT",
-      "description": "Cursor-based multi-action edit. Actions (split by newline or ';'): @L:C goto, /PAT find, ^/$ BOL/EOL, ^^/$$ BOF/EOF, <N/>N left/right, kN/jN up/down, +TEXT insert, -N delete. Self-contained — no prior Read needed",
-      "example": "edit_session:::foo.py:::/def foo;$;+ # marker",
+      "description": "Cursor-based multi-action edit (PREFER over edit::: when inserting multi-line blocks). Actions split by newline or ';': @L:C goto, /PAT find, ^/$ BOL/EOL, ^^/$$ BOF/EOF, <N/>N left/right, kN/jN up/down, o/O open line below/above, +TEXT insert (\\n / \\t decoded — embed for multi-line), -N delete. Self-contained — no prior Read needed.",
+      "example": "edit_session:::skill.md:::/## Process;^;+## Task list\\n\\n1. Foo\\n2. Bar\\n\\n",
       "status": 1,
       "hint": true
     }

--- a/supertool.py
+++ b/supertool.py
@@ -2437,6 +2437,10 @@ def op_edit_session(path: str, script: str) -> str:
     Coordinates stay valid across actions because the engine tracks offsets
     internally — N small edits in 1 round-trip instead of N replace ops.
 
+    Multi-line inserts use the \\n / \\t escapes inside +TEXT — actions are
+    separated by real newlines, but escapes inside +TEXT decode to literal chars.
+    For "open line below/above" semantics use the o / O actions.
+
     Script syntax (actions separated by newlines OR semicolons):
         @LINE:COL   — set cursor (1-indexed)
         /PATTERN    — move cursor to first char of next literal match from
@@ -2449,11 +2453,20 @@ def op_edit_session(path: str, script: str) -> str:
         >N          — move cursor right by N chars (clamps to EOF)
         kN          — move cursor up N rows (preserves column, clamps)
         jN          — move cursor down N rows (preserves column, clamps)
+        o           — open empty line BELOW cursor's line, cursor sits on it
+        O           — open empty line ABOVE cursor's line, cursor sits on it
         +TEXT       — insert at cursor (\\n / \\t decoded), cursor advances past
         -N          — delete N chars from cursor
 
-    Example:
+    Examples:
+        # Annotate a single line
         edit_session:::foo.py:::/def foo;<3;+# annotated\\n
+
+        # Insert a multi-line block before a marker (escape \\n in +TEXT)
+        edit_session:::skill.md:::/## Process;^;+## Task list\\n\\n1. Foo\\n2. Bar\\n\\n
+
+        # Open new line below a header and write into it
+        edit_session:::foo.md:::/# Title;o;+First body line
     """
     if not path:
         return "ERROR: empty path\n"
@@ -2583,6 +2596,18 @@ def op_edit_session(path: str, script: str) -> str:
             except ValueError as e:
                 return f"ERROR: action {i} '{action}': {e}\n"
             log.append(f"  {i}. {direction}{n} (cursor={cursor})")
+        elif action == "o":
+            # Open empty line BELOW current line; cursor sits on the new blank line.
+            eol = _line_end_offset(content, cursor)
+            content = content[:eol] + "\n" + content[eol:]
+            cursor = eol + 1
+            log.append(f"  {i}. o (cursor={cursor}, new blank line below)")
+        elif action == "O":
+            # Open empty line ABOVE current line; cursor sits on the new blank line.
+            bol = _line_start_offset(content, cursor)
+            content = content[:bol] + "\n" + content[bol:]
+            cursor = bol
+            log.append(f"  {i}. O (cursor={cursor}, new blank line above)")
         elif action.startswith("+"):
             text = _decode_escapes(action[1:])
             content = content[:cursor] + text + content[cursor:]
@@ -2606,7 +2631,7 @@ def op_edit_session(path: str, script: str) -> str:
             log.append(f"  {i}. -{n} chars")
         else:
             return (f"ERROR: action {i} '{action}': "
-                    f"unknown action (expected @, +, -, /, ^, $, <, >, k, or j)\n")
+                    f"unknown action (expected @, +, -, /, ^, $, <, >, k, j, o, or O)\n")
 
     try:
         _atomic_write(path, content)

--- a/tests/test_edit_session.py
+++ b/tests/test_edit_session.py
@@ -557,3 +557,79 @@ def test_left_unicode_chars(tmp_path: Path) -> None:
     # @1:5 lands cursor right after 'é' (4 chars in). <2 → between 'a' and 'f'.
     out = supertool.op_edit_session(str(f), "@1:5;<2;+!")
     assert f.read_text() == "ca!fé_end\n"
+
+
+# ---------------------------------------------------------------------------
+# o / O — open new line below/above current line
+# ---------------------------------------------------------------------------
+
+def test_open_below_creates_blank_line(tmp_path: Path) -> None:
+    """`o` opens an empty line below the current line and parks cursor there."""
+    f = tmp_path / "x.py"
+    f.write_text("first\nthird\n")
+    out = supertool.op_edit_session(str(f), "@1:1;o")
+    assert "new blank line below" in out
+    assert f.read_text() == "first\n\nthird\n"
+
+
+def test_open_above_creates_blank_line(tmp_path: Path) -> None:
+    """`O` opens an empty line above the current line and parks cursor there."""
+    f = tmp_path / "x.py"
+    f.write_text("first\nthird\n")
+    out = supertool.op_edit_session(str(f), "@2:1;O")
+    assert "new blank line above" in out
+    assert f.read_text() == "first\n\nthird\n"
+
+
+def test_open_below_then_insert(tmp_path: Path) -> None:
+    """`o` + `+text` writes content into the new blank line."""
+    f = tmp_path / "x.py"
+    f.write_text("title\n")
+    out = supertool.op_edit_session(str(f), "/title;o;+body line one")
+    assert f.read_text() == "title\nbody line one\n"
+
+
+def test_open_above_then_insert(tmp_path: Path) -> None:
+    """`O` + `+text` writes content into the new blank line above."""
+    f = tmp_path / "x.py"
+    f.write_text("## End\n")
+    out = supertool.op_edit_session(str(f), "/## End;O;+## Start")
+    assert f.read_text() == "## Start\n## End\n"
+
+
+def test_open_below_chain_multiple(tmp_path: Path) -> None:
+    """Chain `o` actions to insert several lines below."""
+    f = tmp_path / "x.py"
+    f.write_text("header\n")
+    out = supertool.op_edit_session(
+        str(f), "/header;o;+line a;o;+line b;o;+line c"
+    )
+    assert f.read_text() == "header\nline a\nline b\nline c\n"
+
+
+def test_open_below_on_last_line_no_trailing_newline(tmp_path: Path) -> None:
+    """`o` works at EOF even when file has no trailing newline."""
+    f = tmp_path / "x.py"
+    f.write_text("only line")
+    out = supertool.op_edit_session(str(f), "$;o;+after")
+    # $ → end of "only line", o → opens blank line after (adds \n), +after
+    assert f.read_text() == "only line\nafter"
+
+
+def test_open_above_on_first_line(tmp_path: Path) -> None:
+    """`O` on line 1 inserts a new line at the very top."""
+    f = tmp_path / "x.py"
+    f.write_text("body\n")
+    out = supertool.op_edit_session(str(f), "@1:1;O;+head")
+    assert f.read_text() == "head\nbody\n"
+
+
+def test_open_above_block_before_marker(tmp_path: Path) -> None:
+    """Open + insert chain inserts a block above an existing line — readable
+    alternative to the `+TEXT\\n+TEXT\\n` escape pattern."""
+    f = tmp_path / "x.py"
+    f.write_text("## Process\n")
+    out = supertool.op_edit_session(
+        str(f), "/## Process;O;+## Task list;o;+1. Foo;o;+2. Bar"
+    )
+    assert f.read_text() == "## Task list\n1. Foo\n2. Bar\n## Process\n"


### PR DESCRIPTION
feat(edit_session): add o/O actions for "open line below/above"

## Context

`edit_session` already supported multi-line inserts via `\n` escapes inside `+TEXT`, but discoverability was poor and the escape-heavy syntax (`+## Header\n\nBody line\n\n`) is hard to read. Add vi-style `o` / `O` actions for natural line-by-line composition.

Use case driving this: replacing CLAUDE-orchestrated multi-line block inserts in DVSI's Kevin pipeline. Today Kevin reaches for native `Edit` because `edit_session` looked single-line-only. Making the multi-line path obvious unlocks edit_session as Kevin's default edit op.

## What changes

`supertool.py` — two new actions in `op_edit_session`:

- **`o`** — open empty line BELOW cursor's current line, park cursor on it
- **`O`** — open empty line ABOVE cursor's current line, park cursor on it

Docstring hoists the multi-line guidance to the top of the syntax section and adds two new examples (multi-line via escape, and `o`-based composition). The unknown-action error message lists `o`/`O` too.

`.supertool.json` — `edit_session` op description updated to:
- Mention `o`/`O`
- Call out the `\n` / `\t` escape for multi-line inserts
- Prefer `edit_session` over `edit:::` for multi-line work
- Use a multi-line example (`/## Process;^;+## Task list\n\n1. Foo\n2. Bar\n\n`)

`tests/test_edit_session.py` — 8 new tests:
- `o` / `O` create blank line below/above
- `o` / `O` followed by `+text` writes content
- `o` chained for multiple lines
- `o` at EOF without trailing newline
- `O` on first line
- `O;+head;o;+line1;o;+line2` block-before-marker pattern

## Test plan

- [x] `pytest tests/test_edit_session.py --no-cov` — 72/72 passing (8 new + 64 existing).
- [ ] Full suite green on CI.

🤖 Generated by Max
