### PR TITLE
feat(vi): hint sed-style /PAT/CMD slip in search-failed error

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2686,7 +2686,12 @@ def op_vi(path: str, script: str) -> str:
             if idx == -1:
                 idx = content.find(pat, cursor)
             if idx == -1:
-                return f"ERROR: action {i} '{action}': pattern not found forward\n"
+                hint = ""
+                m = re.search(r"/([oOiIaAJ]|cc|cw|ciw|ci[\"'([{}]|cf|cF|ct|cT|dd|dw|d\$|d0|c\$|c0)\b", pat)
+                if m is not None:
+                    suggested = pat[:m.start()] + ";" + pat[m.start() + 1:]
+                    hint = f" (hint: '/' is not an action separator — did you mean '/{suggested}'? Use ';' to chain actions.)"
+                return f"ERROR: action {i} '{action}': pattern not found forward{hint}\n"
             cursor = idx
             last_search = (pat, "/")
             log.append(f"  {i}. /{pat!r} → {cursor}")


### PR DESCRIPTION
## Summary

When `/PAT` search fails and the pattern contains an embedded vi verb preceded by `/` (e.g. `/foo/O text`), the error now suggests the correct form using `;` as separator:

```
ERROR: action 1 '/85\.71/O * @coverageAuditWarn ...': pattern not found forward (hint: '/' is not an action separator — did you mean '/85\.71;O * @coverageAuditWarn ...'? Use ';' to chain actions.)
```

## Why

Kevin agent runs against the DSL with sed/vim ex syntax baked in (`/PAT/CMD`). My DSL uses `;` between actions. Previously Kevin would get a generic 'pattern not found' and retry with the same bug. This catches the most common failure mode loudly.

## Test plan

- [x] 84 vi tests still pass