### PR TITLE
fix(vi): decode \! to ! (zsh/bash history-expansion artifact)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2039,13 +2039,19 @@ def _decode_escapes(s: str) -> str:
 
     Used by `replace`, `replace_dry`, `edit`, `replace_lines` so callers can
     pass multi-line OLD/NEW/CONTENT via CLI without literal `\n` polluting
-    file contents. Decoded sequences: `\n` `\t` `\r` `\\`. A two-pass sentinel
-    keeps `\\n` (literal backslash + n) intact while still decoding `\n`.
+    file contents. Decoded sequences: `\n` `\t` `\r` `\\` `\!`. A two-pass
+    sentinel keeps `\\n` (literal backslash + n) intact while still decoding
+    `\n`. `\!` decode protects against zsh/bash history-expansion artifacts
+    that prepend a backslash to `!` even inside single quotes.
     """
     if "\\" not in s:
         return s
     out = s.replace("\\\\", _DECODE_ESCAPES_SENTINEL)
     out = out.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
+    # Decode shell-mangled bang: zsh/bash history expansion inserts `\!`
+    # even inside single quotes in some configurations. `\!` has no legitimate
+    # meaning in inserted code, so flatten it back to `!`.
+    out = out.replace("\\!", "!")
     out = out.replace(_DECODE_ESCAPES_SENTINEL, "\\")
     return out
 

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -364,6 +364,14 @@ def test_backslash_escape_in_insert(tmp_path: Path) -> None:
     assert f.read_text() == "path\\to\\file\n"
 
 
+def test_bang_history_escape_is_flattened(tmp_path: Path) -> None:
+    """zsh/bash insert `\\!` even inside single quotes — strip the backslash."""
+    f = tmp_path / "x.py"
+    f.write_text("\n")
+    supertool.op_vi(str(f), "iif (\\!$x->isOk()) {}")
+    assert f.read_text() == "if (!$x->isOk()) {}\n"
+
+
 # ---------------------------------------------------------------------------
 # Regex search
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`zsh`/`bash` history expansion inserts a literal backslash before `!` even inside single quotes in some configurations. Scripts that pass through the shell can arrive at `op_vi` containing `\!` where the user typed `!`.

Real-world impact (Kevin transcript):

```
./supertool 'vi:::file:::322G;:s/.../if (!$x->method())/'
```

Ends up writing `if (\!$x->method())` to the source file — broken PHP.

## Fix

`_decode_escapes` now flattens `\!` → `!`. Safe because `\!` has no legitimate meaning in inserted code (not vi syntax, not regex, not string escape).

## Test plan

- [x] 85 vi tests pass (+1 new test for the bang flatten)

## Stacking

Targets `feat/vi-search-hint` (PR #40). Will rebase to `master` once #39 and #40 merge.