### PR TITLE
fix(vi): \! decode + :s REPL auto-escape (re-land orphaned bang fix)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2037,15 +2037,22 @@ _DECODE_ESCAPES_SENTINEL = "\x00BS\x00"
 def _decode_escapes(s: str) -> str:
     r"""Decode shell-style escape sequences in mutating-op arguments.
 
-    Used by `replace`, `replace_dry`, `edit`, `replace_lines` so callers can
-    pass multi-line OLD/NEW/CONTENT via CLI without literal `\n` polluting
-    file contents. Decoded sequences: `\n` `\t` `\r` `\\`. A two-pass sentinel
-    keeps `\\n` (literal backslash + n) intact while still decoding `\n`.
+    Used by `replace`, `replace_dry`, `edit`, `replace_lines`, `vi` so callers
+    can pass multi-line OLD/NEW/CONTENT via CLI without literal `\n` polluting
+    file contents.
+
+    Decoded sequences: `\n` `\t` `\r` `\\` `\!`. Any other `\X` is left intact
+    so backslashes in code (PHP / JS namespace separators, regex character
+    classes) survive. A two-pass sentinel keeps `\\` (literal backslash)
+    intact across the other substitutions. `\!` decode protects against
+    zsh/bash history-expansion artifacts that prepend a backslash to `!`
+    even inside single quotes.
     """
     if "\\" not in s:
         return s
     out = s.replace("\\\\", _DECODE_ESCAPES_SENTINEL)
     out = out.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
+    out = out.replace("\\!", "!")
     out = out.replace(_DECODE_ESCAPES_SENTINEL, "\\")
     return out
 
@@ -2996,7 +3003,14 @@ def op_vi(path: str, script: str) -> str:
                 return f"ERROR: action {i} '{action}': :s regex: {e}\n"
             n_max = 0 if "g" in sflags else 1
             srepl_dec = _decode_escapes(srepl)
-            new_content, n = rx.subn(srepl_dec, content, count=n_max)
+            # Escape literal backslashes for re.sub: \X (X non-digit) must be
+            # passed as \\X or re.sub raises "bad escape" on \B, \R, etc.
+            # Digit-prefixed backslashes (\1..\9) are preserved as backrefs.
+            srepl_safe = re.sub(r"\\(?=\D)", r"\\\\", srepl_dec)
+            try:
+                new_content, n = rx.subn(srepl_safe, content, count=n_max)
+            except re.error as e:
+                return f"ERROR: action {i} '{action}': :s replacement: {e}\n"
             if n == 0:
                 return f"ERROR: action {i} '{action}': :s no match for {spat!r}\n"
             content = new_content

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -364,6 +364,15 @@ def test_backslash_escape_in_insert(tmp_path: Path) -> None:
     assert f.read_text() == "path\\to\\file\n"
 
 
+def test_bang_history_escape_is_flattened(tmp_path: Path) -> None:
+    """zsh/bash insert `\\!` even inside single quotes — strip the backslash."""
+    f = tmp_path / "x.py"
+    f.write_text("\n")
+    supertool.op_vi(str(f), "iif (\\!$x->isOk()) {}")
+    assert f.read_text() == "if (!$x->isOk()) {}\n"
+
+
+
 # ---------------------------------------------------------------------------
 # Regex search
 # ---------------------------------------------------------------------------
@@ -606,6 +615,18 @@ def test_substitute_no_match_errors(tmp_path: Path) -> None:
     f.write_text("hello\n")
     out = supertool.op_vi(str(f), ":s/missing/x/g")
     assert "ERROR" in out
+
+
+def test_substitute_repl_with_php_namespace_backslashes(tmp_path: Path) -> None:
+    """REPL containing single backslashes (PHP/JS namespace separators) must
+    not crash re.sub with 'bad escape \\B' — backslashes are auto-escaped."""
+    f = tmp_path / "x.php"
+    f.write_text("use OLD;\n")
+    supertool.op_vi(
+        str(f),
+        ":s/OLD/Shared\\BusinessEntities\\ReviewSessionHasEntity/",
+    )
+    assert f.read_text() == "use Shared\\BusinessEntities\\ReviewSessionHasEntity;\n"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related fixes for vi escape handling:

1. **`\!` decode** — flatten `\!` → `!` in `_decode_escapes`. Original landed in #41 but got orphaned when stacked onto #40 before the inner merge propagated to master. Re-landing on master.

2. **`:s` REPL auto-escape for `re.sub`** — REPLs containing single backslashes (PHP `Foo\Bar` namespace separators) crashed `re.sub` with `re.error: bad escape \B`. Now the `:s` handler escapes non-backref backslashes before handing to `re.sub`, and wraps the call in try/except so any remaining edge case returns a clean ERROR string instead of a traceback.

## Why

Real-world Kevin failures:

- zsh history expansion inserts `\!` in shell args even inside single quotes — the original PR #41 fix.
- Kevin's `:s/.../use Shared\\BusinessEntities\\ReviewSessionHasEntity;/` (legitimate PHP namespace replacement) crashed the entire tool.

## Test plan

- [x] 86 vi tests pass including new PHP-namespace-backslash regression test