### PR TITLE
fix(vi): drop \ before punctuation in _decode_escapes (defensive escape)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2041,18 +2041,25 @@ def _decode_escapes(s: str) -> str:
     can pass multi-line OLD/NEW/CONTENT via CLI without literal `\n` polluting
     file contents.
 
-    Decoded sequences: `\n` `\t` `\r` `\\` `\!`. Any other `\X` is left intact
-    so backslashes in code (PHP / JS namespace separators, regex character
-    classes) survive. A two-pass sentinel keeps `\\` (literal backslash)
-    intact across the other substitutions. `\!` decode protects against
-    zsh/bash history-expansion artifacts that prepend a backslash to `!`
-    even inside single quotes.
+    Decoded sequences:
+      `\n` `\t` `\r`           → newline / tab / CR
+      `\\`                     → literal `\`
+      `\<punctuation>`         → drop `\` (shell-style defensive escape:
+                                  `\)`, `\(`, `\$`, `\"`, `\'`, `\ `, `\!`...
+                                  Kevin's defensive `\)` becomes `)`).
+      `\<letter|digit>`        → preserved as-is. PHP namespace `\Foo`,
+                                  regex char classes `\d`/`\w`/`\s`, and
+                                  `:s` backrefs `\1`..`\9` all survive.
+
+    A two-pass sentinel keeps `\\` (literal backslash) intact across the
+    other substitutions.
     """
     if "\\" not in s:
         return s
     out = s.replace("\\\\", _DECODE_ESCAPES_SENTINEL)
     out = out.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
-    out = out.replace("\\!", "!")
+    # Drop `\` before punctuation/symbols (defensive shell escapes).
+    out = re.sub(r"\\([^A-Za-z0-9])", r"\1", out)
     out = out.replace(_DECODE_ESCAPES_SENTINEL, "\\")
     return out
 

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -617,6 +617,14 @@ def test_substitute_no_match_errors(tmp_path: Path) -> None:
     assert "ERROR" in out
 
 
+def test_substitute_strips_defensive_backslash_before_punct(tmp_path: Path) -> None:
+    """Kevin defensively writes `\\)\\;` in REPL — both must collapse to `);`."""
+    f = tmp_path / "x.php"
+    f.write_text("foo(1)\n")
+    supertool.op_vi(str(f), ":s/\\)$/\\)\\;/")
+    assert f.read_text() == "foo(1);\n"
+
+
 def test_substitute_repl_with_php_namespace_backslashes(tmp_path: Path) -> None:
     """REPL containing single backslashes (PHP/JS namespace separators) must
     not crash re.sub with 'bad escape \\B' — backslashes are auto-escaped."""


### PR DESCRIPTION
## Summary

Kevin (and humans) reflexively type `\)` `\(` `\$` `\"` in inserted TEXT and `:s` REPL — shell habit of 'backslash means take this char literally'. Previously these passed through and ended up as `\)` `\(` etc. in the file.

**New rule:** `\<punctuation/symbol>` drops the backslash. `\<letter|digit>` is preserved so:
- PHP namespaces `\Foo\Bar` still produce literal backslashes
- regex char classes `\d` `\w` `\s` still work in `:s` patterns
- `:s` backrefs `\1`..`\9` still work in REPLs

## Real-world bug

Kevin transcript:
```
vi:::file:::40G;:s/\)$/\)\;/
→ written as: foo(1)\)\;
```
Now produces: `foo(1);` ✓

## Test plan

- [x] 87 vi tests pass including new `test_substitute_strips_defensive_backslash_before_punct`