### PR TITLE
feat(vi): auto-split sed-style /PAT/cmd when strict search misses

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2700,10 +2700,39 @@ def op_vi(path: str, script: str) -> str:
             if idx == -1:
                 idx = content.find(pat, cursor)
             if idx == -1:
+                # sed-style auto-split: try truncating pattern at first `/<verb>`
+                # boundary. Kevin's training has `/PAT/cmd` muscle memory; if
+                # the short pattern matches, treat the trailing portion as a
+                # follow-up action.
+                split_m = re.search(
+                    r"/([oOiIaAJ]|cc|cw|ciw|ci[\"'([{}]|cf|cF|ct|cT|dd|dw|d\$|d0|c\$|c0)\b",
+                    pat,
+                )
+                if split_m is not None:
+                    short_pat = pat[:split_m.start()]
+                    trail = pat[split_m.start() + 1:]
+                    s_idx = -1
+                    try:
+                        rx2 = re.compile(short_pat, re.MULTILINE)
+                        sm = rx2.search(content, cursor)
+                        if sm is not None and sm.start() != sm.end():
+                            s_idx = sm.start()
+                    except re.error:
+                        pass
+                    if s_idx == -1:
+                        s_idx = content.find(short_pat, cursor)
+                    if s_idx != -1:
+                        cursor = s_idx
+                        last_search = (short_pat, "/")
+                        log.append(
+                            f"  {i}. /{short_pat!r} → {cursor} (auto-split sed-style)"
+                        )
+                        # queue the trailing action for the next iteration
+                        raw_actions.insert(i, trail)
+                        continue
                 hint = ""
-                m = re.search(r"/([oOiIaAJ]|cc|cw|ciw|ci[\"'([{}]|cf|cF|ct|cT|dd|dw|d\$|d0|c\$|c0)\b", pat)
-                if m is not None:
-                    suggested = pat[:m.start()] + ";" + pat[m.start() + 1:]
+                if split_m is not None:
+                    suggested = pat[:split_m.start()] + ";" + pat[split_m.start() + 1:]
                     hint = f" (hint: '/' is not an action separator — did you mean '/{suggested}'? Use ';' to chain actions.)"
                 return f"ERROR: action {i} '{action}': pattern not found forward{hint}\n"
             cursor = idx

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -413,6 +413,25 @@ def test_regex_backward(tmp_path: Path) -> None:
     assert f.read_text() == "foo1 foo2 LAST\n"
 
 
+def test_sed_style_pat_cmd_auto_splits_on_miss(tmp_path: Path) -> None:
+    """Kevin reflex `/PAT/CMD` (sed-style) auto-splits when strict search misses
+    and the shortened pattern matches. Trailing `<CMD>` becomes the next action."""
+    f = tmp_path / "x.php"
+    f.write_text("<?php\n/**\n * @coverage 85%\n */\nclass Foo {}\n")
+    supertool.op_vi(str(f), '/ \\* @coverage/O * @coverageAuditWarn "x"')
+    assert "@coverageAuditWarn" in f.read_text().splitlines()[2]
+
+
+def test_sed_style_auto_split_does_not_hijack_legit_slash(tmp_path: Path) -> None:
+    """If the full pattern with embedded `/<verb>` matches, no auto-split."""
+    f = tmp_path / "x.txt"
+    f.write_text("/usr/Open at top\n")
+    # Auto-split shouldn't fire because strict search finds 'usr/Op' literally
+    # in the file. Cursor lands at the 'u' (start of match), `i!` inserts there.
+    supertool.op_vi(str(f), "/usr/Op;i!")
+    assert f.read_text() == "/!usr/Open at top\n"
+
+
 def test_regex_special_char_literal_fallback(tmp_path: Path) -> None:
     f = tmp_path / "x.py"
     f.write_text("a = foo(bar)\n")


### PR DESCRIPTION
## Summary

Kevin's training has `/PAT/cmd` muscle memory from sed/ed ("for line matching PAT, do cmd"). The hint system we added in #40 caught the slip and suggested the fix — but Kevin reads the error, sees pattern-not-found, and often retries with the same bug instead of acting on the hint.

This PR makes the parser **self-healing** for that slip. When strict `/PAT` search misses AND the pattern contains a known vi verb prefix after an embedded `/`, retry with the shortened pattern and queue the trailing portion as the next action.

```
# Kevin types (sed habit):
vi:::file:::/ \\* @coverage/O * @coverageAuditWarn "x"

# Now works as if:
vi:::file:::/ \\* @coverage;O * @coverageAuditWarn "x"
```

## Safety

Only triggers when **strict search misses**. Literal `/usr/Op` patterns still match strictly and don't auto-split. New regression test covers that case.

## Test plan

- [x] 88 vi tests pass (+2 new tests: auto-split-fires-on-miss, no-hijack-when-strict-matches)
- [x] Verified on Kevin's exact failing script from session 0c66f4fe