### PR TITLE
feat(vi): :r FILE — ex command to read file into buffer (re-land)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2612,9 +2612,11 @@ def op_vi(path: str, script: str) -> str:
             return (count, "ciw", rest[3:])
         if len(rest) >= 3 and rest[:2] == "ci" and rest[2] in ('"', "'", "(", "[", "{"):
             return (count, "ci" + rest[2], rest[3:])
-        # two-char ex command :s/PAT/REPL/flags
+        # two-char ex commands: :s/PAT/REPL/flags  and  :r FILE
         if len(rest) >= 2 and rest[:2] == ":s":
             return (count, ":s", rest[2:])
+        if len(rest) >= 2 and rest[:2] == ":r":
+            return (count, ":r", rest[2:])
         # two-char yank/delete word/eol: yw, y$, yy, dw, d$, d0, c$, c0, cf, cF, ct, cT, df, dF, dt, dT
         if len(rest) >= 2 and rest[:2] in (
             "gg", "dd", "cc", "cw",
@@ -3067,6 +3069,32 @@ def op_vi(path: str, script: str) -> str:
             content = new_content
             cursor = min(cursor, len(content))
             log.append(f"  {i}. :s/{spat!r}/{srepl_dec!r}/{sflags} ({n} subs)")
+
+        # --- ex read file: :r FILE ---
+        elif verb == ":r":
+            path_arg = arg.strip()
+            if not path_arg:
+                return f"ERROR: action {i} '{action}': :r needs a file path\n"
+            try:
+                with open(path_arg, "r", encoding="utf-8", errors="replace") as _fh:
+                    file_text = _fh.read()
+            except OSError as e:
+                return f"ERROR: action {i} '{action}': :r failed to read {path_arg!r}: {e}\n"
+            # vim :r inserts AFTER the current line. Ensure a newline boundary.
+            eol = _line_end(content, cursor)
+            if eol < len(content):
+                # cursor is on a line followed by `\n`; insert after that `\n`
+                insert_pos = eol + 1
+            else:
+                # cursor on last line with no trailing `\n` — add one
+                if content and not content.endswith("\n"):
+                    content += "\n"
+                insert_pos = len(content)
+            if file_text and not file_text.endswith("\n"):
+                file_text += "\n"
+            content = content[:insert_pos] + file_text + content[insert_pos:]
+            cursor = insert_pos
+            log.append(f"  {i}. :r {path_arg!r} ({len(file_text)} chars inserted)")
 
         # --- change to end-of-line / BOL ---
         elif verb == "c$":

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -648,6 +648,39 @@ def test_substitute_no_match_errors(tmp_path: Path) -> None:
     assert "ERROR" in out
 
 
+# ---------------------------------------------------------------------------
+# Ex read file: :r FILE
+# ---------------------------------------------------------------------------
+
+def test_read_inserts_file_after_current_line(tmp_path: Path) -> None:
+    """vi :r FILE inserts file content after the current line."""
+    target = tmp_path / "main.php"
+    target.write_text("<?php\nclass Foo {\n}\n")
+    snippet = tmp_path / "method.txt"
+    snippet.write_text("    public function bar(): void {}\n")
+    supertool.op_vi(str(target), f"G;k;:r {snippet}")
+    assert (
+        target.read_text()
+        == "<?php\nclass Foo {\n    public function bar(): void {}\n}\n"
+    )
+
+
+def test_read_missing_file_errors(tmp_path: Path) -> None:
+    target = tmp_path / "x.py"
+    target.write_text("a\n")
+    out = supertool.op_vi(str(target), f":r {tmp_path}/does-not-exist")
+    assert "ERROR" in out and ":r failed to read" in out
+
+
+def test_read_adds_trailing_newline(tmp_path: Path) -> None:
+    target = tmp_path / "x.py"
+    target.write_text("line1\n")
+    snippet = tmp_path / "snip.txt"
+    snippet.write_text("no trailing newline")
+    supertool.op_vi(str(target), f":r {snippet}")
+    assert target.read_text() == "line1\nno trailing newline\n"
+
+
 def test_substitute_strips_defensive_backslash_before_punct(tmp_path: Path) -> None:
     """Kevin defensively writes `\\)\\;` in REPL — both must collapse to `);`."""
     f = tmp_path / "x.php"


### PR DESCRIPTION
## Summary

Re-lands PR #46 against master. Original got stranded — it was merged into `fix/vi-G-lands-on-last-line` branch which shipped to master via squash-merge of #45 BEFORE this commit was added on top.

Standard vim `:r FILE` reads a file's contents and inserts after the current line. Lets Kevin (and humans) sidestep multi-line escape hell.

## Workflow

```bash
# Write snippet via heredoc — zero escaping pain
cat > /tmp/snip.php <<'EOF'
    public function bar(): void
    {
        \$this->doStuff();
    }
EOF

# Position cursor + read snippet in one vi call
./supertool 'vi:::file.php:::G;?^};k;:r /tmp/snip.php'
```

## Test plan

- [x] 93 vi tests pass (3 new for :r)