### PR TITLE
feat(vi): :r - reads stdin

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -3139,16 +3139,22 @@ def op_vi(path: str, script: str) -> str:
                 cursor = min(cursor, len(content))
                 log.append(f"  {i}. :s/{spat!r}/{srepl_dec!r}/{sflags} ({n} subs)")
 
-        # --- ex read file: :r FILE ---
+        # --- ex read file: :r FILE  (or :r - for stdin) ---
         elif verb == ":r":
             path_arg = arg.strip()
             if not path_arg:
-                return f"ERROR: action {i} '{action}': :r needs a file path\n"
-            try:
-                with open(path_arg, "r", encoding="utf-8", errors="replace") as _fh:
-                    file_text = _fh.read()
-            except OSError as e:
-                return f"ERROR: action {i} '{action}': :r failed to read {path_arg!r}: {e}\n"
+                return f"ERROR: action {i} '{action}': :r needs a file path (or '-' for stdin)\n"
+            if path_arg == "-":
+                try:
+                    file_text = sys.stdin.read()
+                except OSError as e:
+                    return f"ERROR: action {i} '{action}': :r failed to read stdin: {e}\n"
+            else:
+                try:
+                    with open(path_arg, "r", encoding="utf-8", errors="replace") as _fh:
+                        file_text = _fh.read()
+                except OSError as e:
+                    return f"ERROR: action {i} '{action}': :r failed to read {path_arg!r}: {e}\n"
             # vim :r inserts AFTER the current line. Ensure a newline boundary.
             eol = _line_end(content, cursor)
             if eol < len(content):

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -720,6 +720,22 @@ def test_read_missing_file_errors(tmp_path: Path) -> None:
     assert "ERROR" in out and ":r failed to read" in out
 
 
+def test_read_from_stdin(tmp_path: Path, monkeypatch) -> None:
+    """`:r -` reads from stdin instead of a file path."""
+    import io
+    target = tmp_path / "main.php"
+    target.write_text("<?php\nclass Foo {\n}\n")
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO("    public function bar(): void {}\n"),
+    )
+    supertool.op_vi(str(target), "G;k;:r -")
+    assert (
+        target.read_text()
+        == "<?php\nclass Foo {\n    public function bar(): void {}\n}\n"
+    )
+
+
 def test_read_adds_trailing_newline(tmp_path: Path) -> None:
     target = tmp_path / "x.py"
     target.write_text("line1\n")


### PR DESCRIPTION
## Summary

Standard vim and Unix tools treat `-` as the stdin filename. Lets bash pipe content directly into `:r` without a temp file:

```bash
printf '    public function bar(): void {}\n' | \
  ./supertool 'vi:::test.php:::G;?^};k;:r -'
```

Same insert semantics as `:r FILE` (insert after current line, ensure newline boundary).

## Test plan

- [x] 98 vi tests pass (+1 for :r -)

## Stacking

Targets `feat/vi-cursor-persist-and-s-dry` (PR #48). Rebase to master once that lands.