### PR TITLE
feat(vi): accept :%s and bare %s as aliases for :s (vim canonical form)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2656,6 +2656,12 @@ def op_vi(path: str, script: str) -> str:
             return (count, "ciw", rest[3:])
         if len(rest) >= 3 and rest[:2] == "ci" and rest[2] in ('"', "'", "(", "[", "{"):
             return (count, "ci" + rest[2], rest[3:])
+        # vim alias: :%s/PAT/REPL/flags maps to :s (whole buffer)
+        if len(rest) >= 3 and rest[:3] == ":%s":
+            return (count, ":s", rest[3:])
+        # vim alias without leading colon: %s/PAT/REPL/flags maps to :s
+        if len(rest) >= 2 and rest[:2] == "%s":
+            return (count, ":s", rest[2:])
         # two-char ex commands: :s/PAT/REPL/flags  and  :r FILE
         if len(rest) >= 2 and rest[:2] == ":s":
             return (count, ":s", rest[2:])

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -627,6 +627,22 @@ def test_substitute_global(tmp_path: Path) -> None:
     assert f.read_text() == "BAR BAR BAR\n"
 
 
+def test_substitute_pct_s_alias_with_colon(tmp_path: Path) -> None:
+    """`:%s/PAT/REPL/g` is the vim canonical form — aliases to :s (whole buffer)."""
+    f = tmp_path / "x.py"
+    f.write_text("foo bar foo\n")
+    supertool.op_vi(str(f), ":%s/foo/X/g")
+    assert f.read_text() == "X bar X\n"
+
+
+def test_substitute_pct_s_alias_without_colon(tmp_path: Path) -> None:
+    """`%s/PAT/REPL/g` (no leading colon) is accepted — Kevin sed-style slip."""
+    f = tmp_path / "x.py"
+    f.write_text("foo bar foo\n")
+    supertool.op_vi(str(f), "%s/foo/X/g")
+    assert f.read_text() == "X bar X\n"
+
+
 def test_substitute_case_insensitive(tmp_path: Path) -> None:
     f = tmp_path / "x.py"
     f.write_text("Foo FOO foo\n")


### PR DESCRIPTION
## Summary

Kevin (and humans) type vim's canonical `:%s/PAT/REPL/g` for buffer-wide substitute. The `%` is the line-range prefix meaning "all lines". Our `:s` is already buffer-wide so the prefix is redundant — but rejecting it surprises every vim user.

Also accept the bare `%s/PAT/REPL/g` (no leading colon) since the colon is consumed when entering ex mode in real vim; agents often drop it when writing scripts.

## Test plan

- [x] 99 vi tests pass (+2 new aliases tested)