### PR TITLE
feat(vi): word motions + canonical vim parity + :s literal `;` (lands #51 + #52)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2591,23 +2591,68 @@ def op_vi(path: str, script: str) -> str:
     for line in script.split("\n"):
         # Split on `;` but honor `\;` as a literal semicolon so inserted TEXT
         # can contain semicolons without colliding with the action separator.
+        # Inside an ex-substitute action (`:s/PAT/REPL/flags`, `:%s/...`, or
+        # bare `%s/...`), `;` is treated as literal until the trailing flags
+        # region — so users can write `:s/echo $who;//` without escaping.
         # Backslash-related escapes (`\\`, `\n`, `\t`, `\r`) live in
         # _decode_escapes — applied later on TEXT arguments only.
         parts: List[str] = []
         buf: List[str] = []
+        state = "NORMAL"  # NORMAL | SUBST_PAT | SUBST_REPL | SUBST_FLAGS
         idx = 0
         while idx < len(line):
             ch = line[idx]
-            if ch == "\\" and idx + 1 < len(line) and line[idx + 1] == ";":
-                buf.append(";")
-                idx += 2
-            elif ch == ";":
-                parts.append("".join(buf))
-                buf = []
-                idx += 1
-            else:
+            if state == "NORMAL":
+                if ch == "\\" and idx + 1 < len(line) and line[idx + 1] == ";":
+                    buf.append(";")
+                    idx += 2
+                    continue
+                if ch == ";":
+                    parts.append("".join(buf))
+                    buf = []
+                    idx += 1
+                    continue
+                if ch == "/":
+                    acc = "".join(buf).lstrip()
+                    if acc in (":s", ":%s", "%s"):
+                        buf.append(ch)
+                        state = "SUBST_PAT"
+                        idx += 1
+                        continue
                 buf.append(ch)
                 idx += 1
+                continue
+            if state in ("SUBST_PAT", "SUBST_REPL"):
+                # Inside PAT/REPL: `\/` literal slash; unescaped `/` advances state.
+                if ch == "\\" and idx + 1 < len(line) and line[idx + 1] == "/":
+                    buf.append("\\")
+                    buf.append("/")
+                    idx += 2
+                    continue
+                if ch == "/":
+                    buf.append(ch)
+                    state = "SUBST_REPL" if state == "SUBST_PAT" else "SUBST_FLAGS"
+                    idx += 1
+                    continue
+                # Everything else (including `;`) is literal in PAT/REPL.
+                buf.append(ch)
+                idx += 1
+                continue
+            # state == SUBST_FLAGS
+            if ch == ";":
+                parts.append("".join(buf))
+                buf = []
+                state = "NORMAL"
+                idx += 1
+                continue
+            buf.append(ch)
+            idx += 1
+        if state in ("SUBST_PAT", "SUBST_REPL"):
+            return (
+                "ERROR: unterminated :s — missing closing '/' "
+                f"(state={state}). Use `\\;` to escape literal `;` in TEXT, "
+                "or `:r FILE` for multi-line bodies.\n"
+            )
         parts.append("".join(buf))
         for seg in parts:
             # lstrip only — trailing whitespace inside insert TEXT is significant

--- a/supertool.py
+++ b/supertool.py
@@ -2697,7 +2697,7 @@ def op_vi(path: str, script: str) -> str:
         if c in ("f", "F", "t", "T") and len(rest) >= 2:
             return (count, c, rest[1])
         # standalone
-        if c in ("h", "j", "k", "l", "0", "$", "G", "D", "x", "J", "n", "N", "p", "P"):
+        if c in ("h", "j", "k", "l", "0", "$", "G", "D", "x", "J", "n", "N", "p", "P", "w", "b", "e", "^"):
             return (count, c, rest[1:])
         return (count, "", rest)  # unknown
 
@@ -3035,6 +3035,79 @@ def op_vi(path: str, script: str) -> str:
                 return f"ERROR: action {i} '{action}': {verb}{target!r} not found on line\n"
             cursor = idx
             log.append(f"  {i}. {verb}{target!r} → {cursor}")
+
+        # --- word motion: w b e ^ ---
+        elif verb == "w":
+            def _is_w(ch: str) -> bool:
+                return ch.isalnum() or ch == "_"
+            for _ in range(count):
+                if cursor >= len(content):
+                    break
+                if _is_w(content[cursor]):
+                    while cursor < len(content) and _is_w(content[cursor]):
+                        cursor += 1
+                elif not content[cursor].isspace():
+                    while (
+                        cursor < len(content)
+                        and not _is_w(content[cursor])
+                        and not content[cursor].isspace()
+                    ):
+                        cursor += 1
+                while (
+                    cursor < len(content)
+                    and content[cursor].isspace()
+                    and content[cursor] != "\n"
+                ):
+                    cursor += 1
+            log.append(f"  {i}. {count}w (cursor={cursor})")
+        elif verb == "b":
+            def _is_w(ch: str) -> bool:
+                return ch.isalnum() or ch == "_"
+            for _ in range(count):
+                if cursor == 0:
+                    break
+                cursor -= 1
+                while cursor > 0 and content[cursor].isspace():
+                    cursor -= 1
+                if _is_w(content[cursor]):
+                    while cursor > 0 and _is_w(content[cursor - 1]):
+                        cursor -= 1
+                else:
+                    while (
+                        cursor > 0
+                        and not _is_w(content[cursor - 1])
+                        and not content[cursor - 1].isspace()
+                    ):
+                        cursor -= 1
+            log.append(f"  {i}. {count}b (cursor={cursor})")
+        elif verb == "e":
+            def _is_w(ch: str) -> bool:
+                return ch.isalnum() or ch == "_"
+            for _ in range(count):
+                if cursor >= len(content):
+                    break
+                if (
+                    cursor + 1 < len(content)
+                    and _is_w(content[cursor])
+                    and not _is_w(content[cursor + 1])
+                ):
+                    cursor += 1
+                while cursor < len(content) and content[cursor].isspace():
+                    cursor += 1
+                while (
+                    cursor + 1 < len(content)
+                    and _is_w(content[cursor + 1])
+                ):
+                    cursor += 1
+            log.append(f"  {i}. {count}e (cursor={cursor})")
+        elif verb == "^":
+            bol = _line_start(content, cursor)
+            eol = _line_end(content, cursor)
+            pos = bol
+            while pos < eol and content[pos] in (" ", "\t"):
+                pos += 1
+            cursor = pos
+            log.append(f"  {i}. ^ (cursor={cursor})")
 
         # --- repeat search: n / N ---
         elif verb in ("n", "N"):

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -753,6 +753,52 @@ def test_substitute_strips_defensive_backslash_before_punct(tmp_path: Path) -> N
     assert f.read_text() == "foo(1);\n"
 
 
+def test_substitute_with_literal_semicolon_in_pattern(tmp_path: Path) -> None:
+    """`:s` arg-region treats `;` as literal — no \\; escape needed for in-pattern ;."""
+    f = tmp_path / "x.php"
+    f.write_text("$x = 1; // debug\nkeep\n")
+    supertool.op_vi(str(f), ":s/.*= 1; .*\\n//")
+    assert f.read_text() == "keep\n"
+
+
+def test_substitute_then_chained_action_after_flags(tmp_path: Path) -> None:
+    """`;` after `:s/.../.../[flags]` still acts as action separator."""
+    f = tmp_path / "x.php"
+    f.write_text("foo bar\n")
+    supertool.op_vi(str(f), ":s/foo/X/;A!")
+    assert f.read_text() == "X bar!\n"
+
+
+def test_substitute_with_g_flag_then_chained_action(tmp_path: Path) -> None:
+    """`;` after `:s/.../.../g` (with flag) still chains next action."""
+    f = tmp_path / "x.txt"
+    f.write_text("a a a\n")
+    supertool.op_vi(str(f), ":s/a/X/g;A!")
+    assert f.read_text() == "X X X!\n"
+
+
+def test_substitute_mid_chain_after_prior_action(tmp_path: Path) -> None:
+    """`:s` triggered after a prior action + `;` — state detection works mid-script."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\n")
+    supertool.op_vi(str(f), "A!;:s/foo!/bar/")
+    assert f.read_text() == "bar\n"
+
+
+def test_substitute_unterminated_does_not_swallow_chained_action(tmp_path: Path) -> None:
+    """Unterminated `:s/foo` (no closing `/`) should not silently eat a following `;action`.
+
+    Current behavior: `;` becomes literal inside SUBST_PAT, swallowing chained actions.
+    This test documents what we *want* — chained action still runs, or the malformed
+    `:s` errors loudly. Silent no-op is the bug.
+    """
+    f = tmp_path / "x.txt"
+    f.write_text("foo\n")
+    result = supertool.op_vi(str(f), ":s/foo;A!")
+    assert "ERROR" in result
+    assert f.read_text() == "foo\n"  # file untouched on malformed script
+
+
 def test_substitute_repl_with_php_namespace_backslashes(tmp_path: Path) -> None:
     """REPL containing single backslashes (PHP/JS namespace separators) must
     not crash re.sub with 'bad escape \\B' — backslashes are auto-escaped."""

--- a/tests/test_vi_canonical.py
+++ b/tests/test_vi_canonical.py
@@ -1,0 +1,106 @@
+"""Canonical vim behavior parity test.
+
+Compiled from vim's own tutorial and quick-reference (`:help motion.txt`,
+`:help change.txt`, `vimtutor`). Each case mirrors what a real vim user
+would type and expect. Run with:
+
+    pytest tests/test_vi_canonical.py --no-cov -v
+
+Cases the impl doesn't support yet show up as xfail or fail — those are
+the gap list for the next iteration.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import supertool
+
+
+# (name, initial content, vi script, expected content after)
+CASES = [
+    # --- Motion ---
+    ("gg goes to top",          "a\nb\nc\n",          "G;gg;iX",      "Xa\nb\nc\n"),
+    ("G goes to last line",     "a\nb\nc\n",          "G;iEND",       "a\nb\nENDc\n"),
+    ("3G goes to line 3",       "a\nb\nc\nd\n",       "3G;i*",        "a\nb\n*c\nd\n"),
+    ("0 jumps to BOL",          "hello\n",            "$;0;iX",       "Xhello\n"),
+    ("$ jumps to last char",    "hello\n",            "$;iX",         "hellXo\n"),
+    ("/PAT finds forward",      "alpha beta gamma\n", "/beta;iX",     "alpha Xbeta gamma\n"),
+
+    # --- Inserts ---
+    ("i inserts before cursor", "world\n",            "ihello ",      "hello world\n"),
+    ("a appends after",         "ab\n",               "ax",           "axb\n"),
+    ("I inserts at BOL",        "  text\n",           "$;I>",         ">  text\n"),
+    ("A appends at EOL",        "hello\n",            "A!",           "hello!\n"),
+    ("o opens line below",      "first\nsecond\n",    "gg;onew",      "first\nnew\nsecond\n"),
+    ("O opens line above",      "second\n",           "Oabove",       "above\nsecond\n"),
+
+    # --- Deletes ---
+    ("x deletes char at cursor","abc\n",              "x",            "bc\n"),
+    ("3x deletes 3 chars",      "abcdef\n",           "3x",           "def\n"),
+    ("dd deletes line",         "a\nb\nc\n",          "2G;dd",        "a\nc\n"),
+    ("3dd deletes 3 lines",     "a\nb\nc\nd\ne\n",    "2G;3dd",       "a\ne\n"),
+    ("D deletes to EOL",        "keep|drop\n",        "/|;D",         "keep\n"),
+    ("dw deletes word",         "foo bar baz\n",      "dw",           "bar baz\n"),
+    ("d$ deletes to EOL",       "keep drop\n",        "/d;d$",        "keep \n"),
+
+    # --- Change verbs ---
+    ("ciw changes inner word",  "foo bar baz\n",      "/bar;ciwZZ",   "foo ZZ baz\n"),
+    ("cw changes to word end",  "foo bar baz\n",      "/bar;cwZZ",    "foo ZZ baz\n"),
+    ("cc rewrites line",        "old line\nkeep\n",   "ccnew",        "new\nkeep\n"),
+    ("c$ changes to EOL",       "keep drop\n",        "/d;c$NEW",     "keep NEW\n"),
+    ("ci\" changes inside \"",  'x = "old"\n',         '/";ci"new',   'x = "new"\n'),
+    ("ci' changes inside '",    "x = 'old'\n",         "/';ci'new",   "x = 'new'\n"),
+    ("ci( changes inside ()",   "f(a, b)\n",           "/(;ci(x",     "f(x)\n"),
+    ("ci[ changes inside []",   "a = [1,2]\n",         "/[;ci[9",     "a = [9]\n"),
+    ("ci{ changes inside {}",   "d = {x:1}\n",         "/{;ci{y:2",   "d = {y:2}\n"),
+
+    # --- Char-find ---
+    ("f<c> finds char on line", "abcdef\n",           "fc;iX",        "abXcdef\n"),
+    ("F<c> finds back on line", "abcdef\n",           "$;Fc;iX",      "abXcdef\n"),
+    ("t<c> stops before char",  "abcdef\n",           "tc;iX",        "aXbcdef\n"),
+
+    # --- Word motion (vimhelp.org/usr_02.txt) ---
+    ("w moves to next word",    "hello world\n",      "w;iX",         "hello Xworld\n"),
+    ("b moves back one word",   "hello world\n",      "$;b;iX",       "hello Xworld\n"),
+    ("e moves to word end",     "hello world\n",      "e;aX",          "helloX world\n"),
+    ("^ moves to first non-blank", "   text\n",       "^;iX",         "   Xtext\n"),
+
+    # --- Yank/paste ---
+    ("yy + p duplicates line",  "hello\nworld\n",     "yy;p",         "hello\nhello\nworld\n"),
+    ("yw + p pastes word",      "foo bar\n",          "yw;$;p",       "foo barfoo\n"),
+
+    # --- Replace ---
+    ("r replaces single char",  "abc\n",              "rX",           "Xbc\n"),
+
+    # --- Join ---
+    ("J joins next line",       "foo\nbar\nbaz\n",    "J",            "foo bar\nbaz\n"),
+
+    # --- Ex substitute ---
+    (":s replaces first match", "foo foo\n",          ":s/foo/X/",    "X foo\n"),
+    (":s/g replaces all",       "foo foo\n",          ":s/foo/X/g",   "X X\n"),
+    (":%s alias works",         "foo foo\n",          ":%s/foo/X/g",  "X X\n"),
+    ("%s bare alias works",     "foo foo\n",          "%s/foo/X/g",   "X X\n"),
+    (":s/gi case-insensitive",  "Foo FOO foo\n",      ":s/foo/X/gi",  "X X X\n"),
+    (":s backref",              "a=1\n",              ":s/(\\w+)=(\\d+)/\\2:\\1/", "1:a\n"),
+
+    # --- Counts ---
+    ("5i- repeats insert 5x",   "ok\n",               "5i-",          "-----ok\n"),
+
+    # --- :r FILE ---
+    # covered separately in test_vi.py with tmp file
+]
+
+
+@pytest.mark.parametrize("name, initial, script, expected", CASES, ids=[c[0] for c in CASES])
+def test_canonical_vim_behavior(
+    name: str, initial: str, script: str, expected: str, tmp_path: Path, monkeypatch
+) -> None:
+    """Each canonical vim case: write `initial`, run `script`, check output."""
+    # Isolate cursor cache so cases don't pollute each other
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vi(str(f), script)
+    actual = f.read_text()
+    assert actual == expected, f"{name}\n  script: {script!r}\n  out: {out}\n  got: {actual!r}\n  want: {expected!r}"

--- a/tests/test_vi_integration.py
+++ b/tests/test_vi_integration.py
@@ -1,0 +1,487 @@
+"""Integration test: real-world weirdest combo refactor in ONE vi call.
+
+Combines all features (regex, :s, :%s, /PAT, ?^, k, :r FILE, O insert,
+multi-line block, escape \\;) on a PHP class file. Locks in the script
+that successfully runs end-to-end so we notice if any feature regresses.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+DEMO_BEFORE = """<?php
+
+namespace App\\Demo;
+
+class OldName
+{
+    public const VERSION = "v1";
+
+    public function greet(string $who): string
+    {
+        echo $who; // debug print
+        return "Hello, " . $who;
+    }
+}
+"""
+
+DEMO_AFTER = """<?php
+
+namespace App\\Demo;
+
+/**
+ * @see \\Tests\\GreeterTest
+ */
+final class Greeter
+{
+    public const VERSION = "v2";
+
+    public function greet(string $who): string
+    {
+        return "Howdy, " . $who;
+    }
+
+    public function shout(string $who): string
+    {
+        return strtoupper($this->greet($who));
+    }
+}
+"""
+
+METHOD_BODY = """
+    public function shout(string $who): string
+    {
+        return strtoupper($this->greet($who));
+    }
+"""
+
+
+NGINX_BEFORE = """# nginx site config
+
+server {
+    listen 80;
+    server_name old.example.com;
+
+    location /static/ {
+        root /home/user/old-app/static;
+        expires 1d;
+    }
+
+    location /media/ {
+        root /home/user/old-app/media;
+        expires 7d;
+    }
+
+    # deprecated: legacy upload endpoint
+    location /upload-old/ {
+        proxy_pass http://localhost:9999;
+        deny all;
+    }
+}
+"""
+
+NGINX_AFTER = """# generated 2026-05-16 — DO NOT EDIT
+# nginx site config
+
+server {
+    listen 80;
+    server_name new.example.com;
+
+    location /static/ {
+        root /srv/new-app/static;
+        expires 1d;
+    }
+
+    location /media/ {
+        root /srv/new-app/media;
+        expires 7d;
+    }
+
+
+    location /api/ {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+    }
+}
+"""
+
+NGINX_EXTRA = """
+    location /api/ {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+    }
+"""
+
+
+def test_vimgolf_strip_comments_swap_args(tmp_path: Path, monkeypatch) -> None:
+    """VimGolf-style: strip Python inline comments + swap function args."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.py"
+    f.write_text(
+        "def foo(a, b, c):  # main function\n"
+        "    x = a + b  # add values\n"
+        "    return x\n"
+    )
+    supertool.op_vi(
+        str(f),
+        "%s/  +#.*//g;%s/\\(a, b, c\\)/(c, b, a)/",
+    )
+    assert f.read_text() == (
+        "def foo(c, b, a):\n"
+        "    x = a + b\n"
+        "    return x\n"
+    )
+
+
+def test_vimgolf_whitespace_to_csv(tmp_path: Path, monkeypatch) -> None:
+    """VimGolf-style: collapse runs of spaces into single commas."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.csv"
+    f.write_text(
+        "name    age    city\n"
+        "Alice   30     NYC\n"
+        "Bob     25     LA\n"
+    )
+    supertool.op_vi(str(f), "%s/ +/,/g")
+    assert f.read_text() == (
+        "name,age,city\n"
+        "Alice,30,NYC\n"
+        "Bob,25,LA\n"
+    )
+
+
+def test_vimgolf_collapse_adjacent_duplicates(tmp_path: Path, monkeypatch) -> None:
+    """VimGolf-style: regex backref to collapse adjacent duplicate chars."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("aabbcc\nddeeff\ngghhii\n")
+    supertool.op_vi(str(f), "%s/(.)\\1+/\\1/g")
+    assert f.read_text() == "abc\ndef\nghi\n"
+
+
+def test_strip_blank_lines(tmp_path: Path, monkeypatch) -> None:
+    """Remove all blank lines from a file via regex."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("line1\n\nline2\n\n\nline3\n")
+    supertool.op_vi(str(f), "%s/^\\n//g")
+    assert f.read_text() == "line1\nline2\nline3\n"
+
+
+def test_markdown_deepen_headings(tmp_path: Path, monkeypatch) -> None:
+    """Demote every `# heading` to `## heading` (add a leading `#`)."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.md"
+    f.write_text("# Top\n\n## Sub\n\n# Another top\n")
+    supertool.op_vi(str(f), "%s/^#/##/g")
+    assert f.read_text() == "## Top\n\n### Sub\n\n## Another top\n"
+
+
+def test_python_decorator_wrap_all_defs(tmp_path: Path, monkeypatch) -> None:
+    """Prefix every top-level `def NAME(` with `@profile\\n` decorator line."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.py"
+    f.write_text("def foo():\n    pass\n\ndef bar(x):\n    return x\n")
+    supertool.op_vi(str(f), "%s/^def /@profile\\ndef /g")
+    assert f.read_text() == (
+        "@profile\ndef foo():\n    pass\n\n"
+        "@profile\ndef bar(x):\n    return x\n"
+    )
+
+
+def test_json_config_bump_and_insert(tmp_path: Path, monkeypatch) -> None:
+    """Bump version literal + insert a new field before the closing brace."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "config.json"
+    f.write_text(
+        "{\n"
+        '    "version": "1.0.0",\n'
+        '    "name": "demo"\n'
+        "}\n"
+    )
+    supertool.op_vi(
+        str(f),
+        '%s/"1.0.0"/"2.0.0"/;%s/"name": "demo"$/"name": "demo",/;G;?^};O    "debug": true',
+    )
+    assert f.read_text() == (
+        "{\n"
+        '    "version": "2.0.0",\n'
+        '    "name": "demo",\n'
+        '    "debug": true\n'
+        "}\n"
+    )
+
+
+def test_online_delete_lines_matching_pattern(tmp_path: Path, monkeypatch) -> None:
+    """Source: learnvim.irian.to/basics/the_global_command (`:g/console/d`).
+    Adapted: remove all lines containing `console` using :%s with whole-line regex."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.js"
+    f.write_text(
+        "const one = 1;\n"
+        'console.log("one: ", one);\n'
+        "const two = 2;\n"
+        'console.log("two: ", two);\n'
+        "const three = 3;\n"
+        'console.log("three: ", three);\n'
+    )
+    supertool.op_vi(str(f), "%s/^.*console.*\\n//g")
+    assert f.read_text() == (
+        "const one = 1;\n"
+        "const two = 2;\n"
+        "const three = 3;\n"
+    )
+
+
+def test_online_append_semicolon_non_empty_lines(tmp_path: Path, monkeypatch) -> None:
+    """Source: learnvim.irian.to (`:g/./normal A;`). Adapted with :%s backref."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.js"
+    f.write_text("const x = 5\nconst y = 10\nconst z = 15\n")
+    supertool.op_vi(str(f), "%s/(.+)$/\\1;/g")
+    assert f.read_text() == "const x = 5;\nconst y = 10;\nconst z = 15;\n"
+
+
+def test_online_reorder_lastname_firstname(tmp_path: Path, monkeypatch) -> None:
+    """Source: devhints.io/vim — `LastName, FirstName` → `FirstName LastName`."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "names.txt"
+    f.write_text(
+        "Smith, John\nJohnson, Sarah\nWilliams, Mike\nBrown, Emma\nDavis, Robert\n"
+    )
+    supertool.op_vi(str(f), "%s/(.*), (.*)/\\2 \\1/g")
+    assert f.read_text() == (
+        "John Smith\nSarah Johnson\nMike Williams\nEmma Brown\nRobert Davis\n"
+    )
+
+
+ZEN_BEFORE = """The Zen of Python, by Tim Peters
+
+Beautiful is better than ugly.
+Explicit is better than implicit.
+Simple is better than complex.
+Complex is better than complicated.
+Flat is better than nested.
+Sparse is better than dense.
+Readability counts.
+Special cases aren't special enough to break the rules.
+Although practicality beats purity.
+Errors should never pass silently.
+Unless explicitly silenced.
+In the face of ambiguity, refuse the temptation to guess.
+There should be one-- and preferably only one --obvious way to do it.
+Although that way may not be obvious at first unless you're Dutch.
+Now is better than never.
+Although never is often better than *right* now.
+If the implementation is hard to explain, it's a bad idea.
+If the implementation is easy to explain, it may be a good idea.
+Namespaces are one honking great idea -- let's do more of those!
+"""
+
+
+def test_online_zen_of_python_refactor(tmp_path: Path, monkeypatch) -> None:
+    """Source: raw.githubusercontent.com/python/cpython Lib/this.py.
+    Real 21-line public text. 6 actions: global word swap, delete line by
+    keyword, prepend MD heading, append signature."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "zen.md"
+    f.write_text(ZEN_BEFORE)
+    supertool.op_vi(
+        str(f),
+        "%s/better/preferable/g"
+        ";%s/^.*Dutch.*\\n//g"
+        ";gg;O# Zen of Python\\n"
+        ";G;oEOF — annotated by Max",
+    )
+    out = f.read_text()
+    assert "# Zen of Python" in out.splitlines()[0]
+    assert "Dutch" not in out
+    assert out.count("preferable") == 8  # all 8 'better' → 'preferable'
+    assert out.rstrip().endswith("EOF — annotated by Max")
+
+
+LINUX_RST = """.. _codingstyle:
+
+Linux kernel coding style
+=========================
+
+This is a short document describing the preferred coding style for the
+linux kernel.  Coding style is very personal, and I won't **force** my
+views on anybody, but this is what goes for anything that I have to be
+able to maintain, and I'd prefer it for most other things too.  Please
+at least consider the points made here.
+
+First off, I'd suggest printing out a copy of the GNU coding standards,
+and NOT read it.  Burn them, it's a great symbolic gesture.
+
+Anyway, here goes:
+
+
+1) Indentation
+--------------
+
+Tabs are 8 characters, and thus indentations are also 8 characters.
+There are heretic movements that try to make indentations 4 (or even 2!)
+characters deep, and that is akin to trying to define the value of PI to
+be 3.
+
+Rationale: The whole idea behind indentation is to clearly define where
+a block of control starts and ends.  Especially when you've been looking
+at your screen for 20 straight hours, you'll find it a lot easier to see
+how the indentation works if you have large indentations.
+
+The preferred way to ease multiple indentation levels in a switch statement is
+to align the ``switch`` and its subordinate ``case`` labels in the same column
+instead of ``double-indenting`` the ``case`` labels.  E.g.:
+"""
+
+
+def test_online_linux_kernel_rst_to_md(tmp_path: Path, monkeypatch) -> None:
+    """Source: raw.githubusercontent.com/torvalds/linux Documentation/process/
+    coding-style.rst — real 33-line public text. 13 actions to convert RST →
+    Markdown: drop section underlines, drop directive, RST inline-code →
+    MD inline-code, add MD heading markers, delete a paragraph, append footer."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "linux.md"
+    f.write_text(LINUX_RST)
+    supertool.op_vi(
+        str(f),
+        "gg;dd;dd"                                              # drop `.. _codingstyle:` + blank
+        ";%s/^=+$\\n//g"                                         # drop RST h1 underline
+        ";%s/^-+$\\n//g"                                         # drop RST h2 underline
+        ";%s/``([^`]+)``/`\\1`/g"                                # RST inline code → MD
+        ";%s/^Linux kernel coding style$/# Linux kernel coding style\\n/"  # h1
+        ";%s/^1\\) Indentation$/## 1) Indentation/"             # h2
+        ";gg;/First off;2dd"                                    # drop paragraph (First off + Burn them)
+        ";G;oConverted from RST by vi",
+    )
+    out = f.read_text()
+    assert out.startswith("# Linux kernel coding style")
+    assert "## 1) Indentation" in out
+    assert "Burn them" not in out
+    assert "First off" not in out  # entire paragraph dropped
+    assert "``switch``" not in out  # RST inline-code rewritten
+    assert "`switch`" in out
+    assert out.rstrip().endswith("Converted from RST by vi")
+
+
+def test_online_prepend_https_to_bare_domains(tmp_path: Path, monkeypatch) -> None:
+    """Source: devhints.io/vim — prepend https:// to domain-only lines, skip
+    lines that already have http:// or https:// prefix."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "urls.txt"
+    f.write_text(
+        "example.com\n"
+        "https://secure.example.com\n"
+        "github.com\n"
+        "http://legacy.example.com\n"
+        "devhints.io\n"
+    )
+    supertool.op_vi(str(f), "%s/^([a-z]+\\.[a-z]+)$/https:\\/\\/\\1/g")
+    assert f.read_text() == (
+        "https://example.com\n"
+        "https://secure.example.com\n"
+        "https://github.com\n"
+        "http://legacy.example.com\n"
+        "https://devhints.io\n"
+    )
+
+
+def test_sql_migration_rename_table(tmp_path: Path, monkeypatch) -> None:
+    """Rename a table everywhere it appears in a SQL migration script."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "migration.sql"
+    f.write_text(
+        "ALTER TABLE old_users ADD COLUMN email VARCHAR(255);\n"
+        "CREATE INDEX idx_old_users_email ON old_users (email);\n"
+        "DROP INDEX idx_old_users_legacy;\n"
+    )
+    supertool.op_vi(str(f), "%s/old_users/account/g")
+    assert f.read_text() == (
+        "ALTER TABLE account ADD COLUMN email VARCHAR(255);\n"
+        "CREATE INDEX idx_account_email ON account (email);\n"
+        "DROP INDEX idx_account_legacy;\n"
+    )
+
+
+def test_nginx_refactor_one_call(tmp_path: Path, monkeypatch) -> None:
+    """Real-world nginx config refactor: rename host, migrate path, drop
+    deprecated block, inject /api/ location, prepend generated header.
+    11 actions, one vi call."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    target = tmp_path / "site.conf"
+    target.write_text(NGINX_BEFORE)
+    extra = tmp_path / "extra.txt"
+    extra.write_text(NGINX_EXTRA)
+
+    script = (
+        "%s/old.example.com/new.example.com/g"
+        ";%s/\\/home\\/user\\/old-app\\//\\/srv\\/new-app\\//g"
+        ";gg;/# deprecated:;5dd"
+        ";G;?^};k"
+        f";:r {extra}"
+        ";gg;O# generated 2026-05-16 — DO NOT EDIT"
+    )
+    out = supertool.op_vi(str(target), script)
+    assert "ERROR" not in out, f"unexpected error:\n{out}"
+    assert target.read_text() == NGINX_AFTER, (
+        f"refactor diverged\n--- got ---\n{target.read_text()}\n--- want ---\n{NGINX_AFTER}"
+    )
+
+
+def test_weirdest_combo_one_call(tmp_path: Path, monkeypatch) -> None:
+    """12 actions in one vi call: rename, kill debug, bump version, add final,
+    swap greeting, inject method inside class, prepend class docblock."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    target = tmp_path / "demo.php"
+    target.write_text(DEMO_BEFORE)
+    body = tmp_path / "method-body.txt"
+    body.write_text(METHOD_BODY)
+
+    script = (
+        "%s/OldName/Greeter/g"
+        ";%s/^        echo \\$who;.*\\n//"
+        ";%s/\"v1\"/\"v2\"/"
+        ";%s/^class Greeter/final class Greeter/"
+        ';%s/"Hello, "/"Howdy, "/'
+        ";G;?^};k"
+        f";:r {body}"
+        ";gg;/class Greeter"
+        ";O/**\\n * @see \\\\Tests\\\\GreeterTest\\n */"
+    )
+    out = supertool.op_vi(str(target), script)
+    assert "ERROR" not in out, f"unexpected error in script:\n{out}"
+    assert target.read_text() == DEMO_AFTER, (
+        f"refactor diverged from expected output\n"
+        f"--- got ---\n{target.read_text()}\n"
+        f"--- want ---\n{DEMO_AFTER}"
+    )
+
+
+def test_literal_semicolon_chained_in_real_script(tmp_path: Path, monkeypatch) -> None:
+    """End-to-end PR #52 fix: `;` literal inside :s PAT/REPL within a chained
+    multi-action script. Strips a PHP debug line whose pattern contains `;`,
+    then appends a trailing marker via A — proves the chain still splits at
+    the `;` AFTER the trailing `/` while keeping in-pattern `;` literal."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.php"
+    f.write_text(
+        "<?php\n"
+        "function go(): void {\n"
+        "    echo $debug; // remove me\n"
+        "    return;\n"
+        "}\n"
+    )
+    supertool.op_vi(
+        str(f),
+        ":s/^.*echo \\$debug; \\/\\/ remove me\\n//"
+        ";gg;A // touched",
+    )
+    assert f.read_text() == (
+        "<?php // touched\n"
+        "function go(): void {\n"
+        "    return;\n"
+        "}\n"
+    )


### PR DESCRIPTION
## Summary

Two stacked PRs (#51 word motions, #52 `:s` literal `;` in PAT/REPL + integration regression) were merged into intermediate branches, not master. This PR lands both as squash-picks onto master in one shot.

- **#51** — vi word motions (`w`, `b`, `e`, `^`) + canonical vim parity test suite
- **#52** — `:s/PAT/REPL/flags` treats `;` as literal until trailing flags; unterminated `:s` now errors loudly; 16-test integration regression suite (Zen of Python, Linux kernel RST, nginx, SQL, weirdest-combo refactor)

## Test plan

- [x] 1235 tests pass, 91.27% coverage
- [x] No diff from upstream squash commits (`2ce78ed`, `7c4fd85`) — just rebased onto current master