### PR TITLE
feat(vi): line-range substitute (`:Ns`, `:N,Ms`, `:.s`, `:$s`)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2659,6 +2659,25 @@ def op_vi(path: str, script: str) -> str:
         # vim alias without leading colon: %s/PAT/REPL/flags maps to :s
         if len(rest) >= 2 and rest[:2] == "%s":
             return (count, ":s", rest[2:])
+        # vim line-range substitute: :Ns/..., :N,Ms/..., :.s/..., :$s/...
+        # Range = optional addr (N | . | $) + optional `,addr`. Encoded into
+        # arg with a `\x1d` (group separator) sentinel: arg becomes
+        # f"\x1d{range_spec}\x1d/PAT/REPL/flags" which the :s handler decodes.
+        if len(rest) >= 2 and rest[0] == ":" and rest[1] in "0123456789.$":
+            j = 1
+            # first address
+            while j < len(rest) and (rest[j].isdigit() or rest[j] in ".$"):
+                j += 1
+            # optional `,addr2`
+            if j < len(rest) and rest[j] == ",":
+                j += 1
+                while j < len(rest) and (rest[j].isdigit() or rest[j] in ".$"):
+                    j += 1
+            # must be followed by `s`
+            if j < len(rest) and rest[j] == "s":
+                range_spec = rest[1:j]
+                body = rest[j + 1:]
+                return (count, ":s", f"\x1d{range_spec}\x1d{body}")
         # two-char ex commands: :s/PAT/REPL/flags  and  :r FILE
         if len(rest) >= 2 and rest[:2] == ":s":
             return (count, ":s", rest[2:])
@@ -3172,6 +3191,64 @@ def op_vi(path: str, script: str) -> str:
 
         # --- ex substitute: :s/PAT/REPL/flags ---
         elif verb == ":s":
+            # Decode optional line-range prefix: \x1d{range}\x1d{body}.
+            # The parser encodes ranges from `:Ns/...`, `:N,Ms/...`, `:.s/...`,
+            # `:$s/...`, etc. Resolve `.` against cursor and `$` against
+            # content here (parse-time didn't have either).
+            sub_start = 0
+            sub_end = len(content)
+            if arg.startswith("\x1d"):
+                close = arg.find("\x1d", 1)
+                if close == -1:
+                    return f"ERROR: action {i} '{action}': :s malformed range encoding\n"
+                range_spec = arg[1:close]
+                arg = arg[close + 1:]
+                lines = content.split("\n")
+                # vim line count excludes trailing-empty from a final `\n`
+                total_lines = len(lines) - (1 if lines and lines[-1] == "" else 0)
+                cursor_line, _ = _offset_to_line_col(content, cursor)
+
+                def _resolve(addr: str) -> int:
+                    if addr == ".":
+                        return cursor_line
+                    if addr == "$":
+                        return total_lines
+                    if addr.isdigit():
+                        return int(addr)
+                    raise ValueError(f"bad address {addr!r}")
+
+                if "," in range_spec:
+                    a, b = range_spec.split(",", 1)
+                else:
+                    a, b = range_spec, range_spec
+                try:
+                    line_a = _resolve(a)
+                    line_b = _resolve(b)
+                except ValueError as e:
+                    return f"ERROR: action {i} '{action}': :s range: {e}\n"
+                if line_a < 1 or line_b < 1 or line_a > total_lines or line_b > total_lines:
+                    return (
+                        f"ERROR: action {i} '{action}': :s range {line_a}..{line_b} "
+                        f"out of bounds (1..{total_lines})\n"
+                    )
+                if line_a > line_b:
+                    return (
+                        f"ERROR: action {i} '{action}': :s range start ({line_a}) "
+                        f"is after end ({line_b})\n"
+                    )
+                # Compute byte slice for lines [line_a..line_b] (inclusive).
+                # line N starts at byte offset of line N's first char.
+                line_starts: List[int] = [0]
+                for k, ch in enumerate(content):
+                    if ch == "\n":
+                        line_starts.append(k + 1)
+                sub_start = line_starts[line_a - 1]
+                # End offset: start of line_b+1 (exclusive), or len(content)
+                # if line_b is the last line.
+                if line_b < len(line_starts):
+                    sub_end = line_starts[line_b]  # exclusive
+                else:
+                    sub_end = len(content)
             if not arg or arg[0] != "/":
                 return f"ERROR: action {i} '{action}': :s needs /PAT/REPL/[flags]\n"
             # parse /PAT/REPL/flags honoring \/ as literal
@@ -3216,7 +3293,31 @@ def op_vi(path: str, script: str) -> str:
             # Digit-prefixed backslashes (\1..\9) are preserved as backrefs.
             srepl_safe = re.sub(r"\\(?=\D)", r"\\\\", srepl_dec)
             try:
-                new_content, n = rx.subn(srepl_safe, content, count=n_max)
+                if sub_start == 0 and sub_end == len(content):
+                    # whole-file path (no range) — preserve existing semantics
+                    new_content, n = rx.subn(srepl_safe, content, count=n_max)
+                else:
+                    # ranged path — iterate per line in the range so non-/g
+                    # replaces the first match on EACH line (vim behavior),
+                    # not just the first match in the whole range.
+                    head = content[:sub_start]
+                    tail = content[sub_end:]
+                    body = content[sub_start:sub_end]
+                    has_trailing_nl = body.endswith("\n")
+                    body_lines = body.split("\n")
+                    if has_trailing_nl:
+                        body_lines = body_lines[:-1]
+                    is_global = "g" in sflags
+                    n = 0
+                    new_lines: List[str] = []
+                    for ln in body_lines:
+                        subbed_ln, k = rx.subn(
+                            srepl_safe, ln, count=0 if is_global else 1
+                        )
+                        new_lines.append(subbed_ln)
+                        n += k
+                    new_body = "\n".join(new_lines) + ("\n" if has_trailing_nl else "")
+                    new_content = head + new_body + tail
             except re.error as e:
                 return f"ERROR: action {i} '{action}': :s replacement: {e}\n"
             if n == 0:

--- a/tests/test_vi_line_range.py
+++ b/tests/test_vi_line_range.py
@@ -1,0 +1,107 @@
+"""Tests for :Ns and :N,Ms line-range substitute in op_vi (vim parity).
+
+Real vim supports:
+- `:Ns/PAT/REPL/[flags]`     — substitute on line N only
+- `:N,Ms/PAT/REPL/[flags]`   — substitute on lines N through M (inclusive)
+- `:.s/...`                  — substitute on current line (cursor's line)
+- `:$s/...`                  — substitute on last line
+- `:.,$s/...`                — current line through end
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def test_single_line_substitute(tmp_path: Path) -> None:
+    """`:3s/foo/X/g` runs only on line 3."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), ":3s/foo/X/g")
+    assert "ERROR" not in out, out
+    # Only line 3 changed
+    assert f.read_text() == "foo\nfoo\nX\nfoo\n"
+
+
+def test_line_range_substitute(tmp_path: Path) -> None:
+    """`:2,3s/foo/X/g` runs on lines 2 and 3."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), ":2,3s/foo/X/g")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "foo\nX\nX\nfoo\n"
+
+
+def test_line_range_substitute_first_only(tmp_path: Path) -> None:
+    """`:2,3s/foo/X/` (no /g flag) replaces first match per line in range."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo foo\nfoo foo\nfoo foo\nfoo foo\n")
+    out = supertool.op_vi(str(f), ":2,3s/foo/X/")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "foo foo\nX foo\nX foo\nfoo foo\n"
+
+
+def test_dollar_means_last_line(tmp_path: Path) -> None:
+    """`:$s/foo/X/g` runs on the last line."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), ":$s/foo/X/g")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "foo\nfoo\nX\n"
+
+
+def test_dot_means_current_line(tmp_path: Path) -> None:
+    """`:.s/foo/X/g` runs on the cursor's current line."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), "2G␞:.s/foo/X/g")
+    assert "ERROR" not in out, out
+    # Cursor on line 2, only that line changes
+    assert f.read_text() == "foo\nX\nfoo\n"
+
+
+def test_dot_to_dollar_range(tmp_path: Path) -> None:
+    """`:.,$s/foo/X/g` runs from current line to last line."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), "3G␞:.,$s/foo/X/g")
+    assert "ERROR" not in out, out
+    # Lines 3 and 4 changed
+    assert f.read_text() == "foo\nfoo\nX\nX\n"
+
+
+def test_line_range_out_of_bounds_errors_clearly(tmp_path: Path) -> None:
+    """`:99s/foo/X/g` on a 3-line file should error, not silently no-op."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), ":99s/foo/X/g")
+    assert "ERROR" in out
+
+
+def test_line_range_inverted_errors(tmp_path: Path) -> None:
+    """`:5,2s/...` (end before start) should error."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), ":5,2s/foo/X/g")
+    assert "ERROR" in out
+
+
+def test_whole_file_alias_still_works(tmp_path: Path) -> None:
+    """Regression — `:%s/foo/X/g` (whole-file alias) unchanged."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), ":%s/foo/X/g")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "X\nX\nX\n"
+
+
+def test_bare_s_still_means_whole_file(tmp_path: Path) -> None:
+    """Regression — `:s/foo/X/g` (no range) — current supertool behavior is
+    whole-file. Vim's bare `:s` is current-line-only; we preserve the
+    existing whole-file semantics to avoid silently breaking the corpus."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nfoo\nfoo\n")
+    out = supertool.op_vi(str(f), ":s/foo/X/g")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "X\nX\nX\n"


### PR DESCRIPTION
## Summary

Real vim parity for `:s`. Kevin reached for `:12s/^Use /use /` and hit `unknown verb`.

- `:Ns/PAT/REPL/[flags]` — line N only
- `:N,Ms/PAT/REPL/[flags]` — lines N..M inclusive
- `.` resolves to cursor line, `$` to last line
- Without `/g`, first match PER LINE in range (vim behavior)
- Out-of-bounds / inverted ranges error loudly
- Bare `:s/` (no range) keeps whole-file semantics for backward compat

## Test plan

- [x] 10 new TDD tests in `tests/test_vi_line_range.py`
- [x] Full suite: 1254 pass, 91% coverage