### PR TITLE
feat(vi): refine bare-verb merge, autocorrect Ngg→NG, BOF retry on search miss

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2604,17 +2604,30 @@ def op_vi(path: str, script: str) -> str:
     # them. Merge: treat the next segment as O's TEXT. Catches the most
     # frequent post-`␞` mistake (same mental model as the old `o;TEXT`).
     _TEXT_VERBS_BARE = {"i", "a", "A", "I", "o", "O"}
+    # Next actions starting with these chars are clearly verbs/commands,
+    # NOT TEXT for the preceding bare text-verb. Skip the merge.
+    _NEXT_IS_CLEARLY_VERB = (":", "/", "?")
     merged: List[str] = []
     k = 0
     while k < len(raw_actions):
         cur = raw_actions[k]
-        if cur in _TEXT_VERBS_BARE and k + 1 < len(raw_actions):
+        if (
+            cur in _TEXT_VERBS_BARE
+            and k + 1 < len(raw_actions)
+            and not raw_actions[k + 1].startswith(_NEXT_IS_CLEARLY_VERB)
+        ):
             merged.append(cur + raw_actions[k + 1])
             k += 2
             continue
         merged.append(cur)
         k += 1
     raw_actions = merged
+    # Autocorrect: `<digits>gg` is wrong — `gg` ignores count in vim, the
+    # correct line-jump form is `<digits>G`. Rewrite to spare Kevin the
+    # silent failure (current behavior: `224gg` jumps to BOF, ignoring 224).
+    raw_actions = [
+        re.sub(r"^([1-9]\d*)gg$", r"\1G", act) for act in raw_actions
+    ]
     # Autocorrect: vi count goes BEFORE the verb, not in the middle.
     # `d5d` → `5dd`, `c5w` → `5cw`, `y5y` → `5yy`. Only rewrite when the
     # first+last char form a known count-able verb pair, to avoid breaking
@@ -2809,6 +2822,24 @@ def op_vi(path: str, script: str) -> str:
                     idx = content.find(trimmed, cursor)
                 if idx != -1:
                     pat = trimmed
+            bof_retry = False
+            if idx == -1 and cursor > 0:
+                # Autocorrect: cursor persists across vi::: calls. If forward
+                # search misses from a mid-file cursor, retry from BOF — the
+                # match might be earlier in the file. Kevin's mental model
+                # assumes each call starts at BOF.
+                try:
+                    rx_b = re.compile(pat, re.MULTILINE)
+                    m_b = rx_b.search(content, 0)
+                    if m_b is not None and m_b.start() != m_b.end():
+                        idx = m_b.start()
+                        bof_retry = True
+                except re.error:
+                    pass
+                if idx == -1:
+                    idx = content.find(pat, 0)
+                    if idx != -1:
+                        bof_retry = True
             if idx == -1:
                 # sed-style auto-split: try truncating pattern at first `/<verb>`
                 # boundary. Kevin's training has `/PAT/cmd` muscle memory; if
@@ -2847,7 +2878,8 @@ def op_vi(path: str, script: str) -> str:
                 return f"ERROR: action {i} '{action}': pattern not found forward{hint}\n"
             cursor = idx
             last_search = (pat, "/")
-            log.append(f"  {i}. /{pat!r} → {cursor}")
+            note = " (retried from BOF — cursor persisted from previous call)" if bof_retry else ""
+            log.append(f"  {i}. /{pat!r} → {cursor}{note}")
         elif verb == "?":
             if not arg:
                 return f"ERROR: action {i} '{action}': empty ? pattern\n"

--- a/tests/test_vi_run3_fixes.py
+++ b/tests/test_vi_run3_fixes.py
@@ -1,0 +1,134 @@
+"""Three follow-up fixes from Kevin's third post-`␞`-cut run.
+
+A. Refine bare-text-verb merge — skip if next action is `:`/`/`/`?`-prefixed.
+   PR #58's merge wrongly absorbed `O␞:r FILE` (treated `:r FILE` as TEXT
+   instead of an ex command). Same for `O␞:s/...`, `O␞/foo`, `O␞?bar`.
+
+B. `<digits>gg` → `<digits>G` autocorrect. Kevin wrote `224gg` thinking it
+   jumped to line 224; real vim semantics: `gg` ignores count, use `224G`.
+
+C. `/PAT` miss-forward retry from BOF. Cursor persists across `vi:::` calls
+   (via _vi_save_cursor). Kevin assumes BOF on each call; when search
+   misses forward from a persisted mid-file cursor, silently retry from
+   BOF. Note the retry in the receipt.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# A. Refine bare-text-verb merge — skip ex/search prefixed next action
+# ---------------------------------------------------------------------------
+
+def test_O_followed_by_r_ex_command_does_not_merge(tmp_path: Path, monkeypatch) -> None:
+    """`G␞O␞:r FILE` — `:r` must be the ex command, NOT TEXT for `O`."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    snippet = tmp_path / "snippet.txt"
+    snippet.write_text("inserted\n")
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\n")
+    out = supertool.op_vi(str(f), f"G␞O␞:r {snippet}")
+    assert "ERROR" not in out, out
+    # The literal text ":r {snippet}" must NOT appear in the file.
+    assert ":r " not in f.read_text(), f.read_text()
+    assert "inserted" in f.read_text()
+
+
+def test_O_followed_by_s_substitute_does_not_merge(tmp_path: Path, monkeypatch) -> None:
+    """`O␞:s/foo/X/g` — `:s` is the substitute verb, not TEXT."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("foo\n")
+    out = supertool.op_vi(str(f), "G␞O␞:s/foo/X/g")
+    assert "ERROR" not in out, out
+    # Substitute should have run; `O` with empty TEXT opened a blank line above
+    assert "X" in f.read_text()
+    assert ":s/" not in f.read_text()
+
+
+def test_O_followed_by_search_does_not_merge(tmp_path: Path, monkeypatch) -> None:
+    """`o␞/bar` — `/bar` is a search action, not TEXT."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nbar\nbaz\n")
+    out = supertool.op_vi(str(f), "gg␞o␞/bar")
+    assert "ERROR" not in out, out
+    # `/bar` should NOT have been inserted as text
+    assert "/bar" not in f.read_text(), f.read_text()
+
+
+def test_O_followed_by_code_keyword_still_merges(tmp_path: Path, monkeypatch) -> None:
+    """Regression — `O␞use Foo;` still merges (the original Kevin pattern)."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.php"
+    f.write_text("<?php\nclass Foo {\n}\n")
+    out = supertool.op_vi(str(f), "G␞O␞use Bar;")
+    assert "ERROR" not in out, out
+    assert "use Bar;" in f.read_text()
+
+
+# ---------------------------------------------------------------------------
+# B. <digits>gg → <digits>G
+# ---------------------------------------------------------------------------
+
+def test_count_gg_autocorrects_to_G(tmp_path: Path, monkeypatch) -> None:
+    """`5gg` should jump to line 5 (real vim uses `5G` for that)."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\nd\ne\nf\n")
+    out = supertool.op_vi(str(f), "5gg␞dd")
+    assert "ERROR" not in out, out
+    # Cursor jumped to line 5 ("e"), dd removed it
+    assert f.read_text() == "a\nb\nc\nd\nf\n"
+
+
+def test_bare_gg_still_goes_to_bof(tmp_path: Path, monkeypatch) -> None:
+    """Regression — `gg` alone (no count) still means go-to-BOF."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\n")
+    out = supertool.op_vi(str(f), "G␞gg␞iX")
+    assert "ERROR" not in out, out
+    # G → last line, gg → BOF, iX → insert X before 'a'
+    assert f.read_text() == "Xa\nb\nc\n"
+
+
+# ---------------------------------------------------------------------------
+# C. /PAT miss-forward retry from BOF
+# ---------------------------------------------------------------------------
+
+def test_search_miss_retries_from_bof(tmp_path: Path) -> None:
+    """When `/PAT` misses forward AND cursor was persisted mid-file, retry
+    from BOF. Catches the Kevin pattern of forgetting cursor persists."""
+    persist_dir = tmp_path / "persist"
+    persist_dir.mkdir()
+    # Use a unique env so we control persistence behavior
+    os.environ.pop("SUPERTOOL_VI_NO_PERSIST", None)
+    os.environ["SUPERTOOL_VI_PERSIST_DIR"] = str(persist_dir)
+
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nbar\nbaz\nquux\n")
+    # First call: jump to line 3 ('baz'), persists cursor there
+    out1 = supertool.op_vi(str(f), "3G")
+    assert "ERROR" not in out1, out1
+    # Second call: search for 'foo' (line 1). Forward miss from cursor (line 3),
+    # but autocorrect retries from BOF and finds it.
+    out2 = supertool.op_vi(str(f), "/foo␞iX")
+    assert "ERROR" not in out2, out2
+    assert f.read_text() == "Xfoo\nbar\nbaz\nquux\n"
+
+    os.environ.pop("SUPERTOOL_VI_PERSIST_DIR", None)
+
+
+def test_search_still_misses_when_truly_absent(tmp_path: Path, monkeypatch) -> None:
+    """Regression — if pattern doesn't exist anywhere, still error."""
+    monkeypatch.setenv("SUPERTOOL_VI_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("foo\nbar\n")
+    out = supertool.op_vi(str(f), "/notthere")
+    assert "ERROR" in out
+    assert "not found" in out


### PR DESCRIPTION
Three fixes from Kevin's third post-`␞`-cut run. 1272 tests pass.

## Changes
- Bare text-verb merge skips next action if it starts with `:`/`/`/`?` (real verbs, not TEXT)
- `<digits>gg` autocorrects to `<digits>G` (vim line-jump)
- `/PAT` miss-forward retries from BOF (cursor-persistence safety)

## Test plan
- [x] 8 new TDD tests
- [x] Full suite: 1272 pass, 91%