### PR TITLE
feat(vim): operator-motion family — dG dgg d<motion> for delete and yank

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2666,8 +2666,17 @@ def op_vim(path: str, script: str) -> str:
         # Delete with char arg: df<c>/dF<c>/dt<c>/dT<c>, yf<c>...
         if c in "dy" and start + 1 < n and normalized[start + 1] in "fFtT":
             return (min(start + 3, n), False)
-        # Two-char no-arg verbs in d/y family: dd dw d$ d0, yy yw y$
-        if c in "dy" and start + 1 < n and normalized[start + 1] in ("d", "c", "w", "y", "$", "0"):
+        # Operator-motion: d/PAT\e, d?PAT\e, y/PAT\e, y?PAT\e — greedy
+        if c in "dy" and start + 1 < n and normalized[start + 1] in ("/", "?"):
+            return (start + 2, True)
+        # Operator-motion: dgg, ygg — three-char no-arg
+        if c in "dy" and start + 2 < n and normalized[start + 1] == "g" and normalized[start + 2] == "g":
+            return (start + 3, False)
+        # Two-char no-arg verbs in d/y family: dd dw d$ d0 dG d^ dh dj dk dl,
+        # yy yw y$ yG y^ yh yj yk yl
+        if c in "dy" and start + 1 < n and normalized[start + 1] in (
+            "d", "c", "w", "y", "$", "0", "G", "^", "h", "j", "k", "l"
+        ):
             return (start + 2, False)
         # gg (go to BOF)
         if c == "g" and start + 1 < n and normalized[start + 1] == "g":
@@ -2784,12 +2793,19 @@ def op_vim(path: str, script: str) -> str:
             return (count, ":s", rest[2:])
         if len(rest) >= 2 and rest[:2] == ":r":
             return (count, ":r", rest[2:])
+        # three-char operator-motion: dgg, ygg
+        if len(rest) >= 3 and rest[:3] in ("dgg", "ygg"):
+            return (count, rest[:3], rest[3:])
         # two-char yank/delete word/eol: yw, y$, yy, dw, d$, d0, c$, c0, cf, cF, ct, cT, df, dF, dt, dT
+        # plus operator-motion: dG d^ dh dj dk dl, yG y^ yh yj yk yl, d/ d? y/ y?
         if len(rest) >= 2 and rest[:2] in (
             "gg", "dd", "cc", "cw",
             "yy", "yw", "y$",
             "dw", "d$", "d0",
             "c$", "c0",
+            "dG", "d^", "dh", "dj", "dk", "dl",
+            "yG", "y^", "yh", "yj", "yk", "yl",
+            "d/", "d?", "y/", "y?",
         ):
             return (count, rest[:2], rest[2:])
         # c/d/y + char-find motion (cf<c>, cF<c>, ct<c>, cT<c>, df<c>, ..., yt<c>)
@@ -3581,6 +3597,112 @@ def op_vim(path: str, script: str) -> str:
             register = content[cursor:eol]
             register_linewise = False
             log.append(f"  {i}. y$ ({len(register)} chars)")
+
+        # --- operator-motion family: d/y + G/gg/^/h/j/k/l/search ---
+        elif len(verb) >= 2 and verb[0] in ("d", "y") and verb[1:] in (
+            "G", "gg", "^", "h", "j", "k", "l", "/", "?"
+        ):
+            op = verb[0]
+            motion = verb[1:]
+            linewise = False
+            if motion == "G":
+                # cursor's line BOL .. EOF (inclusive of trailing newline if any)
+                start = _line_start(content, cursor)
+                end = len(content)
+                linewise = True
+            elif motion == "gg":
+                # BOF .. cursor's line end (inclusive of trailing newline)
+                start = 0
+                line_eol = _line_end(content, cursor)
+                end = line_eol + 1 if line_eol < len(content) else len(content)
+                linewise = True
+            elif motion == "^":
+                # cursor back to first non-blank of line
+                bol = _line_start(content, cursor)
+                eol = _line_end(content, cursor)
+                first_nb = bol
+                while first_nb < eol and content[first_nb] in (" ", "\t"):
+                    first_nb += 1
+                if first_nb <= cursor:
+                    start, end = first_nb, cursor
+                else:
+                    # cursor already at/before first non-blank — empty motion
+                    start, end = cursor, cursor
+            elif motion == "h":
+                start = max(0, cursor - 1)
+                end = cursor
+            elif motion == "l":
+                start = cursor
+                end = min(len(content), cursor + 1)
+            elif motion == "j":
+                # current line BOL .. end of next line (inclusive of next \n)
+                start = _line_start(content, cursor)
+                first_nl = content.find("\n", cursor)
+                if first_nl == -1:
+                    end = len(content)
+                else:
+                    second_nl = content.find("\n", first_nl + 1)
+                    end = second_nl + 1 if second_nl != -1 else len(content)
+                linewise = True
+            elif motion == "k":
+                # previous line BOL .. end of current line (inclusive of \n)
+                bol = _line_start(content, cursor)
+                if bol == 0:
+                    # no previous line — operate only on current line
+                    prev_bol = 0
+                else:
+                    prev_bol = _line_start(content, bol - 1)
+                cur_eol = _line_end(content, cursor)
+                start = prev_bol
+                end = cur_eol + 1 if cur_eol < len(content) else len(content)
+                linewise = True
+            elif motion == "/":
+                if not arg:
+                    return f"ERROR: action {i} '{action}': {verb} empty pattern\n"
+                pat = arg
+                idx = -1
+                try:
+                    rx = re.compile(pat, re.MULTILINE)
+                    m = rx.search(content, cursor)
+                    if m is not None and m.start() != m.end():
+                        idx = m.start()
+                except re.error:
+                    pass
+                if idx == -1:
+                    idx = content.find(pat, cursor)
+                if idx == -1:
+                    return f"ERROR: action {i} '{action}': pattern not found forward\n"
+                last_search = (pat, "/")
+                start, end = cursor, idx
+            else:  # "?"
+                if not arg:
+                    return f"ERROR: action {i} '{action}': {verb} empty pattern\n"
+                pat = arg
+                idx = -1
+                try:
+                    rx = re.compile(pat, re.MULTILINE)
+                    last = None
+                    for m in rx.finditer(content[:cursor]):
+                        if m.start() != m.end():
+                            last = m
+                    if last is not None:
+                        idx = last.start()
+                except re.error:
+                    pass
+                if idx == -1:
+                    idx = content.rfind(pat, 0, cursor)
+                if idx == -1:
+                    return f"ERROR: action {i} '{action}': pattern not found backward\n"
+                last_search = (pat, "?")
+                start, end = idx, cursor
+
+            slice_ = content[start:end]
+            register = slice_
+            register_linewise = linewise
+            if op == "d":
+                content = content[:start] + content[end:]
+                cursor = min(start, len(content))
+            log.append(f"  {i}. {verb} ({len(slice_)} chars{', linewise' if linewise else ''})")
 
         # --- paste ---
         elif verb == "p":

--- a/tests/test_vim_operator_motion.py
+++ b/tests/test_vim_operator_motion.py
@@ -1,0 +1,176 @@
+"""Tests for op_vim operator-motion family: d/y + G, gg, /PAT, ?PAT, ^, h, j, k, l.
+
+c<motion> family is intentionally skipped — the parser currently can't cleanly
+split the search-arg terminator (\\e) from the trailing insert TEXT for forms
+like `c/PAT\\eTEXT\\e`. Limited to delete + yank, which require no insert text.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# dG — delete from cursor's line to EOF (inclusive)
+# ---------------------------------------------------------------------------
+
+def test_dG_from_bof_deletes_whole_file(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\nd\ne\n")
+    supertool.op_vim(str(f), "gg␞dG")
+    assert f.read_text() == ""
+
+
+def test_dG_from_line3_of_5_leaves_first_2(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\nd\ne\n")
+    supertool.op_vim(str(f), "gg␞3G␞dG")
+    assert f.read_text() == "a\nb\n"
+
+
+# ---------------------------------------------------------------------------
+# dgg — delete from cursor's line up to BOF (line 1) inclusive
+# ---------------------------------------------------------------------------
+
+def test_dgg_from_line3_of_5_deletes_first_3(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\nd\ne\n")
+    supertool.op_vim(str(f), "gg␞3G␞dgg")
+    assert f.read_text() == "d\ne\n"
+
+
+# ---------------------------------------------------------------------------
+# d/PAT — delete from cursor up to start of next PAT match
+# ---------------------------------------------------------------------------
+
+def test_d_search_forward_deletes_through_match_start(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hello world end\n")
+    # cursor at BOF; d/world␞ should delete "hello " (up to start of "world")
+    supertool.op_vim(str(f), "gg␞d/world␞")
+    assert f.read_text() == "world end\n"
+
+
+# ---------------------------------------------------------------------------
+# d?PAT — delete from cursor back to last PAT match
+# ---------------------------------------------------------------------------
+
+def test_d_search_backward_deletes_to_match(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("alpha beta gamma\n")
+    # land on 'g' in "gamma" via /gamma, then d?beta␞ should delete back to
+    # the start of "beta", removing "beta " — leaving "alpha gamma\n".
+    supertool.op_vim(str(f), "gg␞/gamma␞d?beta ␞")
+    assert f.read_text() == "alpha gamma\n"
+
+
+# ---------------------------------------------------------------------------
+# d^ — delete to first non-blank of line
+# ---------------------------------------------------------------------------
+
+def test_d_caret_deletes_to_first_nonblank(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("    hello world\n")
+    # Move to the 'w' in world, then d^ deletes back to first non-blank ('h').
+    supertool.op_vim(str(f), "gg␞/world␞d^")
+    assert f.read_text() == "    world\n"
+
+
+# ---------------------------------------------------------------------------
+# dh dl — delete one char left / right
+# ---------------------------------------------------------------------------
+
+def test_dl_deletes_char_at_cursor(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("abcdef\n")
+    # cursor on 'a', dl deletes 'a'
+    supertool.op_vim(str(f), "gg␞dl")
+    assert f.read_text() == "bcdef\n"
+
+
+def test_dh_deletes_char_before_cursor(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("abcdef\n")
+    # land on 'd' (index 3), dh deletes char before cursor ('c')
+    supertool.op_vim(str(f), "gg␞3l␞dh")
+    assert f.read_text() == "abdef\n"
+
+
+# ---------------------------------------------------------------------------
+# dj dk — delete current line + line below / above
+# ---------------------------------------------------------------------------
+
+def test_dj_deletes_current_and_next_line(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\nd\n")
+    # cursor on line 2 ('b'), dj deletes 'b' and 'c'
+    supertool.op_vim(str(f), "gg␞2G␞dj")
+    assert f.read_text() == "a\nd\n"
+
+
+def test_dk_deletes_current_and_previous_line(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\nd\n")
+    # cursor on line 3 ('c'), dk deletes 'b' and 'c'
+    supertool.op_vim(str(f), "gg␞3G␞dk")
+    assert f.read_text() == "a\nd\n"
+
+
+# ---------------------------------------------------------------------------
+# yG — yank from cursor's line to EOF, then p pastes
+# ---------------------------------------------------------------------------
+
+def test_yG_then_p_pastes_lines_to_eof(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\nd\ne\n")
+    # yank lines 3..5 ("c\nd\ne\n"), go to line 1, p pastes after line 1.
+    supertool.op_vim(str(f), "gg␞3G␞yG␞gg␞p")
+    assert f.read_text() == "a\nc\nd\ne\nb\nc\nd\ne\n"
+
+
+# ---------------------------------------------------------------------------
+# ygg — yank from cursor's line back to BOF
+# ---------------------------------------------------------------------------
+
+def test_ygg_then_p_pastes_lines_to_bof(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\nd\ne\n")
+    # On line 3, ygg yanks lines 1..3 ("a\nb\nc\n"). Move to EOF, p pastes after.
+    supertool.op_vim(str(f), "gg␞3G␞ygg␞G␞p")
+    assert f.read_text() == "a\nb\nc\nd\ne\na\nb\nc\n"
+
+
+# ---------------------------------------------------------------------------
+# y/PAT — yank from cursor up to start of next PAT match
+# ---------------------------------------------------------------------------
+
+def test_y_search_forward_then_P_pastes_before_cursor(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hello world end\n")
+    # yank "hello " (cursor at BOF up to "world"), then P at cursor pastes
+    # before — duplicating "hello " at BOF.
+    supertool.op_vim(str(f), "gg␞y/world␞P")
+    assert f.read_text() == "hello hello world end\n"
+
+
+# ---------------------------------------------------------------------------
+# y^ y h y l y j y k — basic charwise/linewise yank smoke
+# ---------------------------------------------------------------------------
+
+def test_yl_then_p_duplicates_char(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("abc\n")
+    # cursor on 'a', yl yanks 'a', p pastes after cursor → "aabc\n"
+    supertool.op_vim(str(f), "gg␞yl␞p")
+    assert f.read_text() == "aabc\n"
+
+
+def test_yh_then_p_yanks_prev_char(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("abc\n")
+    # cursor on 'b' (idx 1), yh yanks 'a' (char before cursor)
+    supertool.op_vim(str(f), "gg␞l␞yh␞$␞p")
+    # cursor lands on 'c' via $; p inserts after 'c' → "abcca"... wait, register='a'
+    # After yh, cursor stays; $ moves to last char 'c'; p inserts after 'c' → "abca\n"
+    assert f.read_text() == "abca\n"


### PR DESCRIPTION
## Summary

Adds 14 operator-motion forms (real vim parity):
- `dG ygg dgg ygg` — linewise to EOF / BOF
- `d^ y^` — back to first non-blank
- `dh dj dk dl` + `yh yj yk yl` — single-motion
- `d/PAT\e d?PAT\e y/PAT\e y?PAT\e` — search-bounded

Kevin keeps reaching for `ggdG` to clear files — now works.

## Skipped

`c<motion>` family — parser uses `\e` as search terminator, no clean second boundary for trailing insert TEXT. Existing `cw cc c$ c0 ciw ci<delim>` cover practical change-with-motion cases.

## Test plan
- [x] 15 new tests in `tests/test_vim_operator_motion.py`
- [x] Full suite: 1287 passed, 90.78% coverage