### PR TITLE
feat(vim): :s backslash over-escape autocorrect (retry with halved \\)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -3472,34 +3472,56 @@ def op_vim(path: str, script: str) -> str:
             # passed as \\X or re.sub raises "bad escape" on \B, \R, etc.
             # Digit-prefixed backslashes (\1..\9) are preserved as backrefs.
             srepl_safe = re.sub(r"\\(?=\D)", r"\\\\", srepl_dec)
-            try:
+            def _run_sub(_rx):
                 if sub_start == 0 and sub_end == len(content):
-                    # whole-file path (no range) — preserve existing semantics
-                    new_content, n = rx.subn(srepl_safe, content, count=n_max)
-                else:
-                    # ranged path — iterate per line in the range so non-/g
-                    # replaces the first match on EACH line (vim behavior),
-                    # not just the first match in the whole range.
-                    head = content[:sub_start]
-                    tail = content[sub_end:]
-                    body = content[sub_start:sub_end]
-                    has_trailing_nl = body.endswith("\n")
-                    body_lines = body.split("\n")
-                    if has_trailing_nl:
-                        body_lines = body_lines[:-1]
-                    is_global = "g" in sflags
-                    n = 0
-                    new_lines: List[str] = []
-                    for ln in body_lines:
-                        subbed_ln, k = rx.subn(
-                            srepl_safe, ln, count=0 if is_global else 1
-                        )
-                        new_lines.append(subbed_ln)
-                        n += k
-                    new_body = "\n".join(new_lines) + ("\n" if has_trailing_nl else "")
-                    new_content = head + new_body + tail
+                    return _rx.subn(srepl_safe, content, count=n_max)
+                # ranged path — iterate per line in the range so non-/g
+                # replaces the first match on EACH line (vim behavior),
+                # not just the first match in the whole range.
+                head = content[:sub_start]
+                tail = content[sub_end:]
+                body = content[sub_start:sub_end]
+                has_trailing_nl = body.endswith("\n")
+                body_lines = body.split("\n")
+                if has_trailing_nl:
+                    body_lines = body_lines[:-1]
+                is_global = "g" in sflags
+                _n = 0
+                new_lines: List[str] = []
+                for ln in body_lines:
+                    subbed_ln, k = _rx.subn(
+                        srepl_safe, ln, count=0 if is_global else 1
+                    )
+                    new_lines.append(subbed_ln)
+                    _n += k
+                new_body = "\n".join(new_lines) + ("\n" if has_trailing_nl else "")
+                return head + new_body + tail, _n
+            try:
+                new_content, n = _run_sub(rx)
             except re.error as e:
                 return f"ERROR: action {i} '{action}': :s replacement: {e}\n"
+            # Backslash over-escape autocorrect: Kevin (and bash users) often
+            # write `\\\\` (4 chars after bash-quoting) when 2 are correct.
+            # `\\\\` in a regex matches 2 literal backslashes; to match ONE,
+            # write `\\`. If the original pattern matched nothing AND contains
+            # 4 consecutive backslashes, retry with each `\\\\` halved to `\\`.
+            autocorrect_hint = ""
+            if n == 0 and "\\\\\\\\" in spat:
+                spat_fixed = spat.replace("\\\\\\\\", "\\\\")
+                try:
+                    rx_fixed = re.compile(spat_fixed, flags_re)
+                    new_content2, n2 = _run_sub(rx_fixed)
+                except re.error:
+                    n2 = 0
+                    new_content2 = content
+                if n2 > 0:
+                    new_content = new_content2
+                    n = n2
+                    rx = rx_fixed
+                    spat = spat_fixed
+                    autocorrect_hint = (
+                        f" [autocorrect: halved \\\\\\\\ → \\\\ in pattern → {spat_fixed!r}]"
+                    )
             if n == 0:
                 return f"ERROR: action {i} '{action}': :s no match for {spat!r}\n"
             if is_dry:
@@ -3528,7 +3550,10 @@ def op_vim(path: str, script: str) -> str:
             else:
                 content = new_content
                 cursor = min(cursor, len(content))
-                log.append(f"  {i}. :s/{spat!r}/{srepl_dec!r}/{sflags} ({n} subs)")
+                log.append(
+                    f"  {i}. :s/{spat!r}/{srepl_dec!r}/{sflags} ({n} subs)"
+                    + autocorrect_hint
+                )
 
         # --- ex read file: :r FILE  (or `:r -` to read stdin) ---
         elif verb == ":r":

--- a/tests/test_vim_s_backslash_autocorrect.py
+++ b/tests/test_vim_s_backslash_autocorrect.py
@@ -1,0 +1,98 @@
+"""Autocorrect for over-escaped backslashes in `:s/PAT/REPL/[flags]`.
+
+Kevin keeps writing 4 backslashes in `:s` patterns when 2 are correct.
+Bash single-quote passes `\\\\` through as 4 chars; the regex then sees
+`\\\\` = match 2 literal backslashes. To match ONE literal backslash
+(e.g. a PHP namespace `\\Foo`), the correct bash-quoted form is `\\\\Foo`
+(2 backslashes → 2 chars to regex → matches one `\\`).
+
+When the original pattern matches zero times AND contains 4 consecutive
+backslashes, the handler retries with each `\\\\\\\\` halved to `\\\\`. If
+that retry matches, it's used and a hint is appended to the log so the
+caller learns the correct form for next time.
+
+Note about Python string literals in this file: `\\\\\\\\` (8 chars in
+source) is 4 literal backslashes at runtime — the form Kevin would type
+in bash. `\\\\` (4 chars in source) is 2 literal backslashes — the correct
+form. We test both.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def test_over_escaped_backslash_autocorrects(tmp_path: Path) -> None:
+    """`:s/\\\\\\\\Http\\\\\\\\Mock/X/g` on file with `\\Http\\Mock` matches via retry."""
+    f = tmp_path / "x.php"
+    f.write_text("use Acme\\Http\\Mock;\n")
+    # Pattern as it would arrive after bash: 4-4-4 backslashes.
+    out = supertool.op_vim(str(f), ":s/\\\\\\\\Http\\\\\\\\Mock/X/g")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "use AcmeX;\n", f.read_text()
+
+
+def test_correct_two_backslash_form_still_works(tmp_path: Path) -> None:
+    """`:s/\\\\Http\\\\Mock/X/g` (correct form, 2 bs each) matches directly — no retry."""
+    f = tmp_path / "x.php"
+    f.write_text("use Acme\\Http\\Mock;\n")
+    out = supertool.op_vim(str(f), ":s/\\\\Http\\\\Mock/X/g")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "use AcmeX;\n", f.read_text()
+    # No retry hint when the original pattern matched.
+    assert "autocorrect" not in out.lower()
+
+
+def test_autocorrect_emits_retry_hint(tmp_path: Path) -> None:
+    """When the autocorrect fires, the receipt contains a hint about it."""
+    f = tmp_path / "x.php"
+    f.write_text("use Acme\\Http\\Mock;\n")
+    # Same form as the first test — assert specifically on the hint text.
+    out = supertool.op_vim(str(f), ":s/\\\\\\\\Http\\\\\\\\Mock/X/g")
+    assert "ERROR" not in out, out
+    assert "autocorrect" in out.lower(), out
+    # The hint should mention the halved pattern.
+    assert "halved" in out.lower(), out
+
+
+def test_no_backslashes_unchanged(tmp_path: Path) -> None:
+    """Regression: plain `:s/foo/X/` with no backslashes is untouched."""
+    f = tmp_path / "x.txt"
+    f.write_text("foo bar\n")
+    out = supertool.op_vim(str(f), ":s/foo/X/")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "X bar\n"
+    assert "autocorrect" not in out.lower()
+
+
+def test_legit_four_backslash_pattern_when_no_match(tmp_path: Path) -> None:
+    """If the file has `\\\\Foo` (literal double backslash) and the pattern is
+    `:s/\\\\\\\\\\\\\\\\Foo/X/` (8 bs in bash = needs literal `\\\\` to match),
+    the original pattern matches — no retry needed.
+
+    This is the legitimate 4-backslash case. After bash single-quoting,
+    8 backslashes become 8 chars; regex sees `\\\\\\\\Foo` = match 4 literal
+    backslashes? No — `\\\\\\\\` to the regex = `\\\\\\\\` chars = matches 2
+    literal `\\\\` pairs = 2 backslashes. Confusing, but: testing what we do.
+    """
+    f = tmp_path / "x.txt"
+    # File has 2 literal backslashes then Foo.
+    f.write_text("\\\\Foo\n")
+    # Pattern with 4 runtime backslashes (Python source `\\\\\\\\` = 4 chars).
+    # Regex `\\\\\\\\` (4 chars) matches 2 literal backslashes. So it matches.
+    out = supertool.op_vim(str(f), ":s/\\\\\\\\Foo/X/")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "X\n", f.read_text()
+    # No retry because the original pattern matched.
+    assert "autocorrect" not in out.lower()
+
+
+def test_autocorrect_with_range(tmp_path: Path) -> None:
+    """The autocorrect also fires under a `:%s/...` range when no match."""
+    f = tmp_path / "x.php"
+    f.write_text("a = Acme\\Foo;\nb = Acme\\Foo;\n")
+    out = supertool.op_vim(str(f), ":%s/Acme\\\\\\\\Foo/X/g")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "a = X;\nb = X;\n", f.read_text()
+    assert "autocorrect" in out.lower()


### PR DESCRIPTION
## Summary

Kevin keeps writing 4 backslashes in `:s` patterns when 2 are correct (matching PHP namespaces). Pattern fails, frustration mounts. Now: on no-match, retry with each `\\\\` halved to `\\`. If match found, use corrected pattern + note in receipt.

## Test plan
- [x] 6 TDD tests in `tests/test_vim_s_backslash_autocorrect.py`
- [x] Full suite: 1313 pass, 90.52% coverage