### PR TITLE
fix(vim): literal-fallback decodes \xHH and \uHHHH before stripping

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -2913,6 +2913,25 @@ def _vim_render_lint(path: str) -> str:
     return f"--- POST-EDIT LINT FAILED — {tool} ---\n{output or '(no output)'}\n"
 
 
+def _vim_literal_decode(pat: str) -> str:
+    """Convert a regex-style pattern to the literal string the caller
+    probably meant. Used by the no-match autocorrect on `/PAT` and `:s`.
+
+    - Decode `\\xHH`, `\\uHHHH`, `\\n`, `\\t`, `\\r` to real chars (preserve
+      their intended meaning before stripping).
+    - Iteratively strip `\\X` → `X` for non-digit X so over-escaped
+      `\\$this` → `\\$this` → `$this` flattens to literal.
+    """
+    out = re.sub(r"\\x([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), pat)
+    out = re.sub(r"\\u([0-9A-Fa-f]{4})", lambda m: chr(int(m.group(1), 16)), out)
+    out = out.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
+    while True:
+        nxt = re.sub(r"\\(\D)", r"\1", out)
+        if nxt == out:
+            return out
+        out = nxt
+
+
 def _vim_nearest_literal_hint(content: str, pat: str, max_lines: int = 3) -> str:
     """When /PAT or :s misses, return a short hint with file lines that
     contain the longest literal chunk of the pattern. Helps the caller see
@@ -3752,15 +3771,10 @@ def op_vim(path: str, script: str) -> str:
                         # queue the trailing action for the next iteration
                         raw_actions.insert(i, trail)
                         continue
-                # Literal-fallback: strip backslash escapes iteratively, try
-                # plain content.find. Same logic as :s — handles unescaped
-                # `(`, `)`, `$` Kevin meant as literals.
-                literal_pat = pat
-                while True:
-                    nxt = re.sub(r"\\(\D)", r"\1", literal_pat)
-                    if nxt == literal_pat:
-                        break
-                    literal_pat = nxt
+                # Literal-fallback: decode then strip backslash escapes,
+                # try plain content.find. Same logic as :s — handles
+                # unescaped `(`, `)`, `$` and hex/unicode escapes.
+                literal_pat = _vim_literal_decode(pat)
                 if literal_pat and literal_pat != pat:
                     for start in (cursor, 0):
                         lit_idx = content.find(literal_pat, start)
@@ -4716,14 +4730,7 @@ def op_vim(path: str, script: str) -> str:
             # Strip `\<X>` → `<X>` to get his intended literal string and try
             # plain content.replace. If it hits, use that result.
             if n == 0:
-                # Strip backslash escapes iteratively until stable, so
-                # `\\$this` → `\$this` → `$this` (two passes).
-                literal_pat = spat
-                while True:
-                    next_pat = re.sub(r"\\(\D)", r"\1", literal_pat)
-                    if next_pat == literal_pat:
-                        break
-                    literal_pat = next_pat
+                literal_pat = _vim_literal_decode(spat)
                 if literal_pat and literal_pat != spat:
                     body = content[sub_start:sub_end]
                     occurrences = body.count(literal_pat)

--- a/tests/test_vim_kevin_fixes.py
+++ b/tests/test_vim_kevin_fixes.py
@@ -315,6 +315,44 @@ def test_kevin_real_multiline_search_with_newline_chunks():
         os.unlink(p)
 
 
+def test_kevin_real_hex_escape_x27_in_subst_pat():
+    """Real Kevin paste 2026-05-17 10:17 — `:%s/assertArrayHasKey(\\x27name\\x27, \\$options);/.../`.
+
+    `\\x27` is hex escape for `'`. The `(` is unescaped (regex group),
+    which Kevin meant as literal. Literal-fallback should strip the
+    `\\` from `\\$` and `\\X` non-hex, BUT preserve `\\x27` as the char
+    it represents (so the literal probe finds `assertArrayHasKey('name',`
+    in the file).
+    """
+    p = _tmp(
+        "    $this->assertArrayHasKey('name', $options);\n"
+        "    $this->assertArrayHasKey('monitor_name', $options);\n"
+    )
+    try:
+        r = st.op_vim(
+            p,
+            r":%s/assertArrayHasKey(\x27name\x27, \$options);/REPLACED/",
+        )
+        new = open(p).read()
+        assert "REPLACED" in new, f"failed: {r!r}"
+        # Other line untouched
+        assert "assertArrayHasKey('monitor_name'" in new
+        assert "autocorrect" in r.lower()
+    finally:
+        os.unlink(p)
+
+
+def test_kevin_real_hex_escape_x27_in_subst_repl():
+    """`\\x27` in REPL should decode to `'` via _decode_escapes."""
+    p = _tmp("placeholder\n")
+    try:
+        r = st.op_vim(p, r":%s/placeholder/\x27quoted\x27/")
+        new = open(p).read()
+        assert new == "'quoted'\n", f"got: {new!r}"
+    finally:
+        os.unlink(p)
+
+
 def test_kevin_real_paste1_cciw_chain():
     """Paste 1 (faithful): /assertIsBool\\e cciw assertTrue \\e — find then
     change-inner-word. Kevin's actual paste had `cciw` which is `cc` then


### PR DESCRIPTION
## Summary

Kevin run 2026-05-17 10:17 hit `:%s/assertArrayHasKey(\x27name\x27, \$options);/.../`. The literal-fallback naively stripped backslashes from `\x27` → `x27`, losing the intended `'` char and breaking the probe.

- Extract `_vim_literal_decode(pat)` helper:
  1. Decode `\xHH`, `\uHHHH`, `\n`, `\t`, `\r` to real chars first
  2. Then iteratively strip `\X` → `X` for non-digit X
- Both `/PAT` and `:s` literal-fallback sites now call it
- Universal escape muscle memory now covered: `\x27` `'`, `\x22` `"`, `\x5c` `\`, `'`, etc.

## Test plan

- [x] +2 tests in `test_vim_kevin_fixes.py` mirroring Kevin's actual paste
- [x] Full suite: 1498 passed (was 1496, +2)

🤖 Generated by Max — Hex was hiding in plain sight.