### PR TITLE
fix(vim): always try literal-fallback on /PAT and :s miss

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -3880,7 +3880,7 @@ def _op_vim_impl(path: str, script: str) -> str:
                 # try plain content.find. Same logic as :s — handles
                 # unescaped `(`, `)`, `$` and hex/unicode escapes.
                 literal_pat = _vim_literal_decode(pat)
-                if literal_pat and literal_pat != pat:
+                if literal_pat:
                     for start in (cursor, 0):
                         lit_idx = content.find(literal_pat, start)
                         if lit_idx != -1:
@@ -4835,8 +4835,11 @@ def _op_vim_impl(path: str, script: str) -> str:
             # Strip `\<X>` → `<X>` to get his intended literal string and try
             # plain content.replace. If it hits, use that result.
             if n == 0:
+                # Always try literal fallback when regex misses — handles
+                # both over-escaped patterns (`\\$`, `\\[`) AND unescaped
+                # regex metas Kevin meant as literals (`(`, `)`, `.`).
                 literal_pat = _vim_literal_decode(spat)
-                if literal_pat and literal_pat != spat:
+                if literal_pat:
                     body = content[sub_start:sub_end]
                     occurrences = body.count(literal_pat)
                     if occurrences > 0:

--- a/tests/test_vim_kevin_fixes.py
+++ b/tests/test_vim_kevin_fixes.py
@@ -453,6 +453,28 @@ def test_kevin_real_V_in_insert_text_not_rewritten():
         os.unlink(p)
 
 
+def test_kevin_log_unescaped_paren_assertTrue_true():
+    """Kevin run 2026-05-17 11:48 paste — `:s/assertTrue(true);/REPL/`.
+
+    Pattern has unescaped `(`/`)` — regex groups, not literal parens.
+    Kevin meant them literal. Literal-fallback was previously skipped
+    because the decoded pattern equalled the original (no backslashes
+    to strip). Should still try literal `content.replace` as the
+    ultimate fallback when regex misses.
+    """
+    p = _tmp("        $this->assertTrue(true);\n        $other = 1;\n")
+    try:
+        r = st.op_vim(
+            p,
+            r":s/assertTrue(true);/assertFalse(SiTalkModule::hasUsedDependency());/",
+        )
+        new = open(p).read()
+        assert "assertFalse(SiTalkModule::hasUsedDependency());" in new, f"got: {new!r}; receipt: {r}"
+        assert "ERROR" not in r
+    finally:
+        os.unlink(p)
+
+
 def test_kevin_log_HasTagChecker_overescape_dollar():
     """Mined from log 9abd0ba5 — Kevin actual paste:
     `:s/HasTagChecker::class, \\$checkerClass/$checkerClass, HasTagChecker::class/`.


### PR DESCRIPTION
## Summary

Kevin run 2026-05-17 11:48 typed `:s/assertTrue(true);/.../` thinking parens are literal. They're regex groups, so regex misses. Literal-fallback was gated on `literal_pat != pat` (decoded pattern had to differ from original) — preventing fallback for patterns with unescaped regex meta but no backslashes.

Drop the gate. Always try `_vim_literal_decode(pat)` + `content.find` when regex misses. Covers Kevin's `(`, `)`, `.`, `+`, `*`, `?` as literal habits.

## Test plan

- [x] +1 test in `test_vim_kevin_fixes.py` (verbatim from Kevin log)
- [x] Full suite: 1515 passed

🤖 Generated by Max — Parens mean what Kevin thinks they mean.