### PR TITLE
fix(glob): multi-`**` patterns fall back to glob.glob

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -1977,8 +1977,11 @@ def _glob_files(
     """
     max_results = _get_op_int("glob", "max_results", MAX_GLOB_RESULTS)
 
-    if exclude_paths and "**" in pattern:
+    if exclude_paths and "**" in pattern and pattern.count("**") == 1:
         # Walk-based implementation for recursive globs with exclusions.
+        # Only safe when pattern has a single `**` — multi-`**` patterns
+        # (`**/X/**/Y`) need full glob semantics on every segment, which
+        # fnmatch can't express. Fall through to glob.glob + post-filter.
         # Split on the first '**' to get the root dir and the tail pattern.
         import fnmatch
         star_idx = pattern.index("**")

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -120,6 +120,20 @@ def test_glob_prefix_strip_threshold() -> None:
     assert len("src/") <= 10  # confirms threshold would skip it
 
 
+def test_glob_double_star_in_middle_segment(tmp_path: Path, monkeypatch) -> None:
+    """Multi-`**` patterns must work — Kevin run 2026-05-17 11:55 hit
+    `**/TestHelper/**/ConversationHelper*` returning 0 files when the
+    target was at `src2/SiPHPUnit/TestHelper/BusinessEntities/ConversationHelper.class.php`.
+    """
+    deep = tmp_path / "Dvsi" / "dvsi-private" / "src2" / "SiPHPUnit" / "TestHelper" / "BusinessEntities"
+    deep.mkdir(parents=True)
+    (deep / "ConversationHelper.class.php").write_text("")
+    monkeypatch.chdir(tmp_path)
+    out = supertool.op_glob("**/TestHelper/**/ConversationHelper*")
+    assert "ConversationHelper.class.php" in out, f"got: {out!r}"
+    assert "(0 files)" not in out
+
+
 def test_glob_question_mark_is_wildcard(tmp_path: Path, monkeypatch) -> None:
     (tmp_path / "a.py").write_text("")
     (tmp_path / "b.py").write_text("")


### PR DESCRIPTION
## Summary

Kevin run 2026-05-17 11:55 used `**/TestHelper/**/ConversationHelper*` and got 0 matches. The walker splits at the first `**` and uses fnmatch on the tail — but fnmatch can't express recursive `**`, so the second `**` becomes a literal that doesn't match anywhere.

Detect multi-`**` patterns (`pattern.count("**") > 1`) and fall through to `glob.glob(recursive=True)` with post-hoc exclude filter. Single-`**` walker path preserved for the prune optimization on large repos.

## Test plan

- [x] +1 test in `test_glob.py` reproducing Kevin's exact case
- [x] Full suite: 1516 passed

🤖 Generated by Max — Two stars are better than one.