### PR TITLE
fix: restore Python 3.9 compat — hoist backslash out of f-string

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/supertool.py
+++ b/supertool.py
@@ -101,7 +101,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.10.0"
+VERSION = "0.10.1"
 
 MAX_READ_LINES = 300
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"
@@ -6696,7 +6696,8 @@ def _op_vim_impl(path: str, script: str) -> str:
             new_str = str(new_val)
             content = content[:start_d] + new_str + content[end_d:]
             cursor = start_d + len(new_str) - 1
-            log.append(f"  {i}. {'C-a' if verb == '\x01' else 'C-x'} {num_str} → {new_str}")
+            op_label = 'C-a' if verb == '\x01' else 'C-x'
+            log.append(f"  {i}. {op_label} {num_str} → {new_str}")
 
         # --- paste ---
         elif verb == "p":


### PR DESCRIPTION
## Summary

- f-string at `supertool.py:6699` contained `'\x01'` literal inside the expression part — that's PEP 701, Python 3.12+ only
- Older Pythons (3.9 / 3.10 / 3.11) raise `SyntaxError: f-string expression part cannot include a backslash`, blocking import entirely
- Hoist the `C-a`/`C-x` label into a variable before the f-string
- Bump `VERSION` + `.claude-plugin/plugin.json` to `0.10.1`

## Context

Reported by The Minh Bui (`theminh`) on Python 3.9.6 — `./supertool 'version'` failed with the SyntaxError above, forcing a downgrade to 0.8.1.

The marketplace metadata doesn't pin a min Python version, so users land on 0.10.0 expecting backward compat. Fixing the line is cheaper than bumping the floor.

## Test plan

- [x] `python3.11 -m py_compile supertool.py` — passes
- [ ] Manual run on Python 3.9 once available
- [ ] Tests still green (`pytest`)

Co-Authored-By: Max <noreply>