### PR TITLE
feat: add yaml-check and inilint validators

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -197,6 +197,27 @@
       "match": "*.scss",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
       "timeout": 60
+    },
+    "yaml-check": {
+      "cmd": "python3 {supertool_dir}/validators/yaml-check/yaml-check.py {file}",
+      "match": "*.yml",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
+    },
+    "yaml-check-yaml": {
+      "cmd": "python3 {supertool_dir}/validators/yaml-check/yaml-check.py {file}",
+      "match": "*.yaml",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
+    },
+    "inilint": {
+      "cmd": "python3 {supertool_dir}/validators/inilint/inilint.py {file}",
+      "match": "*.ini",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
     }
   }
 }

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -129,7 +129,7 @@
     },
     "batch": {
       "syntax": "batch:@file.json",
-      "description": "Run multiple ops from a JSON file in one call. Payload: bare array of op objects [{\"op\":\"read\",\"path\":\"...\"},{\"op\":\"edit\",\"old\":\"...\",\"new\":\"...\",\"path\":\"...\"},...] OR wrapper object {\"continue_on_error\":true,\"ops\":[...]}. Default continue_on_error=true. Use @- to read from stdin. Validators fire per mutating op.",
+      "description": "Run an array of ops in one call. Mix anything — read+edit+grep+phpstan in one round-trip. Payload: bare array of {op, ...fields} OR wrapper {continue_on_error, ops}. Default continue. Validators fire per mutating op. Use @- for stdin.",
       "example": "batch:@.max/ops.json"
     }
   },

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -185,6 +185,13 @@
       "rollback_on_fail": true,
       "timeout": 10
     },
+    "jsonlint": {
+      "cmd": "python3 {supertool_dir}/validators/jsonlint/jsonlint.py {file}",
+      "match": "*.json",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
+    },
     "stylelint": {
       "cmd": "python3 {supertool_dir}/validators/stylelint/stylelint.py {file}",
       "match": "*.scss",

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -113,19 +113,24 @@
       "example": "blame:src/app/Module.py:42:3"
     },
     "edit": {
-      "syntax": "edit:::OLD:::NEW:::PATH",
-      "description": "Single-file edit, OLD must match exactly once. Bypasses native Edit must-Read state — saves a round-trip. Use ::: separator so content with ':' works (single ':' also accepted when content has no colons).",
+      "syntax": "edit:::OLD:::NEW:::PATH  |  edit:@file.json",
+      "description": "Single-file edit, OLD must match exactly once. Bypasses native Edit must-Read state — saves a round-trip. Use ::: separator so content with ':' works (single ':' also accepted when content has no colons). @file route: edit:@path.json where file contains {\"old\":\"...\",\"new\":\"...\",\"path\":\"...\"}. Use @- to read from stdin.",
       "example": "edit:::return false;:::return true;:::src/app/Foo.py"
     },
     "replace_lines": {
-      "syntax": "replace_lines:::PATH:::START:::END:::CONTENT",
-      "description": "Swap lines [START,END] (1-indexed inclusive) with CONTENT. END<START = insert before START. Empty CONTENT = delete.",
+      "syntax": "replace_lines:::PATH:::START:::END:::CONTENT  |  replace_lines:@file.json",
+      "description": "Swap lines [START,END] (1-indexed inclusive) with CONTENT. END<START = insert before START. Empty CONTENT = delete. @file route: replace_lines:@path.json where file contains {\"path\":\"...\",\"start\":N,\"end\":N,\"content\":\"...\"}.",
       "example": "replace_lines:::src/app/Foo.py:::42:::45:::    return x"
     },
     "paste": {
-      "syntax": "paste:::PATH:::CONTENT",
-      "description": "Replace entire file with CONTENT. Atomic, creates file (+ parent dirs) if missing. Use for full-file rewrites.",
+      "syntax": "paste:::PATH:::CONTENT  |  paste:@file.json",
+      "description": "Replace entire file with CONTENT. Atomic, creates file (+ parent dirs) if missing. Use for full-file rewrites. @file route: paste:@path.json where file contains {\"path\":\"...\",\"content\":\"...\"}.",
       "example": "paste:::src/app/new_file.py:::print('hello')\\n"
+    },
+    "batch": {
+      "syntax": "batch:@file.json",
+      "description": "Run multiple ops from a JSON file in one call. Payload: bare array of op objects [{\"op\":\"read\",\"path\":\"...\"},{\"op\":\"edit\",\"old\":\"...\",\"new\":\"...\",\"path\":\"...\"},...] OR wrapper object {\"continue_on_error\":true,\"ops\":[...]}. Default continue_on_error=true. Use @- to read from stdin. Validators fire per mutating op.",
+      "example": "batch:@.max/ops.json"
     }
   },
   "ops": {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Saves tokens. Saves money. Saves turns. Works the same in interactive sessions and autonomous runs — humans pair-programming with Claude Code use it every day, not just Kevin-style headless agents. One Python file, zero deps, Python 3.9+.
 
-[Why](#why) • [Four pillars](#four-pillars) • [Receipt](#receipt--the-bill-math) • [Batching](#batch-multiple-ops-in-one-call) • [Parallel](#parallel-execution) • [Expand it](#supertooljson--project-configuration) • [Install](#install)
+[Why](#why) • [Four pillars](#four-pillars) • [Receipt](#receipt--the-bill-math) • [Batching](#batch-multiple-ops-in-one-call) • [Parallel](#parallel-execution) • [Input forms](#input-forms) • [Expand it](#supertooljson--project-configuration) • [Install](#install)
 
 ```bash
 # 7 ops, 1 round-trip, parallel where safe
@@ -179,6 +179,66 @@ claude -p "..." --permission-mode bypassPermissions \
 | `replace` / `replace_dry` | `replace:::OLD:::NEW:::PATH` | Recursive find/replace across PATH (`replace_dry` = preview). Use `:::` separator when content has `:`. |
 
 **LLM onboarding in one call:** `./supertool 'introduction' 'output-format' 'ops'` — outputs everything an LLM needs to use supertool.
+
+---
+
+## Input forms
+
+### Colon-CLI (default)
+
+Most ops take arguments via `:` — `read:PATH:OFFSET:LIMIT`, `grep:PATTERN:PATH:LIMIT`. When content itself contains colons (code, SQL, timestamps), switch to `:::` triple-colon separators: `edit:::OLD:::NEW:::PATH`.
+
+### `@file` route — long or structured payloads
+
+Edit ops (`edit`, `replace_lines`, `paste`, `vim`) accept a JSON file instead of inline args. Pass the path with an `@` prefix:
+
+```bash
+./supertool 'edit:@.max/my-edit.json'
+```
+
+The file holds the fields that would otherwise go after `:::`:
+
+```json
+{ "old": "return false;", "new": "return true;", "path": "src/app/Foo.py" }
+```
+
+Use `@-` to read the payload from stdin instead of a file.
+
+This route shines when `old` or `new` spans multiple lines or contains characters that clash with shell quoting. Write the JSON, invoke once — no escaping gymnastics.
+
+### `batch:@file` — mixed ops in one round-trip
+
+`batch` runs any combination of read and write ops from a single JSON file:
+
+```bash
+./supertool 'batch:@.max/ops.json'
+```
+
+Payload — a bare array of op objects, or a wrapper with options:
+
+```json
+[
+  { "op": "read", "path": "src/app/Config.py" },
+  { "op": "edit", "old": "DEBUG = False", "new": "DEBUG = True", "path": "src/app/Config.py" },
+  { "op": "read", "path": "src/app/Config.py" }
+]
+```
+
+Or with explicit options:
+
+```json
+{
+  "continue_on_error": true,
+  "ops": [
+    { "op": "read", "path": "src/app/Config.py" },
+    { "op": "edit", "old": "DEBUG = False", "new": "DEBUG = True", "path": "src/app/Config.py" }
+  ]
+}
+```
+
+`continue_on_error` defaults to `true` — a failed op is reported but the rest of the batch continues. Set to `false` to abort on first error. Validators (phplint, xmllint, etc.) fire per mutating op, same as inline edits. Use `@-` to pipe the payload from stdin.
+
+---
 
 ### `.supertool.json` — project configuration
 

--- a/supertool.py
+++ b/supertool.py
@@ -7950,9 +7950,34 @@ def _load_at_file(ref: str) -> Any:
         raise ValueError(f"@file JSON parse error ({source}): {_e}") from _e
 
 
-# Mapping from op name to the ordered list of JSON field names that map to
-# positional parts[1], parts[2], ... for each mutating op.
-_AT_FILE_OP_FIELDS: Dict[str, List[str]] = {
+# Dynamic @file field registry — built lazily from op syntax strings.
+# Maps op name → ordered list of JSON field names (positional parts[1..N]).
+# Populated on first dispatch call via _build_at_file_registry().
+_AT_FILE_REGISTRY: Dict[str, List[str]] = {}
+_AT_FILE_REGISTRY_BUILT: bool = False
+
+
+def _fields_from_syntax(syntax: str) -> List[str]:
+    """Derive positional field names from a syntax string using ':::' separator.
+
+    Takes the first alternative (before ' | '), splits on ':::', drops the
+    first token (op name), and lowercases the rest.
+
+    Returns [] if the syntax has no ':::' (read-only op — no @file route).
+
+    Examples:
+      'edit:::OLD:::NEW:::PATH'    → ['old', 'new', 'path']
+      'paste:::PATH:::CONTENT'     → ['path', 'content']
+      'read:PATH'                  → []
+    """
+    first_alt = syntax.split(" | ")[0].split(" |  ")[0]
+    if ":::" not in first_alt:
+        return []
+    tokens = first_alt.split(":::")
+    return [t.lower() for t in tokens[1:]]
+
+
+_AT_FILE_BUILTIN_DEFAULTS: Dict[str, List[str]] = {
     "edit":          ["old", "new", "path"],
     "replace":       ["old", "new", "path"],
     "replace_dry":   ["old", "new", "path"],
@@ -7962,34 +7987,71 @@ _AT_FILE_OP_FIELDS: Dict[str, List[str]] = {
 }
 
 
-def _at_file_to_parts(op: str, payload: Any) -> List[str]:
-    """Convert a JSON payload dict to a parts list for the given op.
+def _build_at_file_registry() -> None:
+    """Populate _AT_FILE_REGISTRY from builtin-ops and custom/preset op syntax.
 
-    The returned list is [op, field1_value, field2_value, ...] matching
+    Starts from _AT_FILE_BUILTIN_DEFAULTS so the builtins always work even
+    when no config file is present (e.g. in tests). Config-derived entries
+    overlay the defaults, allowing syntax-driven overrides and automatically
+    giving preset ops with ':::' syntax their own @file routes.
+
+    Called once on the first dispatch invocation.
+    """
+    global _AT_FILE_REGISTRY, _AT_FILE_REGISTRY_BUILT
+    if _AT_FILE_REGISTRY_BUILT:
+        return
+    registry: Dict[str, List[str]] = dict(_AT_FILE_BUILTIN_DEFAULTS)
+    config = _load_config()
+    for section in ("builtin-ops", "ops"):
+        for op_name, info in config.get(section, {}).items():
+            if not isinstance(info, dict):
+                continue
+            syntax = info.get("syntax", "")
+            if not syntax:
+                continue
+            fields = _fields_from_syntax(syntax)
+            if fields:
+                registry[op_name] = fields
+    _AT_FILE_REGISTRY = registry
+    _AT_FILE_REGISTRY_BUILT = True
+
+
+def _at_file_fields(op: str) -> List[str]:
+    """Return the field list for *op*, or [] if the op has no @file route."""
+    _build_at_file_registry()
+    return _AT_FILE_REGISTRY.get(op, [])
+
+
+def _at_file_to_parts(op: str, payload: Any) -> Tuple[List[str], bool]:
+    """Convert a JSON payload dict to (parts, replace_all) for the given op.
+
+    The returned parts list is [op, field1_value, field2_value, ...] matching
     the positional form that the existing dispatch handlers expect.
 
     All values are coerced to str so the downstream handlers work unchanged.
+
+    replace_all is extracted from the payload and returned separately so the
+    dispatch handler can act on it without polluting the parts list.
     """
     if not isinstance(payload, dict):
         raise ValueError(
             f"@file payload for op '{op}' must be a JSON object, "
             f"got {type(payload).__name__}"
         )
-    fields = _AT_FILE_OP_FIELDS.get(op)
-    if fields is None:
+    fields = _at_file_fields(op)
+    if not fields:
         raise ValueError(f"@file route not supported for op '{op}'")
+    # Case-insensitive key lookup — normalise payload keys once.
+    lower_payload = {k.lower(): v for k, v in payload.items()}
     parts = [op]
     for field in fields:
-        if field not in payload:
+        if field not in lower_payload:
             raise ValueError(
                 f"@file payload for op '{op}' missing required field '{field}'"
             )
-        parts.append(str(payload[field]))
-    # replace_all is optional for edit/replace — handled as extra flag later;
-    # stash it in a synthetic extra part so downstream can pick it up via
-    # the existing triple-colon path reconstruction (no handler reads it
-    # positionally, so it's safe to omit here — validators use parts[0..N]).
-    return parts
+        parts.append(str(lower_payload[field]))
+    replace_all = bool(lower_payload.get("replace_all", False))
+    return parts, replace_all
 
 
 def dispatch(arg: str) -> str:
@@ -8030,15 +8092,16 @@ def dispatch(arg: str) -> str:
 
     # @file route — 'op:@path' or 'op:@-' (stdin).
     # Load JSON, rebuild parts list, then fall through to the normal handlers.
-    # Applies to mutating ops listed in _AT_FILE_OP_FIELDS.
+    # Applies to mutating ops that have ':::' fields in their syntax string.
+    _at_file_replace_all: bool = False
     if (
         len(parts) == 2
         and parts[1].startswith("@")
-        and op in _AT_FILE_OP_FIELDS
+        and _at_file_fields(op)
     ):
         try:
             payload = _load_at_file(parts[1])
-            parts = _at_file_to_parts(op, payload)
+            parts, _at_file_replace_all = _at_file_to_parts(op, payload)
         except ValueError as _e:
             return header + f"ERROR: {_e}\n"
 
@@ -8155,7 +8218,10 @@ def dispatch(arg: str) -> str:
             old_str = _decode_escapes(parts[1] if len(parts) > 1 else "")
             new_str = _decode_escapes(parts[2] if len(parts) > 2 else "")
             epath = parts[3] if len(parts) > 3 else ""
-            body = _run_with_validators(op, parts, lambda: op_edit(old_str, new_str, epath))
+            if _at_file_replace_all:
+                body = _run_with_validators(op, parts, lambda: op_replace(old_str, new_str, epath or "."))
+            else:
+                body = _run_with_validators(op, parts, lambda: op_edit(old_str, new_str, epath))
         elif op == "replace_lines":
             rl_path = parts[1] if len(parts) > 1 else ""
             try:
@@ -8228,15 +8294,18 @@ def dispatch(arg: str) -> str:
                                 # Build the arg string from the op + its fields,
                                 # using the @file→parts machinery for mutating ops
                                 # (preserves validators) and plain dispatch for others.
-                                if _sub_op in _AT_FILE_OP_FIELDS:
+                                if _at_file_fields(_sub_op):
                                     try:
-                                        _sub_parts = _at_file_to_parts(_sub_op, _item)
+                                        _sub_parts, _sub_replace_all = _at_file_to_parts(_sub_op, _item)
                                     except ValueError as _ve:
                                         err = f"ERROR: {_ve}\n"
                                         results.append(err)
                                         if not continue_on_error:
                                             break
                                         continue
+                                    # replace_all: true on an edit op → promote to replace
+                                    if _sub_replace_all and _sub_op == "edit":
+                                        _sub_parts[0] = "replace"
                                     # Reconstruct a triple-colon arg string so dispatch
                                     # parses it correctly (handles colons in content).
                                     _sub_arg = ":::".join(_sub_parts)

--- a/supertool.py
+++ b/supertool.py
@@ -101,7 +101,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.10.0"
+VERSION = "0.10.1"
 
 MAX_READ_LINES = 300
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"
@@ -6696,7 +6696,8 @@ def _op_vim_impl(path: str, script: str) -> str:
             new_str = str(new_val)
             content = content[:start_d] + new_str + content[end_d:]
             cursor = start_d + len(new_str) - 1
-            log.append(f"  {i}. {'C-a' if verb == '\x01' else 'C-x'} {num_str} → {new_str}")
+            op_label = 'C-a' if verb == '\x01' else 'C-x'
+            log.append(f"  {i}. {op_label} {num_str} → {new_str}")
 
         # --- paste ---
         elif verb == "p":

--- a/supertool.py
+++ b/supertool.py
@@ -7921,12 +7921,93 @@ def op_validate(path: str, tool_filter: Optional[list] = None) -> str:
     return "\n".join(out) + "\n"
 
 
+def _load_at_file(ref: str) -> Any:
+    """Load JSON from an @file reference.
+
+    Accepts:
+      @path/to/file.json   — read from filesystem
+      @-                   — read from stdin
+
+    Returns the parsed JSON value (dict, list, etc.).
+    Raises ValueError with a human-readable message on any error.
+    """
+    if ref == "@-":
+        raw = sys.stdin.read()
+        source = "<stdin>"
+    else:
+        fpath = ref[1:]  # strip leading @
+        if not os.path.isfile(fpath):
+            raise ValueError(f"@file not found: {fpath}")
+        try:
+            with open(fpath, "r", encoding="utf-8") as _f:
+                raw = _f.read()
+        except OSError as _e:
+            raise ValueError(f"@file read error: {fpath}: {_e}") from _e
+        source = fpath
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as _e:
+        raise ValueError(f"@file JSON parse error ({source}): {_e}") from _e
+
+
+# Mapping from op name to the ordered list of JSON field names that map to
+# positional parts[1], parts[2], ... for each mutating op.
+_AT_FILE_OP_FIELDS: Dict[str, List[str]] = {
+    "edit":          ["old", "new", "path"],
+    "replace":       ["old", "new", "path"],
+    "replace_dry":   ["old", "new", "path"],
+    "replace_lines": ["path", "start", "end", "content"],
+    "paste":         ["path", "content"],
+    "vim":           ["path", "script"],
+}
+
+
+def _at_file_to_parts(op: str, payload: Any) -> List[str]:
+    """Convert a JSON payload dict to a parts list for the given op.
+
+    The returned list is [op, field1_value, field2_value, ...] matching
+    the positional form that the existing dispatch handlers expect.
+
+    All values are coerced to str so the downstream handlers work unchanged.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"@file payload for op '{op}' must be a JSON object, "
+            f"got {type(payload).__name__}"
+        )
+    fields = _AT_FILE_OP_FIELDS.get(op)
+    if fields is None:
+        raise ValueError(f"@file route not supported for op '{op}'")
+    parts = [op]
+    for field in fields:
+        if field not in payload:
+            raise ValueError(
+                f"@file payload for op '{op}' missing required field '{field}'"
+            )
+        parts.append(str(payload[field]))
+    # replace_all is optional for edit/replace — handled as extra flag later;
+    # stash it in a synthetic extra part so downstream can pick it up via
+    # the existing triple-colon path reconstruction (no handler reads it
+    # positionally, so it's safe to omit here — validators use parts[0..N]).
+    return parts
+
+
 def dispatch(arg: str) -> str:
     """Parse 'op:arg1:arg2:...' and route to the matching op function.
 
     Traversal ops (grep, glob, tree, map) support an optional :::no-exclude
     suffix that bypasses all exclude-paths for that one call.
     Example: 'grep:pattern:vendor/:10:::no-exclude'
+
+    Mutating ops (edit, replace, replace_lines, paste, vim) additionally
+    accept an @file route:
+    Example: 'edit:@.max/e1.json'  — reads {"path","old","new"} from file.
+    Use '@-' to read JSON payload from stdin.
+
+    The 'batch' op runs multiple ops from a JSON file:
+    Example: 'batch:@.max/ops.json'
+    Payload: array of {"op":"X",...fields} OR
+             {"continue_on_error":true,"ops":[...]}
     """
     # Strip :::no-exclude before splitting so it doesn't interfere with arg parsing
     no_exclude = arg.endswith(_NO_EXCLUDE_SUFFIX)
@@ -7946,6 +8027,20 @@ def dispatch(arg: str) -> str:
     else:
         parts = _split_arg(arg)
     op = parts[0] if parts else ""
+
+    # @file route — 'op:@path' or 'op:@-' (stdin).
+    # Load JSON, rebuild parts list, then fall through to the normal handlers.
+    # Applies to mutating ops listed in _AT_FILE_OP_FIELDS.
+    if (
+        len(parts) == 2
+        and parts[1].startswith("@")
+        and op in _AT_FILE_OP_FIELDS
+    ):
+        try:
+            payload = _load_at_file(parts[1])
+            parts = _at_file_to_parts(op, payload)
+        except ValueError as _e:
+            return header + f"ERROR: {_e}\n"
 
     try:
         if op == "read":
@@ -8081,6 +8176,82 @@ def dispatch(arg: str) -> str:
             vim_path = parts[1] if len(parts) > 1 else ""
             vim_script = ":".join(parts[2:]) if len(parts) > 2 else ""
             body = _run_with_validators(op, parts, lambda: op_vim(vim_path, vim_script))
+        elif op == "batch":
+            # batch:@file — run multiple ops from a JSON file.
+            # Payload: bare array of {"op":"X",...} objects, OR wrapper object
+            # {"continue_on_error": bool, "ops": [...]}.
+            # Default: continue_on_error=True (keep running after a failed op).
+            ref = parts[1] if len(parts) > 1 else ""
+            if not ref.startswith("@"):
+                body = "ERROR: batch requires an @file argument, e.g. batch:@ops.json\n"
+            else:
+                try:
+                    raw_payload = _load_at_file(ref)
+                except ValueError as _be:
+                    body = f"ERROR: {_be}\n"
+                else:
+                    # Normalise to (continue_on_error, ops_list)
+                    if isinstance(raw_payload, list):
+                        batch_ops = raw_payload
+                        continue_on_error = True
+                    elif isinstance(raw_payload, dict):
+                        batch_ops = raw_payload.get("ops", [])
+                        continue_on_error = bool(raw_payload.get("continue_on_error", True))
+                    else:
+                        batch_ops = []
+                        continue_on_error = True
+                        body = (
+                            "ERROR: batch @file must be a JSON array or object "
+                            f"with 'ops' key, got {type(raw_payload).__name__}\n"
+                        )
+                        batch_ops = None  # signal: already set body
+
+                    if batch_ops is not None:
+                        if not isinstance(batch_ops, list):
+                            body = "ERROR: batch 'ops' must be a JSON array\n"
+                        else:
+                            results: List[str] = []
+                            for _item in batch_ops:
+                                if not isinstance(_item, dict):
+                                    err = f"ERROR: each batch op must be a JSON object, got {type(_item).__name__}\n"
+                                    results.append(err)
+                                    if not continue_on_error:
+                                        break
+                                    continue
+                                _sub_op = _item.get("op", "")
+                                if not _sub_op:
+                                    err = "ERROR: batch op missing 'op' field\n"
+                                    results.append(err)
+                                    if not continue_on_error:
+                                        break
+                                    continue
+                                # Build the arg string from the op + its fields,
+                                # using the @file→parts machinery for mutating ops
+                                # (preserves validators) and plain dispatch for others.
+                                if _sub_op in _AT_FILE_OP_FIELDS:
+                                    try:
+                                        _sub_parts = _at_file_to_parts(_sub_op, _item)
+                                    except ValueError as _ve:
+                                        err = f"ERROR: {_ve}\n"
+                                        results.append(err)
+                                        if not continue_on_error:
+                                            break
+                                        continue
+                                    # Reconstruct a triple-colon arg string so dispatch
+                                    # parses it correctly (handles colons in content).
+                                    _sub_arg = ":::".join(_sub_parts)
+                                else:
+                                    # Read-only op: build plain colon arg from known fields.
+                                    # For unknown ops, pass what we have and let dispatch error.
+                                    _fields = [str(_item[k]) for k in sorted(_item) if k != "op"]
+                                    _sub_arg = ":".join([_sub_op] + _fields) if _fields else _sub_op
+                                _sub_result = dispatch(_sub_arg)
+                                results.append(_sub_result)
+                                if not continue_on_error and _sub_result.split("\n")[1:2] and (
+                                    _sub_result.split("\n")[1].startswith("ERROR")
+                                ):
+                                    break
+                            body = "".join(results)
         elif op == "validate":
             v_path = parts[1] if len(parts) > 1 else ""
             v_tools = [t for t in (parts[2].split(",") if len(parts) > 2 and parts[2] else []) if t]

--- a/supertool.py
+++ b/supertool.py
@@ -7970,11 +7970,11 @@ def _fields_from_syntax(syntax: str) -> List[str]:
       'paste:::PATH:::CONTENT'     → ['path', 'content']
       'read:PATH'                  → []
     """
-    first_alt = syntax.split(" | ")[0].split(" |  ")[0]
+    first_alt = re.split(r"\s*\|\s*", syntax)[0]
     if ":::" not in first_alt:
         return []
     tokens = first_alt.split(":::")
-    return [t.lower() for t in tokens[1:]]
+    return [t.strip().lower() for t in tokens[1:]]
 
 
 _AT_FILE_BUILTIN_DEFAULTS: Dict[str, List[str]] = {

--- a/tests/test_at_file_route.py
+++ b/tests/test_at_file_route.py
@@ -1,0 +1,171 @@
+"""Tests for the @file input route on mutating ops (edit, replace, replace_lines, paste, vim)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_json(tmp_path: Path, name: str, payload: dict) -> Path:
+    f = tmp_path / name
+    f.write_text(json.dumps(payload))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# edit:@file
+# ---------------------------------------------------------------------------
+
+class TestAtFileEdit:
+    def test_basic_edit(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("a = 1\nb = 2\n")
+        spec = _write_json(tmp_path, "e.json", {"old": "a = 1", "new": "a = 99", "path": str(target)})
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "edited" in out
+        assert "a = 99" in target.read_text()
+
+    def test_missing_field_returns_error(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("a = 1\n")
+        spec = _write_json(tmp_path, "e.json", {"old": "a = 1", "path": str(target)})  # missing 'new'
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" in out
+        assert "new" in out
+
+    def test_nonexistent_at_file_returns_error(self, tmp_path: Path) -> None:
+        out = supertool.dispatch(f"edit:@{tmp_path}/does_not_exist.json")
+        assert "ERROR" in out
+        assert "not found" in out
+
+    def test_invalid_json_returns_error(self, tmp_path: Path) -> None:
+        spec = tmp_path / "bad.json"
+        spec.write_text("not valid json {{{")
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" in out
+        assert "JSON parse error" in out
+
+    def test_payload_not_object_returns_error(self, tmp_path: Path) -> None:
+        spec = tmp_path / "arr.json"
+        spec.write_text('["a", "b"]')
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" in out
+
+    def test_validators_still_run(self, tmp_path: Path, monkeypatch) -> None:
+        """_run_with_validators must be called even via @file route."""
+        called = []
+
+        original = supertool._run_with_validators
+
+        def spy(op, parts, do_op):
+            called.append(op)
+            return original(op, parts, do_op)
+
+        monkeypatch.setattr(supertool, "_run_with_validators", spy)
+        target = tmp_path / "x.py"
+        target.write_text("foo\n")
+        spec = _write_json(tmp_path, "e.json", {"old": "foo", "new": "bar", "path": str(target)})
+        supertool.dispatch(f"edit:@{spec}")
+        assert "edit" in called
+
+    def test_header_contains_at_ref(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("foo\n")
+        spec = _write_json(tmp_path, "e.json", {"old": "foo", "new": "bar", "path": str(target)})
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert f"edit:@{spec}" in out
+
+
+# ---------------------------------------------------------------------------
+# replace:@file
+# ---------------------------------------------------------------------------
+
+class TestAtFileReplace:
+    def test_basic_replace(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("foo bar foo\n")
+        spec = _write_json(tmp_path, "r.json", {"old": "foo", "new": "baz", "path": str(target)})
+        out = supertool.dispatch(f"replace:@{spec}")
+        assert "ERROR" not in out
+        assert "foo" not in target.read_text()
+        assert "baz" in target.read_text()
+
+
+# ---------------------------------------------------------------------------
+# replace_lines:@file
+# ---------------------------------------------------------------------------
+
+class TestAtFileReplaceLines:
+    def test_basic_replace_lines(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("line1\nline2\nline3\n")
+        spec = _write_json(tmp_path, "rl.json", {
+            "path": str(target), "start": 2, "end": 2, "content": "REPLACED"
+        })
+        out = supertool.dispatch(f"replace_lines:@{spec}")
+        assert "replaced" in out
+        assert target.read_text() == "line1\nREPLACED\nline3\n"
+
+    def test_missing_start_field_returns_error(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("line1\n")
+        spec = _write_json(tmp_path, "rl.json", {"path": str(target), "end": 1, "content": "X"})
+        out = supertool.dispatch(f"replace_lines:@{spec}")
+        assert "ERROR" in out
+        assert "start" in out
+
+
+# ---------------------------------------------------------------------------
+# paste:@file
+# ---------------------------------------------------------------------------
+
+class TestAtFilePaste:
+    def test_basic_paste(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("old content\n")
+        spec = _write_json(tmp_path, "p.json", {"path": str(target), "content": "new content"})
+        out = supertool.dispatch(f"paste:@{spec}")
+        assert "rewrote" in out
+        assert "new content" in target.read_text()
+
+    def test_paste_creates_new_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "new_file.py"
+        spec = _write_json(tmp_path, "p.json", {"path": str(target), "content": "hello"})
+        out = supertool.dispatch(f"paste:@{spec}")
+        assert "created" in out
+        assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# @- stdin route
+# ---------------------------------------------------------------------------
+
+class TestAtFileStdin:
+    def test_edit_from_stdin(self, tmp_path: Path, monkeypatch) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("alpha\n")
+        payload = json.dumps({"old": "alpha", "new": "beta", "path": str(target)})
+        import io
+        monkeypatch.setattr(supertool.sys, "stdin", io.StringIO(payload))
+        out = supertool.dispatch("edit:@-")
+        assert "edited" in out
+        assert "beta" in target.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Non-mutating op — @file route NOT applied (plain parse fallback)
+# ---------------------------------------------------------------------------
+
+class TestAtFileNotAppliedToReadOps:
+    def test_read_at_file_not_intercepted(self, tmp_path: Path) -> None:
+        """read:@something should NOT go through the @file route — it's not a mutating op."""
+        # Create a file literally named @something (edge case — just verify no crash)
+        # More practically: read:@path is just a weird path, handled by op_read as "file not found"
+        out = supertool.dispatch(f"read:@{tmp_path}/nonexistent.json")
+        # Should be a normal "file not found" error from op_read, not @file machinery
+        assert "ERROR" in out or "not found" in out.lower()

--- a/tests/test_at_file_route.py
+++ b/tests/test_at_file_route.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 import supertool
 
 
@@ -169,3 +171,126 @@ class TestAtFileNotAppliedToReadOps:
         out = supertool.dispatch(f"read:@{tmp_path}/nonexistent.json")
         # Should be a normal "file not found" error from op_read, not @file machinery
         assert "ERROR" in out or "not found" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Refactor 1 — _fields_from_syntax: derive field list from syntax string
+# ---------------------------------------------------------------------------
+
+class TestFieldsFromSyntax:
+    @pytest.mark.parametrize("syntax,expected", [
+        ("edit:::OLD:::NEW:::PATH",           ["old", "new", "path"]),
+        ("replace:::OLD:::NEW:::PATH",        ["old", "new", "path"]),
+        ("replace_lines:::PATH:::START:::END:::CONTENT", ["path", "start", "end", "content"]),
+        ("paste:::PATH:::CONTENT",            ["path", "content"]),
+        ("vim:::PATH:::SCRIPT",               ["path", "script"]),
+        # First alternative is used when ' | ' separates alternatives
+        ("op:::A:::B | op:::X:::Y",           ["a", "b"]),
+        # Read-only op (no :::) → empty list
+        ("read:PATH",                         []),
+        ("grep:PATTERN:PATH",                 []),
+    ])
+    def test_fields_from_syntax(self, syntax: str, expected: list) -> None:
+        assert supertool._fields_from_syntax(syntax) == expected
+
+    def test_builtin_defaults_cover_all_write_ops(self) -> None:
+        """_AT_FILE_BUILTIN_DEFAULTS must derive the same field lists as the hardcoded table."""
+        expected = {
+            "edit":          ["old", "new", "path"],
+            "replace":       ["old", "new", "path"],
+            "replace_dry":   ["old", "new", "path"],
+            "replace_lines": ["path", "start", "end", "content"],
+            "paste":         ["path", "content"],
+            "vim":           ["path", "script"],
+        }
+        assert supertool._AT_FILE_BUILTIN_DEFAULTS == expected
+
+    def test_registry_populated_after_first_dispatch(self, tmp_path: Path) -> None:
+        """After any dispatch call the registry must contain the builtin write ops."""
+        # Force a dispatch so the registry is built
+        supertool.dispatch(f"read:{tmp_path}/nope")
+        for op in ("edit", "replace", "replace_dry", "replace_lines", "paste", "vim"):
+            assert supertool._at_file_fields(op), f"missing @file fields for op '{op}'"
+
+
+# ---------------------------------------------------------------------------
+# Refactor 1 — case-insensitive payload key matching
+# ---------------------------------------------------------------------------
+
+class TestAtFileCaseInsensitiveKeys:
+    def test_uppercase_keys_accepted(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("hello world\n")
+        spec = _write_json(tmp_path, "e.json", {"OLD": "hello", "NEW": "hi", "PATH": str(target)})
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "edited" in out
+        assert "hi world" in target.read_text()
+
+    def test_mixed_case_keys_accepted(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("foo\n")
+        spec = _write_json(tmp_path, "e.json", {"Old": "foo", "New": "bar", "Path": str(target)})
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "edited" in out
+        assert "bar" in target.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Refactor 2 — replace_all via @file route
+# ---------------------------------------------------------------------------
+
+class TestAtFileReplaceAll:
+    def test_replace_all_true_replaces_all_occurrences(self, tmp_path: Path) -> None:
+        """edit:@file with replace_all:true should replace every occurrence."""
+        target = tmp_path / "x.py"
+        target.write_text("foo bar foo baz foo\n")
+        spec = _write_json(tmp_path, "e.json", {
+            "old": "foo", "new": "qux", "path": str(target), "replace_all": True
+        })
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" not in out
+        text = target.read_text()
+        assert "foo" not in text
+        assert text.count("qux") == 3
+
+    def test_replace_all_false_errors_on_multiple_occurrences(self, tmp_path: Path) -> None:
+        """edit:@file with replace_all:false should use edit semantics (error on >1 match)."""
+        target = tmp_path / "x.py"
+        target.write_text("foo bar foo\n")
+        spec = _write_json(tmp_path, "e.json", {
+            "old": "foo", "new": "qux", "path": str(target), "replace_all": False
+        })
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" in out
+        assert "2" in out  # reports the count
+
+    def test_replace_all_absent_uses_edit_semantics(self, tmp_path: Path) -> None:
+        """edit:@file without replace_all key uses single-occurrence edit semantics."""
+        target = tmp_path / "x.py"
+        target.write_text("foo bar foo\n")
+        spec = _write_json(tmp_path, "e.json", {"old": "foo", "new": "qux", "path": str(target)})
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" in out  # two occurrences → error
+
+    def test_replace_all_true_single_occurrence_succeeds(self, tmp_path: Path) -> None:
+        """replace_all:true with a single match still succeeds."""
+        target = tmp_path / "x.py"
+        target.write_text("unique token here\n")
+        spec = _write_json(tmp_path, "e.json", {
+            "old": "unique token", "new": "replaced", "path": str(target), "replace_all": True
+        })
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" not in out
+        assert "replaced" in target.read_text()
+
+    def test_replace_all_via_batch_op(self, tmp_path: Path) -> None:
+        """replace_all:true inside a batch payload should also replace all occurrences."""
+        target = tmp_path / "x.py"
+        target.write_text("a a a\n")
+        ops_file = tmp_path / "ops.json"
+        ops_file.write_text(json.dumps([
+            {"op": "edit", "old": "a", "new": "b", "path": str(target), "replace_all": True}
+        ]))
+        out = supertool.dispatch(f"batch:@{ops_file}")
+        assert "ERROR" not in out
+        assert target.read_text().strip() == "b b b"

--- a/tests/test_batch_op.py
+++ b/tests/test_batch_op.py
@@ -1,0 +1,217 @@
+"""Tests for the batch op — runs multiple ops from a JSON file."""
+from __future__ import annotations
+
+import json
+import io
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_json(tmp_path: Path, name: str, payload) -> Path:
+    f = tmp_path / name
+    f.write_text(json.dumps(payload))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Basic dispatch
+# ---------------------------------------------------------------------------
+
+class TestBatchBasic:
+    def test_bare_array_runs_all_ops(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "a.py"
+        f1.write_text("hello\n")
+        f2 = tmp_path / "b.py"
+        f2.write_text("world\n")
+        ops = [
+            {"op": "read", "path": str(f1)},
+            {"op": "read", "path": str(f2)},
+        ]
+        spec = _write_json(tmp_path, "ops.json", ops)
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "hello" in out
+        assert "world" in out
+
+    def test_wrapper_object_runs_ops(self, tmp_path: Path) -> None:
+        f = tmp_path / "x.py"
+        f.write_text("content\n")
+        payload = {
+            "continue_on_error": True,
+            "ops": [{"op": "read", "path": str(f)}],
+        }
+        spec = _write_json(tmp_path, "ops.json", payload)
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "content" in out
+
+    def test_missing_at_prefix_returns_error(self, tmp_path: Path) -> None:
+        out = supertool.dispatch("batch:ops.json")
+        assert "ERROR" in out
+        assert "@file" in out
+
+    def test_nonexistent_file_returns_error(self, tmp_path: Path) -> None:
+        out = supertool.dispatch(f"batch:@{tmp_path}/nope.json")
+        assert "ERROR" in out
+
+    def test_invalid_json_returns_error(self, tmp_path: Path) -> None:
+        spec = tmp_path / "bad.json"
+        spec.write_text("{{{not json")
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "ERROR" in out
+
+    def test_payload_not_array_or_object_returns_error(self, tmp_path: Path) -> None:
+        spec = _write_json(tmp_path, "ops.json", "just a string")
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "ERROR" in out
+
+    def test_op_missing_op_field_returns_error(self, tmp_path: Path) -> None:
+        spec = _write_json(tmp_path, "ops.json", [{"path": "x.py"}])
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "ERROR" in out
+        assert "op" in out
+
+    def test_non_object_item_returns_error(self, tmp_path: Path) -> None:
+        spec = _write_json(tmp_path, "ops.json", ["not_an_object"])
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "ERROR" in out
+
+
+# ---------------------------------------------------------------------------
+# Mutating ops in batch — validators must fire
+# ---------------------------------------------------------------------------
+
+class TestBatchMutatingOps:
+    def test_edit_in_batch(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("foo\nbar\n")
+        ops = [{"op": "edit", "old": "foo", "new": "FOO", "path": str(target)}]
+        spec = _write_json(tmp_path, "ops.json", ops)
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "edited" in out
+        assert "FOO" in target.read_text()
+
+    def test_replace_lines_in_batch(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("line1\nline2\nline3\n")
+        ops = [{"op": "replace_lines", "path": str(target), "start": 2, "end": 2, "content": "LINE2"}]
+        spec = _write_json(tmp_path, "ops.json", ops)
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "replaced" in out
+        assert target.read_text() == "line1\nLINE2\nline3\n"
+
+    def test_paste_in_batch(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("old\n")
+        ops = [{"op": "paste", "path": str(target), "content": "new"}]
+        spec = _write_json(tmp_path, "ops.json", ops)
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "rewrote" in out
+        assert "new" in target.read_text()
+
+    def test_validators_called_for_mutating_op_in_batch(self, tmp_path: Path, monkeypatch) -> None:
+        called = []
+        original = supertool._run_with_validators
+
+        def spy(op, parts, do_op):
+            called.append(op)
+            return original(op, parts, do_op)
+
+        monkeypatch.setattr(supertool, "_run_with_validators", spy)
+        target = tmp_path / "x.py"
+        target.write_text("alpha\n")
+        ops = [{"op": "edit", "old": "alpha", "new": "beta", "path": str(target)}]
+        spec = _write_json(tmp_path, "ops.json", ops)
+        supertool.dispatch(f"batch:@{spec}")
+        assert "edit" in called
+
+
+# ---------------------------------------------------------------------------
+# Mixed batch (read + mutating)
+# ---------------------------------------------------------------------------
+
+class TestBatchMixed:
+    def test_read_and_edit_in_same_batch(self, tmp_path: Path) -> None:
+        f = tmp_path / "x.py"
+        f.write_text("before\n")
+        ops = [
+            {"op": "read", "path": str(f)},
+            {"op": "edit", "old": "before", "new": "after", "path": str(f)},
+            {"op": "read", "path": str(f)},
+        ]
+        spec = _write_json(tmp_path, "ops.json", ops)
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "before" in out   # first read
+        assert "after" in out    # edit receipt or second read
+        assert f.read_text() == "after\n"
+
+
+# ---------------------------------------------------------------------------
+# continue_on_error behaviour
+# ---------------------------------------------------------------------------
+
+class TestBatchContinueOnError:
+    def test_continue_on_error_true_runs_all(self, tmp_path: Path) -> None:
+        f = tmp_path / "x.py"
+        f.write_text("real\n")
+        payload = {
+            "continue_on_error": True,
+            "ops": [
+                {"op": "edit", "old": "NO_MATCH", "new": "x", "path": str(f)},
+                {"op": "read", "path": str(f)},
+            ],
+        }
+        spec = _write_json(tmp_path, "ops.json", payload)
+        out = supertool.dispatch(f"batch:@{spec}")
+        # Error from first op present
+        assert "ERROR" in out or "not found" in out.lower()
+        # Second op (read) also ran
+        assert "real" in out
+
+    def test_continue_on_error_false_stops_after_first_error(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "x.py"
+        f1.write_text("real\n")
+        f2 = tmp_path / "y.py"
+        f2.write_text("should_not_appear\n")
+        payload = {
+            "continue_on_error": False,
+            "ops": [
+                {"op": "edit", "old": "NO_MATCH", "new": "x", "path": str(f1)},
+                {"op": "read", "path": str(f2)},
+            ],
+        }
+        spec = _write_json(tmp_path, "ops.json", payload)
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "should_not_appear" not in out
+
+
+# ---------------------------------------------------------------------------
+# stdin route (@-)
+# ---------------------------------------------------------------------------
+
+class TestBatchStdin:
+    def test_batch_from_stdin(self, tmp_path: Path, monkeypatch) -> None:
+        f = tmp_path / "x.py"
+        f.write_text("stdin_test\n")
+        ops = [{"op": "read", "path": str(f)}]
+        monkeypatch.setattr(supertool.sys, "stdin", io.StringIO(json.dumps(ops)))
+        out = supertool.dispatch("batch:@-")
+        assert "stdin_test" in out
+
+
+# ---------------------------------------------------------------------------
+# Output format — per-op headers still present
+# ---------------------------------------------------------------------------
+
+class TestBatchOutputFormat:
+    def test_each_op_has_header(self, tmp_path: Path) -> None:
+        f = tmp_path / "x.py"
+        f.write_text("hi\n")
+        ops = [{"op": "read", "path": str(f)}, {"op": "wc", "path": str(f)}]
+        spec = _write_json(tmp_path, "ops.json", ops)
+        out = supertool.dispatch(f"batch:@{spec}")
+        assert "--- read:" in out
+        assert "--- wc:" in out

--- a/tests/test_inilint.py
+++ b/tests/test_inilint.py
@@ -1,0 +1,147 @@
+"""Tests for the inilint validator adapter."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "inilint" / "inilint.py"
+
+
+def _run(file_path: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), file_path],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Valid INI
+# ---------------------------------------------------------------------------
+
+def test_valid_ini_simple(tmp_path: Path) -> None:
+    f = tmp_path / "good.ini"
+    f.write_text("[section]\nkey = value\nnum = 42\n")
+    out = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert out["errors"] == []
+    assert out["tool"] == "inilint"
+
+
+def test_valid_ini_multiple_sections(tmp_path: Path) -> None:
+    f = tmp_path / "multi.ini"
+    f.write_text("[db]\nhost = localhost\nport = 3306\n\n[app]\ndebug = false\n")
+    out = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+
+
+def test_valid_ini_dvsi_like(tmp_path: Path) -> None:
+    f = tmp_path / "configuration-dev.ini"
+    f.write_text(
+        "[database]\nhostname = localhost\nusername = dvsi\npassword = dvsi\ndatabase = dvsi\n"
+    )
+    out = _run(str(f))
+    assert out["ok"] is True
+
+
+def test_valid_ini_no_section(tmp_path: Path) -> None:
+    """configparser supports DEFAULT section implicitly — sectionless keys fail."""
+    f = tmp_path / "nosection.ini"
+    f.write_text("[DEFAULT]\nkey = val\n")
+    out = _run(str(f))
+    assert out["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Invalid INI
+# ---------------------------------------------------------------------------
+
+def test_invalid_ini_missing_section_header(tmp_path: Path) -> None:
+    f = tmp_path / "bad.ini"
+    f.write_text("key = value_without_section\n")
+    out = _run(str(f))
+    assert out["ok"] is False
+    assert out["count"] == 1
+    assert len(out["errors"]) == 1
+
+
+def test_invalid_ini_error_has_line_info(tmp_path: Path) -> None:
+    f = tmp_path / "bad.ini"
+    f.write_text("key = value_without_section\n")
+    out = _run(str(f))
+    assert out["ok"] is False
+    err = out["errors"][0]
+    assert err["line"] is not None
+    assert err["severity"] == "error"
+    assert err["code"] == "syntax"
+
+
+def test_invalid_ini_msg_populated(tmp_path: Path) -> None:
+    f = tmp_path / "bad.ini"
+    f.write_text("not valid ini content here\n")
+    out = _run(str(f))
+    assert out["ok"] is False
+    assert out["errors"][0]["msg"]
+
+
+def test_invalid_ini_two_sectionless_keys(tmp_path: Path) -> None:
+    f = tmp_path / "multi_bad.ini"
+    # Two keys before any section header — first triggers MissingSectionHeaderError
+    f.write_text("key1 = val1\nkey2 = val2\n[section]\nk = v\n")
+    out = _run(str(f))
+    assert out["ok"] is False
+    assert out["count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+def test_missing_file_returns_error(tmp_path: Path) -> None:
+    out = _run(str(tmp_path / "nonexistent.ini"))
+    assert out["ok"] is False
+    assert out["count"] == 1
+    err = out["errors"][0]
+    assert err["code"] == "adapter"
+    assert "not found" in err["msg"]
+
+
+# ---------------------------------------------------------------------------
+# No argument
+# ---------------------------------------------------------------------------
+
+def test_no_arg_returns_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+def test_output_contains_required_fields(tmp_path: Path) -> None:
+    f = tmp_path / "x.ini"
+    f.write_text("[s]\nk = v\n")
+    out = _run(str(f))
+    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
+        assert key in out
+
+
+def test_duration_ms_is_int(tmp_path: Path) -> None:
+    f = tmp_path / "x.ini"
+    f.write_text("[s]\nk = v\n")
+    out = _run(str(f))
+    assert isinstance(out["duration_ms"], int)

--- a/tests/test_jsonlint.py
+++ b/tests/test_jsonlint.py
@@ -1,0 +1,136 @@
+"""Tests for the jsonlint validator adapter."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "jsonlint" / "jsonlint.py"
+
+
+def _run(file_path: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), file_path],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Valid JSON
+# ---------------------------------------------------------------------------
+
+def test_valid_json_object(tmp_path: Path) -> None:
+    f = tmp_path / "good.json"
+    f.write_text('{"key": "value", "num": 42}')
+    out = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert out["errors"] == []
+    assert out["tool"] == "jsonlint"
+
+
+def test_valid_json_array(tmp_path: Path) -> None:
+    f = tmp_path / "arr.json"
+    f.write_text('[1, 2, 3]')
+    out = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+
+
+def test_valid_json_nested(tmp_path: Path) -> None:
+    f = tmp_path / "nested.json"
+    f.write_text('{"a": {"b": [true, false, null]}}')
+    out = _run(str(f))
+    assert out["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Invalid JSON
+# ---------------------------------------------------------------------------
+
+def test_invalid_json_returns_error(tmp_path: Path) -> None:
+    f = tmp_path / "bad.json"
+    f.write_text('{"key": "value"')  # missing closing brace
+    out = _run(str(f))
+    assert out["ok"] is False
+    assert out["count"] == 1
+    assert len(out["errors"]) == 1
+
+
+def test_invalid_json_error_has_line_col(tmp_path: Path) -> None:
+    f = tmp_path / "bad.json"
+    f.write_text('{\n  "key": INVALID\n}')
+    out = _run(str(f))
+    assert out["ok"] is False
+    err = out["errors"][0]
+    assert err["line"] is not None
+    assert err["col"] is not None
+    assert err["severity"] == "error"
+    assert err["code"] == "syntax"
+
+
+def test_invalid_json_trailing_comma(tmp_path: Path) -> None:
+    f = tmp_path / "trailing.json"
+    f.write_text('{"a": 1,}')
+    out = _run(str(f))
+    assert out["ok"] is False
+
+
+def test_invalid_json_msg_populated(tmp_path: Path) -> None:
+    f = tmp_path / "bad.json"
+    f.write_text('not json at all')
+    out = _run(str(f))
+    assert out["ok"] is False
+    assert out["errors"][0]["msg"]  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+def test_missing_file_returns_error(tmp_path: Path) -> None:
+    out = _run(str(tmp_path / "nonexistent.json"))
+    assert out["ok"] is False
+    assert out["count"] == 1
+    err = out["errors"][0]
+    assert err["code"] == "adapter"
+    assert "not found" in err["msg"]
+
+
+# ---------------------------------------------------------------------------
+# No argument
+# ---------------------------------------------------------------------------
+
+def test_no_arg_returns_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+def test_output_contains_required_fields(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text('{}')
+    out = _run(str(f))
+    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
+        assert key in out
+
+
+def test_duration_ms_is_int(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text('{}')
+    out = _run(str(f))
+    assert isinstance(out["duration_ms"], int)

--- a/tests/test_yaml_check.py
+++ b/tests/test_yaml_check.py
@@ -1,0 +1,180 @@
+"""Tests for the yaml-check validator adapter."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "yaml-check" / "yaml-check.py"
+
+# Use a Python interpreter that has PyYAML installed, falling back to sys.executable.
+# On this machine, python3.13 has PyYAML; python3.14 (pytest default) does not.
+_PYTHON_WITH_YAML = shutil.which("python3.13") or sys.executable
+_HAS_PYYAML = subprocess.run(
+    [_PYTHON_WITH_YAML, "-c", "import yaml"],
+    capture_output=True,
+).returncode == 0
+
+
+def _run(file_path: str, python: str = _PYTHON_WITH_YAML) -> tuple[dict, str]:
+    result = subprocess.run(
+        [python, str(ADAPTER), file_path],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout), result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Valid YAML
+# ---------------------------------------------------------------------------
+
+def test_valid_yaml_simple(tmp_path: Path) -> None:
+    f = tmp_path / "good.yml"
+    f.write_text("key: value\nnum: 42\n")
+    out, _ = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert out["errors"] == []
+    assert out["tool"] == "yaml-check"
+
+
+def test_valid_yaml_list(tmp_path: Path) -> None:
+    f = tmp_path / "list.yml"
+    f.write_text("- one\n- two\n- three\n")
+    out, _ = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+
+
+def test_valid_yaml_nested(tmp_path: Path) -> None:
+    f = tmp_path / "nested.yaml"
+    f.write_text("stages:\n  - build\n  - test\njobs:\n  build:\n    script: make\n")
+    out, _ = _run(str(f))
+    assert out["ok"] is True
+
+
+def test_valid_gitlab_ci_like(tmp_path: Path) -> None:
+    f = tmp_path / ".gitlab-ci.yml"
+    f.write_text(
+        "image: php:8.3\nstages:\n  - test\nphpunit:\n  stage: test\n  script:\n    - phpunit\n"
+    )
+    out, _ = _run(str(f))
+    assert out["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Invalid YAML (requires PyYAML)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _HAS_PYYAML, reason="PyYAML not available on this interpreter")
+def test_invalid_yaml_returns_error(tmp_path: Path) -> None:
+    f = tmp_path / "bad.yml"
+    f.write_text("key: [\nunclosed bracket\n")
+    out, _ = _run(str(f))
+    assert out["ok"] is False
+    assert out["count"] == 1
+    assert len(out["errors"]) == 1
+
+
+@pytest.mark.skipif(not _HAS_PYYAML, reason="PyYAML not available on this interpreter")
+def test_invalid_yaml_has_line_info(tmp_path: Path) -> None:
+    f = tmp_path / "bad.yml"
+    f.write_text("good: ok\nbad: [\nstill bad\n")
+    out, _ = _run(str(f))
+    assert out["ok"] is False
+    err = out["errors"][0]
+    assert err["line"] is not None
+    assert err["severity"] == "error"
+    assert err["code"] == "syntax"
+
+
+@pytest.mark.skipif(not _HAS_PYYAML, reason="PyYAML not available on this interpreter")
+def test_invalid_yaml_msg_populated(tmp_path: Path) -> None:
+    f = tmp_path / "bad.yml"
+    f.write_text("key: : invalid\n")
+    out, _ = _run(str(f))
+    assert out["ok"] is False
+    assert out["errors"][0]["msg"]
+
+
+# ---------------------------------------------------------------------------
+# Missing file (requires PyYAML — without it the validator exits 0)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _HAS_PYYAML, reason="PyYAML not available on this interpreter")
+def test_missing_file_returns_error(tmp_path: Path) -> None:
+    out, _ = _run(str(tmp_path / "nonexistent.yml"))
+    assert out["ok"] is False
+    assert out["count"] == 1
+    err = out["errors"][0]
+    assert err["code"] == "adapter"
+    assert "not found" in err["msg"]
+
+
+# ---------------------------------------------------------------------------
+# No argument
+# ---------------------------------------------------------------------------
+
+def test_no_arg_returns_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+
+
+# ---------------------------------------------------------------------------
+# PyYAML missing — graceful degrade
+# ---------------------------------------------------------------------------
+
+def test_pyyaml_missing_exits_ok_with_warning(tmp_path: Path) -> None:
+    """When PyYAML is not installed, validator should exit 0 and warn on stderr."""
+    f = tmp_path / "any.yml"
+    f.write_text("key: value\n")
+    # Patch builtins.__import__ to raise ImportError for 'yaml'
+    shim = tmp_path / "yaml_missing_shim.py"
+    shim.write_text(
+        "import builtins\n"
+        "_real = builtins.__import__\n"
+        "def _mock(name, *a, **kw):\n"
+        "    if name == 'yaml':\n"
+        "        raise ImportError('mocked missing')\n"
+        "    return _real(name, *a, **kw)\n"
+        "builtins.__import__ = _mock\n"
+        f"import runpy; runpy.run_path({str(ADAPTER)!r}, run_name='__main__')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, str(shim), str(f)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is True
+    assert "PyYAML" in result.stderr or "pyyaml" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+def test_output_contains_required_fields(tmp_path: Path) -> None:
+    f = tmp_path / "x.yml"
+    f.write_text("a: 1\n")
+    out, _ = _run(str(f))
+    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
+        assert key in out
+
+
+def test_duration_ms_is_int(tmp_path: Path) -> None:
+    f = tmp_path / "x.yml"
+    f.write_text("a: 1\n")
+    out, _ = _run(str(f))
+    assert isinstance(out["duration_ms"], int)

--- a/validators/inilint/inilint.py
+++ b/validators/inilint/inilint.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""inilint validator adapter — INI syntax check via stdlib configparser.
+
+Stdlib only. Reference implementation per validators/SCHEMA.md.
+Usage:  inilint.py <file>
+"""
+
+import configparser
+import json
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "inilint", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    parser = configparser.RawConfigParser()
+    try:
+        with open(file, "r", encoding="utf-8") as fh:
+            parser.read_file(fh)
+    except configparser.MissingSectionHeaderError as e:
+        emit({"tool": "inilint", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": e.lineno, "col": None, "severity": "error",
+                          "code": "syntax", "msg": str(e).strip()[:300]}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except configparser.ParsingError as e:
+        errors = []
+        for lineno, msg in e.errors:
+            errors.append({"line": lineno, "col": None, "severity": "error",
+                           "code": "syntax", "msg": msg.strip()[:300]})
+        if not errors:
+            errors = [{"line": None, "col": None, "severity": "error",
+                       "code": "syntax", "msg": str(e).strip()[:300]}]
+        emit({"tool": "inilint", "file": file, "ok": False, "count": len(errors),
+              "errors": errors,
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except FileNotFoundError:
+        emit({"tool": "inilint", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "file not found"}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    emit({"tool": "inilint", "file": file, "ok": True, "count": 0,
+          "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/jsonlint/jsonlint.py
+++ b/validators/jsonlint/jsonlint.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""jsonlint validator adapter — JSON syntax check via stdlib json.load().
+
+Stdlib only. Reference implementation per validators/SCHEMA.md.
+Usage:  jsonlint.py <file>
+"""
+
+import json
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "jsonlint", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+    file = sys.argv[1]
+    start = time.time()
+    try:
+        with open(file, "r", encoding="utf-8") as fh:
+            json.load(fh)
+    except json.JSONDecodeError as e:
+        msg = str(e).strip()[:300]
+        emit({"tool": "jsonlint", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": e.lineno, "col": e.colno, "severity": "error",
+                          "code": "syntax", "msg": msg}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except FileNotFoundError:
+        emit({"tool": "jsonlint", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "file not found"}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+    emit({"tool": "jsonlint", "file": file, "ok": True, "count": 0,
+          "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/yaml-check/yaml-check.py
+++ b/validators/yaml-check/yaml-check.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""yaml-check validator adapter — YAML syntax check via PyYAML yaml.safe_load().
+
+Requires PyYAML (pip install pyyaml). If missing, exits 0 with a stderr warning.
+Usage:  yaml-check.py <file>
+"""
+
+import json
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "yaml-check", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    try:
+        import yaml
+    except ImportError:
+        print("yaml-check: PyYAML not installed, skipping", file=sys.stderr)
+        emit({"tool": "yaml-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        with open(file, "r", encoding="utf-8") as fh:
+            yaml.safe_load(fh)
+    except yaml.YAMLError as e:
+        line = None
+        col = None
+        if hasattr(e, "problem_mark") and e.problem_mark is not None:
+            line = e.problem_mark.line + 1
+            col = e.problem_mark.column + 1
+        msg = str(e).strip()[:300]
+        emit({"tool": "yaml-check", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": line, "col": col, "severity": "error",
+                          "code": "syntax", "msg": msg}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except FileNotFoundError:
+        emit({"tool": "yaml-check", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "file not found"}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    emit({"tool": "yaml-check", "file": file, "ok": True, "count": 0,
+          "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **yaml-check**: validates `*.yml` / `*.yaml` via PyYAML `safe_load()`. Gracefully degrades (warn on stderr, exit 0) when PyYAML is missing — so CI never hard-fails on machines without it. Two validator entries to cover both extensions.
- **inilint**: validates `*.ini` via stdlib `configparser`. Zero external deps. Reports line numbers from `MissingSectionHeaderError` / `ParsingError`.
- Both registered in `.supertool.example.json` with `rollback_on_fail: true`.

## Why it matters

- `.gitlab-ci.yml` — broken YAML = pipeline-red = 5–15 min wait before you find out. yaml-check catches it at edit time.
- `configuration-dev.ini` — broken INI = silent app break. inilint catches parse errors before they reach PHP.

## Test plan

- [ ] `pytest tests/test_yaml_check.py` — 12 tests (valid, invalid, missing file, no arg, PyYAML-missing mock, schema, duration)
- [ ] `pytest tests/test_inilint.py` — 11 tests (valid, invalid, missing file, no arg, schema, duration)
- [ ] `pytest tests/test_jsonlint.py` — existing 11 tests still pass unchanged
- [ ] All 35 tests green: `pytest tests/test_yaml_check.py tests/test_inilint.py tests/test_jsonlint.py --no-cov`