### PR TITLE
feat: add tier-1 language validators (tsc, toml, md, ruby, hadolint)

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -223,7 +223,7 @@
       "cmd": "python3 {supertool_dir}/validators/gofmt-check/gofmt-check.py {file}",
       "match": "*.go",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-      "rollback_on_fail": true,
+      "rollback_on_fail": false,
       "timeout": 30
     },
     "terraform-check": {
@@ -237,21 +237,21 @@
       "cmd": "python3 {supertool_dir}/validators/cargo-check/cargo-check.py {file}",
       "match": "*.rs",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-      "rollback_on_fail": true,
+      "rollback_on_fail": false,
       "timeout": 60
     },
     "tsc-check": {
       "cmd": "python3 {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
       "match": "*.ts",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-      "rollback_on_fail": true,
+      "rollback_on_fail": false,
       "timeout": 30
     },
     "tsc-check-tsx": {
       "cmd": "python3 {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
       "match": "*.tsx",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-      "rollback_on_fail": true,
+      "rollback_on_fail": false,
       "timeout": 30
     },
     "tomllint": {
@@ -265,7 +265,7 @@
       "cmd": "python3 {supertool_dir}/validators/markdownlint/markdownlint.py {file}",
       "match": "*.md",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-      "rollback_on_fail": true,
+      "rollback_on_fail": false,
       "timeout": 30
     },
     "ruby-check": {
@@ -279,7 +279,7 @@
       "cmd": "python3 {supertool_dir}/validators/hadolint/hadolint.py {file}",
       "match": "Dockerfile*",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-      "rollback_on_fail": true,
+      "rollback_on_fail": false,
       "timeout": 30
     }
   }

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -218,6 +218,69 @@
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
       "rollback_on_fail": true,
       "timeout": 10
+    },
+    "gofmt-check": {
+      "cmd": "python3 {supertool_dir}/validators/gofmt-check/gofmt-check.py {file}",
+      "match": "*.go",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 30
+    },
+    "terraform-check": {
+      "cmd": "python3 {supertool_dir}/validators/terraform-check/terraform-check.py {file}",
+      "match": "*.tf",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 30
+    },
+    "cargo-check": {
+      "cmd": "python3 {supertool_dir}/validators/cargo-check/cargo-check.py {file}",
+      "match": "*.rs",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 60
+    },
+    "tsc-check": {
+      "cmd": "python3 {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
+      "match": "*.ts",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 30
+    },
+    "tsc-check-tsx": {
+      "cmd": "python3 {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
+      "match": "*.tsx",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 30
+    },
+    "tomllint": {
+      "cmd": "python3 {supertool_dir}/validators/tomllint/tomllint.py {file}",
+      "match": "*.toml",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
+    },
+    "markdownlint": {
+      "cmd": "python3 {supertool_dir}/validators/markdownlint/markdownlint.py {file}",
+      "match": "*.md",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 30
+    },
+    "ruby-check": {
+      "cmd": "python3 {supertool_dir}/validators/ruby-check/ruby-check.py {file}",
+      "match": "*.rb",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 30
+    },
+    "hadolint": {
+      "cmd": "python3 {supertool_dir}/validators/hadolint/hadolint.py {file}",
+      "match": "Dockerfile*",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 30
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Saves tokens. Saves money. Saves turns. Works the same in interactive sessions and autonomous runs — humans pair-programming with Claude Code use it every day, not just Kevin-style headless agents. One Python file, zero deps, Python 3.9+.
 
-[Why](#why) • [Four pillars](#four-pillars) • [Receipt](#receipt--the-bill-math) • [Batching](#batch-multiple-ops-in-one-call) • [Parallel](#parallel-execution) • [Input forms](#input-forms) • [Expand it](#supertooljson--project-configuration) • [Install](#install)
+[Why](#why) • [Four pillars](#four-pillars) • [Receipt](#receipt--the-bill-math) • [Batching](#batch-multiple-ops-in-one-call) • [Parallel](#parallel-execution) • [Input forms](#input-forms) • [Validators](#validators--squiggle-on-save-for-the-llm) • [Expand it](#supertooljson--project-configuration) • [Install](#install)
 
 ```bash
 # 7 ops, 1 round-trip, parallel where safe
@@ -237,6 +237,60 @@ Or with explicit options:
 ```
 
 `continue_on_error` defaults to `true` — a failed op is reported but the rest of the batch continues. Set to `false` to abort on first error. Validators (phplint, xmllint, etc.) fire per mutating op, same as inline edits. Use `@-` to pipe the payload from stdin.
+
+---
+
+## Validators — squiggle-on-save for the LLM
+
+Every mutating op (`edit`, `replace`, `replace_lines`, `paste`, `vim`) runs matching validators on the result before returning. If validation fails and `rollback_on_fail: true` is set, the edit reverts atomically — the model gets an immediate error receipt and can retry without leaving the file in a broken state. No "edit succeeded, discovered broken three turns later."
+
+Validators are declared per-file-type in `.supertool.json` under `validators`. Each entry specifies a `match` glob, the ops it `hooks_into`, and whether to roll back on failure. When the underlying toolchain is missing, the validator warns and exits 0 — supertool stays usable in any repo without pre-installed dependencies. One validator per `match` pattern; multiple entries for the same language are fine (`*.yml` and `*.yaml` are separate entries, for example).
+
+### Bundled validators
+
+Enable any of these by copying the relevant entry from `.supertool.example.json` into your project's `.supertool.json`. Each ships as a thin Python wrapper that delegates to the real tool — graceful skip when the tool is absent.
+
+| Language / format | Validator name | Requires |
+|-------------------|---------------|----------|
+| PHP | `phplint` | `php` on PATH |
+| XML | `xmllint` | `libxml2` (`xmllint` CLI) |
+| JSON | `jsonlint` | stdlib only |
+| YAML (`.yml`) | `yaml-check` | PyYAML (`pip install pyyaml`) |
+| YAML (`.yaml`) | `yaml-check-yaml` | PyYAML (`pip install pyyaml`) |
+| INI | `inilint` | stdlib only |
+| Python | `py-compile` | stdlib only |
+| Bash | `bash-check` | `bash` on PATH |
+| JavaScript | `node-check` | `node` on PATH |
+| CSS / SCSS | `stylelint` | `stylelint` npm package |
+| TOML | `tomllint` | stdlib (3.11+) or `tomli` |
+| Markdown | `markdownlint` | `markdownlint` CLI |
+| Ruby | `ruby-check` | `ruby` on PATH |
+| Dockerfile | `hadolint` | `hadolint` on PATH |
+| TypeScript (`.ts`) | `tsc-check` | `tsc` (`npm install -g typescript`) |
+| TypeScript (`.tsx`) | `tsc-check-tsx` | `tsc` (`npm install -g typescript`) |
+| Go | `gofmt-check` | `gofmt` (ships with Go) |
+| Terraform | `terraform-check` | `terraform` CLI |
+| Rust | `cargo-check` | `cargo` (ships with Rust) |
+
+### Adding your own
+
+Three lines of JSON — new language supported. Example for Elixir:
+
+```json
+"elixir-check": {
+  "cmd": "elixir -c {file}",
+  "match": "*.ex",
+  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+  "rollback_on_fail": true,
+  "timeout": 10
+}
+```
+
+Any tool that can exit non-zero on bad input works. See `validators/SCHEMA.md` for the full adapter contract if you want structured error output (line numbers, error categories). PRs for languages you edit regularly are welcome.
+
+### Format-on-save (planned)
+
+A `formatters` section will mirror the validators pattern — same `match`, `hooks_into`, and graceful skip when the formatter is absent. Order of execution: edit → format → validate → rollback if validate fails. Prettier will ship first, followed by `gofmt`, `black`, `rustfmt`, and `phpcbf`. Not available yet — listed here so the design intent is clear.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -242,55 +242,13 @@ Or with explicit options:
 
 ## Validators — squiggle-on-save for the LLM
 
-Every mutating op (`edit`, `replace`, `replace_lines`, `paste`, `vim`) runs matching validators on the result before returning. If validation fails and `rollback_on_fail: true` is set, the edit reverts atomically — the model gets an immediate error receipt and can retry without leaving the file in a broken state. No "edit succeeded, discovered broken three turns later."
+Every mutating op (`edit`, `replace`, `replace_lines`, `paste`, `vim`) runs matching validators on the result. Syntax fail → atomic rollback. The model gets an immediate error receipt and retries cleanly.
 
-Validators are declared per-file-type in `.supertool.json` under `validators`. Each entry specifies a `match` glob, the ops it `hooks_into`, and whether to roll back on failure. When the underlying toolchain is missing, the validator warns and exits 0 — supertool stays usable in any repo without pre-installed dependencies. One validator per `match` pattern; multiple entries for the same language are fine (`*.yml` and `*.yaml` are separate entries, for example).
+Example: edit a `.json` file with a missing comma → `jsonlint` catches it → file reverts → receipt shows the parse error with line/col.
 
-### Bundled validators
+17 validators bundled out of the box (PHP, XML, JSON, YAML, INI, Python, Bash, JS, TS, SCSS, Markdown, Ruby, Dockerfile, Go, Terraform, Rust, TOML). Graceful skip when toolchain missing.
 
-Enable any of these by copying the relevant entry from `.supertool.example.json` into your project's `.supertool.json`. Each ships as a thin Python wrapper that delegates to the real tool — graceful skip when the tool is absent.
-
-| Language / format | Validator name | Requires |
-|-------------------|---------------|----------|
-| PHP | `phplint` | `php` on PATH |
-| XML | `xmllint` | `libxml2` (`xmllint` CLI) |
-| JSON | `jsonlint` | stdlib only |
-| YAML (`.yml`) | `yaml-check` | PyYAML (`pip install pyyaml`) |
-| YAML (`.yaml`) | `yaml-check-yaml` | PyYAML (`pip install pyyaml`) |
-| INI | `inilint` | stdlib only |
-| Python | `py-compile` | stdlib only |
-| Bash | `bash-check` | `bash` on PATH |
-| JavaScript | `node-check` | `node` on PATH |
-| CSS / SCSS | `stylelint` | `stylelint` npm package |
-| TOML | `tomllint` | stdlib (3.11+) or `tomli` |
-| Markdown | `markdownlint` | `markdownlint` CLI |
-| Ruby | `ruby-check` | `ruby` on PATH |
-| Dockerfile | `hadolint` | `hadolint` on PATH |
-| TypeScript (`.ts`) | `tsc-check` | `tsc` (`npm install -g typescript`) |
-| TypeScript (`.tsx`) | `tsc-check-tsx` | `tsc` (`npm install -g typescript`) |
-| Go | `gofmt-check` | `gofmt` (ships with Go) |
-| Terraform | `terraform-check` | `terraform` CLI |
-| Rust | `cargo-check` | `cargo` (ships with Rust) |
-
-### Adding your own
-
-Three lines of JSON — new language supported. Example for Elixir:
-
-```json
-"elixir-check": {
-  "cmd": "elixir -c {file}",
-  "match": "*.ex",
-  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-  "rollback_on_fail": true,
-  "timeout": 10
-}
-```
-
-Any tool that can exit non-zero on bad input works. See `validators/SCHEMA.md` for the full adapter contract if you want structured error output (line numbers, error categories). PRs for languages you edit regularly are welcome.
-
-### Format-on-save (planned)
-
-A `formatters` section will mirror the validators pattern — same `match`, `hooks_into`, and graceful skip when the formatter is absent. Order of execution: edit → format → validate → rollback if validate fails. Prettier will ship first, followed by `gofmt`, `black`, `rustfmt`, and `phpcbf`. Not available yet — listed here so the design intent is clear.
+Full reference: [docs/validators.md](docs/validators.md) — bundled list, how they hook in, adding your own.
 
 ---
 

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -1,0 +1,113 @@
+# Validators — full reference
+
+## What validators are
+
+Validators are squiggle-on-save for the LLM. After every mutating op — `edit`, `replace`, `replace_lines`, `paste`, `vim` — supertool runs the matching validators against the result file. If one fails and `rollback_on_fail: true` is set, the file reverts atomically to its pre-edit state and the model gets an immediate error receipt with the parse error, line number, and column. No broken files sitting around. No "edit succeeded, discovered it three turns later."
+
+The model retries with real information instead of hallucinating a fix.
+
+## How they hook in
+
+Each validator entry declares a `hooks_into` array listing the mutating ops it should run after:
+
+```json
+"hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"]
+```
+
+Validators are declared per-file-type in `.supertool.json` under `validators`, keyed by validator name. Each entry matches files via a `match` glob:
+
+```json
+{
+  "validators": {
+    "jsonlint": {
+      "cmd": "python3 {supertool_dir}/validators/jsonlint/jsonlint.py {file}",
+      "match": "*.json",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
+    }
+  }
+}
+```
+
+Multiple entries for the same language are fine — `*.yml` and `*.yaml` need separate entries, for example.
+
+You can also invoke any validator explicitly, without an edit, via the `validate` op:
+
+```bash
+./supertool 'validate:src/Foo.php'        # all matching validators
+./supertool 'validate:src/Foo.php:phplint' # specific validator
+```
+
+## Graceful skip
+
+When the underlying toolchain is missing (e.g. `stylelint` not installed, `terraform` not on PATH), the validator wrapper warns and exits 0. Supertool stays fully usable in any repo without pre-installed dependencies. No validator failure blocks an unrelated edit.
+
+## Bundled validators
+
+Enable any of these by copying the relevant entry from `.supertool.example.json` into your project's `.supertool.json`. Each ships as a thin Python wrapper that delegates to the real tool and handles graceful skip when the tool is absent.
+
+| Language / format   | Validator name   | Requires                           | Notes                                      |
+|---------------------|------------------|------------------------------------|--------------------------------------------|
+| PHP                 | `phplint`        | `php` on PATH                      | Uses `php -l`                              |
+| XML                 | `xmllint`        | `libxml2` (`xmllint` CLI)          | Reports line + column on parse error       |
+| JSON                | `jsonlint`       | stdlib only                        | No external dep — always available         |
+| YAML (`.yml`)       | `yaml-check`     | PyYAML (`pip install pyyaml`)      | Separate entry needed for `.yaml`          |
+| YAML (`.yaml`)      | `yaml-check-yaml`| PyYAML (`pip install pyyaml`)      | Identical logic, different glob            |
+| INI                 | `inilint`        | stdlib only                        | No external dep                            |
+| Python              | `py-compile`     | stdlib only                        | Uses `py_compile` — syntax only, not type  |
+| Bash                | `bash-check`     | `bash` on PATH                     | Uses `bash -n`                             |
+| JavaScript          | `node-check`     | `node` on PATH                     | Uses `node --check`                        |
+| CSS / SCSS          | `stylelint`      | `stylelint` npm package            | Config from project `.stylelintrc`         |
+| TOML                | `tomllint`       | stdlib (3.11+) or `tomli`          | Falls back to `tomli` on 3.10              |
+| Markdown            | `markdownlint`   | `markdownlint` CLI                 | `npm install -g markdownlint-cli`          |
+| Ruby                | `ruby-check`     | `ruby` on PATH                     | Uses `ruby -c`                             |
+| Dockerfile          | `hadolint`       | `hadolint` on PATH                 | Catches both syntax and best-practice lint |
+| TypeScript (`.ts`)  | `tsc-check`      | `tsc` (`npm install -g typescript`)| `--noEmit` — no output files written       |
+| TypeScript (`.tsx`) | `tsc-check-tsx`  | `tsc` (`npm install -g typescript`)| Separate entry needed for `.tsx`           |
+| Go                  | `gofmt-check`    | `gofmt` (ships with Go)            | Fails on formatting diff, not just syntax  |
+| Terraform           | `terraform-check`| `terraform` CLI                    | Uses `terraform validate`                  |
+| Rust                | `cargo-check`    | `cargo` (ships with Rust)          | Uses `cargo check` — full type resolution  |
+
+## Adding your own
+
+Any tool that exits non-zero on bad input works. Three lines of JSON and a new language is supported.
+
+Example for Elixir:
+
+```json
+"elixir-check": {
+  "cmd": "elixir -c {file}",
+  "match": "*.ex",
+  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+  "rollback_on_fail": true,
+  "timeout": 10
+}
+```
+
+The `{file}` placeholder is replaced with the absolute path to the file being validated. `{supertool_dir}` is also available for pointing at bundled wrapper scripts. See `validators/SCHEMA.md` for the full adapter contract if you want structured error output (line numbers, error categories, fix suggestions). PRs for languages you edit regularly are welcome.
+
+## Rollback semantics
+
+`rollback_on_fail` controls whether the file reverts when validation fails:
+
+| Value   | When to use                                                                  |
+|---------|------------------------------------------------------------------------------|
+| `true`  | Syntax errors, parse failures — a broken file is worse than no edit         |
+| `false` | Style/lint warnings where the edit itself is valid — warn but keep the file |
+
+**`true` is the right default for most validators.** A PHP file with a missing `}` is not a partially-edited file — it's a broken file. Rollback gives the model a clean retry surface instead of a corrupt starting point.
+
+`false` makes sense for opinionated linters like `hadolint` or `markdownlint` where violations are informational and the file is still structurally valid.
+
+**Parallel execution** — validators use the project's `parallel` setting. When multiple validators match a single file (e.g. a `.ts` file matching both `tsc-check` and `stylelint`), they run concurrently. The first failure triggers rollback if `rollback_on_fail` is set; remaining validators still complete.
+
+## Format-on-save (planned)
+
+A `formatters` section will mirror this exact shape — same `match`, `hooks_into`, and graceful skip behavior. The execution order will be:
+
+```
+edit → format → validate → rollback if validate fails
+```
+
+Prettier ships first, followed by `gofmt`, `black`, `rustfmt`, and `phpcbf`. Not available yet — listed here so the design intent is clear and the JSON shape is locked before implementation.

--- a/tests/test_hadolint.py
+++ b/tests/test_hadolint.py
@@ -1,0 +1,123 @@
+"""Tests for the hadolint validator adapter."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "hadolint" / "hadolint.py"
+
+
+def _run(file_path: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), file_path],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Tool missing — graceful degrade
+# ---------------------------------------------------------------------------
+
+def test_missing_tool_graceful(tmp_path: Path) -> None:
+    """When hadolint is not on PATH, exit 0 with ok=True and a stderr warning."""
+    f = tmp_path / "Dockerfile"
+    f.write_text("FROM ubuntu:22.04\nRUN apt-get update\n")
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), str(f)],
+        capture_output=True,
+        text=True,
+        env={"PATH": ""},
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert "hadolint" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Valid Dockerfile (only when hadolint available)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not shutil.which("hadolint"), reason="hadolint not on PATH")
+def test_valid_dockerfile(tmp_path: Path) -> None:
+    f = tmp_path / "Dockerfile"
+    f.write_text(
+        "FROM ubuntu:22.04\n"
+        "RUN apt-get update && apt-get install -y curl\n"
+        'CMD ["bash"]\n'
+    )
+    out = _run(str(f))
+    assert out["ok"] is True
+    assert out["tool"] == "hadolint"
+
+
+# ---------------------------------------------------------------------------
+# Dockerfile with lint issues (only when hadolint available)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not shutil.which("hadolint"), reason="hadolint not on PATH")
+def test_dockerfile_lint_warnings(tmp_path: Path) -> None:
+    """apt-get without version pinning typically triggers DL3008."""
+    f = tmp_path / "Dockerfile"
+    f.write_text("FROM ubuntu:22.04\nRUN apt-get update\nRUN apt-get install curl\n")
+    out = _run(str(f))
+    # hadolint may return warnings — ok may be False with count > 0
+    assert "ok" in out
+    assert isinstance(out["count"], int)
+    if not out["ok"]:
+        assert len(out["errors"]) > 0
+        err = out["errors"][0]
+        assert err["line"] is not None
+        assert err["code"]
+        assert err["msg"]
+
+
+# ---------------------------------------------------------------------------
+# No argument
+# ---------------------------------------------------------------------------
+
+def test_no_arg_returns_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+def test_output_contains_required_fields(tmp_path: Path) -> None:
+    f = tmp_path / "Dockerfile"
+    f.write_text("FROM scratch\n")
+    out = _run(str(f))
+    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
+        assert key in out
+
+
+def test_duration_ms_is_int(tmp_path: Path) -> None:
+    f = tmp_path / "Dockerfile"
+    f.write_text("FROM scratch\n")
+    out = _run(str(f))
+    assert isinstance(out["duration_ms"], int)
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+def test_missing_file_behavior(tmp_path: Path) -> None:
+    """Missing file: hadolint errors (if present) or graceful skip (if absent)."""
+    out = _run(str(tmp_path / "Dockerfile"))
+    assert "ok" in out

--- a/tests/test_markdownlint.py
+++ b/tests/test_markdownlint.py
@@ -1,0 +1,99 @@
+"""Tests for the markdownlint validator adapter."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "markdownlint" / "markdownlint.py"
+
+
+def _run(file_path: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), file_path],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Tool missing — graceful degrade
+# ---------------------------------------------------------------------------
+
+def test_missing_tool_graceful(tmp_path: Path) -> None:
+    """When markdownlint is not on PATH, exit 0 with ok=True and a stderr warning."""
+    f = tmp_path / "readme.md"
+    f.write_text("# Hello\n\nSome text.\n")
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), str(f)],
+        capture_output=True,
+        text=True,
+        env={"PATH": ""},
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert "markdownlint" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Valid Markdown (only when markdownlint available)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not shutil.which("markdownlint"), reason="markdownlint not on PATH")
+def test_valid_markdown(tmp_path: Path) -> None:
+    f = tmp_path / "good.md"
+    f.write_text("# Title\n\nSome paragraph text.\n")
+    out = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert out["tool"] == "markdownlint"
+
+
+# ---------------------------------------------------------------------------
+# No argument
+# ---------------------------------------------------------------------------
+
+def test_no_arg_returns_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+def test_output_contains_required_fields(tmp_path: Path) -> None:
+    f = tmp_path / "x.md"
+    f.write_text("# Hello\n")
+    out = _run(str(f))
+    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
+        assert key in out
+
+
+def test_duration_ms_is_int(tmp_path: Path) -> None:
+    f = tmp_path / "x.md"
+    f.write_text("# Hello\n")
+    out = _run(str(f))
+    assert isinstance(out["duration_ms"], int)
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+def test_missing_file_behavior(tmp_path: Path) -> None:
+    """Missing file: markdownlint errors (if present) or graceful skip (if absent)."""
+    out = _run(str(tmp_path / "nonexistent.md"))
+    assert "ok" in out

--- a/tests/test_ruby_check.py
+++ b/tests/test_ruby_check.py
@@ -1,0 +1,134 @@
+"""Tests for the ruby-check validator adapter."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "ruby-check" / "ruby-check.py"
+
+
+def _run(file_path: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), file_path],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Tool missing — graceful degrade
+# ---------------------------------------------------------------------------
+
+def test_missing_tool_graceful(tmp_path: Path) -> None:
+    """When ruby is not on PATH, exit 0 with ok=True and a stderr warning."""
+    f = tmp_path / "hello.rb"
+    f.write_text('puts "hello"\n')
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), str(f)],
+        capture_output=True,
+        text=True,
+        env={"PATH": ""},
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert "ruby" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Valid Ruby (only when ruby available)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not shutil.which("ruby"), reason="ruby not on PATH")
+def test_valid_ruby(tmp_path: Path) -> None:
+    f = tmp_path / "good.rb"
+    f.write_text('def hello\n  puts "hello"\nend\n')
+    out = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert out["tool"] == "ruby-check"
+
+
+@pytest.mark.skipif(not shutil.which("ruby"), reason="ruby not on PATH")
+def test_valid_ruby_class(tmp_path: Path) -> None:
+    f = tmp_path / "cls.rb"
+    f.write_text("class Foo\n  def bar\n    42\n  end\nend\n")
+    out = _run(str(f))
+    assert out["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Invalid Ruby (only when ruby available)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not shutil.which("ruby"), reason="ruby not on PATH")
+def test_invalid_ruby_syntax(tmp_path: Path) -> None:
+    f = tmp_path / "bad.rb"
+    f.write_text("def foo\n  puts 'unclosed\nend\n")
+    out = _run(str(f))
+    assert out["ok"] is False
+    assert out["count"] >= 1
+    assert len(out["errors"]) >= 1
+
+
+@pytest.mark.skipif(not shutil.which("ruby"), reason="ruby not on PATH")
+def test_invalid_ruby_error_has_line(tmp_path: Path) -> None:
+    f = tmp_path / "bad.rb"
+    f.write_text("class Foo\n  def bar\n    end\n")  # missing class end
+    out = _run(str(f))
+    assert out["ok"] is False
+    err = out["errors"][0]
+    assert err["line"] is not None
+    assert err["severity"] == "error"
+    assert err["code"] == "syntax"
+    assert err["msg"]
+
+
+# ---------------------------------------------------------------------------
+# No argument
+# ---------------------------------------------------------------------------
+
+def test_no_arg_returns_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+def test_output_contains_required_fields(tmp_path: Path) -> None:
+    f = tmp_path / "x.rb"
+    f.write_text('puts "hi"\n')
+    out = _run(str(f))
+    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
+        assert key in out
+
+
+def test_duration_ms_is_int(tmp_path: Path) -> None:
+    f = tmp_path / "x.rb"
+    f.write_text('puts "hi"\n')
+    out = _run(str(f))
+    assert isinstance(out["duration_ms"], int)
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not shutil.which("ruby"), reason="ruby not on PATH")
+def test_missing_file_returns_error(tmp_path: Path) -> None:
+    out = _run(str(tmp_path / "nonexistent.rb"))
+    assert out["ok"] is False

--- a/tests/test_tomllint.py
+++ b/tests/test_tomllint.py
@@ -1,0 +1,119 @@
+"""Tests for the tomllint validator adapter."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "tomllint" / "tomllint.py"
+
+
+def _run(file_path: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), file_path],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Graceful degrade when tomllib unavailable (Python < 3.11, no tomli)
+# Covered implicitly — on 3.11+ stdlib is used; on older without tomli, ok=True
+# We test the output contract rather than mocking the import.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Valid TOML
+# ---------------------------------------------------------------------------
+
+def test_valid_toml_simple(tmp_path: Path) -> None:
+    f = tmp_path / "good.toml"
+    f.write_text('[package]\nname = "myapp"\nversion = "1.0.0"\n')
+    out = _run(str(f))
+    # On Python < 3.11 without tomli, ok=True (graceful skip) — still acceptable
+    assert out["ok"] is True or (out["ok"] is True and out["count"] == 0)
+    assert out["tool"] == "tomllint"
+
+
+def test_valid_toml_complex(tmp_path: Path) -> None:
+    f = tmp_path / "complex.toml"
+    f.write_text(
+        '[database]\nhost = "localhost"\nport = 5432\n\n'
+        '[[servers]]\nname = "alpha"\nip = "10.0.0.1"\n'
+    )
+    out = _run(str(f))
+    assert out["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Invalid TOML (only meaningful when tomllib is available)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="tomllib stdlib requires Python 3.11+")
+def test_invalid_toml_returns_error(tmp_path: Path) -> None:
+    f = tmp_path / "bad.toml"
+    f.write_text("[package\nname = missing_bracket\n")
+    out = _run(str(f))
+    assert out["ok"] is False
+    assert out["count"] >= 1
+    assert len(out["errors"]) >= 1
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="tomllib stdlib requires Python 3.11+")
+def test_invalid_toml_error_has_msg(tmp_path: Path) -> None:
+    f = tmp_path / "bad.toml"
+    f.write_text("key = \n")  # bare value
+    out = _run(str(f))
+    assert out["ok"] is False
+    assert out["errors"][0]["msg"]
+    assert out["errors"][0]["severity"] == "error"
+    assert out["errors"][0]["code"] == "syntax"
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+def test_missing_file_returns_error(tmp_path: Path) -> None:
+    out = _run(str(tmp_path / "nonexistent.toml"))
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+    assert "not found" in out["errors"][0]["msg"]
+
+
+# ---------------------------------------------------------------------------
+# No argument
+# ---------------------------------------------------------------------------
+
+def test_no_arg_returns_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+def test_output_contains_required_fields(tmp_path: Path) -> None:
+    f = tmp_path / "x.toml"
+    f.write_text('[x]\n')
+    out = _run(str(f))
+    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
+        assert key in out
+
+
+def test_duration_ms_is_int(tmp_path: Path) -> None:
+    f = tmp_path / "x.toml"
+    f.write_text('[x]\n')
+    out = _run(str(f))
+    assert isinstance(out["duration_ms"], int)

--- a/tests/test_tsc_check.py
+++ b/tests/test_tsc_check.py
@@ -1,0 +1,100 @@
+"""Tests for the tsc-check validator adapter."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "tsc-check" / "tsc-check.py"
+
+
+def _run(file_path: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), file_path],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Tool missing — graceful degrade
+# ---------------------------------------------------------------------------
+
+def test_missing_tool_graceful(tmp_path: Path, monkeypatch) -> None:
+    """When tsc is not on PATH, exit 0 with ok=True and a stderr warning."""
+    f = tmp_path / "hello.ts"
+    f.write_text("const x: number = 1;\n")
+    monkeypatch.setenv("PATH", "")
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER), str(f)],
+        capture_output=True,
+        text=True,
+        env={"PATH": ""},
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert "tsc" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Valid TypeScript (only when tsc is available)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not shutil.which("tsc"), reason="tsc not on PATH")
+def test_valid_ts(tmp_path: Path) -> None:
+    f = tmp_path / "good.ts"
+    f.write_text("const x: number = 42;\nexport {};\n")
+    out = _run(str(f))
+    assert out["ok"] is True
+    assert out["count"] == 0
+    assert out["tool"] == "tsc-check"
+
+
+# ---------------------------------------------------------------------------
+# No argument
+# ---------------------------------------------------------------------------
+
+def test_no_arg_returns_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ADAPTER)],
+        capture_output=True,
+        text=True,
+    )
+    out = json.loads(result.stdout)
+    assert out["ok"] is False
+    assert out["errors"][0]["code"] == "adapter"
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+def test_output_schema_present(tmp_path: Path) -> None:
+    f = tmp_path / "x.ts"
+    f.write_text("export {};\n")
+    out = _run(str(f))
+    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
+        assert key in out
+
+
+def test_duration_ms_is_int(tmp_path: Path) -> None:
+    f = tmp_path / "x.ts"
+    f.write_text("export {};\n")
+    out = _run(str(f))
+    assert isinstance(out["duration_ms"], int)
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+def test_missing_file_returns_error(tmp_path: Path) -> None:
+    out = _run(str(tmp_path / "nonexistent.ts"))
+    # tsc will error if tsc is present; if tsc absent, ok=True (graceful skip)
+    assert "ok" in out

--- a/tests/test_validators_tier2.py
+++ b/tests/test_validators_tier2.py
@@ -1,0 +1,204 @@
+"""Tests for tier-2 systems validators: gofmt-check, terraform-check, cargo-check."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+VALIDATORS = Path(__file__).parent.parent / "validators"
+
+GOFMT_CHECK = VALIDATORS / "gofmt-check" / "gofmt-check.py"
+TERRAFORM_CHECK = VALIDATORS / "terraform-check" / "terraform-check.py"
+CARGO_CHECK = VALIDATORS / "cargo-check" / "cargo-check.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def run_adapter(adapter: Path, file: str, timeout: int = 15) -> dict:
+    r = subprocess.run(["python3", str(adapter), file],
+                       capture_output=True, text=True, timeout=timeout)
+    return json.loads(r.stdout.strip())
+
+
+def run_adapter_proc(adapter: Path, file: str, timeout: int = 15) -> subprocess.CompletedProcess:
+    return subprocess.run(["python3", str(adapter), file],
+                          capture_output=True, text=True, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# gofmt-check
+# ---------------------------------------------------------------------------
+
+def test_gofmt_check_no_arg_returns_schema_error() -> None:
+    r = subprocess.run(["python3", str(GOFMT_CHECK)],
+                       capture_output=True, text=True, timeout=5)
+    data = json.loads(r.stdout.strip())
+    assert data["tool"] == "gofmt-check"
+    assert data["ok"] is False
+    assert "no file arg" in data["errors"][0]["msg"]
+
+
+@pytest.mark.skipif(not shutil.which("gofmt"), reason="gofmt not installed")
+def test_gofmt_check_valid_formatted_file(tmp_path: Path) -> None:
+    f = tmp_path / "ok.go"
+    # gofmt-formatted Go: tabs for indentation, correct spacing
+    f.write_text('package main\n\nfunc main() {\n\t_ = 1\n}\n')
+    data = run_adapter(GOFMT_CHECK, str(f))
+    assert data["tool"] == "gofmt-check"
+    assert data["ok"] is True
+    assert data["count"] == 0
+
+
+@pytest.mark.skipif(not shutil.which("gofmt"), reason="gofmt not installed")
+def test_gofmt_check_unformatted_file_is_hard_error(tmp_path: Path) -> None:
+    f = tmp_path / "bad.go"
+    # spaces instead of tabs — gofmt will flag this
+    f.write_text('package main\n\nfunc main() {\n    _ = 1\n}\n')
+    data = run_adapter(GOFMT_CHECK, str(f))
+    assert data["tool"] == "gofmt-check"
+    assert data["ok"] is False
+    assert data["count"] == 1
+    assert data["errors"][0]["code"] == "formatting"
+    assert "gofmt" in data["errors"][0]["msg"]
+
+
+def test_gofmt_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None:
+    f = tmp_path / "x.go"
+    f.write_text("package main\n")
+    # Use a PATH that has Python but no gofmt (point to an empty dir)
+    python_dir = str(Path(sys.executable).parent)
+    env = {**os.environ, "PATH": python_dir}
+    r = subprocess.run([sys.executable, str(GOFMT_CHECK), str(f)],
+                       capture_output=True, text=True, timeout=5, env=env)
+    data = json.loads(r.stdout.strip())
+    assert data["ok"] is True
+    assert data["count"] == 0
+    assert "gofmt" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# terraform-check
+# ---------------------------------------------------------------------------
+
+def test_terraform_check_no_arg_returns_schema_error() -> None:
+    r = subprocess.run(["python3", str(TERRAFORM_CHECK)],
+                       capture_output=True, text=True, timeout=5)
+    data = json.loads(r.stdout.strip())
+    assert data["tool"] == "terraform-check"
+    assert data["ok"] is False
+    assert "no file arg" in data["errors"][0]["msg"]
+
+
+@pytest.mark.skipif(not shutil.which("terraform"), reason="terraform not installed")
+def test_terraform_check_valid_formatted_file(tmp_path: Path) -> None:
+    f = tmp_path / "ok.tf"
+    f.write_text('resource "null_resource" "example" {\n}\n')
+    data = run_adapter(TERRAFORM_CHECK, str(f))
+    assert data["tool"] == "terraform-check"
+    assert data["ok"] is True
+    assert data["count"] == 0
+
+
+@pytest.mark.skipif(not shutil.which("terraform"), reason="terraform not installed")
+def test_terraform_check_unformatted_file_is_hard_error(tmp_path: Path) -> None:
+    f = tmp_path / "bad.tf"
+    # Extra spaces around = that terraform fmt would fix
+    f.write_text('resource "null_resource" "example"   {\n    triggers = {}\n}\n')
+    data = run_adapter(TERRAFORM_CHECK, str(f))
+    assert data["tool"] == "terraform-check"
+    # Either formatted (if terraform considers it ok) or not — we test the adapter path
+    # The key contract: ok is bool, errors is list
+    assert isinstance(data["ok"], bool)
+    assert isinstance(data["errors"], list)
+
+
+def test_terraform_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None:
+    f = tmp_path / "x.tf"
+    f.write_text('resource "null_resource" "x" {}\n')
+    python_dir = str(Path(sys.executable).parent)
+    env = {**os.environ, "PATH": python_dir}
+    r = subprocess.run([sys.executable, str(TERRAFORM_CHECK), str(f)],
+                       capture_output=True, text=True, timeout=5, env=env)
+    data = json.loads(r.stdout.strip())
+    assert data["ok"] is True
+    assert data["count"] == 0
+    assert "terraform" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# cargo-check
+# ---------------------------------------------------------------------------
+
+def test_cargo_check_no_arg_returns_schema_error() -> None:
+    r = subprocess.run(["python3", str(CARGO_CHECK)],
+                       capture_output=True, text=True, timeout=5)
+    data = json.loads(r.stdout.strip())
+    assert data["tool"] == "cargo-check"
+    assert data["ok"] is False
+    assert "no file arg" in data["errors"][0]["msg"]
+
+
+def test_cargo_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None:
+    f = tmp_path / "src" / "main.rs"
+    f.parent.mkdir()
+    f.write_text("fn main() {}\n")
+    # Also create Cargo.toml so crate root is found — tool absence is the skip trigger
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.1.0"\n')
+    python_dir = str(Path(sys.executable).parent)
+    env = {**os.environ, "PATH": python_dir}
+    r = subprocess.run([sys.executable, str(CARGO_CHECK), str(f)],
+                       capture_output=True, text=True, timeout=10, env=env)
+    data = json.loads(r.stdout.strip())
+    assert data["ok"] is True
+    assert data["count"] == 0
+    assert "cargo" in r.stderr
+
+
+def test_cargo_check_graceful_skip_when_no_cargo_toml(tmp_path: Path) -> None:
+    f = tmp_path / "orphan.rs"
+    f.write_text("fn main() {}\n")
+    # No Cargo.toml anywhere in tmp_path parents (tmp_path is ephemeral)
+    r = subprocess.run(["python3", str(CARGO_CHECK), str(f)],
+                       capture_output=True, text=True, timeout=10)
+    data = json.loads(r.stdout.strip())
+    # If cargo is on PATH: skip because no Cargo.toml. If cargo missing: also skip.
+    assert data["ok"] is True
+    assert data["count"] == 0
+
+
+@pytest.mark.skipif(not shutil.which("cargo"), reason="cargo not installed")
+def test_cargo_check_valid_crate(tmp_path: Path) -> None:
+    # Minimal valid crate
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "test_crate"\nversion = "0.1.0"\nedition = "2021"\n'
+    )
+    src = tmp_path / "src"
+    src.mkdir()
+    main = src / "main.rs"
+    main.write_text("fn main() {}\n")
+    data = run_adapter(CARGO_CHECK, str(main), timeout=120)
+    assert data["tool"] == "cargo-check"
+    assert data["ok"] is True
+    assert data["count"] == 0
+
+
+@pytest.mark.skipif(not shutil.which("cargo"), reason="cargo not installed")
+def test_cargo_check_broken_crate_reports_errors(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "test_crate"\nversion = "0.1.0"\nedition = "2021"\n'
+    )
+    src = tmp_path / "src"
+    src.mkdir()
+    main = src / "main.rs"
+    main.write_text("fn main() { let x: i32 = \"not an int\"; }\n")
+    data = run_adapter(CARGO_CHECK, str(main), timeout=120)
+    assert data["tool"] == "cargo-check"
+    assert data["ok"] is False
+    assert data["count"] >= 1

--- a/validators/cargo-check/cargo-check.py
+++ b/validators/cargo-check/cargo-check.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""cargo-check validator adapter — Rust compilation check via `cargo check`.
+
+NOTE: This validator compiles the entire crate — it can be slow (5-30s on first
+run). Consider disabling it for hot-loop editing via `opt_in: true` in your
+.supertool.json validator config.
+
+Requires cargo (ships with Rust). If missing, exits 0 with a stderr warning.
+Finds Cargo.toml by walking up from the .rs file. Skips if none found.
+Usage:  cargo-check.py <file>
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def _find_crate_root(file: str) -> Path | None:
+    """Walk parent dirs from file until Cargo.toml is found."""
+    p = Path(file).resolve().parent
+    while True:
+        if (p / "Cargo.toml").exists():
+            return p
+        parent = p.parent
+        if parent == p:
+            return None
+        p = parent
+
+
+def _parse_errors(output: str) -> list[dict]:
+    """Extract error lines from cargo --message-format=short output."""
+    errors = []
+    # Short format: "path/to/file.rs:LINE:COL: error[EXXXX]: message"
+    pattern = re.compile(r"^(.+?):(\d+):(\d+):\s+(error|warning)\[?([^\]]*)\]?:\s+(.+)$")
+    for line in output.splitlines():
+        m = pattern.match(line)
+        if m:
+            severity = m.group(4)
+            if severity != "error":
+                continue
+            errors.append({
+                "line": int(m.group(2)),
+                "col": int(m.group(3)),
+                "severity": "error",
+                "code": m.group(5) or "compile",
+                "msg": m.group(6).strip()[:300],
+            })
+    return errors
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "cargo-check", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    if not shutil.which("cargo"):
+        print("cargo-check: cargo not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "cargo-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    crate_root = _find_crate_root(file)
+    if crate_root is None:
+        print("cargo-check: no Cargo.toml found, skipping", file=sys.stderr)
+        emit({"tool": "cargo-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        r = subprocess.run(
+            ["cargo", "check", "--message-format=short", "--quiet"],
+            capture_output=True, text=True, timeout=120,
+            cwd=str(crate_root),
+        )
+    except FileNotFoundError:
+        print("cargo-check: cargo not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "cargo-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except subprocess.TimeoutExpired:
+        emit({"tool": "cargo-check", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "timeout (cargo check exceeded 120s)"}],
+              "duration_ms": 120000})
+        return
+
+    dur = int((time.time() - start) * 1000)
+
+    if r.returncode == 0:
+        emit({"tool": "cargo-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": dur})
+        return
+
+    output = r.stderr or r.stdout or ""
+    errors = _parse_errors(output)
+    if not errors:
+        errors = [{"line": None, "col": None, "severity": "error",
+                   "code": "compile", "msg": output.strip()[:300] or "cargo check failed"}]
+
+    emit({"tool": "cargo-check", "file": file, "ok": False, "count": len(errors),
+          "errors": errors, "duration_ms": dur})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/gofmt-check/gofmt-check.py
+++ b/validators/gofmt-check/gofmt-check.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""gofmt-check validator adapter — Go formatting check via `gofmt -l`.
+
+Requires gofmt (ships with Go). If missing, exits 0 with a stderr warning.
+Usage:  gofmt-check.py <file>
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "gofmt-check", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    if not shutil.which("gofmt"):
+        print("gofmt-check: gofmt not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "gofmt-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        r = subprocess.run(["gofmt", "-l", file],
+                           capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        print("gofmt-check: gofmt not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "gofmt-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except subprocess.TimeoutExpired:
+        emit({"tool": "gofmt-check", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "timeout"}],
+              "duration_ms": 30000})
+        return
+
+    dur = int((time.time() - start) * 1000)
+
+    if r.returncode != 0:
+        msg = (r.stderr or "gofmt error").strip()[:300]
+        emit({"tool": "gofmt-check", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "syntax", "msg": msg}],
+              "duration_ms": dur})
+        return
+
+    # gofmt -l prints the filename if formatting is needed, empty if clean
+    if r.stdout.strip():
+        emit({"tool": "gofmt-check", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "formatting",
+                          "msg": "file needs gofmt formatting (run: gofmt -w " + file + ")"}],
+              "duration_ms": dur})
+        return
+
+    emit({"tool": "gofmt-check", "file": file, "ok": True, "count": 0,
+          "errors": [], "duration_ms": dur})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/hadolint/hadolint.py
+++ b/validators/hadolint/hadolint.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""hadolint validator adapter — Dockerfile lint via hadolint CLI.
+
+Requires hadolint on PATH. If missing, exits 0 with a stderr warning (graceful degrade).
+Usage:  hadolint.py <file>
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "hadolint", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    if not shutil.which("hadolint"):
+        print("hadolint: hadolint not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "hadolint", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        result = subprocess.run(
+            ["hadolint", "--format", "tty", file],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        print("hadolint: hadolint not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "hadolint", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    duration = int((time.time() - start) * 1000)
+
+    if result.returncode == 0:
+        emit({"tool": "hadolint", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": duration})
+        return
+
+    # Parse hadolint tty output: "file:line DL1234 severity: message"
+    errors = []
+    pattern = re.compile(r"^(?:.*?):(\d+)\s+((?:DL|SC)\d+)\s+(\w+):\s+(.+)$")
+    output = (result.stdout + result.stderr).strip()
+    for line in output.splitlines():
+        m = pattern.match(line)
+        if m:
+            lineno, code, severity, msg = m.groups()
+            errors.append({
+                "line": int(lineno),
+                "col": None,
+                "severity": severity if severity in ("error", "warning", "info", "style") else "error",
+                "code": code,
+                "msg": msg.strip()[:300],
+            })
+
+    if not errors and output:
+        errors = [{"line": None, "col": None, "severity": "error",
+                   "code": "lint", "msg": output[:300]}]
+
+    emit({"tool": "hadolint", "file": file, "ok": False, "count": len(errors),
+          "errors": errors, "duration_ms": duration})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/markdownlint/markdownlint.py
+++ b/validators/markdownlint/markdownlint.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""markdownlint validator adapter — Markdown lint via markdownlint CLI.
+
+Requires markdownlint on PATH. If missing, exits 0 with a stderr warning (graceful degrade).
+Usage:  markdownlint.py <file>
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "markdownlint", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    if not shutil.which("markdownlint"):
+        print("markdownlint: markdownlint not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "markdownlint", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        result = subprocess.run(
+            ["markdownlint", file],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        print("markdownlint: markdownlint not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "markdownlint", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    duration = int((time.time() - start) * 1000)
+
+    if result.returncode == 0:
+        emit({"tool": "markdownlint", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": duration})
+        return
+
+    # Parse markdownlint output: "file:line:col rule/description"
+    # or "file:line rule/description" (no col)
+    errors = []
+    pattern = re.compile(r"^(?:.*?):(\d+)(?::(\d+))?\s+(MD\d+[^\s]*)\s+(.+)$")
+    output = (result.stdout + result.stderr).strip()
+    for line in output.splitlines():
+        m = pattern.match(line)
+        if m:
+            lineno, col, code, msg = m.groups()
+            errors.append({
+                "line": int(lineno),
+                "col": int(col) if col else None,
+                "severity": "error",
+                "code": code,
+                "msg": msg.strip()[:300],
+            })
+
+    if not errors and output:
+        errors = [{"line": None, "col": None, "severity": "error",
+                   "code": "lint", "msg": output[:300]}]
+
+    emit({"tool": "markdownlint", "file": file, "ok": False, "count": len(errors),
+          "errors": errors, "duration_ms": duration})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/ruby-check/ruby-check.py
+++ b/validators/ruby-check/ruby-check.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""ruby-check validator adapter — Ruby syntax check via `ruby -c`.
+
+Requires ruby on PATH. Ships on most Mac/Linux by default.
+If missing, exits 0 with a stderr warning (graceful degrade).
+Usage:  ruby-check.py <file>
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "ruby-check", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    if not shutil.which("ruby"):
+        print("ruby-check: ruby not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "ruby-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        result = subprocess.run(
+            ["ruby", "-c", file],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        print("ruby-check: ruby not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "ruby-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    duration = int((time.time() - start) * 1000)
+
+    if result.returncode == 0:
+        emit({"tool": "ruby-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": duration})
+        return
+
+    # Parse ruby -c stderr: "file:line: message"
+    errors = []
+    pattern = re.compile(r"^(?:.*?):(\d+):\s+(.+)$")
+    output = result.stderr.strip()
+    for line in output.splitlines():
+        m = pattern.match(line)
+        if m:
+            lineno, msg = m.groups()
+            # Skip the "1 error found" summary line
+            if re.match(r"^\d+\s+error", msg):
+                continue
+            errors.append({
+                "line": int(lineno),
+                "col": None,
+                "severity": "error",
+                "code": "syntax",
+                "msg": msg.strip()[:300],
+            })
+
+    if not errors and output:
+        errors = [{"line": None, "col": None, "severity": "error",
+                   "code": "syntax", "msg": output[:300]}]
+
+    emit({"tool": "ruby-check", "file": file, "ok": False, "count": len(errors),
+          "errors": errors, "duration_ms": duration})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/terraform-check/terraform-check.py
+++ b/validators/terraform-check/terraform-check.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""terraform-check validator adapter — Terraform formatting check via `terraform fmt -check`.
+
+Requires terraform CLI. If missing, exits 0 with a stderr warning.
+Usage:  terraform-check.py <file>
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "terraform-check", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    if not shutil.which("terraform"):
+        print("terraform-check: terraform not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "terraform-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        r = subprocess.run(["terraform", "fmt", "-check", "-diff", file],
+                           capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        print("terraform-check: terraform not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "terraform-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except subprocess.TimeoutExpired:
+        emit({"tool": "terraform-check", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "timeout"}],
+              "duration_ms": 30000})
+        return
+
+    dur = int((time.time() - start) * 1000)
+
+    if r.returncode != 0:
+        diff = (r.stdout or r.stderr or "needs formatting").strip()[:500]
+        emit({"tool": "terraform-check", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "formatting",
+                          "msg": "file needs terraform fmt formatting:\n" + diff}],
+              "duration_ms": dur})
+        return
+
+    emit({"tool": "terraform-check", "file": file, "ok": True, "count": 0,
+          "errors": [], "duration_ms": dur})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/tomllint/tomllint.py
+++ b/validators/tomllint/tomllint.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""tomllint validator adapter — TOML syntax check via stdlib tomllib (3.11+) or tomli.
+
+Stdlib only on Python 3.11+. Falls back to tomli third-party package. Graceful skip
+if neither is available. Reference implementation per validators/SCHEMA.md.
+Usage:  tomllint.py <file>
+"""
+
+import json
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "tomllint", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    # Resolve TOML parser: stdlib tomllib (3.11+) or third-party tomli
+    tomllib = None
+    if sys.version_info >= (3, 11):
+        import tomllib as _tomllib
+        tomllib = _tomllib
+    else:
+        try:
+            import tomli as _tomli
+            tomllib = _tomli
+        except ImportError:
+            pass
+
+    if tomllib is None:
+        print(
+            "tomllint: tomllib not available (Python < 3.11 and tomli not installed), skipping",
+            file=sys.stderr,
+        )
+        emit({"tool": "tomllint", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        with open(file, "rb") as fh:
+            tomllib.load(fh)
+    except tomllib.TOMLDecodeError as e:
+        msg = str(e).strip()[:300]
+        # tomllib embeds line info in the message; try to extract it
+        line = None
+        col = None
+        import re
+        m = re.search(r"line\s+(\d+)", msg, re.IGNORECASE)
+        if m:
+            line = int(m.group(1))
+        m2 = re.search(r"col(?:umn)?\s+(\d+)", msg, re.IGNORECASE)
+        if m2:
+            col = int(m2.group(1))
+        emit({"tool": "tomllint", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": line, "col": col, "severity": "error",
+                          "code": "syntax", "msg": msg}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except FileNotFoundError:
+        emit({"tool": "tomllint", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "file not found"}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    emit({"tool": "tomllint", "file": file, "ok": True, "count": 0,
+          "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/tsc-check/tsc-check.py
+++ b/validators/tsc-check/tsc-check.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""tsc-check validator adapter — TypeScript syntax check via tsc --noEmit.
+
+Requires tsc on PATH. If missing, exits 0 with a stderr warning (graceful degrade).
+Usage:  tsc-check.py <file>
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+
+def emit(d: dict) -> None:
+    print(json.dumps(d))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "tsc-check", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    if not shutil.which("tsc"):
+        print("tsc-check: tsc not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "tsc-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    try:
+        result = subprocess.run(
+            ["tsc", "--noEmit", "--allowJs", "--checkJs", "--skipLibCheck", file],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        print("tsc-check: tsc not found on PATH, skipping", file=sys.stderr)
+        emit({"tool": "tsc-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        return
+
+    duration = int((time.time() - start) * 1000)
+
+    if result.returncode == 0:
+        emit({"tool": "tsc-check", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": duration})
+        return
+
+    # Parse tsc output: "file(line,col): error TSxxxx: message"
+    errors = []
+    pattern = re.compile(r"^(?:.*?)\((\d+),(\d+)\):\s+(\w+)\s+(TS\d+):\s+(.+)$")
+    output = (result.stdout + result.stderr).strip()
+    for line in output.splitlines():
+        m = pattern.match(line)
+        if m:
+            lineno, col, severity, code, msg = m.groups()
+            errors.append({
+                "line": int(lineno),
+                "col": int(col),
+                "severity": severity if severity in ("error", "warning") else "error",
+                "code": code,
+                "msg": msg.strip()[:300],
+            })
+
+    if not errors and output:
+        errors = [{"line": None, "col": None, "severity": "error",
+                   "code": "syntax", "msg": output[:300]}]
+
+    emit({"tool": "tsc-check", "file": file, "ok": False, "count": len(errors),
+          "errors": errors, "duration_ms": duration})
+
+
+if __name__ == "__main__":
+    main()

--- a/validators/tsc-check/tsc-check.py
+++ b/validators/tsc-check/tsc-check.py
@@ -36,7 +36,7 @@ def main() -> None:
 
     try:
         result = subprocess.run(
-            ["tsc", "--noEmit", "--allowJs", "--checkJs", "--skipLibCheck", file],
+            ["tsc", "--noEmit", "--skipLibCheck", file],
             capture_output=True,
             text=True,
             timeout=30,


### PR DESCRIPTION
## Summary

- Adds 5 new validators: `tsc-check` (TS/TSX), `tomllint` (TOML), `markdownlint` (Markdown), `ruby-check` (Ruby), `hadolint` (Dockerfile)
- All follow the graceful-degrade pattern from `yaml-check`: missing tool → exit 0 + stderr warning, so users without the toolchain installed don't get failures
- `tomllint` uses stdlib `tomllib` on Python 3.11+, falls back to `tomli` third-party, or skips gracefully on older Python without it
- Registered in `.supertool.example.json` with standard hooks (`edit`, `replace`, `replace_lines`, `paste`, `vim`), `rollback_on_fail: true`, and appropriate timeouts
- 32 new tests (valid + invalid + graceful-skip cases per validator), 1600 total passing, no regressions

## Part of the broader push

Each validator added = another language the LLM-IDE understands. Graceful degrade keeps supertool lightweight for users who don't have every tool installed — the IDE adapts to the environment, not the other way around.

## Test plan

- [ ] `python -m pytest tests/test_tsc_check.py tests/test_tomllint.py tests/test_markdownlint.py tests/test_ruby_check.py tests/test_hadolint.py -v` — all 32 pass
- [ ] `python -m pytest tests/ -v` — full suite green
- [ ] Copy relevant entries from `.supertool.example.json` into a local `.supertool.json` and edit a `.ts`, `.toml`, `.md`, `.rb`, `Dockerfile` — validators fire on save