### PR TITLE
docs: dedupe validator section — move details to docs/validators.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,69 +611,6 @@ Override via env: `SUPERTOOL_PARALLEL=4 ./supertool 'read:a' 'grep:x:b/' 'glob:c
 
 Speedup: I/O-bound ops on different files. ~3-5× faster on cold filesystem; modest gain on warm cache.
 
-### Validator hooks
-
-Wrap edit ops (`edit`, `replace`, `replace_lines`, `paste`, `vim`) with pre/post validation. Pre-snapshots the file via configured validators, runs the op, re-runs validators, renders a diff. Optional auto-rollback on regression.
-
-**Use case:** stop edits that break syntax (or worse) the moment they happen, in the same call — no "edit succeeded, found broken on next turn."
-
-**Adapter contract** — `validators/SCHEMA.md`. Each adapter takes one file arg, prints a JSON object on stdout. Ships reference adapters in `validators/`:
-
-- `phplint` — PHP syntax (`php -l`)
-- `xmllint` — XML well-formedness (libxml2)
-- `node-check` — JS syntax (`node --check`)
-- `stylelint` — CSS/SCSS lint (auto-falls back to `npx`)
-- `py-compile` — Python syntax (`py_compile`)
-- `bash-check` — Bash syntax (`bash -n`)
-
-**Config** in `.supertool.json`:
-
-```json
-{
-  "validators": {
-    "phplint": {
-      "cmd": "python3 {supertool_dir}/validators/phplint/phplint.py {file}",
-      "match": "*.php",
-      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-      "rollback_on_fail": true,
-      "timeout": 30
-    },
-    "phpstan": {
-      "cmd": "bash .my-project/run-phpstan.sh {file}",
-      "match": "*.php",
-      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
-      "timeout": 120
-    }
-  }
-}
-```
-
-| Field              | Notes                                                                                  |
-|--------------------|----------------------------------------------------------------------------------------|
-| `cmd`              | Shell command. `{file}` → target path. `{supertool_dir}` → supertool install dir.      |
-| `match`            | Glob filter on the target path (default `*`).                                          |
-| `hooks_into`       | Op names to wrap. PR1: subset of edit ops above.                                       |
-| `rollback_on_fail` | Restore pre-edit file content if the validator's count went up or ok flipped to false. |
-| `resolve`          | Shell cmd returning an alternate target path (e.g. source-file → test-file).           |
-| `timeout`          | Seconds. Default 60.                                                                    |
-| `opt_in`           | If true, validator only runs on explicit request via the `validate` op.                |
-
-**Auto-cache** at `~/.cache/supertool/validators/`, keyed on `sha256(file_content) + name + cmd`. Disable per-call with `SUPERTOOL_NO_VALIDATOR_CACHE=1` or per-project with `"validator_cache": false`.
-
-**Parallel** — uses the existing `parallel` setting. Validators run concurrently when `parallel >= 2`.
-
-**Manual run** — `./supertool 'validate:src/Foo.php'` (all matching validators) or `./supertool 'validate:src/Foo.php:phplint,phpstan'` (filtered).
-
-**Output example** — after an edit that breaks PHP syntax:
-
-```
-[validators]
-phplint : 0 → 1        (+1)   ✗
-  + L42 parse  Parse error: syntax error, unexpected token "{" in ... on line 42
-
-[rolled back] phplint regressed; file restored
-```
-
 ### Excluding paths from traversal ops
 
 `glob`, `grep`, `tree`, and `map` walk the filesystem recursively. On large repos this can be slow and noisy — `.git/objects/`, `node_modules/`, `vendor/`, and similar dirs rarely contain what you're looking for.

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -102,6 +102,55 @@ The `{file}` placeholder is replaced with the absolute path to the file being va
 
 **Parallel execution** — validators use the project's `parallel` setting. When multiple validators match a single file (e.g. a `.ts` file matching both `tsc-check` and `stylelint`), they run concurrently. The first failure triggers rollback if `rollback_on_fail` is set; remaining validators still complete.
 
+## Field reference
+
+Full list of `.supertool.json` validator config fields:
+
+| Field              | Notes                                                                                  |
+|--------------------|----------------------------------------------------------------------------------------|
+| `cmd`              | Shell command. `{file}` → target path. `{supertool_dir}` → supertool install dir.      |
+| `match`            | Glob filter on the target path (default `*`).                                          |
+| `hooks_into`       | Op names to wrap (subset of `edit`, `replace`, `replace_lines`, `paste`, `vim`).       |
+| `rollback_on_fail` | Restore pre-edit file content if the validator's count went up or ok flipped to false. |
+| `resolve`          | Shell cmd returning an alternate target path (e.g. source-file → test-file).           |
+| `timeout`          | Seconds. Default 60.                                                                    |
+| `opt_in`           | If true, validator only runs on explicit request via the `validate` op.                |
+
+## Caching
+
+Results are auto-cached at `~/.cache/supertool/validators/`, keyed on `sha256(file_content) + name + cmd`. Validators skip re-running when the file hasn't changed since the last pass.
+
+Disable caching per-call with the `SUPERTOOL_NO_VALIDATOR_CACHE=1` env var, or per-project with `"validator_cache": false` in `.supertool.json`.
+
+## Manual run
+
+Run validators explicitly against any file without an edit op:
+
+```bash
+./supertool 'validate:src/Foo.php'                    # all matching validators
+./supertool 'validate:src/Foo.php:phplint,phpstan'    # filtered to named validators
+```
+
+Useful for a pre-commit sweep or spot-checking a file you didn't edit this session.
+
+## Output example
+
+After an edit that breaks PHP syntax with `rollback_on_fail: true`:
+
+```
+[validators]
+phplint : 0 → 1        (+1)   ✗
+  + L42 parse  Parse error: syntax error, unexpected token "{" in ... on line 42
+
+[rolled back] phplint regressed; file restored
+```
+
+The model gets a clean retry surface with the exact line and error — no broken file left behind.
+
+## Adapter contract
+
+Custom validators must conform to the adapter contract in `validators/SCHEMA.md`. Each adapter takes one file arg and prints a JSON object on stdout with a standardised shape (ok, count, errors). The bundled adapters (`validators/phplint/`, `validators/xmllint/`, etc.) are the reference implementations.
+
 ## Format-on-save (planned)
 
 A `formatters` section will mirror this exact shape — same `match`, `hooks_into`, and graceful skip behavior. The execution order will be:


### PR DESCRIPTION
## Summary

- Removes the duplicate `### Validator hooks` block from README (lines 614–675) — the pitch + link at line 243 remains
- Appends the relocated content to `docs/validators.md`: field reference table, caching (`~/.cache/supertool/validators/`, `SUPERTOOL_NO_VALIDATOR_CACHE`, `validator_cache: false`), manual `validate:PATH` run syntax, output/rollback example, and adapter contract pointer
- Completes the validator doc story started in PR #87 — all reference detail now lives in one place

## Test plan

- [ ] README no longer contains `### Validator hooks` section
- [ ] `docs/validators.md` renders correctly with new sections after "Rollback semantics"
- [ ] No content from the removed block is lost