### PR TITLE
docs: split Operations into docs/operations/ with map.md deep-dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,38 +147,13 @@ claude -p "..." --permission-mode bypassPermissions \
 
 ## Operations
 
-| Op | Syntax | Notes |
-|----|--------|-------|
-| `read` | `read:PATH` or `read:PATH:OFFSET:LIMIT` | 300 lines / 20KB cap |
-| `read` (filter) | `read:PATH:OFFSET:LIMIT:grep=PATTERN` | Only show lines matching PATTERN (original line numbers preserved). Use `read:PATH:::grep=PATTERN` for defaults. |
-| `grep` | `grep:PATTERN:PATH` or `grep:PATTERN:PATH:LIMIT` | 10 results default, code + doc extensions only. **Auto-reads** full file if PATH is a concrete file < 20KB with a match. |
-| `grep` (context) | `grep:PATTERN:PATH:LIMIT:CONTEXT` | Show CONTEXT lines before/after each match (like `grep -C`). Match lines: `path:lineno:content`. Context lines: `path-lineno-content`. Non-adjacent groups separated by `--`. |
-| `grep` (count) | `grep:PATTERN:PATH:LIMIT:CONTEXT:count` | Return match counts per file instead of content. Output: `filepath:COUNT` per line. |
-| `glob` | `glob:PATTERN` | `**` supported. **Auto-reads** if PATTERN is a concrete file path (no wildcards). |
-| `ls` | `ls:PATH` | Trailing `/` on subdirs |
-| `tail` | `tail:PATH:N` | Last N lines (default 20) |
-| `head` | `head:PATH:N` | First N lines (default 20) |
-| `wc` | `wc:PATH` | Line/word/char count (like unix `wc`). Output: `LINES WORDS CHARS PATH`. |
-| `around` | `around:PATTERN:PATH` or `around:PATTERN:PATH:N` | Show N lines (default 10) before and after the **first** match of PATTERN in a single file. Uses line-numbered output like `read`. |
-| `grep_around` | `grep_around:PATTERN:PATH` or `grep_around:PATTERN:PATH:N:LIMIT` | Every match across files with N lines context (default N=3, LIMIT=10). Alias for `grep:PATTERN:PATH:LIMIT:CONTEXT` with sane defaults — useful for "show me how everyone uses this". |
-| `map` | `map:PATH` | Symbol map of a file or directory. Shows classes, functions, methods, constants as an indented tree with line numbers. Three-tier: tree-sitter → ctags → regex. Supports PHP, Python, JS, TS, Go, Rust, Java, Ruby. |
-| `introduction` | `introduction` | Output the project introduction text from `.supertool.json`. No `---` dispatch header — clean markdown. |
-| `output-format` | `output-format` | Output format examples from `.supertool.json`. Shows what responses look like. |
-| `ops` | `ops` | Full operations reference from `.supertool.json` — built-in ops, custom ops, and aliases with descriptions and examples. |
-| `diff` | `diff:PATH1:PATH2` | Unified diff between two files. |
-| `stat` | `stat:PATH` | File/directory metadata: size (bytes), last modified (ISO datetime), type (file/dir). |
-| `around_line` | `around_line:PATH:LINE` or `around_line:PATH:LINE:N` | Show N lines (default 10) of context around a specific line number. Target line marked with `→`. |
-| `between` | `between:SYMBOL:PATH` or `between:re:START:END:PATH` | Return a chunk of a file. **Symbol mode (default):** full body of a named function/method/class via tree-sitter (PHP, Python, JS, TS, Go, Rust, Java, Ruby — symbols with `::` like PHP `Foo::bar` work). **Pattern mode (`re:` prefix):** inclusive line slice from first line matching START regex to first line after matching END regex (language-agnostic). |
-| `tree` | `tree:PATH` or `tree:PATH:DEPTH` | Directory structure with depth limit (default 3). Hides dotfiles. Files listed before subdirectories. |
-| `blame` | `blame:PATH:LINE` or `blame:PATH:LINE:N` | Git blame for N lines (default 5) around a specific line number. Requires git repo. |
-| `version` | `version` | Show supertool version. |
-| `edit` | `edit:::OLD:::NEW:::PATH` | Single-file, single-occurrence edit (mirrors native Edit). Errors if 0 or >1 matches. **Bypasses native Edit must-Read state** — saves a round-trip when you already know the unique snippet. Use `:::` separator so content with `:` works. |
-| `replace_lines` | `replace_lines:::PATH:::START:::END:::CONTENT` | Swap lines `[START, END]` (1-indexed, inclusive) with CONTENT. `END < START` = pure insert before line START. Empty CONTENT = delete. Receipt shows new line numbers + ±2 context. |
-| `paste` | `paste:::PATH:::CONTENT` | **NARROW USE:** replace ENTIRE file. Only for creating a new file or fully rewriting one. NOT for partial edits — `vim` is the default for those. Atomic, creates file + parent dirs if missing. CONTENT via triple-colon → holds any chars (`:`, quotes, braces, newlines). |
-| `vim` | `vim:::PATH:::SCRIPT` | vim-flavored cursor-based multi-action edit. SCRIPT is parsed like a real vim macro: chars are verbs in NORMAL mode; insert verbs (`i`/`a`/`A`/`I`/`o`/`O`), search (`/`/`?`), and ex (`:...`) enter "greedy" modes where all following chars are TEXT/PAT until `\e` (ESC, U+001B) returns to NORMAL. **No separator chars** — `;`, `{`, `}`, newlines etc. are literal data, never special. **Cursor:** `gg`/`G` (BOF/EOF), `nG` (goto line), bare `:N`/`:$`/`:.` (line goto), `0`/`$` (BOL/EOL), `/PAT`/`?PAT` (search fwd/bwd), `nh`/`nl`/`nj`/`nk` (move). **Inserts** (TEXT runs until `\e` or EOS, `\n`/`\t` decoded): `iTEXT`/`aTEXT`/`ITEXT`/`ATEXT`/`oTEXT`/`OTEXT`. `o`/`O` AUTO-INDENT first line to current line's indent. **Deletes:** `x`/`nx`, `dd`/`ndd`, `D`. **Ex:** `:s/PAT/REPL/[gid]` (literal-fallback on unescaped parens), `:%s`, `:Nd`/`:N,Md`/`:.,/PAT/d`, `:g/PAT/d`/`:v/PAT/d` (bare `g/PAT/d` and `%g/PAT/d` autoprefixed with `:`), `:r FILE`/`:r -`/`:Nr FILE`, `:Na\nBODY\n.` (ex append after line N), `:w`/`:wq` (no-op — supertool writes atomically). **Autocorrects:** `oi<ws>TEXT` strips redundant verb-bleed, `:%%d` → `:%d`, `V<N>Gd` → `:.,Nd`, abandoned range `64,` silently dropped. **DEFAULT EDIT OP** for any pattern-based edit. Only fall back to `paste`/`edit`/`replace_lines` when vim doesn't fit. |
-| `replace` / `replace_dry` | `replace:::OLD:::NEW:::PATH` | Recursive find/replace across PATH (`replace_dry` = preview). Use `:::` separator when content has `:`. |
+~40 ops across reads, search, edits, symbol mapping, and meta. The full reference lives in [docs/operations/index.md](docs/operations/index.md) with per-category pages and a dedicated [`map`](docs/operations/map.md) deep-dive.
 
-**LLM onboarding in one call:** `./supertool 'introduction' 'output-format' 'ops'` — outputs everything an LLM needs to use supertool.
+Quick examples:
+
+```bash
+./supertool 'read:src/Foo.py' 'grep:TODO:src/' 'map:src/'
+```
 
 ---
 

--- a/docs/operations/edits.md
+++ b/docs/operations/edits.md
@@ -1,0 +1,96 @@
+# Edits
+
+Mutating ops for modifying files. Every edit op runs matching validators on the result — syntax failure triggers atomic rollback before the receipt reaches the model.
+
+**Default edit op:** `vim`. Use `edit` for single known snippets, `replace` for cross-file renames, `paste` only for full rewrites or new files.
+
+## Ops
+
+| Op | Syntax | What it does |
+|----|--------|--------------|
+| `vim` | `vim:::PATH:::SCRIPT` | vim-flavored cursor-based multi-action edit. SCRIPT is parsed like a real vim macro: chars are verbs in NORMAL mode; insert verbs (`i`/`a`/`A`/`I`/`o`/`O`), search (`/`/`?`), and ex (`:...`) enter "greedy" modes where all following chars are TEXT/PAT until `\e` (ESC, U+001B) returns to NORMAL. **No separator chars** — `;`, `{`, `}`, newlines etc. are literal data, never special. **Cursor:** `gg`/`G` (BOF/EOF), `nG` (goto line), bare `:N`/`:$`/`:.` (line goto), `0`/`$` (BOL/EOL), `/PAT`/`?PAT` (search fwd/bwd), `nh`/`nl`/`nj`/`nk` (move). **Inserts** (TEXT runs until `\e` or EOS, `\n`/`\t` decoded): `iTEXT`/`aTEXT`/`ITEXT`/`ATEXT`/`oTEXT`/`OTEXT`. `o`/`O` AUTO-INDENT first line to current line's indent. **Deletes:** `x`/`nx`, `dd`/`ndd`, `D`. **Ex:** `:s/PAT/REPL/[gid]` (literal-fallback on unescaped parens), `:%s`, `:Nd`/`:N,Md`/`:.,/PAT/d`, `:g/PAT/d`/`:v/PAT/d`, `:r FILE`/`:r -`/`:Nr FILE`, `:Na\nBODY\n.` (ex append after line N), `:w`/`:wq` (no-op — supertool writes atomically). **DEFAULT EDIT OP** for any pattern-based edit. |
+| `edit` | `edit:::OLD:::NEW:::PATH` | Single-file, single-occurrence edit (mirrors native Edit). Errors if 0 or >1 matches. **Bypasses native Edit must-Read state** — saves a round-trip when you already know the unique snippet. Use `:::` separator so content with `:` works. |
+| `replace` | `replace:::OLD:::NEW:::PATH` | Recursive find/replace across PATH. Use `:::` separator when content has `:`. |
+| `replace_dry` | `replace_dry:::OLD:::NEW:::PATH` | Preview of `replace` — shows what would change without writing. |
+| `replace_lines` | `replace_lines:::PATH:::START:::END:::CONTENT` | Swap lines `[START, END]` (1-indexed, inclusive) with CONTENT. `END < START` = pure insert before line START. Empty CONTENT = delete. Receipt shows new line numbers + ±2 context. |
+| `paste` | `paste:::PATH:::CONTENT` | **NARROW USE:** replace ENTIRE file. Only for creating a new file or fully rewriting one. NOT for partial edits — `vim` is the default for those. Atomic, creates file + parent dirs if missing. CONTENT via triple-colon → holds any chars (`:`, quotes, braces, newlines). |
+
+## Common patterns
+
+Pattern-based edit at a searched location (default case):
+
+```bash
+./supertool 'vim:::src/app/Config.py:::/DEBUG\e:s/False/True/'
+```
+
+Single known unique snippet — skip the Read round-trip:
+
+```bash
+./supertool 'edit:::return False;:::return True;:::src/app/Module.py'
+```
+
+Preview a cross-file rename before committing:
+
+```bash
+./supertool 'replace_dry:::OldClassName:::NewClassName:::src/'
+```
+
+Then apply:
+
+```bash
+./supertool 'replace:::OldClassName:::NewClassName:::src/'
+```
+
+Insert a line before line 42, delete lines 10–12:
+
+```bash
+./supertool 'replace_lines:::src/app/Module.py:::42:::41:::    new_line_here' \
+            'replace_lines:::src/app/Module.py:::10:::12:::'
+```
+
+Create a new file (or fully rewrite one):
+
+```bash
+./supertool 'paste:::src/app/NewModule.py:::class NewModule:\n    pass'
+```
+
+## Input forms
+
+### Triple-colon separators (`:::`)
+
+All edit ops use `:::` as the field separator so content with `:` (SQL, URLs, timestamps, code) works unambiguously.
+
+### `@file` route — long or structured payloads
+
+When `old` or `new` spans multiple lines or contains characters that clash with shell quoting, write a JSON file and pass it with `@`:
+
+```bash
+./supertool 'edit:@.max/my-edit.json'
+```
+
+```json
+{ "old": "return false;", "new": "return true;", "path": "src/app/Foo.py" }
+```
+
+Use `@-` to pipe from stdin instead of a file.
+
+### `batch:@file` — mixed ops in one round-trip
+
+Read, edit, and re-read in a single call:
+
+```bash
+./supertool 'batch:@.max/ops.json'
+```
+
+```json
+[
+  { "op": "read", "path": "src/app/Config.py" },
+  { "op": "edit", "old": "DEBUG = False", "new": "DEBUG = True", "path": "src/app/Config.py" },
+  { "op": "read", "path": "src/app/Config.py" }
+]
+```
+
+## See also
+
+- [docs/validators.md](../validators.md) — full validator reference: bundled list, rollback behavior, adding your own
+- [index.md](index.md) — full op table with all categories

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,0 +1,48 @@
+# Operations Reference
+
+~40 ops across five categories. Use this page for a quick "all ops at a glance" lookup, then follow the per-category links for patterns and recipes.
+
+## Categories
+
+| Category | Ops | Page |
+|----------|-----|------|
+| **Reads** | `read`, `read-grep`, `head`, `tail`, `wc`, `stat`, `ls`, `glob`, `tree`, `diff` | [reads.md](reads.md) |
+| **Search** | `grep`, `grep-count`, `grep_around`, `around`, `around_line`, `between` | [search.md](search.md) |
+| **Symbol map** | `map` | [map.md](map.md) |
+| **Edits** | `edit`, `replace`, `replace_dry`, `replace_lines`, `paste`, `vim` | [edits.md](edits.md) |
+| **Meta** | `introduction`, `output-format`, `ops`, `version` | [meta.md](meta.md) |
+
+## Full op table
+
+| Op | Syntax | What it does |
+|----|--------|--------------|
+| `read` | `read:PATH` or `read:PATH:OFFSET:LIMIT` | 300 lines / 20KB cap |
+| `read` (filter) | `read:PATH:OFFSET:LIMIT:grep=PATTERN` | Only show lines matching PATTERN (original line numbers preserved). Use `read:PATH:::grep=PATTERN` for defaults. |
+| `grep` | `grep:PATTERN:PATH` or `grep:PATTERN:PATH:LIMIT` | 10 results default, code + doc extensions only. **Auto-reads** full file if PATH is a concrete file < 20KB with a match. |
+| `grep` (context) | `grep:PATTERN:PATH:LIMIT:CONTEXT` | Show CONTEXT lines before/after each match (like `grep -C`). Match lines: `path:lineno:content`. Context lines: `path-lineno-content`. Non-adjacent groups separated by `--`. |
+| `grep` (count) | `grep:PATTERN:PATH:LIMIT:CONTEXT:count` | Return match counts per file instead of content. Output: `filepath:COUNT` per line. |
+| `glob` | `glob:PATTERN` | `**` supported. **Auto-reads** if PATTERN is a concrete file path (no wildcards). |
+| `ls` | `ls:PATH` | Trailing `/` on subdirs |
+| `tail` | `tail:PATH:N` | Last N lines (default 20) |
+| `head` | `head:PATH:N` | First N lines (default 20) |
+| `wc` | `wc:PATH` | Line/word/char count (like unix `wc`). Output: `LINES WORDS CHARS PATH`. |
+| `around` | `around:PATTERN:PATH` or `around:PATTERN:PATH:N` | Show N lines (default 10) before and after the **first** match of PATTERN in a single file. Uses line-numbered output like `read`. |
+| `grep_around` | `grep_around:PATTERN:PATH` or `grep_around:PATTERN:PATH:N:LIMIT` | Every match across files with N lines context (default N=3, LIMIT=10). Alias for `grep:PATTERN:PATH:LIMIT:CONTEXT` with sane defaults — useful for "show me how everyone uses this". |
+| `map` | `map:PATH` | Symbol map of a file or directory. Shows classes, functions, methods, constants as an indented tree with line numbers. Three-tier: tree-sitter → ctags → regex. Supports PHP, Python, JS, TS, Go, Rust, Java, Ruby. |
+| `introduction` | `introduction` | Output the project introduction text from `.supertool.json`. No `---` dispatch header — clean markdown. |
+| `output-format` | `output-format` | Output format examples from `.supertool.json`. Shows what responses look like. |
+| `ops` | `ops` | Full operations reference from `.supertool.json` — built-in ops, custom ops, and aliases with descriptions and examples. |
+| `diff` | `diff:PATH1:PATH2` | Unified diff between two files. |
+| `stat` | `stat:PATH` | File/directory metadata: size (bytes), last modified (ISO datetime), type (file/dir). |
+| `around_line` | `around_line:PATH:LINE` or `around_line:PATH:LINE:N` | Show N lines (default 10) of context around a specific line number. Target line marked with `→`. |
+| `between` | `between:SYMBOL:PATH` or `between:re:START:END:PATH` | Return a chunk of a file. **Symbol mode (default):** full body of a named function/method/class via tree-sitter (PHP, Python, JS, TS, Go, Rust, Java, Ruby — symbols with `::` like PHP `Foo::bar` work). **Pattern mode (`re:` prefix):** inclusive line slice from first line matching START regex to first line after matching END regex (language-agnostic). |
+| `tree` | `tree:PATH` or `tree:PATH:DEPTH` | Directory structure with depth limit (default 3). Hides dotfiles. Files listed before subdirectories. |
+| `blame` | `blame:PATH:LINE` or `blame:PATH:LINE:N` | Git blame for N lines (default 5) around a specific line number. Requires git repo. |
+| `version` | `version` | Show supertool version. |
+| `edit` | `edit:::OLD:::NEW:::PATH` | Single-file, single-occurrence edit (mirrors native Edit). Errors if 0 or >1 matches. **Bypasses native Edit must-Read state** — saves a round-trip when you already know the unique snippet. Use `:::` separator so content with `:` works. |
+| `replace_lines` | `replace_lines:::PATH:::START:::END:::CONTENT` | Swap lines `[START, END]` (1-indexed, inclusive) with CONTENT. `END < START` = pure insert before line START. Empty CONTENT = delete. Receipt shows new line numbers + ±2 context. |
+| `paste` | `paste:::PATH:::CONTENT` | **NARROW USE:** replace ENTIRE file. Only for creating a new file or fully rewriting one. NOT for partial edits — `vim` is the default for those. Atomic, creates file + parent dirs if missing. CONTENT via triple-colon → holds any chars (`:`, quotes, braces, newlines). |
+| `vim` | `vim:::PATH:::SCRIPT` | vim-flavored cursor-based multi-action edit. SCRIPT is parsed like a real vim macro. **DEFAULT EDIT OP** for any pattern-based edit. See [edits.md](edits.md) for full syntax reference. |
+| `replace` / `replace_dry` | `replace:::OLD:::NEW:::PATH` | Recursive find/replace across PATH (`replace_dry` = preview). Use `:::` separator when content has `:`. |
+
+**LLM onboarding in one call:** `./supertool 'introduction' 'output-format' 'ops'`

--- a/docs/operations/map.md
+++ b/docs/operations/map.md
@@ -1,0 +1,161 @@
+# map — symbol tree extraction
+
+`map` gives you the skeleton of a file or directory: every class, function, method, constant, and struct — as an indented tree with line numbers, without reading the full source. It's the fastest way to understand the shape of an unfamiliar codebase or verify a refactor didn't move something unexpected.
+
+Use it when you want orientation, not content. Reading a 500-line file costs 500 lines of tokens; `map` costs ~20.
+
+## Syntax
+
+```
+map:PATH
+```
+
+- `PATH` can be a single file or a directory (recursive).
+- Directories skip `vendor/`, `.git/`, `Generated/`, `node_modules/` automatically.
+
+```bash
+# Single file
+./supertool 'map:src/Module.php'
+
+# Directory (recursive)
+./supertool 'map:src/SiProject/'
+
+# Batch with reads
+./supertool 'map:src/' 'read:src/Module.py'
+```
+
+## Output shape
+
+Indented tree. Each entry shows the symbol name and line number in brackets.
+
+```
+src/SiProject/SiProjectModule.class.php (55 lines)
+  class SiProjectModule  [31]
+    const TYPE_PRIMARY  [39]
+    const MENU_ITEM  [42]
+    method init  [48]
+
+src/SiProject/SiProjectPermissions.class.php (120 lines)
+  class SiProjectPermissions  [12]
+    const CAN_VIEW  [14]
+    const CAN_EDIT  [15]
+    method getPermissions  [20]
+    method checkAccess  [45]
+```
+
+## Backend chain
+
+Three tiers — supertool picks the best available at first `map` call (result cached for the session):
+
+| Tier | Trigger | What you get |
+|------|---------|--------------|
+| 1. tree-sitter | `tree_sitter_language_pack` or `tree_sitter_languages` importable | Full AST: accurate nesting, signatures, all node types |
+| 2. ctags | `ctags` on PATH (universal-ctags) | JSON tags: class/method/function/constant with scope |
+| 3. regex | Always available | Pattern matching on `class`, `function`, `def`, `interface`, `trait`, `enum`, `const`, `struct`, `impl` |
+
+Fallback is automatic and silent. No configuration needed.
+
+### Installing for richer output
+
+```bash
+# Tier 1 — tree-sitter (best; requires Python 3.10+)
+pip install tree-sitter-language-pack
+
+# Tier 1 alternative — works on Python 3.8–3.12
+pip install tree-sitter-languages
+
+# Tier 2 — ctags (good; works everywhere)
+brew install universal-ctags   # macOS
+apt install universal-ctags    # Linux
+```
+
+Without either, the regex fallback works for all supported languages — nesting detection is limited (except Python, which uses indentation).
+
+## Language support
+
+| Language | tree-sitter | ctags | regex |
+|----------|-------------|-------|-------|
+| PHP | Full AST | classes, methods, consts | class, function, interface, trait, enum, const |
+| Python | Full AST | classes, functions | class, def |
+| JavaScript | Full AST | functions, classes | function, class, const |
+| TypeScript (+ JSX/TSX) | Full AST | functions, classes | function, class, const |
+| Go | Full AST | functions, types | func, type, struct, interface |
+| Rust | Full AST | functions, structs, impls | fn, struct, impl, enum, trait |
+| Java | Full AST | classes, methods | class, interface, enum |
+| Ruby | Full AST | classes, methods | class, def, module |
+
+## Examples per language
+
+**PHP — class with methods and constants:**
+
+```
+src/Module.class.php (80 lines)
+  class SiProjectModule  [10]
+    const TYPE_PRIMARY  [12]
+    method init  [20]
+    method getDependencies  [35]
+```
+
+**Python — module with classes and functions:**
+
+```
+src/app/auth.py (120 lines)
+  class AuthService  [8]
+    method __init__  [10]
+    method verify_token  [22]
+    method refresh  [45]
+  function create_session  [90]
+```
+
+**TypeScript — interfaces and classes:**
+
+```
+src/api/Client.ts (95 lines)
+  interface ClientConfig  [3]
+  class ApiClient  [12]
+    method constructor  [14]
+    method get  [28]
+    method post  [44]
+```
+
+## Common workflows
+
+**"Give me the shape of this module"**
+
+```bash
+./supertool 'map:src/SiProject/'
+```
+
+Costs ~20 tokens instead of reading every file. Use it before deciding which file to `read` next.
+
+**"Find all classes that implement X"**
+
+```bash
+./supertool 'map:src/' | grep -i "implements MyInterface"
+# or pipe through supertool's own grep:
+./supertool 'map:src/' 'grep:implements MyInterface:src/'
+```
+
+**"Compare structure before/after a refactor"**
+
+```bash
+# Before (on a git revision via temp checkout or diff)
+./supertool 'map:src/OldModule/'
+
+# After
+./supertool 'map:src/NewModule/'
+```
+
+**"Orient fast, then read the interesting part"**
+
+```bash
+./supertool 'map:src/app/' 'between:handle_request:src/app/Module.py'
+```
+
+`map` tells you what exists and where; `between` extracts the body once you know the symbol name.
+
+## See also
+
+- [search.md](search.md) — `between` extracts a full symbol body once you know its name from `map`
+- [reads.md](reads.md) — `read` for full file content after `map` narrows the target
+- [index.md](index.md) — full op table

--- a/docs/operations/meta.md
+++ b/docs/operations/meta.md
@@ -1,0 +1,41 @@
+# Meta
+
+Ops for self-documentation and version introspection. Used primarily in session-start hooks and agent prompts to onboard an LLM to a project's supertool setup in one call.
+
+## Ops
+
+| Op | Syntax | What it does |
+|----|--------|--------------|
+| `introduction` | `introduction` | Output the project introduction text from `.supertool.json`. No `---` dispatch header — clean markdown. |
+| `output-format` | `output-format` | Output format examples from `.supertool.json`. Shows what responses look like. |
+| `ops` | `ops` | Full operations reference from `.supertool.json` — built-in ops, custom ops, and aliases with descriptions and examples. |
+| `version` | `version` | Show supertool version. |
+
+## Common patterns
+
+Full LLM onboarding in one call — everything an agent needs to use supertool:
+
+```bash
+./supertool 'introduction' 'output-format' 'ops'
+```
+
+Use this in session-start hooks or agent system prompts. The model learns what ops exist, how output is formatted, and what the project uses supertool for — without reading any config files.
+
+Check installed version:
+
+```bash
+./supertool 'version'
+```
+
+Compact variant used by the session-start hook to stay under Claude Code's ~7KB hook output cap:
+
+```bash
+./supertool 'introduction' 'output-format' 'ops-compact'
+```
+
+`ops-compact` drops examples on self-explanatory ops and prepends a warning if output still exceeds the cap, telling the model to fetch the full listing via `./supertool 'ops'`.
+
+## See also
+
+- [index.md](index.md) — full op table for all categories
+- [docs/validators.md](../validators.md) — validator reference

--- a/docs/operations/reads.md
+++ b/docs/operations/reads.md
@@ -1,0 +1,50 @@
+# Reads
+
+File reading and directory listing ops. Reach for these when you know the path and want content — a single file, a directory listing, or metadata without searching.
+
+## Ops
+
+| Op | Syntax | What it does |
+|----|--------|--------------|
+| `read` | `read:PATH` or `read:PATH:OFFSET:LIMIT` | 300 lines / 20KB cap |
+| `read` (filter) | `read:PATH:OFFSET:LIMIT:grep=PATTERN` | Only show lines matching PATTERN (original line numbers preserved). Use `read:PATH:::grep=PATTERN` for defaults. |
+| `head` | `head:PATH:N` | First N lines (default 20) |
+| `tail` | `tail:PATH:N` | Last N lines (default 20) |
+| `wc` | `wc:PATH` | Line/word/char count (like unix `wc`). Output: `LINES WORDS CHARS PATH`. |
+| `stat` | `stat:PATH` | File/directory metadata: size (bytes), last modified (ISO datetime), type (file/dir). |
+| `ls` | `ls:PATH` | Directory listing. Trailing `/` on subdirs. |
+| `glob` | `glob:PATTERN` | `**` supported. **Auto-reads** if PATTERN is a concrete file path (no wildcards). |
+| `tree` | `tree:PATH` or `tree:PATH:DEPTH` | Directory structure with depth limit (default 3). Hides dotfiles. Files listed before subdirectories. |
+| `diff` | `diff:PATH1:PATH2` | Unified diff between two files. |
+
+## Common patterns
+
+Read three files in one round-trip — parallel where safe:
+
+```bash
+./supertool 'read:src/Module.py' 'read:src/Config.py' 'read:src/Auth.py'
+```
+
+Survey a directory then read the interesting file:
+
+```bash
+./supertool 'tree:src/app/' 'glob:src/app/**/*.py' 'read:src/app/Module.py'
+```
+
+Read only matching lines from a large file (line numbers preserved):
+
+```bash
+./supertool 'read:src/app/Config.py:::grep=DEBUG'
+```
+
+Check size before deciding to read:
+
+```bash
+./supertool 'stat:src/app/BigFile.py' 'head:src/app/BigFile.py:50'
+```
+
+## See also
+
+- [search.md](search.md) — when you don't know the path yet (`grep`, `between`, `around`)
+- [map.md](map.md) — when you want the symbol skeleton of a file/directory without reading every line
+- [docs/validators.md](../validators.md) — validators run automatically on mutating ops

--- a/docs/operations/search.md
+++ b/docs/operations/search.md
@@ -1,0 +1,60 @@
+# Search
+
+Pattern-based ops for finding content across files or zooming into a known location. Reach for these when you don't know the exact file yet, or when you want context around a match.
+
+## Ops
+
+| Op | Syntax | What it does |
+|----|--------|--------------|
+| `grep` | `grep:PATTERN:PATH` or `grep:PATTERN:PATH:LIMIT` | 10 results default, code + doc extensions only. **Auto-reads** full file if PATH is a concrete file < 20KB with a match. |
+| `grep` (context) | `grep:PATTERN:PATH:LIMIT:CONTEXT` | Show CONTEXT lines before/after each match (like `grep -C`). Match lines: `path:lineno:content`. Context lines: `path-lineno-content`. Non-adjacent groups separated by `--`. |
+| `grep` (count) | `grep:PATTERN:PATH:LIMIT:CONTEXT:count` | Return match counts per file instead of content. Output: `filepath:COUNT` per line. |
+| `grep_around` | `grep_around:PATTERN:PATH` or `grep_around:PATTERN:PATH:N:LIMIT` | Every match across files with N lines context (default N=3, LIMIT=10). Alias for `grep:PATTERN:PATH:LIMIT:CONTEXT` with sane defaults — useful for "show me how everyone uses this". |
+| `around` | `around:PATTERN:PATH` or `around:PATTERN:PATH:N` | Show N lines (default 10) before and after the **first** match of PATTERN in a single file. Uses line-numbered output like `read`. |
+| `around_line` | `around_line:PATH:LINE` or `around_line:PATH:LINE:N` | Show N lines (default 10) of context around a specific line number. Target line marked with `→`. |
+| `between` | `between:SYMBOL:PATH` or `between:re:START:END:PATH` | Return a chunk of a file. **Symbol mode (default):** full body of a named function/method/class via tree-sitter (PHP, Python, JS, TS, Go, Rust, Java, Ruby — symbols with `::` like PHP `Foo::bar` work). **Pattern mode (`re:` prefix):** inclusive line slice from first line matching START regex to first line after matching END regex (language-agnostic). |
+
+## Common patterns
+
+Find all usages of a function across a codebase, with 2 lines of context:
+
+```bash
+./supertool 'grep:handle_request:src/:20:2'
+```
+
+Count which files reference a symbol most:
+
+```bash
+./supertool 'grep:MyClass:src/:50:0:count'
+```
+
+Show how a pattern is used everywhere ("show me how everyone uses this"):
+
+```bash
+./supertool 'grep_around:def handle:src/:5:15'
+```
+
+Jump to a known line and see surrounding context:
+
+```bash
+./supertool 'around_line:src/app/Module.py:142:8'
+```
+
+Extract a full function body by name:
+
+```bash
+./supertool 'between:handle_request:src/app/Module.py'
+./supertool 'between:MyClass::handle:src/app/Module.php'
+```
+
+Extract a block by regex anchors (language-agnostic):
+
+```bash
+./supertool 'between:re:^def handle_request:^def :src/app/Module.py'
+```
+
+## See also
+
+- [reads.md](reads.md) — when you know the path and want raw content
+- [map.md](map.md) — when you want all symbols in a file/directory at once (faster than grep for orientation)
+- [docs/validators.md](../validators.md) — validators fire on edits triggered after search-guided changes


### PR DESCRIPTION
## Summary

- Extracts the README §Operations table (32 rows) into `docs/operations/` with 6 pages: `index.md` (full table), `reads.md`, `search.md`, `map.md` (deep-dive), `edits.md`, `meta.md`
- `map.md` gets the star treatment: backend chain, language support table, per-language output examples, common workflows
- README §Operations collapses to 3-line summary + link

## Test plan

- [ ] All op rows from the original README table are present in `docs/operations/index.md`
- [ ] Cross-links between pages work (relative paths)
- [ ] README renders cleanly with the stub section