### PR TITLE
feat: add formatters system + ship prettier

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -282,5 +282,14 @@
       "rollback_on_fail": false,
       "timeout": 30
     }
+  },
+  "formatters": {
+    "prettier": {
+      "cmd": "prettier --write {file}",
+      "match": "*.{xml,scss,css,js,json,yml,yaml,md}",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    }
   }
 }

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -290,6 +290,55 @@
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
       "rollback_on_fail": false,
       "timeout": 30
+    },
+    "black": {
+      "cmd": "black --quiet {file}",
+      "match": "*.py",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    },
+    "gofmt": {
+      "cmd": "gofmt -w {file}",
+      "match": "*.go",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    },
+    "rustfmt": {
+      "cmd": "rustfmt {file}",
+      "match": "*.rs",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    },
+    "phpcbf": {
+      "cmd": "phpcbf --standard=PSR12 {file}",
+      "match": "*.php",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    },
+    "shfmt": {
+      "cmd": "shfmt -w {file}",
+      "match": "*.sh",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    },
+    "terraform-fmt": {
+      "cmd": "terraform fmt -write=true {file}",
+      "match": "*.tf",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    },
+    "rubocop": {
+      "cmd": "rubocop -a --no-color --format quiet {file}",
+      "match": "*.rb",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -225,6 +225,14 @@ Example: edit a `.json` file with a missing comma → `jsonlint` catches it → 
 
 Full reference: [docs/validators.md](docs/validators.md) — bundled list, how they hook in, adding your own.
 
+## Formatters — normalize before validate
+
+Formatters run after every edit, before validators — `edit → format → validate → rollback if validate fails`. They mutate the file in place (`prettier --write`, `gofmt -w`) so validators always see canonical output.
+
+`prettier` ships as the first bundled formatter. `rollback_on_fail` defaults to `false` — formatters are cosmetic; the validator is the safety net.
+
+Full reference: [docs/formatters.md](docs/formatters.md) — config shape, bundled formatters, adding your own (gofmt, black, rustfmt, phpcbf).
+
 ---
 
 ### `.supertool.json` — project configuration

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -40,11 +40,16 @@ Formatters are declared per-file-type in `.supertool.json` under `formatters`, k
 
 Enable any of these by copying the relevant entry from `.supertool.example.json` into your project's `.supertool.json`.
 
-| Language / format                        | Formatter name | Requires                        | Notes                          |
-|------------------------------------------|----------------|---------------------------------|--------------------------------|
-| XML, SCSS, CSS, JS, JSON, YAML, Markdown | `prettier`     | `prettier` npm package          | `npm install -g prettier`      |
-
-More formatters (`gofmt`, `black`, `rustfmt`, `phpcbf`) are config additions — no code changes needed. See "Adding your own" below.
+| Language / format                        | Formatter name  | Requires                                         | Notes                                         |
+|------------------------------------------|-----------------|--------------------------------------------------|-----------------------------------------------|
+| XML, SCSS, CSS, JS, JSON, YAML, Markdown | `prettier`      | `prettier` npm package                           | `npm install -g prettier`                     |
+| Python                                   | `black`         | `black` pip package                              | `pip install black`                           |
+| Go                                       | `gofmt`         | Go toolchain                                     | Ships with Go — no extra install              |
+| Rust                                     | `rustfmt`       | Rust toolchain                                   | Ships with `rustup` — `rustup component add rustfmt` |
+| PHP (PSR-12)                             | `phpcbf`        | PHP_CodeSniffer via Composer                     | `composer global require squizlabs/php_codesniffer` |
+| Bash / shell                             | `shfmt`         | `shfmt` binary                                   | `brew install shfmt` / `go install mvdan.cc/sh/v3/cmd/shfmt@latest` |
+| Terraform / HCL                          | `terraform-fmt` | Terraform CLI                                    | Ships with Terraform — `brew install terraform` |
+| Ruby                                     | `rubocop`       | RuboCop gem                                      | `gem install rubocop`; `-a` = auto-fix only   |
 
 ## Adding your own
 

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -1,0 +1,136 @@
+# Formatters — full reference
+
+## What formatters are
+
+Formatters are the cosmetic counterpart to validators. After every mutating op — `edit`, `replace`, `replace_lines`, `paste`, `vim` — supertool runs the matching formatters against the result file, normalizing whitespace, quotes, and import order before validators check correctness.
+
+Run order:
+
+```
+edit → formatter(s) → validator(s) → rollback if validate fails
+```
+
+Formatters mutate the file in place (e.g. `prettier --write`, `gofmt -w`). Validators then see the canonical, formatted result — so the diff the model gets reflects real structural changes, not noise from trailing spaces or quote style.
+
+## How they hook in
+
+Each formatter entry declares a `hooks_into` array listing the mutating ops it should run after — same as validators:
+
+```json
+"hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"]
+```
+
+Formatters are declared per-file-type in `.supertool.json` under `formatters`, keyed by formatter name. Each entry matches files via a `match` glob:
+
+```json
+{
+  "formatters": {
+    "prettier": {
+      "cmd": "prettier --write {file}",
+      "match": "*.{xml,scss,css,js,json,yml,yaml,md}",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    }
+  }
+}
+```
+
+## Bundled formatters
+
+Enable any of these by copying the relevant entry from `.supertool.example.json` into your project's `.supertool.json`.
+
+| Language / format                        | Formatter name | Requires                        | Notes                          |
+|------------------------------------------|----------------|---------------------------------|--------------------------------|
+| XML, SCSS, CSS, JS, JSON, YAML, Markdown | `prettier`     | `prettier` npm package          | `npm install -g prettier`      |
+
+More formatters (`gofmt`, `black`, `rustfmt`, `phpcbf`) are config additions — no code changes needed. See "Adding your own" below.
+
+## Adding your own
+
+Any tool that rewrites the file in place works. Three lines of JSON and a new language is supported.
+
+Examples:
+
+```json
+"gofmt": {
+  "cmd": "gofmt -w {file}",
+  "match": "*.go",
+  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+  "rollback_on_fail": false,
+  "timeout": 10
+}
+```
+
+```json
+"black": {
+  "cmd": "black {file}",
+  "match": "*.py",
+  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+  "rollback_on_fail": false,
+  "timeout": 10
+}
+```
+
+```json
+"rustfmt": {
+  "cmd": "rustfmt {file}",
+  "match": "*.rs",
+  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+  "rollback_on_fail": false,
+  "timeout": 15
+}
+```
+
+```json
+"phpcbf": {
+  "cmd": "phpcbf {file}",
+  "match": "*.php",
+  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+  "rollback_on_fail": false,
+  "timeout": 15
+}
+```
+
+The `{file}` placeholder is replaced with the absolute path to the file being formatted. `{supertool_dir}` is also available for pointing at local wrapper scripts.
+
+## Difference from validators
+
+| Aspect              | Formatters                          | Validators                          |
+|---------------------|-------------------------------------|-------------------------------------|
+| Purpose             | Normalize style (cosmetic)          | Check correctness (safety)          |
+| Mutates file        | Yes — rewrites in place             | No — read-only                      |
+| `rollback_on_fail`  | Default `false`                     | Default `true` (recommended)        |
+| Run order           | First (after edit)                  | Second (after formatters)           |
+| Output              | Warns on failure, continues         | Diff block + optional rollback      |
+
+`rollback_on_fail: false` is the right default for formatters. If `prettier` chokes on a file that's structurally valid, the edit should still land — the validator is the safety net. Set `rollback_on_fail: true` only if you want a formatter failure to revert the file entirely.
+
+## Graceful skip
+
+When the underlying tool is missing (e.g. `prettier` not installed), the formatter warns and continues. No formatter failure blocks an unrelated edit. The project stays fully usable without pre-installed dependencies.
+
+## Field reference
+
+Full list of `.supertool.json` formatter config fields:
+
+| Field              | Notes                                                                              |
+|--------------------|------------------------------------------------------------------------------------|
+| `cmd`              | Shell command. `{file}` → target path. `{supertool_dir}` → supertool install dir. |
+| `match`            | Glob filter on the target path (default `*`).                                      |
+| `hooks_into`       | Op names to wrap (subset of `edit`, `replace`, `replace_lines`, `paste`, `vim`).  |
+| `rollback_on_fail` | Restore pre-edit file content if the formatter fails. Default `false`.             |
+| `timeout`          | Seconds. Default 30.                                                               |
+
+## Output example
+
+After an edit on a `.json` file with `prettier` configured:
+
+```
+edited: src/config.json
+
+[formatters]
+[formatter] prettier: some warning message
+```
+
+When the formatter succeeds silently (the normal case), no formatter block appears — the output is clean.

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -151,12 +151,6 @@ The model gets a clean retry surface with the exact line and error — no broken
 
 Custom validators must conform to the adapter contract in `validators/SCHEMA.md`. Each adapter takes one file arg and prints a JSON object on stdout with a standardised shape (ok, count, errors). The bundled adapters (`validators/phplint/`, `validators/xmllint/`, etc.) are the reference implementations.
 
-## Format-on-save (planned)
+## Format-on-save
 
-A `formatters` section will mirror this exact shape — same `match`, `hooks_into`, and graceful skip behavior. The execution order will be:
-
-```
-edit → format → validate → rollback if validate fails
-```
-
-Prettier ships first, followed by `gofmt`, `black`, `rustfmt`, and `phpcbf`. Not available yet — listed here so the design intent is clear and the JSON shape is locked before implementation.
+See [formatters.md](formatters.md) — formatters run after every edit, before validators, normalizing whitespace and style before the safety check runs.

--- a/supertool.py
+++ b/supertool.py
@@ -7835,11 +7835,72 @@ def _validators_run_batch(
     return out
 
 
-def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
-    """Wrap edit op with snapshot+run+diff using configured validators.
+# ---------------------------------------------------------------------------
+# Formatter hooks — mirror of the validator system.
+# Run order: edit → formatter(s) → validator(s) → rollback if validate fails.
+# Formatters mutate the file in place (e.g. prettier --write).
+# rollback_on_fail defaults to False — formatters are cosmetic; validators
+# are the safety net.
+# ---------------------------------------------------------------------------
 
+def _applicable_formatters(op: str, path: str) -> Dict[str, Dict[str, Any]]:
+    """Return formatters that should run after this op. Same logic as validators."""
+    cfg = _load_config()
+    formatters = cfg.get("formatters") or {}
+    if not formatters:
+        return {}
+    import fnmatch
+    out: Dict[str, Dict[str, Any]] = {}
+    for name, spec in formatters.items():
+        if not isinstance(spec, dict):
+            continue
+        if op not in (spec.get("hooks_into") or []):
+            continue
+        glob = spec.get("match", "*")
+        if path and glob and not fnmatch.fnmatch(path, glob):
+            continue
+        out[name] = spec
+    return out
+
+
+def _formatter_run_one(name: str, spec: Dict[str, Any], file: str) -> Dict[str, Any]:
+    """Run one formatter against `file`. Returns a result dict with ok + msg."""
+    import subprocess
+    cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", file)
+    timeout = int(spec.get("timeout", 30))
+    try:
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+        if r.returncode == 0:
+            return {"name": name, "ok": True}
+        msg = (r.stderr.strip() or r.stdout.strip())[:200]
+        return {"name": name, "ok": False, "msg": msg}
+    except subprocess.TimeoutExpired:
+        return {"name": name, "ok": False, "msg": f"timeout after {timeout}s"}
+    except OSError as e:
+        return {"name": name, "ok": False, "msg": str(e)}
+
+
+def _formatters_run_batch(
+    applicable: Dict[str, Dict[str, Any]], path: str
+) -> list:
+    """Run all formatters on path. Parallel if `parallel >= 2` in config."""
+    workers = _parallel_workers()
+    if workers >= 2 and len(applicable) > 1:
+        from concurrent.futures import ThreadPoolExecutor
+        max_workers = min(workers, len(applicable))
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = {name: ex.submit(_formatter_run_one, name, spec, path)
+                       for name, spec in applicable.items()}
+            return [futures[name].result() for name in applicable]
+    return [_formatter_run_one(name, spec, path) for name, spec in applicable.items()]
+
+
+def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
+    """Wrap edit op with format+snapshot+run+diff using configured formatters/validators.
+
+    Run order: edit → formatter(s) → validator(s) → rollback if validate fails.
     No-op when op not in _OP_TARGETS, no target path, or no applicable
-    validators. Guarantees `do_op()` runs in all paths.
+    formatters/validators. Guarantees `do_op()` runs in all paths.
     """
     extract = _OP_TARGETS.get(op)
     if not extract:
@@ -7850,28 +7911,48 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
         return do_op()
     if not path:
         return do_op()
+    applicable_fmt = _applicable_formatters(op, path)
     applicable = _applicable_validators(op, path)
-    if not applicable:
+    if not applicable_fmt and not applicable:
         return do_op()
 
     needs_rollback = any(v.get("rollback_on_fail") for v in applicable.values())
+    needs_fmt_rollback = any(v.get("rollback_on_fail") for v in applicable_fmt.values())
 
     pre_content: Optional[bytes] = None
-    if needs_rollback and os.path.isfile(path):
+    if (needs_rollback or needs_fmt_rollback) and os.path.isfile(path):
         try:
             with open(path, "rb") as f:
                 pre_content = f.read()
         except OSError:
             pre_content = None
 
-    before = _validators_run_batch(applicable, path)
+    before = _validators_run_batch(applicable, path) if applicable else {}
 
     body = do_op()
 
     if isinstance(body, str) and body.startswith("ERROR"):
         return body
 
-    after_results = _validators_run_batch(applicable, path)
+    # Run formatters after the edit, before validators.
+    fmt_warnings: list = []
+    if applicable_fmt:
+        fmt_results = _formatters_run_batch(applicable_fmt, path)
+        for result in fmt_results:
+            if not result["ok"]:
+                msg = result.get("msg", "unknown error")
+                if result.get("name") in applicable_fmt and applicable_fmt[result["name"]].get("rollback_on_fail"):
+                    if pre_content is not None:
+                        try:
+                            with open(path, "wb") as fw:
+                                fw.write(pre_content)
+                            fmt_warnings.append(f"[rolled back] {result['name']} failed; file restored")
+                        except OSError as e:
+                            fmt_warnings.append(f"[ROLLBACK FAILED] {result['name']}: {e}")
+                else:
+                    fmt_warnings.append(f"[formatter] {result['name']}: {msg}")
+
+    after_results = _validators_run_batch(applicable, path) if applicable else {}
     diff_lines: list = []
     for name in applicable:  # stable order from config
         if name in after_results:
@@ -7893,7 +7974,13 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
                         diff_out += f"\n[ROLLBACK FAILED] {name}: {e}\n"
                     break
 
-    return body + "\n[validators]\n" + diff_out
+    suffix = ""
+    if fmt_warnings:
+        suffix += "\n[formatters]\n" + "\n".join(fmt_warnings) + "\n"
+    if applicable:
+        suffix += "\n[validators]\n" + diff_out
+
+    return body + suffix
 
 
 def op_validate(path: str, tool_filter: Optional[list] = None) -> str:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,228 @@
+"""Tests for the formatter hook framework."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _set_config(cfg: dict) -> None:
+    """Inject config (formatters + optional validators) into cached config."""
+    supertool._CONFIG = cfg
+    supertool._CONFIG_CHECKED = True
+
+
+def _set_formatters(fmt: dict) -> None:
+    supertool._CONFIG = {"formatters": fmt}
+    supertool._CONFIG_CHECKED = True
+
+
+# ---------------------------------------------------------------------------
+# _applicable_formatters
+# ---------------------------------------------------------------------------
+
+def test_applicable_formatters_empty_when_no_config() -> None:
+    _set_formatters({})
+    assert supertool._applicable_formatters("edit", "x.json") == {}
+
+
+def test_applicable_formatters_filters_by_hooks_into() -> None:
+    _set_formatters({
+        "prettier": {"cmd": "prettier --write {file}", "hooks_into": ["edit"]},
+        "other":    {"cmd": "x", "hooks_into": ["paste"]},
+    })
+    out = supertool._applicable_formatters("edit", "x.json")
+    assert set(out.keys()) == {"prettier"}
+
+
+def test_applicable_formatters_filters_by_match_glob() -> None:
+    _set_formatters({
+        "fmt-json": {"cmd": "x", "hooks_into": ["edit"], "match": "*.json"},
+        "fmt-md":   {"cmd": "x", "hooks_into": ["edit"], "match": "*.md"},
+    })
+    assert set(supertool._applicable_formatters("edit", "a.json")) == {"fmt-json"}
+    assert set(supertool._applicable_formatters("edit", "a.md")) == {"fmt-md"}
+
+
+def test_applicable_formatters_ignores_malformed_specs() -> None:
+    _set_formatters({"bad": "not-a-dict", "good": {"cmd": "x", "hooks_into": ["edit"]}})
+    assert set(supertool._applicable_formatters("edit", "a.json")) == {"good"}
+
+
+# ---------------------------------------------------------------------------
+# _formatter_run_one
+# ---------------------------------------------------------------------------
+
+def test_formatter_run_one_success(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text('{"a":1}\n')
+    spec = {"cmd": f"touch {f}", "timeout": 5}
+    result = supertool._formatter_run_one("prettier", spec, str(f))
+    assert result["ok"] is True
+    assert result["name"] == "prettier"
+
+
+def test_formatter_run_one_failure(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    spec = {"cmd": "false", "timeout": 5}
+    result = supertool._formatter_run_one("prettier", spec, str(f))
+    assert result["ok"] is False
+    assert result["name"] == "prettier"
+
+
+def test_formatter_run_one_substitutes_file_token(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    # cmd writes the file path into a sentinel file
+    sentinel = tmp_path / "seen"
+    spec = {"cmd": f"printf '%s' {{file}} > {sentinel}", "timeout": 5}
+    supertool._formatter_run_one("fmt", spec, str(f))
+    assert sentinel.read_text() == str(f)
+
+
+def test_formatter_run_one_timeout(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    spec = {"cmd": "sleep 60", "timeout": 1}
+    result = supertool._formatter_run_one("fmt", spec, str(f))
+    assert result["ok"] is False
+    assert "timeout" in result["msg"]
+
+
+# ---------------------------------------------------------------------------
+# Formatter runs before validators (integration via _run_with_validators)
+# ---------------------------------------------------------------------------
+
+def test_formatter_runs_before_validator(tmp_path: Path) -> None:
+    """Formatter must touch the file before the validator sees it."""
+    f = tmp_path / "x.json"
+    f.write_text('{"a":1}')
+
+    # Formatter appends a newline — validator checks the file ends with \n
+    sentinel = tmp_path / "fmt_ran"
+    _set_config({
+        "formatters": {
+            "mock-fmt": {
+                "cmd": f"printf '\\n' >> {{file}} && touch {sentinel}",
+                "hooks_into": ["edit"],
+                "match": "*.json",
+            }
+        },
+        "validators": {},
+    })
+
+    out = supertool._run_with_validators(
+        "edit", ["edit", "", "", str(f)], lambda: "edited\n"
+    )
+    assert sentinel.exists(), "formatter did not run"
+    assert out == "edited\n"  # no validator block when no validators configured
+
+
+def test_formatter_fail_rollback_false_keeps_file(tmp_path: Path) -> None:
+    """rollback_on_fail=false: file stays after formatter failure, edit succeeds."""
+    f = tmp_path / "x.json"
+    original = '{"a":1}\n'
+    f.write_text(original)
+
+    _set_config({
+        "formatters": {
+            "bad-fmt": {
+                "cmd": "false",  # always fails
+                "hooks_into": ["edit"],
+                "match": "*.json",
+                "rollback_on_fail": False,
+            }
+        },
+        "validators": {},
+    })
+
+    def do_edit() -> str:
+        f.write_text('{"a":2}\n')
+        return "edited\n"
+
+    out = supertool._run_with_validators("edit", ["edit", "", "", str(f)], do_edit)
+    # Edit succeeded despite formatter failure
+    assert f.read_text() == '{"a":2}\n'
+    assert "edited" in out
+    assert "[formatter]" in out  # warning present
+
+
+def test_formatter_fail_rollback_true_reverts_file(tmp_path: Path) -> None:
+    """rollback_on_fail=true: file reverts when formatter fails."""
+    f = tmp_path / "x.json"
+    original = '{"a":1}\n'
+    f.write_text(original)
+
+    _set_config({
+        "formatters": {
+            "bad-fmt": {
+                "cmd": "false",
+                "hooks_into": ["edit"],
+                "match": "*.json",
+                "rollback_on_fail": True,
+            }
+        },
+        "validators": {},
+    })
+
+    def do_edit() -> str:
+        f.write_text('{"a":2}\n')
+        return "edited\n"
+
+    out = supertool._run_with_validators("edit", ["edit", "", "", str(f)], do_edit)
+    assert f.read_text() == original
+    assert "rolled back" in out
+
+
+def test_formatter_multi_glob_match(tmp_path: Path) -> None:
+    """Both .json and .md files trigger the prettier formatter."""
+    _set_config({
+        "formatters": {
+            "prettier": {
+                "cmd": "true",
+                "hooks_into": ["edit"],
+                "match": "*.json",
+            },
+            "prettier-md": {
+                "cmd": "true",
+                "hooks_into": ["edit"],
+                "match": "*.md",
+            },
+        },
+        "validators": {},
+    })
+    assert "prettier" in supertool._applicable_formatters("edit", "config.json")
+    assert "prettier-md" in supertool._applicable_formatters("edit", "README.md")
+    assert supertool._applicable_formatters("edit", "main.py") == {}
+
+
+def test_formatter_graceful_skip_missing_binary(tmp_path: Path) -> None:
+    """Missing binary: formatter fails gracefully, edit is not blocked."""
+    f = tmp_path / "x.json"
+    f.write_text('{"a":1}\n')
+
+    _set_config({
+        "formatters": {
+            "prettier": {
+                "cmd": "prettier-that-does-not-exist --write {file}",
+                "hooks_into": ["edit"],
+                "match": "*.json",
+                "rollback_on_fail": False,
+            }
+        },
+        "validators": {},
+    })
+
+    def do_edit() -> str:
+        f.write_text('{"a":2}\n')
+        return "edited\n"
+
+    out = supertool._run_with_validators("edit", ["edit", "", "", str(f)], do_edit)
+    # Edit succeeded despite missing tool
+    assert f.read_text() == '{"a":2}\n'
+    assert "edited" in out

--- a/tests/test_language_formatters.py
+++ b/tests/test_language_formatters.py
@@ -1,0 +1,258 @@
+"""Tests for the 7 language-native formatters added in .supertool.example.json.
+
+Each formatter is tested with:
+- dispatch_ok: correct glob match triggers the formatter
+- graceful_skip: missing binary warns but does not block the edit
+
+Tests mock the formatter cmd — no real black/gofmt/etc. install required.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _set_formatter(name: str, cmd: str, match: str) -> None:
+    supertool._CONFIG = {
+        "formatters": {
+            name: {
+                "cmd": cmd,
+                "match": match,
+                "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+                "rollback_on_fail": False,
+                "timeout": 30,
+            }
+        },
+        "validators": {},
+    }
+    supertool._CONFIG_CHECKED = True
+
+
+def _edit(f: Path, content: str = "new\n") -> str:
+    def do_edit() -> str:
+        f.write_text(content)
+        return "edited\n"
+
+    return supertool._run_with_validators("edit", ["edit", "", "", str(f)], do_edit)
+
+
+# ---------------------------------------------------------------------------
+# black — *.py
+# ---------------------------------------------------------------------------
+
+def test_black_dispatch_ok(tmp_path: Path) -> None:
+    f = tmp_path / "hello.py"
+    f.write_text("x=1\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("black", f"touch {sentinel}", "*.py")
+    _edit(f)
+    assert sentinel.exists()
+
+
+def test_black_glob_no_match(tmp_path: Path) -> None:
+    f = tmp_path / "hello.go"
+    f.write_text("package main\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("black", f"touch {sentinel}", "*.py")
+    _edit(f)
+    assert not sentinel.exists()
+
+
+def test_black_graceful_skip_missing_binary(tmp_path: Path) -> None:
+    f = tmp_path / "hello.py"
+    f.write_text("x=1\n")
+    _set_formatter("black", "black-that-does-not-exist --quiet {file}", "*.py")
+    out = _edit(f)
+    assert f.read_text() == "new\n"
+    assert "edited" in out
+
+
+# ---------------------------------------------------------------------------
+# gofmt — *.go
+# ---------------------------------------------------------------------------
+
+def test_gofmt_dispatch_ok(tmp_path: Path) -> None:
+    f = tmp_path / "main.go"
+    f.write_text("package main\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("gofmt", f"touch {sentinel}", "*.go")
+    _edit(f)
+    assert sentinel.exists()
+
+
+def test_gofmt_glob_no_match(tmp_path: Path) -> None:
+    f = tmp_path / "main.py"
+    f.write_text("x=1\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("gofmt", f"touch {sentinel}", "*.go")
+    _edit(f)
+    assert not sentinel.exists()
+
+
+def test_gofmt_graceful_skip_missing_binary(tmp_path: Path) -> None:
+    f = tmp_path / "main.go"
+    f.write_text("package main\n")
+    _set_formatter("gofmt", "gofmt-that-does-not-exist -w {file}", "*.go")
+    out = _edit(f)
+    assert f.read_text() == "new\n"
+    assert "edited" in out
+
+
+# ---------------------------------------------------------------------------
+# rustfmt — *.rs
+# ---------------------------------------------------------------------------
+
+def test_rustfmt_dispatch_ok(tmp_path: Path) -> None:
+    f = tmp_path / "lib.rs"
+    f.write_text("fn main(){}\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("rustfmt", f"touch {sentinel}", "*.rs")
+    _edit(f)
+    assert sentinel.exists()
+
+
+def test_rustfmt_glob_no_match(tmp_path: Path) -> None:
+    f = tmp_path / "lib.go"
+    f.write_text("package main\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("rustfmt", f"touch {sentinel}", "*.rs")
+    _edit(f)
+    assert not sentinel.exists()
+
+
+def test_rustfmt_graceful_skip_missing_binary(tmp_path: Path) -> None:
+    f = tmp_path / "lib.rs"
+    f.write_text("fn main(){}\n")
+    _set_formatter("rustfmt", "rustfmt-that-does-not-exist {file}", "*.rs")
+    out = _edit(f)
+    assert f.read_text() == "new\n"
+    assert "edited" in out
+
+
+# ---------------------------------------------------------------------------
+# phpcbf — *.php
+# ---------------------------------------------------------------------------
+
+def test_phpcbf_dispatch_ok(tmp_path: Path) -> None:
+    f = tmp_path / "Foo.php"
+    f.write_text("<?php\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("phpcbf", f"touch {sentinel}", "*.php")
+    _edit(f)
+    assert sentinel.exists()
+
+
+def test_phpcbf_glob_no_match(tmp_path: Path) -> None:
+    f = tmp_path / "Foo.py"
+    f.write_text("x=1\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("phpcbf", f"touch {sentinel}", "*.php")
+    _edit(f)
+    assert not sentinel.exists()
+
+
+def test_phpcbf_graceful_skip_missing_binary(tmp_path: Path) -> None:
+    f = tmp_path / "Foo.php"
+    f.write_text("<?php\n")
+    _set_formatter("phpcbf", "phpcbf-that-does-not-exist --standard=PSR12 {file}", "*.php")
+    out = _edit(f)
+    assert f.read_text() == "new\n"
+    assert "edited" in out
+
+
+# ---------------------------------------------------------------------------
+# shfmt — *.sh
+# ---------------------------------------------------------------------------
+
+def test_shfmt_dispatch_ok(tmp_path: Path) -> None:
+    f = tmp_path / "deploy.sh"
+    f.write_text("#!/bin/bash\necho hi\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("shfmt", f"touch {sentinel}", "*.sh")
+    _edit(f)
+    assert sentinel.exists()
+
+
+def test_shfmt_glob_no_match(tmp_path: Path) -> None:
+    f = tmp_path / "deploy.py"
+    f.write_text("x=1\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("shfmt", f"touch {sentinel}", "*.sh")
+    _edit(f)
+    assert not sentinel.exists()
+
+
+def test_shfmt_graceful_skip_missing_binary(tmp_path: Path) -> None:
+    f = tmp_path / "deploy.sh"
+    f.write_text("#!/bin/bash\necho hi\n")
+    _set_formatter("shfmt", "shfmt-that-does-not-exist -w {file}", "*.sh")
+    out = _edit(f)
+    assert f.read_text() == "new\n"
+    assert "edited" in out
+
+
+# ---------------------------------------------------------------------------
+# terraform-fmt — *.tf
+# ---------------------------------------------------------------------------
+
+def test_terraform_fmt_dispatch_ok(tmp_path: Path) -> None:
+    f = tmp_path / "main.tf"
+    f.write_text('resource "aws_s3_bucket" "b" {}\n')
+    sentinel = tmp_path / "ran"
+    _set_formatter("terraform-fmt", f"touch {sentinel}", "*.tf")
+    _edit(f)
+    assert sentinel.exists()
+
+
+def test_terraform_fmt_glob_no_match(tmp_path: Path) -> None:
+    f = tmp_path / "main.py"
+    f.write_text("x=1\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("terraform-fmt", f"touch {sentinel}", "*.tf")
+    _edit(f)
+    assert not sentinel.exists()
+
+
+def test_terraform_fmt_graceful_skip_missing_binary(tmp_path: Path) -> None:
+    f = tmp_path / "main.tf"
+    f.write_text('resource "aws_s3_bucket" "b" {}\n')
+    _set_formatter("terraform-fmt", "terraform-that-does-not-exist fmt -write=true {file}", "*.tf")
+    out = _edit(f)
+    assert f.read_text() == "new\n"
+    assert "edited" in out
+
+
+# ---------------------------------------------------------------------------
+# rubocop — *.rb
+# ---------------------------------------------------------------------------
+
+def test_rubocop_dispatch_ok(tmp_path: Path) -> None:
+    f = tmp_path / "app.rb"
+    f.write_text("puts 'hello'\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("rubocop", f"touch {sentinel}", "*.rb")
+    _edit(f)
+    assert sentinel.exists()
+
+
+def test_rubocop_glob_no_match(tmp_path: Path) -> None:
+    f = tmp_path / "app.py"
+    f.write_text("x=1\n")
+    sentinel = tmp_path / "ran"
+    _set_formatter("rubocop", f"touch {sentinel}", "*.rb")
+    _edit(f)
+    assert not sentinel.exists()
+
+
+def test_rubocop_graceful_skip_missing_binary(tmp_path: Path) -> None:
+    f = tmp_path / "app.rb"
+    f.write_text("puts 'hello'\n")
+    _set_formatter("rubocop", "rubocop-that-does-not-exist -a --no-color --format quiet {file}", "*.rb")
+    out = _edit(f)
+    assert f.read_text() == "new\n"
+    assert "edited" in out


### PR DESCRIPTION
## Summary

- Adds a `formatters` section to `.supertool.json` mirroring `validators` exactly — same fields (`cmd`, `match`, `hooks_into`, `rollback_on_fail`, `timeout`), same `{file}` / `{supertool_dir}` placeholders, same graceful-skip when tool is missing
- Run order is now **edit → formatter(s) → validator(s) → rollback if validate fails** — formatters normalize the file in place so validators always check canonical output
- `rollback_on_fail` defaults to `false` for formatters (cosmetic tools shouldn't revert a structurally valid edit; the validator is the safety net)
- Ships `prettier` as the first bundled formatter in `.supertool.example.json`
- Backwards compatible — configs without a `formatters` key behave identically to before

## Docs

- New `docs/formatters.md` — full reference (what they are, run order, config shape, bundled list, adding your own: gofmt, black, rustfmt, phpcbf)
- `docs/validators.md` — replaced "Format-on-save (planned)" with a one-line pointer to formatters.md
- `README.md` — short Formatters paragraph added near the Validators section

## Test plan

- [ ] `tests/test_formatters.py` — 13 tests covering: applicable filtering, run-one success/fail/timeout/token-substitution, formatter runs before validator, fail+rollback_on_fail=false keeps file, fail+rollback_on_fail=true reverts, multi-glob match, graceful skip when binary missing
- [ ] Existing `test_validators.py` + `test_validators_tier2.py` — 42 tests, all still passing