### PR TITLE
feat: TOML payload route for @file — backslash-safe code blocks

### DIFF
--- a/docs/input-forms.md
+++ b/docs/input-forms.md
@@ -8,21 +8,50 @@ Most ops take arguments via `:` — `read:PATH:OFFSET:LIMIT`, `grep:PATTERN:PATH
 
 ## `@file` route — long or structured payloads
 
-Edit ops (`edit`, `replace_lines`, `paste`, `vim`) accept a JSON file instead of inline args. Pass the path with an `@` prefix:
+Mutating ops (`edit`, `replace`, `replace_lines`, `paste`, `vim`) accept a payload file instead of inline args. Pass the path with an `@` prefix; use `@-` for stdin.
 
 ```bash
 ./supertool 'edit:@.max/my-edit.json'
+./supertool 'paste:@-' < my-paste.toml
 ```
 
-The file holds the fields that would otherwise go after `:::`:
+The payload holds the fields that would otherwise go after `:::`. Format auto-detected from the first non-whitespace character — `{` or `[` → **JSON**, anything else → **TOML**.
+
+### JSON — concise, machine-friendly
 
 ```json
 { "old": "return false;", "new": "return true;", "path": "src/app/Foo.py" }
 ```
 
-Use `@-` to read the payload from stdin instead of a file.
+Best for CI scripts and sub-agent output (every JSON encoder produces it). Drawback: every backslash and newline in content needs double-escaping (`\\n`, `\\\\`), which compounds fast for code blocks.
 
-This route shines when `old` or `new` spans multiple lines or contains characters that clash with shell quoting. Write the JSON, invoke once — no escaping gymnastics.
+### TOML — human-friendly for code-block content
+
+```bash
+./supertool 'paste:@-' <<'PAYLOAD'
+path = "scripts/deploy.sh"
+content = '''
+#!/usr/bin/env bash
+claude -p "..." --permission-mode bypassPermissions \
+  --disallowedTools "Grep,Glob,LS"
+'''
+PAYLOAD
+```
+
+Use TOML's **triple-single-quote literal strings** (`'''...'''`) when content has backslashes, quotes, or `\e` (vim's ESC) — they're preserved byte-for-byte, no escaping. Triple-double-quote (`"""..."""`) supports basic escapes (`\n`, `\t`, `\\`) if you want them.
+
+| TOML form         | When to use                                    |
+| ----------------- | ---------------------------------------------- |
+| `"basic"`         | Single-line strings with standard escapes      |
+| `'literal'`       | Single-line strings, no escape processing (vim scripts: `'/foo\eciw...\e'`) |
+| `"""multi\nline"""` | Multi-line with escapes processed             |
+| `'''multi\nline'''` | Multi-line, literal — **the default for code blocks** |
+
+Other TOML primitives supported in payloads: integers (`start = 42`), booleans (`replace_all = true`), `# comments`. Arrays, tables, dotted keys, and dates aren't needed — payloads are flat key/value maps.
+
+### Implementation note
+
+TOML parsing uses stdlib `tomllib` on Python 3.11+; a minimal built-in parser handles 3.9 / 3.10 fallback (bare keys, strings, ints, bools, comments — nothing else).
 
 ## `batch:@file` — mixed ops in one round-trip
 

--- a/supertool.py
+++ b/supertool.py
@@ -8008,14 +8008,151 @@ def op_validate(path: str, tool_filter: Optional[list] = None) -> str:
     return "\n".join(out) + "\n"
 
 
+def _detect_payload_format(raw: str) -> str:
+    """Return 'json' if first non-whitespace char is { or [, else 'toml'."""
+    for c in raw:
+        if c in " \t\r\n":
+            continue
+        return "json" if c in "{[" else "toml"
+    return "json"
+
+
+_TOML_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", '"': '"', "b": "\b", "f": "\f"}
+
+
+def _toml_basic_unescape(s: str) -> str:
+    out = []
+    i = 0
+    while i < len(s):
+        if s[i] == "\\" and i + 1 < len(s):
+            out.append(_TOML_ESCAPES.get(s[i + 1], s[i + 1]))
+            i += 2
+        else:
+            out.append(s[i])
+            i += 1
+    return "".join(out)
+
+
+def _mini_toml_loads(raw: str) -> Dict[str, Any]:
+    """Minimal TOML parser for @file payloads.
+
+    Supports: bare keys, integers, true/false, single-line strings
+    ("..." with escapes, '...' literal), multi-line strings (\"\"\"...\"\"\"
+    with escapes, '''...''' literal), # comments. No arrays, no tables,
+    no dotted keys, no dates — only what payloads need.
+
+    Used as fallback when stdlib `tomllib` is unavailable (Python <3.11).
+    """
+    result: Dict[str, Any] = {}
+    i, n = 0, len(raw)
+    while i < n:
+        while i < n and raw[i] in " \t\r\n":
+            i += 1
+        if i >= n:
+            break
+        if raw[i] == "#":
+            while i < n and raw[i] != "\n":
+                i += 1
+            continue
+        ks = i
+        while i < n and (raw[i].isalnum() or raw[i] in "_-"):
+            i += 1
+        if i == ks:
+            raise ValueError(f"bad key at offset {i}")
+        key = raw[ks:i]
+        while i < n and raw[i] in " \t":
+            i += 1
+        if i >= n or raw[i] != "=":
+            raise ValueError(f"expected '=' after key '{key}'")
+        i += 1
+        while i < n and raw[i] in " \t":
+            i += 1
+        if i >= n:
+            raise ValueError(f"missing value for '{key}'")
+        if raw[i:i + 3] == '"""':
+            i += 3
+            end = raw.find('"""', i)
+            if end < 0:
+                raise ValueError(f"unterminated \"\"\" for '{key}'")
+            val = _toml_basic_unescape(raw[i:end])
+            if val.startswith("\r\n"):
+                val = val[2:]
+            elif val.startswith("\n"):
+                val = val[1:]
+            i = end + 3
+        elif raw[i:i + 3] == "'''":
+            i += 3
+            end = raw.find("'''", i)
+            if end < 0:
+                raise ValueError(f"unterminated ''' for '{key}'")
+            val = raw[i:end]
+            if val.startswith("\r\n"):
+                val = val[2:]
+            elif val.startswith("\n"):
+                val = val[1:]
+            i = end + 3
+        elif raw[i] == '"':
+            i += 1
+            buf = []
+            while i < n and raw[i] != '"':
+                if raw[i] == "\\" and i + 1 < n:
+                    buf.append(_TOML_ESCAPES.get(raw[i + 1], raw[i + 1]))
+                    i += 2
+                elif raw[i] == "\n":
+                    raise ValueError(f"newline in single-line string for '{key}'")
+                else:
+                    buf.append(raw[i])
+                    i += 1
+            if i >= n:
+                raise ValueError(f"unterminated string for '{key}'")
+            val = "".join(buf)
+            i += 1
+        elif raw[i] == "'":
+            i += 1
+            end = raw.find("'", i)
+            if end < 0 or raw.find("\n", i, end) >= 0:
+                raise ValueError(f"unterminated literal for '{key}'")
+            val = raw[i:end]
+            i = end + 1
+        elif raw[i:i + 4] == "true" and (i + 4 == n or not raw[i + 4].isalnum()):
+            val = True
+            i += 4
+        elif raw[i:i + 5] == "false" and (i + 5 == n or not raw[i + 5].isalnum()):
+            val = False
+            i += 5
+        elif raw[i] == "-" or raw[i].isdigit():
+            ns = i
+            if raw[i] == "-":
+                i += 1
+            while i < n and raw[i].isdigit():
+                i += 1
+            try:
+                val = int(raw[ns:i])
+            except ValueError as _e:
+                raise ValueError(f"bad number for '{key}': {_e}") from _e
+        else:
+            raise ValueError(f"unknown value type for '{key}' at offset {i}")
+        result[key] = val
+        while i < n and raw[i] in " \t":
+            i += 1
+        if i < n and raw[i] == "#":
+            while i < n and raw[i] != "\n":
+                i += 1
+    return result
+
+
 def _load_at_file(ref: str) -> Any:
-    """Load JSON from an @file reference.
+    """Load JSON or TOML from an @file reference.
 
     Accepts:
       @path/to/file.json   — read from filesystem
       @-                   — read from stdin
 
-    Returns the parsed JSON value (dict, list, etc.).
+    Format detected from first non-whitespace char: { or [ → JSON, else TOML.
+    TOML lets you embed code blocks with backslashes/quotes/newlines without
+    JSON's double-escaping. Use '''triple-single-quote''' for literal content.
+
+    Returns the parsed value (dict, list, etc.).
     Raises ValueError with a human-readable message on any error.
     """
     if ref == "@-":
@@ -8031,10 +8168,21 @@ def _load_at_file(ref: str) -> Any:
         except OSError as _e:
             raise ValueError(f"@file read error: {fpath}: {_e}") from _e
         source = fpath
+    fmt = _detect_payload_format(raw)
+    if fmt == "json":
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as _e:
+            raise ValueError(f"@file JSON parse error ({source}): {_e}") from _e
     try:
-        return json.loads(raw)
-    except json.JSONDecodeError as _e:
-        raise ValueError(f"@file JSON parse error ({source}): {_e}") from _e
+        import tomllib  # stdlib, Python 3.11+
+        parser = tomllib.loads
+    except ImportError:
+        parser = _mini_toml_loads
+    try:
+        return parser(raw)
+    except Exception as _e:
+        raise ValueError(f"@file TOML parse error ({source}): {_e}") from _e
 
 
 # Dynamic @file field registry — built lazily from op syntax strings.
@@ -8181,6 +8329,7 @@ def dispatch(arg: str) -> str:
     # Load JSON, rebuild parts list, then fall through to the normal handlers.
     # Applies to mutating ops that have ':::' fields in their syntax string.
     _at_file_replace_all: bool = False
+    _at_file_used: bool = False
     if (
         len(parts) == 2
         and parts[1].startswith("@")
@@ -8189,8 +8338,14 @@ def dispatch(arg: str) -> str:
         try:
             payload = _load_at_file(parts[1])
             parts, _at_file_replace_all = _at_file_to_parts(op, payload)
+            _at_file_used = True
         except ValueError as _e:
             return header + f"ERROR: {_e}\n"
+
+    # When parts come from @file (JSON/TOML payload), they hold literal
+    # bytes — backslashes and newlines must NOT be reinterpreted as shell-
+    # style escapes. Only colon-CLI input needs `_decode_escapes`.
+    _dec = (lambda s: s) if _at_file_used else _decode_escapes
 
     try:
         if op == "read":
@@ -8296,14 +8451,14 @@ def dispatch(arg: str) -> str:
             d = int(parts[2]) if len(parts) > 2 and parts[2] else 3
             body = op_tree(path, d, exclude_paths=_get_exclude_paths("tree", no_exclude))
         elif op in ("replace", "replace_dry"):
-            old_str = _decode_escapes(parts[1] if len(parts) > 1 else "")
-            new_str = _decode_escapes(parts[2] if len(parts) > 2 else "")
+            old_str = _dec(parts[1] if len(parts) > 1 else "")
+            new_str = _dec(parts[2] if len(parts) > 2 else "")
             rpath = parts[3] if len(parts) > 3 and parts[3] else "."
             dry = op == "replace_dry"
             body = _run_with_validators(op, parts, lambda: op_replace(old_str, new_str, rpath, dry=dry))
         elif op == "edit":
-            old_str = _decode_escapes(parts[1] if len(parts) > 1 else "")
-            new_str = _decode_escapes(parts[2] if len(parts) > 2 else "")
+            old_str = _dec(parts[1] if len(parts) > 1 else "")
+            new_str = _dec(parts[2] if len(parts) > 2 else "")
             epath = parts[3] if len(parts) > 3 else ""
             if _at_file_replace_all:
                 body = _run_with_validators(op, parts, lambda: op_replace(old_str, new_str, epath or "."))
@@ -8318,12 +8473,12 @@ def dispatch(arg: str) -> str:
                 body = "ERROR: replace_lines START/END must be integers\n"
             else:
                 # CONTENT may legitimately contain ':' — rejoin remaining parts
-                rl_content = _decode_escapes(":".join(parts[4:]) if len(parts) > 4 else "")
+                rl_content = _dec(":".join(parts[4:]) if len(parts) > 4 else "")
                 body = _run_with_validators(op, parts, lambda: op_replace_lines(rl_path, rl_start, rl_end, rl_content))
         elif op == "paste":
             p_path = parts[1] if len(parts) > 1 else ""
             # CONTENT may contain ':' — rejoin everything after the path
-            p_content = _decode_escapes(":".join(parts[2:]) if len(parts) > 2 else "")
+            p_content = _dec(":".join(parts[2:]) if len(parts) > 2 else "")
             body = _run_with_validators(op, parts, lambda: op_paste(p_path, p_content))
         elif op == "vim":
             vim_path = parts[1] if len(parts) > 1 else ""

--- a/tests/test_at_file_route.py
+++ b/tests/test_at_file_route.py
@@ -47,7 +47,8 @@ class TestAtFileEdit:
 
     def test_invalid_json_returns_error(self, tmp_path: Path) -> None:
         spec = tmp_path / "bad.json"
-        spec.write_text("not valid json {{{")
+        # Payload format auto-detected: starts with `{` → JSON route.
+        spec.write_text("{not valid json {{{")
         out = supertool.dispatch(f"edit:@{spec}")
         assert "ERROR" in out
         assert "JSON parse error" in out
@@ -294,3 +295,121 @@ class TestAtFileReplaceAll:
         out = supertool.dispatch(f"batch:@{ops_file}")
         assert "ERROR" not in out
         assert target.read_text().strip() == "b b b"
+
+
+# ---------------------------------------------------------------------------
+# TOML payload route — auto-detected when first non-whitespace char is not { or [
+# ---------------------------------------------------------------------------
+
+class TestTomlPayload:
+    def test_paste_with_triple_literal_preserves_backslash(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.sh"
+        spec = tmp_path / "p.toml"
+        spec.write_text(
+            f'path = "{target}"\n'
+            "content = '''\n"
+            "claude -p \"...\" --permission-mode bypass \\\n"
+            "  --disallowedTools \"Grep,Glob\"\n"
+            "'''\n"
+        )
+        out = supertool.dispatch(f"paste:@{spec}")
+        assert "ERROR" not in out
+        # The trailing backslash + newline survives the round-trip — that's
+        # the whole point of the TOML route over JSON.
+        body = target.read_text()
+        assert "bypass \\\n" in body
+        assert "--disallowedTools" in body
+
+    def test_edit_with_double_quoted_string(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("DEBUG = False\n")
+        spec = tmp_path / "e.toml"
+        spec.write_text(
+            'old = "DEBUG = False"\n'
+            'new = "DEBUG = True"\n'
+            f'path = "{target}"\n'
+        )
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" not in out
+        assert target.read_text() == "DEBUG = True\n"
+
+    def test_replace_lines_with_integers_and_triple_literal(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("a\nb\nc\nd\n")
+        spec = tmp_path / "rl.toml"
+        spec.write_text(
+            f'path = "{target}"\n'
+            "start = 2\n"
+            "end = 3\n"
+            "content = '''X\nY'''\n"
+        )
+        out = supertool.dispatch(f"replace_lines:@{spec}")
+        assert "ERROR" not in out
+        assert target.read_text() == "a\nX\nY\nd\n"
+
+    def test_stdin_toml(self, tmp_path: Path, monkeypatch) -> None:
+        target = tmp_path / "out.txt"
+        import io
+        payload = (
+            f'path = "{target}"\n'
+            "content = '''line1\nline2 with \\ backslash\nline3'''\n"
+        )
+        monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+        out = supertool.dispatch("paste:@-")
+        assert "ERROR" not in out
+        assert target.read_text() == "line1\nline2 with \\ backslash\nline3\n"
+
+    def test_format_auto_detect_brace_routes_to_json(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.py"
+        target.write_text("a = 1\n")
+        spec = tmp_path / "e.payload"
+        # Starts with `{` → JSON route even though extension isn't .json.
+        spec.write_text(json.dumps({"old": "a = 1", "new": "a = 2", "path": str(target)}))
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" not in out
+        assert target.read_text() == "a = 2\n"
+
+    def test_invalid_toml_returns_error(self, tmp_path: Path) -> None:
+        spec = tmp_path / "bad.toml"
+        spec.write_text("not = 'unclosed\n")
+        out = supertool.dispatch(f"edit:@{spec}")
+        assert "ERROR" in out
+        assert "TOML parse error" in out
+
+
+# ---------------------------------------------------------------------------
+# Mini TOML parser fallback (used when stdlib tomllib unavailable, Python <3.11)
+# ---------------------------------------------------------------------------
+
+class TestMiniTomlLoads:
+    def test_double_quoted_with_escapes(self) -> None:
+        d = supertool._mini_toml_loads('a = "x\\ny"\n')
+        assert d == {"a": "x\ny"}
+
+    def test_single_quoted_literal(self) -> None:
+        d = supertool._mini_toml_loads("a = 'x\\ny'\n")
+        assert d == {"a": "x\\ny"}
+
+    def test_triple_basic_with_leading_newline_stripped(self) -> None:
+        d = supertool._mini_toml_loads('a = """\nhello"""\n')
+        assert d == {"a": "hello"}
+
+    def test_triple_literal_preserves_backslash(self) -> None:
+        d = supertool._mini_toml_loads("a = '''\nlinex \\\nliney'''\n")
+        assert d == {"a": "linex \\\nliney"}
+
+    def test_int_and_bool(self) -> None:
+        d = supertool._mini_toml_loads("n = 42\nm = -5\nt = true\nf = false\n")
+        assert d == {"n": 42, "m": -5, "t": True, "f": False}
+
+    def test_comments_skipped(self) -> None:
+        d = supertool._mini_toml_loads("# header\na = 1  # trailing\nb = 2\n")
+        assert d == {"a": 1, "b": 2}
+
+    def test_bad_key_raises(self) -> None:
+        with pytest.raises(ValueError):
+            supertool._mini_toml_loads("= 1\n")
+
+    def test_unterminated_string_raises(self) -> None:
+        with pytest.raises(ValueError):
+            supertool._mini_toml_loads('a = "unterminated\n')


### PR DESCRIPTION
## Summary

The JSON @file route works, but every backslash and newline in content needs double-escaping. For code blocks — vim scripts with `\e`, shell snippets with line-continuations, regex patterns — this compounds fast and is the single biggest source of payload bugs in interactive sessions.

TOML's `'''triple-single-quote'''` literal strings preserve content byte-for-byte, no escaping. Payloads become copy-pasteable.

```bash
./supertool 'paste:@-' <<'PAYLOAD'
path = "scripts/deploy.sh"
content = '''
#!/usr/bin/env bash
claude -p "..." --permission-mode bypassPermissions \
  --disallowedTools "Grep,Glob,LS"
'''
PAYLOAD
```

## Changes

- **Format auto-detect** on `@file` payloads — first non-whitespace char `{` or `[` → JSON, anything else → TOML. JSON callers see zero change.
- **TOML parser** — `tomllib` (stdlib, 3.11+) preferred; minimal ~110-line fallback for 3.9/3.10 (bare keys, strings, ints, bools, comments — nothing else). No new dependencies.
- **Bugfix:** `_decode_escapes` was applied to @file-sourced content, stripping backslashes from JSON payloads too. Now gated by `_at_file_used` — only runs for colon-CLI input.
- **Tests:** +8 TOML route tests, +8 mini-parser tests. Suite: 1808 passed, 8 skipped, 84% coverage.
- **Docs:** `docs/input-forms.md` gains TOML section with all four string forms and when to use each.

## Test plan
- [x] `pytest tests/` — 1808 passed
- [x] Manual: backslash-line-continuation in shell heredoc preserved end-to-end (was eaten before this PR)
- [x] Manual: vim script via TOML single-quoted literal (`'/foo\eciw...\e'`) — `\e` survives
- [ ] Reviewer: confirm JSON payloads with `\\` in content (e.g. Windows paths) now reach disk unchanged (was double-stripped before)