### PR TITLE
fix: escape quotes in hooks.json to fix JSON parse error

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh""
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
           }
         ]
       }


### PR DESCRIPTION
Commit 87c6ec56 accidentally removed the backslash escapes from the double quotes in the SessionStart hook command, breaking JSON parsing.

**Error:**
```
JSON Parse error: Expected '}', line 8 column 31
```

**Before (broken):**
```json
"command": "bash "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh""
```

**After (fixed):**
```json
"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
```

The inner quotes around `${CLAUDE_PLUGIN_ROOT}/...` must be escaped as `\"` for valid JSON.