### PR TITLE
fix(.supertool.json): add jsonlint validator on mutating ops

### DIFF
--- a/.supertool.json
+++ b/.supertool.json
@@ -149,5 +149,14 @@
     }
   },
   "ops": {},
-  "aliases": {}
+  "aliases": {},
+  "validators": {
+    "jsonlint": {
+      "cmd": "python3 -m json.tool {file}",
+      "match": "*.json",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
+    }
+  }
 }


### PR DESCRIPTION
## Why

Follow-up to #103. The broken JSON in `hooks/hooks.json` slipped through because supertool's own `.supertool.json` had no `jsonlint` validator hooked into the mutating ops — so when we edited the file via `edit`/`paste`/`vim`, no JSON check fired. Validator added now; rolls back the edit on parse fail.

## Test

```bash
./supertool 'edit:::"command": "ok":::"command": "bad ":::tests/fixtures/sample.json'
# expect: rollback, file unchanged
```

## Test plan

- [x] Edit a *.json with malformed quotes via supertool — verify rollback
- [x] Edit a *.json with valid syntax — verify success