### PR TITLE
chore: add GitHub community standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.py]
+indent_size = 4
+
+[*.{json,yml,yaml,toml,md}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report something that doesn't work as expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+What broke?
+
+## Reproduction
+
+Steps to reproduce:
+
+1.
+2.
+3.
+
+Minimal supertool command if applicable:
+
+```bash
+./supertool '...'
+```
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Actual behavior
+
+What happened instead? Include error output / traceback.
+
+## Environment
+
+- supertool version: (`./supertool version`)
+- Python version: (`python3 --version`)
+- OS:
+- Claude Code version (if relevant):

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Digital-Process-Tools/claude-supertool/security/policy
+    about: Please report security issues privately via email (see SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest a new op, alias, or capability
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What workflow is awkward today? Which round-trips could be collapsed?
+
+## Proposed solution
+
+What op / alias / flag would solve it? Example call:
+
+```bash
+./supertool 'newop:args'
+```
+
+## Alternatives considered
+
+Other approaches and why they fall short.
+
+## Additional context
+
+Links, related ops, sample payloads, anything else.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+What does this PR change and why?
+
+## Changes
+
+- 
+- 
+
+## Test plan
+
+- [ ] `pytest` passes locally (469+ tests)
+- [ ] New op / behavior covered by a test
+- [ ] Manual check: `./supertool 'your-op:args'` works as expected
+
+## Checklist
+
+- [ ] Docs updated if a new op or alias was added (README, `./supertool 'ops'`)
+- [ ] Version bumped in `.claude-plugin/plugin.json` if shipping a release
+- [ ] CHANGELOG entry added

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,5 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-cov
+      - name: Create supertool symlink
+        run: ln -sf supertool.py supertool
       - name: Run tests
         run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+      - name: Run tests
+        run: pytest

--- a/.supertool.json
+++ b/.supertool.json
@@ -149,5 +149,14 @@
     }
   },
   "ops": {},
-  "aliases": {}
+  "aliases": {},
+  "validators": {
+    "jsonlint": {
+      "cmd": "python3 -m json.tool {file}",
+      "match": "*.json",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
+    }
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.11.0]
+
+Initial public changelog. See git history for prior versions.
+
+[Unreleased]: https://github.com/Digital-Process-Tools/claude-supertool/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/Digital-Process-Tools/claude-supertool/releases/tag/v0.11.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**fdavid@digitalprocesstools.com**. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 > **Cut your Claude Code bill by 50%.**
 > `git-status`, but it tells you what to do next.
 
+[![Tests](https://github.com/Digital-Process-Tools/claude-supertool/actions/workflows/tests.yml/badge.svg)](https://github.com/Digital-Process-Tools/claude-supertool/actions/workflows/tests.yml)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Community-brightgreen)](LICENSE)
 [![Version](https://img.shields.io/badge/version-0.11.0-orange)](.claude-plugin/plugin.json)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 > **Cut your Claude Code bill by 50%.**
 > `git-status`, but it tells you what to do next.
 
+[![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-Community-brightgreen)](LICENSE)
+[![Version](https://img.shields.io/badge/version-0.11.0-orange)](.claude-plugin/plugin.json)
+
 Saves tokens. Saves money. Saves turns. Works the same in interactive sessions and autonomous runs — humans pair-programming with Claude Code use it every day, not just Kevin-style headless agents. One Python file, zero deps, Python 3.9+.
 
 [Why](#why) • [Four pillars](#four-pillars) • [Receipt](#receipt--the-bill-math) • [Batching](#batch-multiple-ops-in-one-call) • [Parallel](docs/configuration.md#parallel-execution) • [Input forms](#input-forms) • [Validators](#validators--squiggle-on-save-for-the-llm) • [Expand it](#supertooljson--project-configuration) • [Install](#install)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor version receives security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.11.x  | :white_check_mark: |
+| < 0.11  | :x:                |
+
+## Reporting a Vulnerability
+
+**Do not open public GitHub issues for security vulnerabilities.**
+
+Email **fdavid@digitalprocesstools.com** with:
+
+- A description of the issue
+- Steps to reproduce
+- Affected version (`./supertool version`)
+- Impact assessment if known
+
+You can expect an acknowledgment within 7 days. We will work with you to
+understand and resolve the issue, and credit you in the release notes if
+desired.

--- a/presets/bluesky/_atproto.py
+++ b/presets/bluesky/_atproto.py
@@ -6,6 +6,8 @@ Auth flow:
   3. Subsequent calls use the cached accessJwt
   4. On 401, refresh via refreshJwt; on refresh failure, recreate from app password
 """
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/presets/bluesky/_auth.py
+++ b/presets/bluesky/_auth.py
@@ -17,6 +17,8 @@ app password:
 
 Tokens never returned to stdout — only used in HTTP requests.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/bluesky/_sanitize.py
+++ b/presets/bluesky/_sanitize.py
@@ -20,6 +20,8 @@ Defense layers:
 This file is duplicated per preset dir (bluesky/devto/hashnode) so
 each preset stays self-contained. Keep them in sync.
 """
+from __future__ import annotations
+
 import re
 
 # Known injection trigger phrases — case-insensitive.

--- a/presets/bluesky/follow.py
+++ b/presets/bluesky/follow.py
@@ -7,6 +7,8 @@ Pass |force as 2nd pipe-separated field to bypass: bluesky_follow:HANDLE|force
 If the pre-flight check fails, a warning is printed and the follow proceeds
 (graceful degrade — don't block on platform issues).
 """
+from __future__ import annotations
+
 import datetime as _dt
 import sys
 from pathlib import Path

--- a/presets/bluesky/like.py
+++ b/presets/bluesky/like.py
@@ -7,6 +7,8 @@ Pass |force as 2nd pipe-separated field to bypass: bluesky_like:URI|force
 If the pre-flight check fails, a warning is printed and the like proceeds
 (graceful degrade — don't block on platform issues).
 """
+from __future__ import annotations
+
 import datetime as _dt
 import sys
 from pathlib import Path

--- a/presets/bluesky/list.py
+++ b/presets/bluesky/list.py
@@ -3,6 +3,8 @@
 
 N defaults to SUPERTOOL_DEFAULT_LIMIT or 10.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/bluesky/publish.py
+++ b/presets/bluesky/publish.py
@@ -16,6 +16,8 @@ same root already exists. Pass |force as 3rd pipe-separated field to bypass.
 If the pre-flight check fails, a warning is printed and publish proceeds
 (graceful degrade — don't block on platform issues).
 """
+from __future__ import annotations
+
 import datetime as _dt
 import re
 import sys

--- a/presets/bluesky/read.py
+++ b/presets/bluesky/read.py
@@ -3,6 +3,8 @@
 
 Aggregates: post body + author + stats + top N replies (with URIs) + NEXT chain hints.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/bluesky/repost.py
+++ b/presets/bluesky/repost.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Bluesky repost: bluesky_repost:AT_URI_OR_WEB_URL — boost (retweet) a post."""
+from __future__ import annotations
+
 import datetime as _dt
 import sys
 from pathlib import Path

--- a/presets/bluesky/search.py
+++ b/presets/bluesky/search.py
@@ -3,6 +3,8 @@
 
 Searches recent posts. Useful for mentions ('max-ai-dev', 'claude-supertool', 'max.dp.tools').
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/bluesky/status_since.py
+++ b/presets/bluesky/status_since.py
@@ -5,6 +5,8 @@ Native notifications endpoint (unlike Forem) — no outbound ledger needed.
 Surfaces likes, replies, mentions, follows since the timestamp.
 No arg = uses ~/.config/bluesky/last_check (auto-tracked).
 """
+from __future__ import annotations
+
 import datetime as _dt
 import os
 import sys

--- a/presets/claude-log/_common.py
+++ b/presets/claude-log/_common.py
@@ -1,4 +1,6 @@
 """Shared helpers for claude-log ops."""
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path

--- a/presets/claude-log/list.py
+++ b/presets/claude-log/list.py
@@ -4,6 +4,8 @@
 For each session, output: UUID, mtime, line count, first user-message excerpt.
 Useful to pick the right UUID before running claude-log-tail / claude-log-summary.
 """
+from __future__ import annotations
+
 import sys
 from datetime import datetime
 from pathlib import Path

--- a/presets/claude-log/summary.py
+++ b/presets/claude-log/summary.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Whole-session digest: model, duration, tokens, tool calls, errors, final text."""
+from __future__ import annotations
+
 import sys
 from collections import Counter
 from datetime import datetime

--- a/presets/claude-log/tail.py
+++ b/presets/claude-log/tail.py
@@ -6,6 +6,8 @@ Output one line per content part:
   [assistant] TOOL Bash: {"command": "..."}
   [result] PASS/FAIL/output: ...
 """
+from __future__ import annotations
+
 import json
 import sys
 from pathlib import Path

--- a/presets/devto/_auth.py
+++ b/presets/devto/_auth.py
@@ -7,6 +7,8 @@ Resolution order (first hit wins):
 
 Tokens never returned to stdout — only used in HTTP requests.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/devto/_me.py
+++ b/presets/devto/_me.py
@@ -3,6 +3,8 @@
 Cache: ~/.config/devto/me_username (one line). Override with
 DEVTO_USERNAME env var if you want to skip the lookup.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/devto/_outbound.py
+++ b/presets/devto/_outbound.py
@@ -8,6 +8,8 @@ Format: JSON-lines at ~/.config/devto/my_outbound_comments. One record
 per comment posted via this tool. Records never expire automatically;
 prune by hand if needed.
 """
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path

--- a/presets/devto/_resolve.py
+++ b/presets/devto/_resolve.py
@@ -13,6 +13,8 @@ Accepted inputs:
   - "article-slug-with-suffix-3j3e"               → bare slug (no author, no scheme)
                                                       → resolved via /articles?slug=...
 """
+from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path

--- a/presets/devto/_rest.py
+++ b/presets/devto/_rest.py
@@ -1,4 +1,6 @@
 """Dev.to REST request helper. Stdlib-only."""
+from __future__ import annotations
+
 import json
 import sys
 import urllib.error

--- a/presets/devto/_sanitize.py
+++ b/presets/devto/_sanitize.py
@@ -20,6 +20,8 @@ Defense layers:
 This file is duplicated per preset dir (bluesky/devto/hashnode) so
 each preset stays self-contained. Keep them in sync.
 """
+from __future__ import annotations
+
 import re
 
 # Known injection trigger phrases — case-insensitive.

--- a/presets/devto/_session.py
+++ b/presets/devto/_session.py
@@ -16,6 +16,8 @@ Resolution order for the cookie (first hit wins):
 CSRF token is scraped from any /dashboard fetch (which we already do).
 Cached for the script run.
 """
+from __future__ import annotations
+
 import os
 import re
 import sys

--- a/presets/devto/browse.py
+++ b/presets/devto/browse.py
@@ -3,6 +3,8 @@
 
 SORT: recent (default) or top (last 7 days top via ?top=7).
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/devto/comment.py
+++ b/presets/devto/comment.py
@@ -28,6 +28,8 @@ as the 4th pipe-separated field to bypass: devto_comment:slug|MSG||force
 If the pre-flight API call fails, a warning is printed and the comment
 proceeds (graceful degrade — don't block on platform issues).
 """
+from __future__ import annotations
+
 import json
 import re
 import sys

--- a/presets/devto/comments.py
+++ b/presets/devto/comments.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Dev.to comments: devto_comments:ARTICLE_ID[:N]"""
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/devto/list.py
+++ b/presets/devto/list.py
@@ -3,6 +3,8 @@
 
 N defaults to SUPERTOOL_DEFAULT_LIMIT or 10.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/devto/publish.py
+++ b/presets/devto/publish.py
@@ -10,6 +10,8 @@ aborts if an article with the same canonical_url already exists. Pass `force` as
 the 7th pipe-separated field to bypass: TITLE|MD|CANONICAL|||||force
 If the pre-flight API call fails, a warning is printed and the publish proceeds.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/devto/react.py
+++ b/presets/devto/react.py
@@ -27,6 +27,8 @@ Two auth modes:
      401 because Dev.to API keys do not authorize reactions; kept as
      placeholder until the platform exposes a proper write scope.
 """
+from __future__ import annotations
+
 import json as _json
 import sys
 from pathlib import Path

--- a/presets/devto/read.py
+++ b/presets/devto/read.py
@@ -5,6 +5,8 @@ Aggregates: title, author, date, body, stats, tags, top N inline comments.
 N via SUPERTOOL_INLINE_COMMENTS (default 5). Comments require numeric ID
 (separate REST call); slug/URL flow only fetches article body.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/devto/status_since.py
+++ b/presets/devto/status_since.py
@@ -8,6 +8,8 @@ uses ~/.config/devto/last_check (auto-tracking).
 Fan-out: GET /articles/me/published, then GET /comments?a_id=X for
 each recent article (limited by SUPERTOOL_STATUS_POSTS, default 10).
 """
+from __future__ import annotations
+
 import datetime as _dt
 import os
 import sys

--- a/presets/git/blame.py
+++ b/presets/git/blame.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Git blame — show N lines around a specific line number with author/date/commit info."""
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/presets/git/checkout.py
+++ b/presets/git/checkout.py
@@ -5,6 +5,8 @@ Combines: switch + branch info + ahead/behind + tracking + recent
 commits + dirty file count. Replaces the checkout/status/log/branch
 flurry with a single round-trip.
 """
+from __future__ import annotations
+
 import subprocess
 import sys
 

--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -13,6 +13,8 @@ Special MSG values:
   --no-edit   Use prepared commit message (MERGE_MSG / CHERRY_PICK_HEAD).
               Only valid when a merge or cherry-pick is in progress.
 """
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/presets/git/conflicts.py
+++ b/presets/git/conflicts.py
@@ -4,6 +4,8 @@
 For when you're already mid-merge (or mid-rebase / mid-cherry-pick)
 and want to see all conflicts in one call without re-running merge.
 """
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/presets/git/diverge.py
+++ b/presets/git/diverge.py
@@ -5,6 +5,8 @@ Combines: ahead/behind count + commits-only-in-branch (oneline) +
 files changed (name-status) + +/- line totals. Replaces the
 log-A..B / log-B..A / diff--stat trio.
 """
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/presets/git/investigate.py
+++ b/presets/git/investigate.py
@@ -6,6 +6,8 @@ Combines:
 2. Uncommitted changes (staged + unstaged diff)
 3. Blame hotspots (most recently changed lines)
 """
+from __future__ import annotations
+
 import os
 import re
 import subprocess

--- a/presets/git/merge.py
+++ b/presets/git/merge.py
@@ -6,6 +6,8 @@ extract first conflict block per file + show merge-base/ours/theirs
 SHAs + suggest abort command. Replaces the merge/status/read-each-file
 hunt with one round-trip.
 """
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/presets/git/resolve.py
+++ b/presets/git/resolve.py
@@ -4,6 +4,8 @@
 Atomic: checkout --SIDE PATH + git add PATH. Receipt shows which
 files were resolved and how many conflicts remain.
 """
+from __future__ import annotations
+
 import subprocess
 import sys
 

--- a/presets/git/status.py
+++ b/presets/git/status.py
@@ -4,6 +4,8 @@
 Combines branch info, recent commits, working tree state, and stash
 list into one structured report.
 """
+from __future__ import annotations
+
 import subprocess
 import sys
 

--- a/presets/git/trail.py
+++ b/presets/git/trail.py
@@ -4,6 +4,8 @@
 Answers: "When was this added? When was it changed? When was it removed?"
 Combines git log -S (pickaxe) with contextual diffs for each hit.
 """
+from __future__ import annotations
+
 import os
 import re
 import subprocess

--- a/presets/github/batch_follow.py
+++ b/presets/github/batch_follow.py
@@ -5,6 +5,8 @@ Lines starting with '#' are skipped (comments). Empty lines skipped.
 Reports per-user status and a final summary. Sleeps 1s between calls
 to be polite to GitHub's abuse-detection.
 """
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/presets/github/batch_star.py
+++ b/presets/github/batch_star.py
@@ -4,6 +4,8 @@
 Lines starting with '#' are comments. Sleeps SUPERTOOL_STAR_DELAY (default 1s)
 between calls.
 """
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/presets/github/find_followable.py
+++ b/presets/github/find_followable.py
@@ -11,6 +11,8 @@ the anchor source as a comment header. Pipe to a file then run
 
 Filters out type=Organization (we follow people, not orgs).
 """
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/presets/github/find_starable.py
+++ b/presets/github/find_starable.py
@@ -11,6 +11,8 @@ Tip: chain multiple topics for a richer pass:
   ./supertool 'gh-find-starable:claude-code' 'gh-find-starable:mcp' \\
               'gh-find-starable:ai-agents'
 """
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/presets/github/follow.py
+++ b/presets/github/follow.py
@@ -3,6 +3,8 @@
 
 Uses the authenticated user's session (`gh auth status`).
 """
+from __future__ import annotations
+
 import subprocess
 import sys
 

--- a/presets/github/following.py
+++ b/presets/github/following.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """gh-following: gh-following[:N] — list users I follow on GitHub."""
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/presets/github/issue.py
+++ b/presets/github/issue.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """GitHub issue details via gh CLI."""
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/presets/github/job.py
+++ b/presets/github/job.py
@@ -10,6 +10,8 @@ Config via SUPERTOOL_ env vars (set from .supertool.json):
   SUPERTOOL_ERROR_PATTERNS  — comma-separated patterns to search
   SUPERTOOL_ERROR_CONTEXT   — lines of context around each error match (default 5)
 """
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/presets/github/pr.py
+++ b/presets/github/pr.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """GitHub pull request details via gh CLI."""
+from __future__ import annotations
+
 import json
 import re
 import subprocess

--- a/presets/github/run.py
+++ b/presets/github/run.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """GitHub Actions workflow run details via gh CLI."""
+from __future__ import annotations
+
 import json
 import subprocess
 import sys

--- a/presets/github/star.py
+++ b/presets/github/star.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """gh-star: gh-star:OWNER/REPO — star a GitHub repository via gh CLI."""
+from __future__ import annotations
+
 import subprocess
 import sys
 

--- a/presets/github/starred.py
+++ b/presets/github/starred.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """gh-starred: gh-starred[:N] — list repos I have starred."""
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/presets/gitlab/issue.py
+++ b/presets/gitlab/issue.py
@@ -4,6 +4,8 @@
 Fetches issue metadata, human comments, related MRs, and downloads
 any images found in description/comments to a local temp directory.
 """
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/presets/gitlab/job.py
+++ b/presets/gitlab/job.py
@@ -10,6 +10,8 @@ Config via SUPERTOOL_ env vars (set from .supertool.json):
   SUPERTOOL_ERROR_PATTERNS  — comma-separated patterns to search (default: ERROR,FAIL,Fatal,------)
   SUPERTOOL_ERROR_CONTEXT   — lines of context around each error match (default 5)
 """
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/presets/gitlab/mr.py
+++ b/presets/gitlab/mr.py
@@ -4,6 +4,8 @@
 Fetches MR metadata, pipeline status, reviewer/approval info,
 diff stats, and human comments. Dashboard-style output.
 """
+from __future__ import annotations
+
 import json
 import re
 import subprocess

--- a/presets/gitlab/pipeline.py
+++ b/presets/gitlab/pipeline.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """GitLab pipeline job list via glab CLI."""
+from __future__ import annotations
+
 import json
 import subprocess
 import sys

--- a/presets/hashnode/_auth.py
+++ b/presets/hashnode/_auth.py
@@ -7,6 +7,8 @@ Resolution order (first hit wins):
 
 Tokens never returned to stdout — only used in HTTP requests.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/hashnode/_graphql.py
+++ b/presets/hashnode/_graphql.py
@@ -1,4 +1,6 @@
 """Hashnode GraphQL request helper. Stdlib-only."""
+from __future__ import annotations
+
 import json
 import sys
 import urllib.error

--- a/presets/hashnode/_me.py
+++ b/presets/hashnode/_me.py
@@ -3,6 +3,8 @@
 Cache: ~/.config/hashnode/me_username (one line). Override with
 HASHNODE_USERNAME env var if you want to skip the lookup.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/hashnode/_outbound.py
+++ b/presets/hashnode/_outbound.py
@@ -6,6 +6,8 @@ detect replies on posts we've engaged with.
 
 Format: JSON-lines at ~/.config/hashnode/my_outbound_comments.
 """
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path

--- a/presets/hashnode/_resolve.py
+++ b/presets/hashnode/_resolve.py
@@ -13,6 +13,8 @@ Accepted inputs:
   - "https://author.hashnode.dev/slug"                   → cross-publication lookup
   - "https://blog.example.com/slug" (custom domain)      → cross-publication lookup
 """
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from urllib.parse import urlparse

--- a/presets/hashnode/_sanitize.py
+++ b/presets/hashnode/_sanitize.py
@@ -20,6 +20,8 @@ Defense layers:
 This file is duplicated per preset dir (bluesky/devto/hashnode) so
 each preset stays self-contained. Keep them in sync.
 """
+from __future__ import annotations
+
 import re
 
 # Known injection trigger phrases — case-insensitive.

--- a/presets/hashnode/browse.py
+++ b/presets/hashnode/browse.py
@@ -4,6 +4,8 @@
 SORT: recent (default) or top/popular. Sub-args separated by '|'
 because supertool tokenizes ':'.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/hashnode/comment.py
+++ b/presets/hashnode/comment.py
@@ -12,6 +12,8 @@ pipe-separated field to bypass: hashnode_comment:POST_ID|MSG|force
 If the pre-flight check fails, a warning is printed and the comment proceeds
 (graceful degrade — don't block on platform issues).
 """
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/presets/hashnode/comments.py
+++ b/presets/hashnode/comments.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Hashnode comments: hashnode_comments:SLUG_OR_URL[:N]"""
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/hashnode/list.py
+++ b/presets/hashnode/list.py
@@ -3,6 +3,8 @@
 
 N defaults to SUPERTOOL_DEFAULT_LIMIT or 10.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/hashnode/publish.py
+++ b/presets/hashnode/publish.py
@@ -11,6 +11,8 @@ already exists. Pass |force as the 6th pipe-separated field to bypass:
 TITLE|MD|CANONICAL||||force
 If the pre-flight check fails, a warning is printed and publish proceeds.
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/hashnode/react.py
+++ b/presets/hashnode/react.py
@@ -23,6 +23,8 @@ treats every call as forced. This is opt-in — silent default would risk
 duplicate reactions if `likePost` were ever idempotent on Hashnode's side
 (it's not today, but the safety remains).
 """
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/presets/hashnode/read.py
+++ b/presets/hashnode/read.py
@@ -4,6 +4,8 @@
 Aggregates: title, author, date, body, stats, top N inline comments, tags.
 N comments via SUPERTOOL_INLINE_COMMENTS (default 5).
 """
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/hashnode/reply.py
+++ b/presets/hashnode/reply.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Hashnode reply: hashnode_reply:COMMENT_ID|MESSAGE_OR_FILE"""
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/presets/hashnode/search.py
+++ b/presets/hashnode/search.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Hashnode search: hashnode_search:QUERY[:N] — text search on configured publication."""
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/presets/hashnode/status_since.py
+++ b/presets/hashnode/status_since.py
@@ -8,6 +8,8 @@ No arg = uses ~/.config/hashnode/last_check (auto-tracking).
 State file is updated with current time on success — so successive
 calls naturally show "what's new since last run".
 """
+from __future__ import annotations
+
 import datetime as _dt
 import os
 import sys

--- a/presets/xml/__init__.py
+++ b/presets/xml/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,30 @@
+[project]
+name = "claude-supertool"
+version = "0.11.0"
+description = "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [{ name = "Digital Process Tools" }]
+keywords = ["claude-code", "batch", "file-ops", "tokens", "autonomous", "kevin", "round-trip"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Utilities",
+]
+
+[project.urls]
+Homepage = "https://github.com/Digital-Process-Tools/claude-supertool"
+Repository = "https://github.com/Digital-Process-Tools/claude-supertool"
+Issues = "https://github.com/Digital-Process-Tools/claude-supertool/issues"
+Changelog = "https://github.com/Digital-Process-Tools/claude-supertool/blob/main/CHANGELOG.md"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=supertool --cov-report=term-missing --cov-fail-under=80"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "claude-supertool"
 version = "0.11.0"
 description = "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 authors = [{ name = "Digital Process Tools" }]
 keywords = ["claude-code", "batch", "file-ops", "tokens", "autonomous", "kevin", "round-trip"]
@@ -12,6 +12,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/validators/bash-check/bash-check.py
+++ b/validators/bash-check/bash-check.py
@@ -5,6 +5,8 @@ Stdlib only. Reference implementation per validators/SCHEMA.md.
 Usage:  bash-check.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import re
 import subprocess

--- a/validators/cargo-check/cargo-check.py
+++ b/validators/cargo-check/cargo-check.py
@@ -10,6 +10,8 @@ Finds Cargo.toml by walking up from the .rs file. Skips if none found.
 Usage:  cargo-check.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/validators/gofmt-check/gofmt-check.py
+++ b/validators/gofmt-check/gofmt-check.py
@@ -5,6 +5,8 @@ Requires gofmt (ships with Go). If missing, exits 0 with a stderr warning.
 Usage:  gofmt-check.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import shutil
 import subprocess

--- a/validators/hadolint/hadolint.py
+++ b/validators/hadolint/hadolint.py
@@ -5,6 +5,8 @@ Requires hadolint on PATH. If missing, exits 0 with a stderr warning (graceful d
 Usage:  hadolint.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import re
 import shutil

--- a/validators/inilint/inilint.py
+++ b/validators/inilint/inilint.py
@@ -5,6 +5,8 @@ Stdlib only. Reference implementation per validators/SCHEMA.md.
 Usage:  inilint.py <file>
 """
 
+from __future__ import annotations
+
 import configparser
 import json
 import sys

--- a/validators/jsonlint/jsonlint.py
+++ b/validators/jsonlint/jsonlint.py
@@ -5,6 +5,8 @@ Stdlib only. Reference implementation per validators/SCHEMA.md.
 Usage:  jsonlint.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import sys
 import time

--- a/validators/markdownlint/markdownlint.py
+++ b/validators/markdownlint/markdownlint.py
@@ -5,6 +5,8 @@ Requires markdownlint on PATH. If missing, exits 0 with a stderr warning (gracef
 Usage:  markdownlint.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import re
 import shutil

--- a/validators/node-check/node-check.py
+++ b/validators/node-check/node-check.py
@@ -5,6 +5,8 @@ Stdlib only. Reference implementation per validators/SCHEMA.md.
 Usage:  node-check.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import re
 import subprocess

--- a/validators/phplint/phplint.py
+++ b/validators/phplint/phplint.py
@@ -9,6 +9,8 @@ Output: one JSON object on stdout.
 Exit:   0 (always, except on missing python — handled by interpreter).
 """
 
+from __future__ import annotations
+
 import json
 import re
 import subprocess

--- a/validators/py-compile/py-compile.py
+++ b/validators/py-compile/py-compile.py
@@ -5,6 +5,8 @@ Stdlib only. Reference implementation per validators/SCHEMA.md.
 Usage:  py-compile.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import py_compile
 import sys

--- a/validators/ruby-check/ruby-check.py
+++ b/validators/ruby-check/ruby-check.py
@@ -6,6 +6,8 @@ If missing, exits 0 with a stderr warning (graceful degrade).
 Usage:  ruby-check.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import re
 import shutil

--- a/validators/stylelint/stylelint.py
+++ b/validators/stylelint/stylelint.py
@@ -6,6 +6,8 @@ Uses project-local stylelint config (auto-discovered by stylelint).
 Usage:  stylelint.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import shutil
 import subprocess

--- a/validators/terraform-check/terraform-check.py
+++ b/validators/terraform-check/terraform-check.py
@@ -5,6 +5,8 @@ Requires terraform CLI. If missing, exits 0 with a stderr warning.
 Usage:  terraform-check.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import shutil
 import subprocess

--- a/validators/tomllint/tomllint.py
+++ b/validators/tomllint/tomllint.py
@@ -6,6 +6,8 @@ if neither is available. Reference implementation per validators/SCHEMA.md.
 Usage:  tomllint.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import sys
 import time

--- a/validators/tsc-check/tsc-check.py
+++ b/validators/tsc-check/tsc-check.py
@@ -5,6 +5,8 @@ Requires tsc on PATH. If missing, exits 0 with a stderr warning (graceful degrad
 Usage:  tsc-check.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import re
 import shutil

--- a/validators/xmllint/xmllint.py
+++ b/validators/xmllint/xmllint.py
@@ -5,6 +5,8 @@ Stdlib only. Reference implementation per validators/SCHEMA.md.
 Usage:  xmllint.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import re
 import subprocess

--- a/validators/yaml-check/yaml-check.py
+++ b/validators/yaml-check/yaml-check.py
@@ -5,6 +5,8 @@ Requires PyYAML (pip install pyyaml). If missing, exits 0 with a stderr warning.
 Usage:  yaml-check.py <file>
 """
 
+from __future__ import annotations
+
 import json
 import sys
 import time


### PR DESCRIPTION
## Summary

Brings the repo up to GitHub's recommended community standards checklist.

## Changes

- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1, contact `fdavid@digitalprocesstools.com`
- `SECURITY.md` — private disclosure policy, supported versions table
- `CHANGELOG.md` — Keep a Changelog seed at v0.11.0
- `.editorconfig` — consistent indent rules
- `.github/ISSUE_TEMPLATE/bug_report.md` + `feature_request.md` + `config.yml` (blank issues disabled)
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/dependabot.yml` — weekly GH Actions bumps
- `pyproject.toml` — `[project]` metadata, URLs, classifiers (PyPI readiness)

## Test plan

- [x] No code changes; doc/config only
- [x] `pyproject.toml` parses (existing pytest config preserved)