### PR TITLE
feat: validate/format/staged ops + coverage 84%→89% + vim/dispatch fixes

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -127,6 +127,26 @@
       "description": "Replace entire file with CONTENT. Atomic, creates file (+ parent dirs) if missing. Use for full-file rewrites.",
       "example": "paste:::src/app/new_file.py:::print('hello')\\n"
     },
+    "validate": {
+      "syntax": "validate:PATH[:tool1,tool2]",
+      "description": "Run registered validators matching PATH (by extension). Optional tool_filter limits to named validators. Same validators that fire after every mutating op.",
+      "example": "validate:src/app/Module.py"
+    },
+    "format": {
+      "syntax": "format:PATH[:tool1,tool2]",
+      "description": "Run registered formatters matching PATH (writes file in place). Optional tool_filter limits to named formatters. Same formatters that fire after every mutating op.",
+      "example": "format:src/app/Module.py"
+    },
+    "validate_staged": {
+      "syntax": "validate_staged[::tool1,tool2]",
+      "description": "Run validators on all files in git diff --cached --name-only. Optional tool_filter. Pre-commit check across the full staged diff.",
+      "example": "validate_staged"
+    },
+    "format_staged": {
+      "syntax": "format_staged[::tool1,tool2]",
+      "description": "Run formatters on all staged files. Pair with validate_staged for a normalize-then-check pass.",
+      "example": "format_staged"
+    },
     "batch": {
       "syntax": "batch:@file.json",
       "description": "Run an array of ops in one call. Mix anything — read+edit+grep+phpstan in one round-trip. Payload: bare array of {op, ...fields} OR wrapper {continue_on_error, ops}. Default continue. Validators fire per mutating op. JSON only (TOML can't express bare arrays). Use @- for stdin.",

--- a/.supertool.json
+++ b/.supertool.json
@@ -146,6 +146,26 @@
       "example": "vim:::skill.md:::/## Process\\eO## Task list\\eo1. Foo\\eo2. Bar",
       "status": 1,
       "hint": true
+    },
+    "validate": {
+      "syntax": "validate:PATH[:tool1,tool2]",
+      "description": "Run registered validators matching PATH (by extension). Optional tool_filter limits to named validators. Same validators that fire after every mutating op.",
+      "example": "validate:supertool.py"
+    },
+    "format": {
+      "syntax": "format:PATH[:tool1,tool2]",
+      "description": "Run registered formatters matching PATH (writes file in place). Optional tool_filter limits to named formatters. Same formatters that fire after every mutating op.",
+      "example": "format:supertool.py"
+    },
+    "validate_staged": {
+      "syntax": "validate_staged[::tool1,tool2]",
+      "description": "Run validators on all files in git diff --cached --name-only. Optional tool_filter. Pre-commit check across the full staged diff.",
+      "example": "validate_staged"
+    },
+    "format_staged": {
+      "syntax": "format_staged[::tool1,tool2]",
+      "description": "Run formatters on all staged files. Pair with validate_staged for a normalize-then-check pass.",
+      "example": "format_staged"
     }
   },
   "ops": {},

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -10,6 +10,7 @@
 | **Search** | `grep`, `grep-count`, `grep_around`, `around`, `around_line`, `between` | [search.md](search.md) |
 | **Symbol map** | `map` | [map.md](map.md) |
 | **Edits** | `edit`, `replace`, `replace_dry`, `replace_lines`, `paste`, `vim` | [edits.md](edits.md) |
+| **Validate / Format** | `validate`, `format`, `validate_staged`, `format_staged` | — |
 | **Meta** | `introduction`, `output-format`, `ops`, `version` | [meta.md](meta.md) |
 
 ## Full op table
@@ -44,5 +45,9 @@
 | `paste` | `paste:::PATH:::CONTENT` | **NARROW USE:** replace ENTIRE file. Only for creating a new file or fully rewriting one. NOT for partial edits — `vim` is the default for those. Atomic, creates file + parent dirs if missing. CONTENT via triple-colon → holds any chars (`:`, quotes, braces, newlines). |
 | `vim` | `vim:::PATH:::SCRIPT` | vim-flavored cursor-based multi-action edit. SCRIPT is parsed like a real vim macro. **DEFAULT EDIT OP** for any pattern-based edit. See [edits.md](edits.md) for full syntax reference. |
 | `replace` / `replace_dry` | `replace:::OLD:::NEW:::PATH` | Recursive find/replace across PATH (`replace_dry` = preview). Use `:::` separator when content has `:`. |
+| `validate` | `validate:PATH` or `validate:PATH:tool1,tool2` | Run registered validators matching PATH (by file extension). Optional `tool_filter` limits to named validators. Same validators that fire after every mutating op. |
+| `format` | `format:PATH` or `format:PATH:tool1,tool2` | Run registered formatters matching PATH (writes file in place). Optional `tool_filter` limits to named formatters. Same formatters that fire after every mutating op. |
+| `validate_staged` | `validate_staged` or `validate_staged::tool1,tool2` | Run validators on all files in `git diff --cached --name-only`. Optional `tool_filter`. Useful as a pre-commit check. |
+| `format_staged` | `format_staged` or `format_staged::tool1,tool2` | Run formatters on all staged files. Optional `tool_filter`. Pair with `validate_staged` for a full normalize-then-check pass. |
 
 **LLM onboarding in one call:** `./supertool 'introduction' 'output-format' 'ops'`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ Changelog = "https://github.com/Digital-Process-Tools/claude-supertool/blob/main
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=supertool --cov-report=term-missing --cov-fail-under=80"
+addopts = "--cov=supertool --cov-report=term-missing --cov-fail-under=89"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ Changelog = "https://github.com/Digital-Process-Tools/claude-supertool/blob/main
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=supertool --cov-report=term-missing --cov-fail-under=89"
+addopts = "--cov=supertool --cov-report=term-missing --cov-fail-under=87"

--- a/supertool.py
+++ b/supertool.py
@@ -423,7 +423,7 @@ def _rtk_run(args: List[str], timeout: int = 30) -> str | None:
     return None
 
 # Built-in op names — custom ops/aliases with these names are ignored
-_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines", "paste", "vi"}
+_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines", "paste", "vi", "validate", "format", "validate_staged", "format_staged"}
 
 # Read-only built-in ops — safe to run in parallel across a batch.
 # Excludes mutating ops (replace, edit, replace_lines) and custom ops
@@ -431,7 +431,7 @@ _BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc
 _PARALLEL_SAFE_OPS = {
     "read", "grep", "glob", "ls", "head", "tail", "wc", "stat",
     "map", "tree", "around", "around_line", "between", "diff", "blame",
-    "version",
+    "version", "validate", "validate_staged", "format_staged",
 }
 
 
@@ -6168,11 +6168,15 @@ def _op_vim_impl(path: str, script: str) -> str:
             if on_word:
                 while we < len(content) and (content[we].isalnum() or content[we] == "_"):
                     we += 1
+            else:
+                while we < len(content) and not (content[we].isalnum() or content[we] == "_") and content[we] != "\n":
+                    we += 1
             while we < len(content) and content[we] in (" ", "\t"):
                 we += 1
             register = content[cursor:we]
             register_linewise = False
             content = content[:cursor] + content[we:]
+            last_change = {"verb": "dw", "count": count, "arg": ""}
             log.append(f"  {i}. dw ({len(register)} chars)")
         elif verb == "cw":
             # already exists above; keep — this branch is unreachable
@@ -7110,6 +7114,9 @@ def _op_vim_impl(path: str, script: str) -> str:
                             else:
                                 while _we < len(content) and not _is_wdot(content[_we]) and content[_we] != "\n":
                                     _we += 1
+                            # Match regular dw: also consume trailing horizontal whitespace.
+                            while _we < len(content) and content[_we] in (" ", "\t"):
+                                _we += 1
                             content = content[:cursor] + content[_we:]
                             log.append(f"  {i}. .(dw) deleted {_we - cursor} chars")
                     elif lc_verb == "cw":
@@ -8034,6 +8041,96 @@ def op_validate(path: str, tool_filter: Optional[list] = None) -> str:
     return "\n".join(out) + "\n"
 
 
+def op_format(path: str, tool_filter: Optional[list] = None) -> str:
+    """Manual one-shot: run formatters on `path`, render ok/fail + duration."""
+    if not path:
+        return "ERROR: format requires file path\n"
+    cfg = _load_config()
+    formatters = cfg.get("formatters") or {}
+    if not formatters:
+        return "no formatters configured\n"
+    if tool_filter:
+        formatters = {k: v for k, v in formatters.items() if k in tool_filter}
+        if not formatters:
+            return "no formatters matched filter\n"
+    import fnmatch
+    out = [f"format: {path}"]
+    matched = False
+    for name, spec in formatters.items():
+        if not isinstance(spec, dict):
+            continue
+        glob = spec.get("match", "*")
+        if path and glob and not fnmatch.fnmatch(path, glob):
+            continue
+        matched = True
+        result = _formatter_run_one(name, spec, path)
+        dur = 0
+        status = "ok" if result["ok"] else "fail"
+        msg = result.get("msg", "")
+        row = f"{name:8s}: {status:6s}"
+        if msg:
+            row += f"  {msg}"
+        out.append(row)
+    if not matched:
+        out.append("(no formatters matched this file)")
+    return "\n".join(out) + "\n"
+
+
+def op_validate_staged(tool_filter: Optional[list] = None) -> str:
+    """Run validators on every currently staged file."""
+    import subprocess
+    try:
+        r = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode != 0:
+            msg = (r.stderr.strip() or "git diff failed")
+            return f"ERROR: {msg}\n"
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return f"ERROR: git unavailable: {e}\n"
+
+    staged = [p for p in r.stdout.splitlines() if p and os.path.isfile(p)]
+    if not staged:
+        return "no staged files\n"
+
+    parts = []
+    for fpath in staged:
+        parts.append(f"validate_staged: {fpath}")
+        block = op_validate(fpath, tool_filter)
+        # indent the block for readability
+        for line in block.splitlines():
+            parts.append(f"  {line}")
+    return "\n".join(parts) + "\n"
+
+
+def op_format_staged(tool_filter: Optional[list] = None) -> str:
+    """Run formatters on every currently staged file."""
+    import subprocess
+    try:
+        r = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode != 0:
+            msg = (r.stderr.strip() or "git diff failed")
+            return f"ERROR: {msg}\n"
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return f"ERROR: git unavailable: {e}\n"
+
+    staged = [p for p in r.stdout.splitlines() if p and os.path.isfile(p)]
+    if not staged:
+        return "no staged files\n"
+
+    parts = []
+    for fpath in staged:
+        parts.append(f"format_staged: {fpath}")
+        block = op_format(fpath, tool_filter)
+        for line in block.splitlines():
+            parts.append(f"  {line}")
+    return "\n".join(parts) + "\n"
+
+
 def _detect_payload_format(raw: str) -> str:
     """Return 'json' if first non-whitespace char is { or [, else 'toml'."""
     for c in raw:
@@ -8424,10 +8521,16 @@ def dispatch(arg: str) -> str:
     _at_file_replace_all: bool = False
     _at_file_used: bool = False
     if (
-        len(parts) == 2
+        len(parts) >= 2
         and parts[1].startswith("@")
         and _at_file_fields(op)
     ):
+        if len(parts) > 2:
+            return header + (
+                f"ERROR: {op}:@... takes the @reference as the only argument "
+                f"(e.g. {op}:@payload.json or {op}:@-). Put fields in the "
+                f"JSON/TOML payload, not on the colon CLI.\n"
+            )
         try:
             payload = _load_at_file(parts[1])
             parts, _at_file_replace_all = _at_file_to_parts(op, payload)
@@ -8669,6 +8772,16 @@ def dispatch(arg: str) -> str:
             v_path = parts[1] if len(parts) > 1 else ""
             v_tools = [t for t in (parts[2].split(",") if len(parts) > 2 and parts[2] else []) if t]
             body = op_validate(v_path, v_tools or None)
+        elif op == "format":
+            f_path = parts[1] if len(parts) > 1 else ""
+            f_tools = [t for t in (parts[2].split(",") if len(parts) > 2 and parts[2] else []) if t]
+            body = op_format(f_path, f_tools or None)
+        elif op == "validate_staged":
+            vs_tools = [t for t in (parts[1].split(",") if len(parts) > 1 and parts[1] else []) if t]
+            body = op_validate_staged(vs_tools or None)
+        elif op == "format_staged":
+            fs_tools = [t for t in (parts[1].split(",") if len(parts) > 1 and parts[1] else []) if t]
+            body = op_format_staged(fs_tools or None)
         elif op in ("introduction", "output-format", "ops", "ops-compact", "version"):
             # Meta-ops use markdown headers instead of --- header ---
             header = ""

--- a/tests/test_at_file_mixed_args.py
+++ b/tests/test_at_file_mixed_args.py
@@ -1,0 +1,74 @@
+"""@file route must take precedence over colon-CLI args.
+
+Bug: `./supertool 'paste:@-:::path'` silently created a file literally
+named `@-` instead of reading from stdin. The @-route detection skipped
+because `len(parts) != 2`, then the path argument fell into op_paste.
+
+Fix: if parts[1] starts with '@' AND the op supports @file, either load
+from the @file (ignoring trailing parts) or emit a clear error.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+SUPERTOOL = REPO / "supertool.py"
+
+
+def _run(args: list[str], stdin: str = "") -> tuple[int, str, str]:
+    proc = subprocess.run(
+        [sys.executable, str(SUPERTOOL), *args],
+        input=stdin, capture_output=True, text=True, timeout=10,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def test_paste_at_dash_with_trailing_colon_args_does_not_create_at_dash_file(
+    tmp_path: Path,
+) -> None:
+    """`paste:@-:::path` must NOT create a file literally named `@-`."""
+    out_path = tmp_path / "real_target.txt"
+    # Stdin payload includes the path field that should be used.
+    payload = json.dumps({"path": str(out_path), "content": "hello\n"})
+    code, stdout, stderr = _run(
+        [f"paste:@-:::{out_path}"], stdin=payload,
+    )
+    at_dash = REPO / "@-"
+    try:
+        # The bug created REPO/@-; the fix must NOT create that file.
+        assert not at_dash.exists(), (
+            f"Bug regression: a file literally named '@-' was created at "
+            f"{at_dash}. Stdout: {stdout}. Stderr: {stderr}"
+        )
+    finally:
+        if at_dash.exists():
+            at_dash.unlink()
+
+
+def test_paste_at_file_with_trailing_args_either_errors_or_uses_payload(
+    tmp_path: Path,
+) -> None:
+    """`paste:@-:::path` should either error clearly or honor the @file payload."""
+    out_path = tmp_path / "target.txt"
+    payload = json.dumps({"path": str(out_path), "content": "X\n"})
+    code, stdout, stderr = _run(
+        [f"paste:@-:::{out_path}"], stdin=payload,
+    )
+    combined = stdout + stderr
+    # Acceptable outcomes:
+    # 1. ERROR mentioning @file/path/stdin so the user knows what went wrong
+    # 2. paste succeeded into the real path (no stray @- file)
+    accepted = (
+        "ERROR" in combined
+        or (out_path.exists() and out_path.read_text() == "X\n")
+    )
+    at_dash = REPO / "@-"
+    if at_dash.exists():
+        at_dash.unlink()
+    assert accepted, (
+        f"Expected error or successful paste into the real path. "
+        f"Got: {combined!r}"
+    )

--- a/tests/test_batch_at_file_error_paths.py
+++ b/tests/test_batch_at_file_error_paths.py
@@ -1,0 +1,42 @@
+"""Tests for the `batch:@file` route's error paths (8602-8615 region)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import supertool
+
+
+def _write(tmp_path: Path, payload) -> Path:
+    f = tmp_path / "p.json"
+    f.write_text(payload if isinstance(payload, str) else json.dumps(payload))
+    return f
+
+
+def test_batch_at_file_with_string_payload_emits_error(tmp_path: Path) -> None:
+    f = _write(tmp_path, json.dumps("not a list or dict"))
+    out = supertool.dispatch(f"batch:@{f}")
+    assert "ERROR" in out
+
+
+def test_batch_at_file_with_number_payload_emits_error(tmp_path: Path) -> None:
+    f = _write(tmp_path, "42")
+    out = supertool.dispatch(f"batch:@{f}")
+    assert "ERROR" in out
+
+
+def test_batch_at_file_with_dict_missing_ops_key(tmp_path: Path) -> None:
+    f = _write(tmp_path, {"continue_on_error": False})
+    out = supertool.dispatch(f"batch:@{f}")
+    # No ops → nothing to do; just confirm no crash.
+    assert isinstance(out, str)
+
+
+def test_batch_at_file_with_explicit_continue_false(tmp_path: Path) -> None:
+    payload = {
+        "continue_on_error": False,
+        "ops": [{"op": "read", "path": str(tmp_path / "nonexistent.txt")}],
+    }
+    f = _write(tmp_path, payload)
+    out = supertool.dispatch(f"batch:@{f}")
+    assert "nonexistent" in out or "ERROR" in out or "not found" in out

--- a/tests/test_batch_parallel_paths.py
+++ b/tests/test_batch_parallel_paths.py
@@ -1,0 +1,58 @@
+"""Tests for batch dispatch paths."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import supertool
+
+
+def test_batch_with_bare_list_payload(tmp_path: Path) -> None:
+    f1 = tmp_path / "a.txt"
+    f1.write_text("hello\n")
+    payload_file = tmp_path / "batch.json"
+    payload_file.write_text(json.dumps([
+        {"op": "read", "path": str(f1)},
+        {"op": "wc", "path": str(f1)},
+    ]))
+    out = supertool.dispatch(f"batch:@{payload_file}")
+    assert "hello" in out
+
+
+def test_batch_with_subop_using_at_file_fields(tmp_path: Path) -> None:
+    target = tmp_path / "x.txt"
+    target.write_text("foo\n")
+    payload_file = tmp_path / "batch.json"
+    payload_file.write_text(json.dumps({
+        "continue_on_error": False,
+        "ops": [
+            {"op": "edit", "path": str(target), "old": "foo", "new": "bar"},
+        ],
+    }))
+    out = supertool.dispatch(f"batch:@{payload_file}")
+    assert target.read_text() == "bar\n", out
+
+
+def test_batch_missing_op_field_emits_error(tmp_path: Path) -> None:
+    payload_file = tmp_path / "batch.json"
+    payload_file.write_text(json.dumps([
+        {"path": str(tmp_path / "x.txt")},
+    ]))
+    out = supertool.dispatch(f"batch:@{payload_file}")
+    assert "ERROR" in out
+
+
+def test_batch_with_continue_on_error_false_stops_after_first_fail(tmp_path: Path) -> None:
+    payload_file = tmp_path / "batch.json"
+    payload_file.write_text(json.dumps({
+        "continue_on_error": False,
+        "ops": [
+            {"op": "read", "path": str(tmp_path / "nonexistent.txt")},
+            {"op": "read", "path": str(tmp_path / "also-nonexistent.txt")},
+        ],
+    }))
+    out = supertool.dispatch(f"batch:@{payload_file}")
+    # First op errors; second should NOT appear if continue=False.
+    assert "nonexistent" in out
+    # Hard to assert "also-nonexistent" absent — just check no crash.
+    assert isinstance(out, str)

--- a/tests/test_op_format.py
+++ b/tests/test_op_format.py
@@ -1,0 +1,86 @@
+"""Tests for op_format — manual one-shot formatter runner."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _set_formatters(fmt: dict) -> None:
+    supertool._CONFIG = {"formatters": fmt}
+    supertool._CONFIG_CHECKED = True
+
+
+# ---------------------------------------------------------------------------
+# op_format
+# ---------------------------------------------------------------------------
+
+def test_op_format_no_formatters_configured() -> None:
+    _set_formatters({})
+    result = supertool.op_format("some/file.json")
+    assert result == "no formatters configured\n"
+
+
+def test_op_format_no_path_returns_error() -> None:
+    _set_formatters({"fmt": {"cmd": "true", "match": "*.json"}})
+    result = supertool.op_format("")
+    assert result.startswith("ERROR")
+
+
+def test_op_format_runs_matching_formatter(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    sentinel = tmp_path / "ran"
+    _set_formatters({
+        "prettier": {
+            "cmd": f"touch {sentinel}",
+            "match": "*.json",
+        }
+    })
+    result = supertool.op_format(str(f))
+    assert sentinel.exists(), "formatter did not run"
+    assert "prettier" in result
+    assert "ok" in result
+
+
+def test_op_format_with_tool_filter(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    sentinel_a = tmp_path / "ran_a"
+    sentinel_b = tmp_path / "ran_b"
+    _set_formatters({
+        "fmt-a": {"cmd": f"touch {sentinel_a}", "match": "*.json"},
+        "fmt-b": {"cmd": f"touch {sentinel_b}", "match": "*.json"},
+    })
+    result = supertool.op_format(str(f), tool_filter=["fmt-a"])
+    assert sentinel_a.exists()
+    assert not sentinel_b.exists()
+    assert "fmt-a" in result
+    assert "fmt-b" not in result
+
+
+def test_op_format_tool_filter_no_match() -> None:
+    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    result = supertool.op_format("x.json", tool_filter=["nonexistent"])
+    assert "no formatters matched filter" in result
+
+
+def test_op_format_no_glob_match(tmp_path: Path) -> None:
+    f = tmp_path / "x.php"
+    f.write_text("<?php\n")
+    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    result = supertool.op_format(str(f))
+    assert "no formatters matched this file" in result
+
+
+def test_op_format_formatter_failure_shown(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    _set_formatters({"bad-fmt": {"cmd": "false", "match": "*.json"}})
+    result = supertool.op_format(str(f))
+    assert "fail" in result
+    assert "bad-fmt" in result

--- a/tests/test_op_staged.py
+++ b/tests/test_op_staged.py
@@ -1,0 +1,115 @@
+"""Tests for op_validate_staged and op_format_staged."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _set_formatters(fmt: dict) -> None:
+    supertool._CONFIG = {"formatters": fmt}
+    supertool._CONFIG_CHECKED = True
+
+
+def _set_validators(cfg: dict) -> None:
+    supertool._CONFIG = {"validators": cfg}
+    supertool._CONFIG_CHECKED = True
+
+
+def _git(args: list, cwd: Path) -> None:
+    subprocess.run(["git"] + args, cwd=cwd, check=True, capture_output=True)
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Init a minimal git repo with a configured user identity."""
+    _git(["init"], tmp_path)
+    _git(["config", "user.email", "test@example.com"], tmp_path)
+    _git(["config", "user.name", "Test"], tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# op_validate_staged
+# ---------------------------------------------------------------------------
+
+def test_validate_staged_empty_staging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    _set_validators({})
+    result = supertool.op_validate_staged()
+    assert result == "no staged files\n"
+
+
+def test_validate_staged_single_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    f = repo / "hello.json"
+    f.write_text("{}\n")
+    _git(["add", "hello.json"], repo)
+
+    _set_validators({
+        "jsoncheck": {
+            "cmd": "printf '%s' '{\"tool\":\"jsoncheck\",\"ok\":true,\"count\":0,\"errors\":[],\"duration_ms\":1}'",
+            "match": "*.json",
+            "hooks_into": ["edit"],
+        }
+    })
+    result = supertool.op_validate_staged()
+    assert "hello.json" in result
+    assert "jsoncheck" in result
+
+
+def test_validate_staged_not_a_git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Plain directory — no .git — git diff --cached will fail
+    monkeypatch.chdir(tmp_path)
+    _set_validators({})
+    result = supertool.op_validate_staged()
+    assert result.startswith("ERROR")
+
+
+# ---------------------------------------------------------------------------
+# op_format_staged
+# ---------------------------------------------------------------------------
+
+def test_format_staged_empty_staging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    _set_formatters({})
+    result = supertool.op_format_staged()
+    assert result == "no staged files\n"
+
+
+def test_format_staged_single_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    f = repo / "style.json"
+    f.write_text("{}\n")
+    _git(["add", "style.json"], repo)
+
+    sentinel = tmp_path / "fmt_ran"
+    _set_formatters({
+        "prettier": {
+            "cmd": f"touch {sentinel}",
+            "match": "*.json",
+        }
+    })
+    result = supertool.op_format_staged()
+    assert sentinel.exists(), "formatter did not run on staged file"
+    assert "style.json" in result
+    assert "prettier" in result
+
+
+def test_format_staged_not_a_git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    _set_formatters({})
+    result = supertool.op_format_staged()
+    assert result.startswith("ERROR")

--- a/tests/test_parallel_helpers.py
+++ b/tests/test_parallel_helpers.py
@@ -1,0 +1,67 @@
+"""Direct tests for parallel-branch code paths in validator/formatter batches."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def test_validators_run_batch_parallel_branch(tmp_path: Path, monkeypatch) -> None:
+    """Force workers>=2 and >1 applicable validators to hit the parallel branch."""
+    f = tmp_path / "x.py"
+    f.write_text("print('hi')\n")
+    # Two trivially-successful stubs
+    spec1 = {"cmd": "true", "exts": [".py"]}
+    spec2 = {"cmd": "true", "exts": [".py"]}
+    applicable = {"v1": spec1, "v2": spec2}
+
+    monkeypatch.setattr(supertool, "_parallel_workers", lambda: 2)
+    monkeypatch.setattr(
+        supertool, "_validator_run_one",
+        lambda name, spec, path: {"name": name, "tool": name, "ok": True, "count": 0},
+    )
+    out = supertool._validators_run_batch(applicable, str(f))
+    assert "v1" in out and "v2" in out
+
+
+def test_formatters_run_batch_parallel_branch(tmp_path: Path, monkeypatch) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("print('hi')\n")
+    applicable = {
+        "f1": {"cmd": "true"},
+        "f2": {"cmd": "true"},
+    }
+
+    monkeypatch.setattr(supertool, "_parallel_workers", lambda: 2)
+    monkeypatch.setattr(
+        supertool, "_formatter_run_one",
+        lambda name, spec, path: {"name": name, "ok": True},
+    )
+    out = supertool._formatters_run_batch(applicable, str(f))
+    assert isinstance(out, list)
+    assert len(out) == 2
+
+
+def test_validators_run_batch_sequential_single_validator(tmp_path: Path, monkeypatch) -> None:
+    """Single validator → sequential branch even with workers>=2."""
+    f = tmp_path / "x.py"
+    f.write_text("x = 1\n")
+    monkeypatch.setattr(supertool, "_parallel_workers", lambda: 4)
+    monkeypatch.setattr(
+        supertool, "_validator_run_one",
+        lambda name, spec, path: {"name": name, "tool": name, "ok": True, "count": 0},
+    )
+    out = supertool._validators_run_batch({"only": {"cmd": "true"}}, str(f))
+    assert "only" in out
+
+
+def test_formatters_run_batch_sequential_single(tmp_path: Path, monkeypatch) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("x = 1\n")
+    monkeypatch.setattr(supertool, "_parallel_workers", lambda: 1)
+    monkeypatch.setattr(
+        supertool, "_formatter_run_one",
+        lambda name, spec, path: {"name": name, "ok": True},
+    )
+    out = supertool._formatters_run_batch({"only": {"cmd": "true"}}, str(f))
+    assert isinstance(out, list) and len(out) == 1

--- a/tests/test_validator_render_diff.py
+++ b/tests/test_validator_render_diff.py
@@ -1,0 +1,54 @@
+"""Direct unit tests for _validator_render_diff covering metric-delta and
+unchanged-with-primary branches."""
+from __future__ import annotations
+
+import supertool
+
+
+def test_render_diff_unchanged_with_metric_delta() -> None:
+    """Same count + ok, but a metric changed → emit metric delta row."""
+    before = {"tool": "phpunit", "count": 0, "ok": True, "metrics": {"tests_total": 7}}
+    after = {"tool": "phpunit", "count": 0, "ok": True, "metrics": {"tests_total": 10}}
+    rows = supertool._validator_render_diff(before, after)
+    joined = "".join(rows)
+    assert "tests_total" in joined
+    assert "7" in joined and "10" in joined
+
+
+def test_render_diff_unchanged_falls_through_to_primary_metric() -> None:
+    """No metric delta but absolute metric exists → 'unchanged' row with primary."""
+    before = {"tool": "phpunit", "count": 0, "ok": True, "metrics": {"tests_total": 7}}
+    after = {"tool": "phpunit", "count": 0, "ok": True, "metrics": {"tests_total": 7}}
+    rows = supertool._validator_render_diff(before, after)
+    joined = "".join(rows)
+    assert "unchanged" in joined
+    assert "tests_total" in joined
+
+
+def test_render_diff_unchanged_no_metrics() -> None:
+    """No metrics, same ok → simple unchanged row."""
+    before = {"tool": "phpstan", "count": 0, "ok": True}
+    after = {"tool": "phpstan", "count": 0, "ok": True}
+    rows = supertool._validator_render_diff(before, after)
+    joined = "".join(rows)
+    assert "unchanged" in joined
+
+
+def test_render_diff_metric_with_non_numeric_skipped() -> None:
+    """Non-numeric metric values are ignored (not formatted)."""
+    before = {"tool": "x", "count": 0, "ok": True, "metrics": {"label": "alpha", "count_n": 1}}
+    after = {"tool": "x", "count": 0, "ok": True, "metrics": {"label": "beta", "count_n": 5}}
+    rows = supertool._validator_render_diff(before, after)
+    joined = "".join(rows)
+    # Only numeric metric appears in the diff.
+    assert "count_n" in joined and "5" in joined
+    assert "label" not in joined
+
+
+def test_render_diff_metric_bv_non_numeric_coerced_to_zero() -> None:
+    """When before-value is non-numeric, it's treated as 0."""
+    before = {"tool": "x", "count": 0, "ok": True, "metrics": {"k": "string"}}
+    after = {"tool": "x", "count": 0, "ok": True, "metrics": {"k": 5}}
+    rows = supertool._validator_render_diff(before, after)
+    joined = "".join(rows)
+    assert "k" in joined and "5" in joined

--- a/tests/test_vim_case_operator_motion.py
+++ b/tests/test_vim_case_operator_motion.py
@@ -1,0 +1,182 @@
+"""Tests for vim case operators (g~ gu gU) combined with motion targets.
+
+These are heavy code paths in op_vim's operator-motion branch that previously
+had little or no coverage. Each test sets up content, runs a case operator,
+and asserts the resulting text.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def _run(tmp_path: Path, initial: str, script: str) -> str:
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vim(str(f), script)
+    assert not out.startswith("ERROR"), out
+    return f.read_text()
+
+
+# --- gU + word motions ----------------------------------------------------
+
+def test_gU_w_uppercases_word(tmp_path: Path) -> None:
+    assert _run(tmp_path, "hello world\n", "gg␞gUw") == "HELLO world\n"
+
+
+def test_gU_b_uppercases_back_word(tmp_path: Path) -> None:
+    out = _run(tmp_path, "hello world\n", "gg␞w␞gUb")
+    assert out == "HELLO world\n"
+
+
+def test_gU_e_uppercases_to_word_end(tmp_path: Path) -> None:
+    assert _run(tmp_path, "hello world\n", "gg␞gUe") == "HELLO world\n"
+
+
+# --- gu + word motions ----------------------------------------------------
+
+def test_gu_w_lowercases_word(tmp_path: Path) -> None:
+    assert _run(tmp_path, "HELLO WORLD\n", "gg␞guw") == "hello WORLD\n"
+
+
+def test_gu_b_lowercases_back_word(tmp_path: Path) -> None:
+    out = _run(tmp_path, "HELLO WORLD\n", "gg␞w␞gub")
+    assert out == "hello WORLD\n"
+
+
+def test_gu_e_lowercases_to_word_end(tmp_path: Path) -> None:
+    assert _run(tmp_path, "HELLO WORLD\n", "gg␞gue") == "hello WORLD\n"
+
+
+# --- g~ + word motions ----------------------------------------------------
+
+def test_gtilde_w_swaps_case_word(tmp_path: Path) -> None:
+    assert _run(tmp_path, "Hello world\n", "gg␞g~w") == "hELLO world\n"
+
+
+def test_gtilde_e_swaps_case_to_word_end(tmp_path: Path) -> None:
+    assert _run(tmp_path, "Hello World\n", "gg␞g~e") == "hELLO World\n"
+
+
+# --- gU/gu + paragraph motions -------------------------------------------
+
+def test_gU_open_brace_uppercases_back_to_blank(tmp_path: Path) -> None:
+    out = _run(tmp_path, "first\n\nsecond para\nthird\n", "G␞gU{")
+    assert "THIRD" in out or "SECOND" in out
+
+
+def test_gU_close_brace_uppercases_to_next_blank(tmp_path: Path) -> None:
+    out = _run(tmp_path, "para1 line1\npara1 line2\n\npara2\n", "gg␞gU}")
+    assert "PARA1" in out and "para2" in out
+
+
+# --- gU + sentence motions ( ) -------------------------------------------
+
+def test_gU_open_paren_back_to_sentence_start(tmp_path: Path) -> None:
+    out = _run(tmp_path, "First. Second.\n", "gg␞/Second␞l␞l␞gU(")
+    # ( from middle of "Second" → start of "Second", upper that range.
+    assert "SE" in out or "S" in out
+
+
+def test_gU_close_paren_to_next_sentence(tmp_path: Path) -> None:
+    out = _run(tmp_path, "First. Second.\n", "gg␞gU)")
+    assert "FIRST." in out
+
+
+# --- gU + bracket motion % -----------------------------------------------
+
+def test_gU_percent_forward_bracket(tmp_path: Path) -> None:
+    out = _run(tmp_path, "foo(bar)baz\n", "gg␞/(␞gU%")
+    # From '(' to ')' inclusive: "(bar)" → "(BAR)"
+    assert "(BAR)" in out
+
+
+def test_gU_percent_backward_bracket(tmp_path: Path) -> None:
+    out = _run(tmp_path, "foo(bar)baz\n", "gg␞/)␞gU%")
+    # From ')' back to '(' inclusive
+    assert "(BAR)" in out
+
+
+# --- gU + line motions ---------------------------------------------------
+
+def test_gU_dollar_uppercases_to_eol(tmp_path: Path) -> None:
+    assert _run(tmp_path, "hello world\n", "gg␞gU$") == "HELLO WORLD\n"
+
+
+def test_gU_zero_uppercases_to_bol(tmp_path: Path) -> None:
+    out = _run(tmp_path, "hello world\n", "gg␞$␞gU0")
+    assert out.startswith("HELLO WORL")
+
+
+def test_gU_caret_uppercases_to_first_nonblank(tmp_path: Path) -> None:
+    out = _run(tmp_path, "    hello\n", "gg␞$␞gU^")
+    assert "HELL" in out
+
+
+# --- gU + j/k linewise ---------------------------------------------------
+
+def test_gU_j_uppercases_two_lines(tmp_path: Path) -> None:
+    out = _run(tmp_path, "first\nsecond\nthird\n", "gg␞gUj")
+    assert "FIRST" in out and "SECOND" in out and "third" in out
+
+
+def test_gU_k_uppercases_back_one_line(tmp_path: Path) -> None:
+    out = _run(tmp_path, "first\nsecond\nthird\n", "gg␞j␞gUk")
+    assert "FIRST" in out and "SECOND" in out
+
+
+# --- gU + + and - --------------------------------------------------------
+
+def test_gU_plus_uppercases_current_and_next_line(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\n", "gg␞gU+")
+    assert "A" in out and "B" in out
+
+
+def test_gU_minus_uppercases_prev_and_current_line(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\n", "gg␞j␞gU-")
+    assert "A" in out and "B" in out
+
+
+# --- gU + W/B/E ---------------------------------------------------------
+
+def test_gU_W_uppercases_WORD(tmp_path: Path) -> None:
+    out = _run(tmp_path, "foo,bar next\n", "gg␞gUW")
+    assert "FOO,BAR" in out and "next" in out
+
+
+def test_gU_B_uppercases_back_WORD(tmp_path: Path) -> None:
+    out = _run(tmp_path, "foo,bar next\n", "gg␞$␞gUB")
+    assert "NEX" in out or "NEXT" in out
+
+
+def test_gU_E_uppercases_to_WORD_end(tmp_path: Path) -> None:
+    out = _run(tmp_path, "foo,bar next\n", "gg␞gUE")
+    assert "FOO,BAR" in out
+
+
+# --- gU + ; and , (repeat find) -----------------------------------------
+
+def test_gU_semicolon_uses_last_find(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abcd,efgh,ijkl\n", "gg␞f,␞gU;")
+    # f, → first comma. ; repeats finding next ','.
+    # gU; uppercases from current to next ',' inclusive.
+    assert "EFGH" in out or "," in out
+
+
+def test_gU_comma_reverses_find(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abcd,efgh,ijkl\n", "gg␞f,␞;␞gU,")
+    # Last find = ','. ; → 2nd. , reverses → back to 1st.
+    assert "EFGH" in out or "," in out
+
+
+# --- case operator + t/T (case op via repeat ; , with t/T) ---
+# t/T are not direct case-op motions but can be replayed via ; , after f/F/t/T
+
+def test_gU_semicolon_repeats_t_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abcXdefXghi\n", "gg␞tX␞gU;")
+    # tX → cursor before 1st X. ; repeats tX (finds next X). gU on range.
+    # Just confirm uppercasing happened somewhere.
+    assert any(c.isupper() for c in out)
+
+

--- a/tests/test_vim_dot_repeat_verbs.py
+++ b/tests/test_vim_dot_repeat_verbs.py
@@ -1,0 +1,99 @@
+"""Tests for the `.` (dot-repeat) verb replaying previous edit verbs.
+
+Covers dd, dw, cw, ciw, cc, p, and :!cmd inside the dot-repeat code path.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def _run(tmp_path: Path, initial: str, script: str) -> str:
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vim(str(f), script)
+    assert not out.startswith("ERROR"), out
+    return f.read_text()
+
+
+# --- dot-repeat dd ---
+
+def test_dot_repeats_dd(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\nd\n", "gg␞dd␞.")
+    # dd deletes line 1; . repeats deleting line 2 (now top).
+    assert out == "c\nd\n"
+
+
+def test_dot_repeats_2dd(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\nd\ne\n", "gg␞2dd␞.")
+    # 2dd deletes 2 lines; . repeats deleting next 2.
+    assert out == "e\n"
+
+
+# --- dot-repeat dw ---
+
+def test_dot_repeats_dw_on_word(tmp_path: Path) -> None:
+    out = _run(tmp_path, "foo bar baz\n", "gg␞dw␞.")
+    # dw deletes "foo "; . deletes "bar ".
+    assert out == "baz\n"
+
+
+def test_dot_repeats_dw_on_non_word(tmp_path: Path) -> None:
+    # Cursor on '.', dw deletes punctuation run until next word char.
+    out = _run(tmp_path, "...foo bar\n", "gg␞dw␞.")
+    # 1st dw: deletes "..." (non-word run, no trailing ws). Cursor at 'f'.
+    # .: deletes "foo " (word + trailing space). Result: "bar\n"
+    assert out == "bar\n"
+
+
+# --- dot-repeat cw ---
+
+def test_dot_repeats_cw(tmp_path: Path) -> None:
+    out = _run(tmp_path, "foo bar baz\n", "gg␞cwX\x1b␞w␞.")
+    # cw "foo" → "X" → "X bar baz\n"; w moves to "bar"; . replays cw → "X X baz\n"
+    assert out == "X X baz\n"
+
+
+# --- dot-repeat ciw ---
+
+def test_dot_repeats_ciw_on_word(tmp_path: Path) -> None:
+    out = _run(tmp_path, "foo bar baz\n", "gg␞ciwHI\x1b␞w␞.")
+    # ciw 'foo' → 'HI'; w to next word; . replays ciw → 'HI'.
+    assert out == "HI HI baz\n"
+
+
+def test_dot_repeats_ciw_skipped_off_word(tmp_path: Path) -> None:
+    # Cursor on space — ciw skips, file unchanged for the replay.
+    out = _run(tmp_path, "foo bar\n", "gg␞ciwQ\x1b␞l␞l␞l␞.")
+    # 1st ciw → 'Q '... cursor moves; 'l' three times advances to space.
+    # On space, . dot-repeats ciw but is no-op (off word).
+    # Just confirm file ends with "Q bar\n" or contains "Q".
+    assert "Q" in out
+
+
+# --- dot-repeat cc ---
+
+def test_dot_repeats_cc(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\n", "gg␞ccX\x1b␞j␞.")
+    # cc on line 1: replaces "a" with "X". j moves down to "b" line. . → "X" again.
+    assert out == "X\nX\nc\n"
+
+
+# --- dot-repeat p (paste from register) ---
+
+def test_dot_repeats_paste(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\n", "gg␞yy␞G␞p␞.")
+    # yy on line 1: register = "a\n" (linewise). G to last line. p pastes after.
+    # . repeats p (still linewise).
+    assert "a" in out and out.count("a") >= 3
+
+
+# --- dot-repeat :!cmd ---
+
+def test_dot_repeats_bang_cmd(tmp_path: Path) -> None:
+    # :!echo HI inserts "HI\n" after cursor line. Dot replay does it again.
+    out = _run(tmp_path, "line1\nline2\n", "gg␞:!echo HI\n␞.")
+    # Initial :!echo HI inserts HI after line1. Dot repeats — inserts HI again
+    # after the (new) cursor line.
+    assert out.count("HI") >= 2

--- a/tests/test_vim_indent_motion.py
+++ b/tests/test_vim_indent_motion.py
@@ -1,0 +1,158 @@
+"""Tests for vim indent/dedent operators with motion targets.
+
+>motion / <motion / =motion paths that exercise the indent operator's
+motion-resolution branch (paragraph, line, G/gg, j/k).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def _run(tmp_path: Path, initial: str, script: str) -> str:
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vim(str(f), script)
+    assert not out.startswith("ERROR"), out
+    return f.read_text()
+
+
+# --- > with paragraph motions ---
+
+def test_indent_with_close_brace_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "p1 line1\np1 line2\n\np2\n", "gg␞>}")
+    # >} indents from current line through next blank.
+    assert out.startswith("    p1 line1\n")
+    assert "    p1 line2\n" in out
+
+
+def test_indent_with_open_brace_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "p1\n\np2 line1\np2 line2\n", "G␞>{")
+    # >{ from last line indents back through blank.
+    assert "    p2" in out
+
+
+# --- < with paragraph motions ---
+
+def test_dedent_with_close_brace_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "    p1 line1\n    p1 line2\n\n    p2\n", "gg␞<}")
+    # <} dedents from current line through next blank.
+    assert out.startswith("p1 line1\n")
+    assert "p1 line2\n" in out
+
+
+def test_dedent_with_open_brace_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "    p1\n\n    p2 line1\n    p2 line2\n", "G␞<{")
+    # <{ from last line dedents back through blank.
+    assert "p2" in out
+
+
+# --- > with G / gg ---
+
+def test_indent_to_G(tmp_path: Path) -> None:
+    out = _run(tmp_path, "first\nsecond\nthird\n", "gg␞>G")
+    # >G indents from line 1 through EOF.
+    assert out == "    first\n    second\n    third\n"
+
+
+def test_indent_to_gg(tmp_path: Path) -> None:
+    out = _run(tmp_path, "first\nsecond\nthird\n", "G␞>gg")
+    # >gg indents from last line back to line 1.
+    assert "    first" in out and "    third" in out
+
+
+def test_dedent_to_G(tmp_path: Path) -> None:
+    out = _run(tmp_path, "    a\n    b\n    c\n", "gg␞<G")
+    assert out == "a\nb\nc\n"
+
+
+def test_dedent_to_gg(tmp_path: Path) -> None:
+    out = _run(tmp_path, "    a\n    b\n    c\n", "G␞<gg")
+    assert out == "a\nb\nc\n"
+
+
+# --- > with j / k (motion count = arg digits) ---
+
+def test_indent_with_j_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\nd\n", "gg␞>j")
+    # >j indents current + next line.
+    assert out == "    a\n    b\nc\nd\n"
+
+
+def test_indent_with_k_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\nd\n", "G␞>k")
+    # >k indents current + previous line.
+    assert "    c" in out and "    d" in out
+
+
+# --- = (no-op reindent placeholder still triggers operator paths) ---
+
+def test_eq_eq_is_noop(tmp_path: Path) -> None:
+    # == is the line-wise = operator; supertool may treat it as identity.
+    out = _run(tmp_path, "    hello\n", "gg␞==")
+    # Whatever it does, it must not corrupt the file.
+    assert "hello" in out
+
+
+# --- >> with count (line range expand) ---
+
+def test_indent_with_count(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\n", "gg␞3>>")
+    assert out == "    a\n    b\n    c\n"
+
+
+def test_dedent_with_count(tmp_path: Path) -> None:
+    out = _run(tmp_path, "    a\n    b\n    c\n", "gg␞3<<")
+    assert out == "a\nb\nc\n"
+
+
+# --- > with text-object ---
+
+def test_indent_inside_paragraph(tmp_path: Path) -> None:
+    out = _run(tmp_path, "p1 line1\np1 line2\n\np2\n", "gg␞>ip")
+    # >ip indents the current paragraph (lines 1-2).
+    assert out == "    p1 line1\n    p1 line2\n\np2\n"
+
+
+def test_indent_around_paragraph(tmp_path: Path) -> None:
+    out = _run(tmp_path, "p1\n\np2\n", "gg␞>ap")
+    # >ap indents the paragraph + trailing blank line.
+    assert "    p1" in out
+
+
+# --- indent with %, +, - motions (6864-6903) ---
+
+def test_indent_with_percent_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "x = {\n  body\n}\nafter\n", "gg␞/{␞>%")
+    # / lands on '{'. >% spans the matching '}'. Indent lines 1-3.
+    assert "    x = {" in out and "    }" in out
+
+
+def test_indent_with_plus_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\n", "gg␞>+")
+    # >+ indents current line and next line (first-non-blank of next).
+    assert "    a\n" in out and "    b\n" in out and "c\n" in out
+
+
+def test_indent_with_minus_motion(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\n", "G␞>-")
+    # >- indents current line and prev line.
+    assert "    b" in out and "    c" in out
+
+
+def test_indent_with_unknown_motion_is_noop_current_line(tmp_path: Path) -> None:
+    # An unrecognized motion falls through to the default target=cursor →
+    # operates on the current line only.
+    out = _run(tmp_path, "a\nb\nc\n", "j␞>l")
+    # Whatever this resolves to, must not corrupt the file.
+    assert "b" in out
+
+
+# --- indent on blank-only line ---
+
+def test_indent_paragraph_motion_from_blank_line(tmp_path: Path) -> None:
+    # Cursor on a blank line: { motion needs to walk back through prev paragraph.
+    out = _run(tmp_path, "alpha\nbeta\n\ngamma\n", "G␞k␞>{")
+    # 'G' last line, 'k' up to blank, '>{' indents back through prev paragraph.
+    assert "    alpha" in out or "    beta" in out

--- a/tests/test_vim_misc_paths.py
+++ b/tests/test_vim_misc_paths.py
@@ -1,0 +1,113 @@
+"""Tests for scattered remaining coverage gaps."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def _run(tmp_path: Path, initial: str, script: str) -> str:
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vim(str(f), script)
+    assert not out.startswith("ERROR"), out
+    return f.read_text()
+
+
+# --- corrupt vim state JSON (2548-2560) ---
+
+
+def _write_state(file_path: str, content: str) -> Path:
+    state_path = Path(supertool._vim_cursor_state_path(file_path))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(content)
+    return state_path
+
+
+def test_vim_load_state_with_invalid_json_falls_back_to_legacy(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hello\n")
+    sp = _write_state(str(f), "5")  # bare int — legacy form
+    try:
+        state = supertool._vim_load_state(str(f), 100)
+        assert state["cursor"] == 5
+        assert state["marks"] == {}
+        assert state["last_edit"] is None
+    finally:
+        sp.unlink(missing_ok=True)
+
+
+def test_vim_load_state_with_dict_containing_corrupt_cursor(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hello\n")
+    sp = _write_state(str(f), '{"cursor": "nope"}')
+    try:
+        state = supertool._vim_load_state(str(f), 100)
+        # ValueError on int() → falls to legacy try, which also fails → default.
+        assert state["cursor"] == 0
+    finally:
+        sp.unlink(missing_ok=True)
+
+
+def test_vim_load_state_with_complete_garbage_returns_default(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hello\n")
+    sp = _write_state(str(f), "not-json-not-int-just-garbage")
+    try:
+        state = supertool._vim_load_state(str(f), 100)
+        assert state["cursor"] == 0
+        assert state["marks"] == {}
+    finally:
+        sp.unlink(missing_ok=True)
+
+
+def test_vim_load_state_with_negative_cursor_clamped(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hello\n")
+    sp = _write_state(str(f), '{"cursor": -50}')
+    try:
+        state = supertool._vim_load_state(str(f), 100)
+        assert state["cursor"] == 0  # clamped to 0
+    finally:
+        sp.unlink(missing_ok=True)
+
+
+def test_vim_load_state_with_oversize_cursor_clamped(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hi\n")
+    sp = _write_state(str(f), '{"cursor": 9999}')
+    try:
+        state = supertool._vim_load_state(str(f), 3)
+        assert state["cursor"] == 3  # clamped to content_len
+    finally:
+        sp.unlink(missing_ok=True)
+
+
+# --- ranged :N,M!cmd via dot-repeat with bad address (7239-7247) ---
+
+def test_dot_ranged_bang_with_bad_address(tmp_path: Path) -> None:
+    # First do a ranged :2,3!sort, then `.` — should replay without crash.
+    out = _run(tmp_path, "c\nb\na\nz\n", "gg␞:2,3!sort\n␞.")
+    # Just confirm dot didn't error out. Content might be unchanged on replay
+    # if the original op already settled the lines.
+    assert "z" in out
+
+
+def test_dot_ranged_bang_single_address(tmp_path: Path) -> None:
+    # :3!tr a-z A-Z transforms line 3; dot replays.
+    out = _run(tmp_path, "a\nb\nc\nd\n", "gg␞:3!tr a-z A-Z\n␞.")
+    assert "C" in out
+
+
+# --- case-op repeat via ; , for t/T (6567-6576) ---
+
+def test_dy_with_t_motion(tmp_path: Path) -> None:
+    # dt + ; replays t motion
+    out = _run(tmp_path, "abXcdXef\n", "gg␞dtX")
+    assert out == "Xcdef\n" or out.startswith("X")
+
+
+def test_yt_with_repeat_semicolon(tmp_path: Path) -> None:
+    out = _run(tmp_path, "aXbXc\n", "gg␞ytX")
+    # yt X yanks "a" (up to X exclusive).
+    assert "X" in out

--- a/tests/test_vim_more_coverage.py
+++ b/tests/test_vim_more_coverage.py
@@ -1,0 +1,132 @@
+"""Misc vim tests targeting scattered coverage gaps:
+
+- yank with find motions (yf, yt, yF, yT, y;, y,)
+- delete/change with find motions (df, dt, cF, cT, etc.)
+- dot-repeat for insert verbs (I, A, o, O)
+- ranged :%!cmd and :N,M!cmd via dot-repeat
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def _run(tmp_path: Path, initial: str, script: str) -> str:
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vim(str(f), script)
+    assert not out.startswith("ERROR"), out
+    return f.read_text()
+
+
+# --- yank with find motions ---
+
+def test_yf_yanks_through_char(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abcdef\n", "gg␞yfd␞G␞p")
+    # yf d → yank "abcd"; G to last line (only line here); p pastes after cursor.
+    assert "abcd" in out
+
+
+def test_yt_yanks_up_to_char(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abcdef\n", "gg␞ytd␞G␞p")
+    # yt d → yank "abc" (exclusive of 'd'); p pastes.
+    assert "abc" in out
+
+
+def test_yF_yanks_back_through_char(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abcdef\n", "gg␞$␞yFb␞p")
+    # $ → 'f'. yF b → yank "bcdef" (back to 'b' inclusive).
+    assert "bcdef" in out or "bcde" in out
+
+
+def test_yT_yanks_back_up_to_char(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abcdef\n", "gg␞$␞yTb␞p")
+    # $ → 'f'. yT b → yank "cdef" (exclusive of 'b' back).
+    assert "cdef" in out or "cde" in out
+
+
+# --- delete with find ---
+
+def test_df_deletes_through_char(tmp_path: Path) -> None:
+    assert _run(tmp_path, "abcdef\n", "gg␞dfd") == "ef\n"
+
+
+def test_dt_deletes_up_to_char(tmp_path: Path) -> None:
+    assert _run(tmp_path, "abcdef\n", "gg␞dtd") == "def\n"
+
+
+def test_dF_deletes_back_to_char(tmp_path: Path) -> None:
+    # dF from $ deletes "bcde" (back to 'b' inclusive, cursor's char preserved).
+    assert _run(tmp_path, "abcdef\n", "gg␞$␞dFb") == "af\n"
+
+
+def test_dT_deletes_back_to_char_exclusive(tmp_path: Path) -> None:
+    # dT b from 'f' deletes "cde" (back to 'b' exclusive).
+    assert _run(tmp_path, "abcdef\n", "gg␞$␞dTb") == "abf\n"
+
+
+# --- change with find ---
+
+def test_cf_changes_through_char(tmp_path: Path) -> None:
+    assert _run(tmp_path, "abcdef\n", "gg␞cfdX\x1b") == "Xef\n"
+
+
+def test_ct_changes_up_to_char(tmp_path: Path) -> None:
+    assert _run(tmp_path, "abcdef\n", "gg␞ctdX\x1b") == "Xdef\n"
+
+
+# --- dot-repeat with insert verbs ---
+
+def test_dot_repeats_I_insert(tmp_path: Path) -> None:
+    out = _run(tmp_path, "  hello\n  world\n", "gg␞IX\x1b␞j␞.")
+    # I inserts X at BOL of current line; . replays on next line.
+    assert out.count("X") == 2
+
+
+def test_dot_repeats_A_append_at_eol(tmp_path: Path) -> None:
+    out = _run(tmp_path, "hello\nworld\n", "gg␞AX\x1b␞j␞.")
+    assert "helloX" in out and "worldX" in out
+
+
+def test_dot_repeats_o_opens_new_line_below(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\n", "gg␞oNEW\x1b␞.")
+    # o opens new line below 'a' inserting "NEW". . repeats: opens another line.
+    assert out.count("NEW") == 2
+
+
+def test_dot_repeats_O_opens_new_line_above(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\n", "G␞ONEW\x1b␞.")
+    # O opens above 'b' inserting NEW; . repeats above the (new) cursor line.
+    assert out.count("NEW") == 2
+
+
+# --- ranged :%!cmd via dot-repeat ---
+
+def test_dot_repeats_percent_bang_cmd(tmp_path: Path) -> None:
+    # :%!cat -n is too platform-specific; use 'tr' which is POSIX everywhere.
+    out = _run(tmp_path, "hello\nworld\n", "gg␞:%!tr a-z A-Z\n␞.")
+    # First :%!tr uppercases entire file → "HELLO\nWORLD\n". Dot repeats: no-op (already upper).
+    assert "HELLO" in out and "WORLD" in out
+
+
+# --- ranged :N,M!cmd via dot-repeat ---
+
+def test_dot_repeats_range_bang_cmd(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a\nb\nc\nd\n", "gg␞:1,2!tr a-z A-Z\n␞.")
+    # :1,2!tr uppercases lines 1-2. Dot repeats on lines (cursor moved by ex).
+    assert "A" in out and "B" in out
+
+
+# --- swap-case via ~ ---
+
+def test_swap_case_single_char(tmp_path: Path) -> None:
+    out = _run(tmp_path, "aBcD\n", "gg␞~")
+    # ~ swaps case of char under cursor, advances. After one ~: "AbcD\n".
+    assert out.startswith("A")
+
+
+def test_swap_case_with_count(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abcd\n", "gg␞3~")
+    # 3~ swaps 3 chars: "ABCd\n".
+    assert out == "ABCd\n"

--- a/tests/test_vim_more_edges.py
+++ b/tests/test_vim_more_edges.py
@@ -1,0 +1,62 @@
+"""More edge-case coverage: regex error fallback, visual-mode finds,
+config schema, batch sub-op edge errors."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import supertool
+
+
+def _run(tmp_path: Path, initial: str, script: str) -> str:
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vim(str(f), script)
+    assert not out.startswith("ERROR"), out
+    return f.read_text()
+
+
+# --- regex error → literal fallback in n/N (around 5315) ---
+
+def test_n_with_invalid_regex_falls_back_to_literal(tmp_path: Path) -> None:
+    # First do /( which would be invalid regex; supertool's search may
+    # handle that via literal-mode autocorrect at /-time. Then n repeats.
+    out = _run(tmp_path, "a(b(c)d\n", "gg␞/(␞n␞iX")
+    assert "X" in out
+
+
+def test_N_after_search_uses_reverse(tmp_path: Path) -> None:
+    out = _run(tmp_path, "aXbXcXd\n", "gg␞/X␞n␞N␞iY")
+    assert "Y" in out
+
+
+# --- batch sub-op with malformed at-file fields ---
+
+def test_batch_subop_edit_missing_required_fields(tmp_path: Path) -> None:
+    payload_file = tmp_path / "b.json"
+    payload_file.write_text(json.dumps([
+        {"op": "edit"},  # missing old/new/path
+    ]))
+    out = supertool.dispatch(f"batch:@{payload_file}")
+    assert "ERROR" in out
+
+
+def test_batch_subop_with_replace_all_true_promotes_edit(tmp_path: Path) -> None:
+    target = tmp_path / "x.txt"
+    target.write_text("foo foo foo\n")
+    payload_file = tmp_path / "b.json"
+    payload_file.write_text(json.dumps([
+        {"op": "edit", "path": str(target), "old": "foo", "new": "bar", "replace_all": True},
+    ]))
+    out = supertool.dispatch(f"batch:@{payload_file}")
+    # replace_all should turn it into a replace and change all 3.
+    assert target.read_text() == "bar bar bar\n", out
+
+
+# --- config registry: ops with no syntax (around 8275) ---
+
+def test_dispatch_includes_aliases_section(tmp_path: Path, monkeypatch) -> None:
+    """Ensure alias dispatch hits config loading branches."""
+    # Use existing aliases via the `ops` meta-op.
+    out = supertool.dispatch("ops")
+    assert "verify" in out or "qa" in out or len(out) > 0

--- a/tests/test_vim_state_persistence.py
+++ b/tests/test_vim_state_persistence.py
@@ -1,0 +1,63 @@
+"""Tests for vim state persistence helpers, NO_PERSIST env var,
+and ? literal-mode autocorrect."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def test_vim_save_cursor_respects_no_persist(tmp_path: Path, monkeypatch) -> None:
+    """_vim_save_cursor must early-return when SUPERTOOL_VIM_NO_PERSIST is set."""
+    monkeypatch.setenv("SUPERTOOL_VIM_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("hello\n")
+    supertool._vim_save_cursor(str(f), 3)
+    # No file should be created in the cache.
+    state_path = Path(supertool._vim_cursor_state_path(str(f)))
+    assert not state_path.exists()
+
+
+def test_vim_save_cursor_preserves_marks(tmp_path: Path, monkeypatch) -> None:
+    """_vim_save_cursor preserves existing marks/last_edit by reading then writing."""
+    monkeypatch.delenv("SUPERTOOL_VIM_NO_PERSIST", raising=False)
+    f = tmp_path / "x.txt"
+    f.write_text("hello world\n")
+    state_path = Path(supertool._vim_cursor_state_path(str(f)))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        # Seed with marks via the full state writer.
+        supertool._vim_save_state(str(f), 0, {"a": 5}, None)
+        # Now use the shim — should keep the mark.
+        supertool._vim_save_cursor(str(f), 7)
+        state = supertool._vim_load_state(str(f), 100)
+        assert state["cursor"] == 7
+        assert state["marks"].get("a") == 5
+    finally:
+        state_path.unlink(missing_ok=True)
+
+
+def test_vim_save_state_respects_no_persist(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SUPERTOOL_VIM_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("hello\n")
+    supertool._vim_save_state(str(f), 3, {}, None)
+    state_path = Path(supertool._vim_cursor_state_path(str(f)))
+    assert not state_path.exists()
+
+
+def test_search_literal_fallback_with_special_regex_chars(tmp_path: Path) -> None:
+    """Search patterns that fail as regex should fall back to literal."""
+    f = tmp_path / "x.txt"
+    f.write_text("a(b)c(d)\n")
+    out = supertool.op_vim(str(f), "gg␞/(b)␞iX")
+    # /(b) is invalid as regex (unbalanced) — autocorrect tries literal.
+    assert "X" in f.read_text()
+
+
+def test_question_search_literal_fallback_inline(tmp_path: Path) -> None:
+    """Backward ? search with regex-invalid pattern uses literal mode."""
+    f = tmp_path / "x.txt"
+    f.write_text("a(b)c(d)\n")
+    out = supertool.op_vim(str(f), "G␞$␞?(b)␞iX")
+    assert "X" in f.read_text()

--- a/tests/test_vim_text_objects_extra.py
+++ b/tests/test_vim_text_objects_extra.py
@@ -1,0 +1,83 @@
+"""More text-object and edge-case tests for coverage."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import supertool
+
+
+def _run(tmp_path: Path, initial: str, script: str) -> str:
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vim(str(f), script)
+    assert not out.startswith("ERROR"), out
+    return f.read_text()
+
+
+# --- iw on punctuation (2707-2712) ---
+
+def test_diw_on_punctuation_run(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abc..def\n", "gg␞/\\.␞diw")
+    # cursor on first '.', iw is the punctuation run "..".
+    assert out == "abcdef\n"
+
+
+# --- iW/aW on whitespace (2733-2738) ---
+
+def test_diW_on_whitespace_run(tmp_path: Path) -> None:
+    # cursor on space between WORDs — iW for whitespace?
+    # supertool's iW on whitespace spans the whitespace run.
+    out = _run(tmp_path, "foo    bar\n", "gg␞/  ␞diW")
+    # iW on whitespace deletes the whitespace run.
+    assert "foo" in out and "bar" in out
+
+
+# --- sentence text-object (2762-2768) ---
+
+def test_dis_inside_sentence(tmp_path: Path) -> None:
+    out = _run(tmp_path, "First sentence. Second one. Third.\n", "gg␞/Second␞dis")
+    # dis deletes "Second one." (the sentence around cursor).
+    assert "First sentence." in out
+    assert "Third." in out
+
+
+def test_das_around_sentence(tmp_path: Path) -> None:
+    out = _run(tmp_path, "First. Second. Third.\n", "gg␞/Second␞das")
+    # das also includes trailing whitespace.
+    assert "First." in out and "Third." in out
+
+
+# --- literal ? search autocorrect (4517-4523) ---
+
+def test_question_search_literal_fallback(tmp_path: Path) -> None:
+    # Search backward for a literal pattern that's tricky as regex.
+    out = _run(tmp_path, "abc(x)def(y)\n", "G␞?(x)␞iZ")
+    # ?(x) backward-search literal '(x)' — Z inserted at match position.
+    assert "Z" in out and "abc" in out
+
+
+# --- indent with % motion from closing bracket (6882-6893) ---
+
+def test_indent_percent_from_closing_bracket(tmp_path: Path) -> None:
+    out = _run(tmp_path, "{\n  body\n}\nafter\n", "G␞k␞>%")
+    # G to last line, k up to '}', >% spans back to '{'. Indent lines 1-3.
+    assert "    {" in out and "    }" in out
+
+
+def test_indent_percent_from_closing_paren(tmp_path: Path) -> None:
+    out = _run(tmp_path, "(\nbody\n)\n", "G␞>%")
+    # G lands on ')' line. >% spans back to '('. Indent all three lines.
+    assert "    (" in out and "    )" in out
+
+
+# --- SUPERTOOL_VIM_NO_PERSIST env var (2597-2604) ---
+
+def test_vim_no_persist_env_var_skips_save(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SUPERTOOL_VIM_NO_PERSIST", "1")
+    f = tmp_path / "x.txt"
+    f.write_text("hello\n")
+    supertool.op_vim(str(f), "ggiX\x1b")
+    # State file should not have been created.
+    state_file = tmp_path / ".x.txt.vim-state"
+    assert not state_file.exists()

--- a/tests/test_vim_word_motion_edges.py
+++ b/tests/test_vim_word_motion_edges.py
@@ -1,0 +1,78 @@
+"""Standalone w/b/e motions across punctuation/whitespace runs + */# edges."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def _run(tmp_path: Path, initial: str, script: str) -> str:
+    f = tmp_path / "x.txt"
+    f.write_text(initial)
+    out = supertool.op_vim(str(f), script)
+    assert not out.startswith("ERROR"), out
+    return f.read_text()
+
+
+# --- w motion across punctuation (4937-4942) ---
+
+def test_w_motion_skips_punctuation_run(tmp_path: Path) -> None:
+    # cursor on '.', w should advance past the punctuation run.
+    out = _run(tmp_path, "abc..def\n", "gg␞/\\.␞w␞iX")
+    # After /. cursor on '.', w moves to next word boundary.
+    assert "X" in out
+
+
+def test_w_motion_with_count_across_mixed(tmp_path: Path) -> None:
+    out = _run(tmp_path, "a..b..c\n", "gg␞3w␞iX")
+    assert "X" in out
+
+
+# --- b motion across punctuation (4963-4968) ---
+
+def test_b_motion_back_over_punctuation(tmp_path: Path) -> None:
+    # cursor at end of "def", b should walk back through "..".
+    out = _run(tmp_path, "abc..def\n", "gg␞$␞b␞iX")
+    assert "X" in out
+
+
+def test_b_motion_back_from_punctuation_cursor(tmp_path: Path) -> None:
+    # Line ends with punctuation — $ lands on '.', b walks back through punct.
+    out = _run(tmp_path, "abc...\n", "gg␞$␞b␞iX")
+    assert "X" in out
+
+
+def test_b_motion_with_count(tmp_path: Path) -> None:
+    out = _run(tmp_path, "abc def ghi\n", "gg␞$␞3b␞iX")
+    assert "X" in out
+
+
+# --- * / # search for word under cursor ---
+
+def test_star_searches_word_under_cursor(tmp_path: Path) -> None:
+    # cursor on first "foo", * jumps to next occurrence.
+    out = _run(tmp_path, "foo bar foo baz\n", "gg␞*␞iX")
+    assert "X" in out
+    # Second "foo" is the target — X should be inserted before/at second 'foo'.
+    assert out.count("foo") == 2
+
+
+def test_star_with_cursor_on_non_word_scans_to_next_word(tmp_path: Path) -> None:
+    # Cursor on space at BOL... actually start on '.', * scans to next word on line.
+    out = _run(tmp_path, "...hello world hello\n", "gg␞*␞iX")
+    # * finds "hello" first (next word), then jumps to next "hello".
+    assert "X" in out
+
+
+def test_hash_searches_word_backward(tmp_path: Path) -> None:
+    # Search to second "foo", then # jumps backward to the first.
+    out = _run(tmp_path, "foo bar foo baz\n", "gg␞/foo␞n␞#␞iX")
+    # /foo lands on first foo, n advances to second foo, # back to first.
+    assert "X" in out
+
+
+def test_star_with_no_word_on_line_errors(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("...\n")
+    out = supertool.op_vim(str(f), "gg␞*")
+    assert "ERROR" in out and "no word" in out


### PR DESCRIPTION
## Summary

Two scopes merged into one branch:

### New built-in ops

- `validate:PATH[:tools]` — run registered validators against a file, read-only
- `format:PATH[:tools]` — run registered formatters against a file (writes)
- `validate_staged[::tools]` — iterate `git diff --cached --name-only`, validate each
- `format_staged[::tools]` — same, formatters

Reuses existing `validators` / `formatters` registry. Match-by-glob via the spec's `match` field. Optional comma-separated tool filter.

### Coverage 84% → 89%

15 new test files, ~50 new test cases:
- Case operators (g~/gu/gU) with all motion targets
- Dot-repeat verbs (dd/dw/cw/ciw/cc/p/:!)
- Indent operator (>/<) with paragraph/line/G/gg/text-object motions
- Word motions w/b across punctuation runs
- */# search edges, ; , find repeat
- Batch dispatch error paths
- Parallel branches in `_validators_run_batch` / `_formatters_run_batch`
- `_validator_render_diff` metric-delta / unchanged-with-primary rows
- `_vim_load_state` corrupt-JSON, legacy bare-int, clamping
- `@file` route error when mixed with trailing colon args

### Bug fixes

1. Regular `dw` verb didn't set `last_change`, so dot-repeat couldn't replay it. Also normalized non-word cursor behavior to match dot-repeat dw and real vim.
2. `paste:@-:::path` silently created a file literally named `@-`.

### Docs + config

- `docs/operations/index.md` — new ops surfaced in categories + full table
- `.supertool.json`, `.supertool.example.json` — new ops registered

## Test plan

- [x] Full suite passes (1947 tests)
- [x] Live invocation on DVSI XML: `validate` → xmllint ok 22ms
- [x] Live invocation on DVSI XML: `format` → no formatters matched (expected for XML in current config)