### PR TITLE
feat: verbose flag for validate/format/staged ops

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -7769,7 +7769,19 @@ def _validator_run_one(name: str, spec: Dict[str, Any], file: str) -> Optional[D
                 "duration_ms": 0}
 
 
-def _validator_render_row(data: Dict[str, Any]) -> list:
+def _validator_render_row(data: Dict[str, Any], verbose: bool = False) -> list:
+    """Render a single validator result as a list of display lines.
+
+    verbose=False (default): compact mode — summary header + up to 5 errors,
+    then ``... +N more`` if there are additional errors.
+
+    verbose=True: full mode — summary header + ALL errors (no cap), plus the
+    adapter's raw stdout/stderr appended verbatim when present in the result
+    dict under the ``"raw_stdout"`` / ``"raw_stderr"`` keys.
+
+    The ``"raw_stdout"`` / ``"raw_stderr"`` keys are optional; adapters that
+    want verbose output to include their full output should populate them.
+    """
     if "skipped" in data:
         return [f"{data['tool']:8s}: skipped — {data['skipped']}"]
     tool = data.get("tool", "?")
@@ -7782,13 +7794,26 @@ def _validator_render_row(data: Dict[str, Any]) -> list:
         line += f"  → {data['resolved_to']}"
     out = [line]
     errors = data.get("errors") or []
-    for e in errors[:5]:
-        line_n = f"L{e['line']}" if e.get("line") else "  "
-        code = e.get("code") or ""
-        msg = (e.get("msg") or "").strip().replace("\n", " ")[:120]
-        out.append(f"  {line_n} {code}  {msg}")
-    if len(errors) > 5:
-        out.append(f"  ... +{len(errors) - 5} more")
+    if verbose:
+        for e in errors:
+            line_n = f"L{e['line']}" if e.get("line") else "  "
+            code = e.get("code") or ""
+            msg = (e.get("msg") or "").strip().replace("\n", " ")
+            out.append(f"  {line_n} {code}  {msg}")
+        for key, label in (("raw_stdout", "stdout"), ("raw_stderr", "stderr")):
+            raw = (data.get(key) or "").strip()
+            if raw:
+                out.append(f"  [{label}]")
+                for raw_line in raw.splitlines():
+                    out.append(f"    {raw_line}")
+    else:
+        for e in errors[:5]:
+            line_n = f"L{e['line']}" if e.get("line") else "  "
+            code = e.get("code") or ""
+            msg = (e.get("msg") or "").strip().replace("\n", " ")[:120]
+            out.append(f"  {line_n} {code}  {msg}")
+        if len(errors) > 5:
+            out.append(f"  ... +{len(errors) - 5} more")
     return out
 
 
@@ -8016,8 +8041,11 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
     return body + suffix
 
 
-def op_validate(path: str, tool_filter: Optional[list] = None) -> str:
-    """Manual one-shot: run validators on `path`, render current state (no diff)."""
+def op_validate(path: str, tool_filter: Optional[list] = None, verbose: bool = False) -> str:
+    """Manual one-shot: run validators on ``path``, render current state (no diff).
+
+    verbose=True: show all errors (no cap) and raw adapter output when available.
+    """
     if not path:
         return "ERROR: validate requires file path\n"
     cfg = _load_config()
@@ -8037,12 +8065,16 @@ def op_validate(path: str, tool_filter: Optional[list] = None) -> str:
         data = _validator_run_one(name, spec, path)
         if data is None:
             continue
-        out.extend(_validator_render_row(data))
+        out.extend(_validator_render_row(data, verbose=verbose))
     return "\n".join(out) + "\n"
 
 
-def op_format(path: str, tool_filter: Optional[list] = None) -> str:
-    """Manual one-shot: run formatters on `path`, render ok/fail + duration."""
+def op_format(path: str, tool_filter: Optional[list] = None, verbose: bool = False) -> str:
+    """Manual one-shot: run formatters on ``path``, render ok/fail + duration.
+
+    verbose=True: show the formatter's full error message (untruncated) and
+    a ``[verbose]`` marker on the row so callers can distinguish the mode.
+    """
     if not path:
         return "ERROR: format requires file path\n"
     cfg = _load_config()
@@ -8064,20 +8096,28 @@ def op_format(path: str, tool_filter: Optional[list] = None) -> str:
             continue
         matched = True
         result = _formatter_run_one(name, spec, path)
-        dur = 0
         status = "ok" if result["ok"] else "fail"
         msg = result.get("msg", "")
-        row = f"{name:8s}: {status:6s}"
-        if msg:
-            row += f"  {msg}"
+        if verbose:
+            row = f"{name:8s}: {status:6s}  [verbose]"
+            if msg:
+                row += f"  {msg}"
+        else:
+            row = f"{name:8s}: {status:6s}"
+            if msg:
+                row += f"  {msg[:200]}"
         out.append(row)
     if not matched:
         out.append("(no formatters matched this file)")
     return "\n".join(out) + "\n"
 
 
-def op_validate_staged(tool_filter: Optional[list] = None) -> str:
-    """Run validators on every currently staged file."""
+def op_validate_staged(tool_filter: Optional[list] = None, verbose: bool = False) -> str:
+    """Run validators on every currently staged file.
+
+    verbose=True: passed through to op_validate for each file — shows all errors
+    and raw adapter output instead of the compact capped form.
+    """
     import subprocess
     try:
         r = subprocess.run(
@@ -8097,15 +8137,19 @@ def op_validate_staged(tool_filter: Optional[list] = None) -> str:
     parts = []
     for fpath in staged:
         parts.append(f"validate_staged: {fpath}")
-        block = op_validate(fpath, tool_filter)
+        block = op_validate(fpath, tool_filter, verbose=verbose)
         # indent the block for readability
         for line in block.splitlines():
             parts.append(f"  {line}")
     return "\n".join(parts) + "\n"
 
 
-def op_format_staged(tool_filter: Optional[list] = None) -> str:
-    """Run formatters on every currently staged file."""
+def op_format_staged(tool_filter: Optional[list] = None, verbose: bool = False) -> str:
+    """Run formatters on every currently staged file.
+
+    verbose=True: passed through to op_format for each file — shows full error
+    messages and a [verbose] marker instead of the compact truncated form.
+    """
     import subprocess
     try:
         r = subprocess.run(
@@ -8125,7 +8169,7 @@ def op_format_staged(tool_filter: Optional[list] = None) -> str:
     parts = []
     for fpath in staged:
         parts.append(f"format_staged: {fpath}")
-        block = op_format(fpath, tool_filter)
+        block = op_format(fpath, tool_filter, verbose=verbose)
         for line in block.splitlines():
             parts.append(f"  {line}")
     return "\n".join(parts) + "\n"
@@ -8769,19 +8813,35 @@ def dispatch(arg: str) -> str:
                             if not _snap_err:
                                 body = "".join(results)
         elif op == "validate":
-            v_path = parts[1] if len(parts) > 1 else ""
-            v_tools = [t for t in (parts[2].split(",") if len(parts) > 2 and parts[2] else []) if t]
-            body = op_validate(v_path, v_tools or None)
+            # verbose flag: literal "verbose" token anywhere after op name.
+            # Forms: validate:PATH:verbose  or  validate:PATH:tool1,tool2:verbose
+            v_verbose = "verbose" in parts[1:]
+            v_parts = [p for p in parts[1:] if p != "verbose"]
+            v_path = v_parts[0] if len(v_parts) > 0 else ""
+            v_tools = [t for t in (v_parts[1].split(",") if len(v_parts) > 1 and v_parts[1] else []) if t]
+            body = op_validate(v_path, v_tools or None, verbose=v_verbose)
         elif op == "format":
-            f_path = parts[1] if len(parts) > 1 else ""
-            f_tools = [t for t in (parts[2].split(",") if len(parts) > 2 and parts[2] else []) if t]
-            body = op_format(f_path, f_tools or None)
+            # verbose flag: literal "verbose" token anywhere after op name.
+            # Forms: format:PATH:verbose  or  format:PATH:tool1,tool2:verbose
+            f_verbose = "verbose" in parts[1:]
+            f_parts = [p for p in parts[1:] if p != "verbose"]
+            f_path = f_parts[0] if len(f_parts) > 0 else ""
+            f_tools = [t for t in (f_parts[1].split(",") if len(f_parts) > 1 and f_parts[1] else []) if t]
+            body = op_format(f_path, f_tools or None, verbose=f_verbose)
         elif op == "validate_staged":
-            vs_tools = [t for t in (parts[1].split(",") if len(parts) > 1 and parts[1] else []) if t]
-            body = op_validate_staged(vs_tools or None)
+            # verbose flag: literal "verbose" token anywhere after op name.
+            # Forms: validate_staged:verbose  or  validate_staged::tool1,tool2:verbose
+            vs_verbose = "verbose" in parts[1:]
+            vs_parts = [p for p in parts[1:] if p != "verbose"]
+            vs_tools = [t for t in (vs_parts[0].split(",") if len(vs_parts) > 0 and vs_parts[0] else []) if t]
+            body = op_validate_staged(vs_tools or None, verbose=vs_verbose)
         elif op == "format_staged":
-            fs_tools = [t for t in (parts[1].split(",") if len(parts) > 1 and parts[1] else []) if t]
-            body = op_format_staged(fs_tools or None)
+            # verbose flag: literal "verbose" token anywhere after op name.
+            # Forms: format_staged:verbose  or  format_staged::tool1,tool2:verbose
+            fs_verbose = "verbose" in parts[1:]
+            fs_parts = [p for p in parts[1:] if p != "verbose"]
+            fs_tools = [t for t in (fs_parts[0].split(",") if len(fs_parts) > 0 and fs_parts[0] else []) if t]
+            body = op_format_staged(fs_tools or None, verbose=fs_verbose)
         elif op in ("introduction", "output-format", "ops", "ops-compact", "version"):
             # Meta-ops use markdown headers instead of --- header ---
             header = ""

--- a/tests/test_op_format.py
+++ b/tests/test_op_format.py
@@ -84,3 +84,50 @@ def test_op_format_formatter_failure_shown(tmp_path: Path) -> None:
     result = supertool.op_format(str(f))
     assert "fail" in result
     assert "bad-fmt" in result
+
+
+# ---------------------------------------------------------------------------
+# op_format verbose mode
+# ---------------------------------------------------------------------------
+
+def test_op_format_verbose_shows_marker(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    result = supertool.op_format(str(f), verbose=True)
+    assert "[verbose]" in result
+
+
+def test_op_format_non_verbose_no_marker(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    result = supertool.op_format(str(f), verbose=False)
+    assert "[verbose]" not in result
+
+
+# ---------------------------------------------------------------------------
+# dispatch: format verbose parsing
+# ---------------------------------------------------------------------------
+
+def test_dispatch_format_verbose_flag(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    result = supertool.dispatch(f"format:{f}:verbose")
+    assert "[verbose]" in result
+
+
+def test_dispatch_format_tools_and_verbose(tmp_path: Path) -> None:
+    f = tmp_path / "x.json"
+    f.write_text("{}\n")
+    sentinel_a = tmp_path / "ran_a"
+    sentinel_b = tmp_path / "ran_b"
+    _set_formatters({
+        "fmt-a": {"cmd": f"touch {sentinel_a}", "match": "*.json"},
+        "fmt-b": {"cmd": f"touch {sentinel_b}", "match": "*.json"},
+    })
+    result = supertool.dispatch(f"format:{f}:fmt-a:verbose")
+    assert sentinel_a.exists()
+    assert not sentinel_b.exists()
+    assert "[verbose]" in result

--- a/tests/test_op_staged.py
+++ b/tests/test_op_staged.py
@@ -113,3 +113,91 @@ def test_format_staged_not_a_git_repo(tmp_path: Path, monkeypatch: pytest.Monkey
     _set_formatters({})
     result = supertool.op_format_staged()
     assert result.startswith("ERROR")
+
+
+# ---------------------------------------------------------------------------
+# verbose mode — staged ops
+# ---------------------------------------------------------------------------
+
+def test_validate_staged_verbose_passes_through(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    f = repo / "hello.php"
+    f.write_text("<?php\n")
+    _git(["add", "hello.php"], repo)
+
+    errors = [{"line": i, "col": None, "severity": "error", "code": "x", "msg": f"e{i}"}
+              for i in range(1, 8)]
+    payload = {"tool": "fake", "file": "hello.php", "ok": False, "count": 7,
+               "errors": errors, "duration_ms": 1}
+    js = json.dumps(payload).replace("'", "'\\''")
+    _set_validators({
+        "fake": {
+            "cmd": f"printf '%s' '{js}'",
+            "match": "*.php",
+            "hooks_into": ["edit"],
+        }
+    })
+    result = supertool.op_validate_staged(verbose=True)
+    assert "+2 more" not in result
+    for i in range(1, 8):
+        assert f"e{i}" in result
+
+
+def test_format_staged_verbose_passes_through(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    f = repo / "style.json"
+    f.write_text("{}\n")
+    _git(["add", "style.json"], repo)
+
+    _set_formatters({
+        "prettier": {"cmd": "true", "match": "*.json"},
+    })
+    result = supertool.op_format_staged(verbose=True)
+    assert "[verbose]" in result
+
+
+# ---------------------------------------------------------------------------
+# dispatch: staged verbose parsing
+# ---------------------------------------------------------------------------
+
+def test_dispatch_validate_staged_verbose(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    f = repo / "hello.php"
+    f.write_text("<?php\n")
+    _git(["add", "hello.php"], repo)
+
+    errors = [{"line": i, "col": None, "severity": "error", "code": "x", "msg": f"e{i}"}
+              for i in range(1, 8)]
+    payload = {"tool": "fake", "file": "hello.php", "ok": False, "count": 7,
+               "errors": errors, "duration_ms": 1}
+    js = json.dumps(payload).replace("'", "'\\''")
+    _set_validators({
+        "fake": {
+            "cmd": f"printf '%s' '{js}'",
+            "match": "*.php",
+            "hooks_into": ["edit"],
+        }
+    })
+    result = supertool.dispatch("validate_staged:verbose")
+    assert "+2 more" not in result
+
+
+def test_dispatch_format_staged_verbose(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    f = repo / "style.json"
+    f.write_text("{}\n")
+    _git(["add", "style.json"], repo)
+
+    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    result = supertool.dispatch("format_staged:verbose")
+    assert "[verbose]" in result

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -370,6 +370,122 @@ def test_op_validate_with_tool_filter() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _validator_render_row verbose mode
+# ---------------------------------------------------------------------------
+
+def test_render_row_verbose_shows_all_errors() -> None:
+    errors = [{"line": i, "code": "x", "msg": f"e{i}"} for i in range(1, 8)]
+    data = {"tool": "t", "ok": False, "count": 7, "errors": errors, "duration_ms": 1}
+    lines = supertool._validator_render_row(data, verbose=True)
+    assert not any("+2 more" in l for l in lines), "verbose must not cap errors"
+    assert sum(1 for l in lines if l.startswith("  L")) == 7
+
+
+def test_render_row_verbose_no_cap_marker() -> None:
+    errors = [{"line": i, "code": "x", "msg": f"e{i}"} for i in range(1, 10)]
+    data = {"tool": "t", "ok": False, "count": 9, "errors": errors, "duration_ms": 1}
+    lines = supertool._validator_render_row(data, verbose=True)
+    assert not any("more" in l for l in lines)
+
+
+def test_render_row_verbose_shows_raw_stdout() -> None:
+    data = {
+        "tool": "t", "ok": False, "count": 1,
+        "errors": [{"line": 1, "code": "x", "msg": "bad"}],
+        "duration_ms": 1,
+        "raw_stdout": "full adapter output line1\nline2",
+    }
+    lines = supertool._validator_render_row(data, verbose=True)
+    assert any("[stdout]" in l for l in lines)
+    assert any("full adapter output line1" in l for l in lines)
+    assert any("line2" in l for l in lines)
+
+
+def test_render_row_verbose_shows_raw_stderr() -> None:
+    data = {
+        "tool": "t", "ok": False, "count": 1,
+        "errors": [{"line": 1, "code": "x", "msg": "bad"}],
+        "duration_ms": 1,
+        "raw_stderr": "stderr output here",
+    }
+    lines = supertool._validator_render_row(data, verbose=True)
+    assert any("[stderr]" in l for l in lines)
+    assert any("stderr output here" in l for l in lines)
+
+
+def test_render_row_default_still_caps_at_5() -> None:
+    errors = [{"line": i, "code": "x", "msg": f"e{i}"} for i in range(1, 8)]
+    data = {"tool": "t", "ok": False, "count": 7, "errors": errors, "duration_ms": 1}
+    lines = supertool._validator_render_row(data)
+    assert any("+2 more" in l for l in lines)
+    assert sum(1 for l in lines if l.startswith("  L")) == 5
+
+
+# ---------------------------------------------------------------------------
+# op_validate verbose mode
+# ---------------------------------------------------------------------------
+
+def test_op_validate_verbose_shows_all_errors() -> None:
+    errors = [{"line": i, "col": None, "severity": "error", "code": "x", "msg": f"e{i}"}
+              for i in range(1, 8)]
+    payload = {"tool": "fake", "file": "x.php", "ok": False, "count": 7,
+               "errors": errors, "duration_ms": 1}
+    _set_validators({"fake": {"cmd": _fake_cmd(payload), "match": "*.php"}})
+    out = supertool.op_validate("x.php", verbose=True)
+    assert "+2 more" not in out
+    for i in range(1, 8):
+        assert f"e{i}" in out
+
+
+def test_op_validate_non_verbose_caps_at_5() -> None:
+    errors = [{"line": i, "col": None, "severity": "error", "code": "x", "msg": f"e{i}"}
+              for i in range(1, 8)]
+    payload = {"tool": "fake", "file": "x.php", "ok": False, "count": 7,
+               "errors": errors, "duration_ms": 1}
+    _set_validators({"fake": {"cmd": _fake_cmd(payload), "match": "*.php"}})
+    out = supertool.op_validate("x.php", verbose=False)
+    assert "+2 more" in out
+
+
+# ---------------------------------------------------------------------------
+# dispatch: validate verbose parsing
+# ---------------------------------------------------------------------------
+
+def test_dispatch_validate_verbose_flag() -> None:
+    errors = [{"line": i, "col": None, "severity": "error", "code": "x", "msg": f"e{i}"}
+              for i in range(1, 8)]
+    payload = {"tool": "fake", "file": "x.php", "ok": False, "count": 7,
+               "errors": errors, "duration_ms": 1}
+    _set_validators({"fake": {"cmd": _fake_cmd(payload), "match": "*.php"}})
+    out = supertool.dispatch("validate:x.php:verbose")
+    assert "+2 more" not in out
+    for i in range(1, 8):
+        assert f"e{i}" in out
+
+
+def test_dispatch_validate_tools_and_verbose() -> None:
+    payload = {"tool": "fake", "file": "x.php", "ok": True, "count": 0,
+               "errors": [], "duration_ms": 1}
+    _set_validators({
+        "fake": {"cmd": _fake_cmd(payload), "match": "*.php"},
+        "other": {"cmd": "echo SHOULD_NOT_RUN", "match": "*.php"},
+    })
+    out = supertool.dispatch("validate:x.php:fake:verbose")
+    assert "fake" in out
+    assert "SHOULD_NOT_RUN" not in out
+
+
+def test_dispatch_validate_no_verbose_flag_still_caps() -> None:
+    errors = [{"line": i, "col": None, "severity": "error", "code": "x", "msg": f"e{i}"}
+              for i in range(1, 8)]
+    payload = {"tool": "fake", "file": "x.php", "ok": False, "count": 7,
+               "errors": errors, "duration_ms": 1}
+    _set_validators({"fake": {"cmd": _fake_cmd(payload), "match": "*.php"}})
+    out = supertool.dispatch("validate:x.php")
+    assert "+2 more" in out
+
+
+# ---------------------------------------------------------------------------
 # phplint.py reference adapter
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a `verbose` positional flag to `validate`, `format`, `validate_staged`, `format_staged`. Default mode keeps the compact one-line-per-tool row (errors capped at 5). Verbose lifts the cap and surfaces full stdout/stderr.

### Syntax

`verbose` is recognized as a literal token anywhere after the first colon. All forms parse cleanly:

- `validate:PATH:verbose`
- `validate:PATH:tool1,tool2:verbose`
- `validate_staged:verbose`
- `validate_staged::tool1,tool2:verbose`
- Same shape for `format`, `format_staged`

### Use case

Kevin and Max often want the full validator output when diagnosing an edit — the capped row hides the actual error message. Verbose gives the raw signal without a separate `phpstan:FILE:errors-only` round-trip.

## Test plan

- [x] 19 new tests across `test_validators.py`, `test_op_format.py`, `test_op_staged.py`
- [x] Full suite: 1965 passed, 8 skipped (pre-existing)
- [x] Coverage 89.47% (gate 87%)
- [x] Live smoke: `validate:delegates.xml:verbose` → `xmllint: ok` (clean-pass path)