### PR TITLE
feat: render source_context + diff in verbose validate/format

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -7800,12 +7800,20 @@ def _validator_render_row(data: Dict[str, Any], verbose: bool = False) -> list:
             code = e.get("code") or ""
             msg = (e.get("msg") or "").strip().replace("\n", " ")
             out.append(f"  {line_n} {code}  {msg}")
+            for ctx_line in (e.get("source_context") or []):
+                out.append(f"    {ctx_line}")
         for key, label in (("raw_stdout", "stdout"), ("raw_stderr", "stderr")):
             raw = (data.get(key) or "").strip()
             if raw:
                 out.append(f"  [{label}]")
                 for raw_line in raw.splitlines():
                     out.append(f"    {raw_line}")
+        diff = (data.get("diff") or "").strip()
+        if diff:
+            out.append("  [diff]")
+            for diff_line in diff.splitlines():
+                out.append(f"  {diff_line}")
+            out.append("  [/diff]")
     else:
         for e in errors[:5]:
             line_n = f"L{e['line']}" if e.get("line") else "  "

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -421,6 +421,58 @@ def test_render_row_default_still_caps_at_5() -> None:
     assert sum(1 for l in lines if l.startswith("  L")) == 5
 
 
+def test_render_row_verbose_source_context_renders_under_error() -> None:
+    ctx = ["40:     return foo;", "41: ", "42→     bar();", "43: }", "44: "]
+    errors = [{"line": 42, "code": "E1", "msg": "bad call", "source_context": ctx}]
+    data = {"tool": "t", "ok": False, "count": 1, "errors": errors, "duration_ms": 1}
+    lines = supertool._validator_render_row(data, verbose=True)
+    error_idx = next(i for i, l in enumerate(lines) if "bad call" in l)
+    ctx_lines = lines[error_idx + 1: error_idx + 1 + len(ctx)]
+    assert len(ctx_lines) == len(ctx)
+    assert all(l.startswith("    ") for l in ctx_lines)
+    assert "42→     bar();" in ctx_lines[2]
+
+
+def test_render_row_verbose_source_context_absent_no_extra_lines() -> None:
+    errors = [{"line": 1, "code": "E1", "msg": "oops"}]
+    data = {"tool": "t", "ok": False, "count": 1, "errors": errors, "duration_ms": 1}
+    lines = supertool._validator_render_row(data, verbose=True)
+    # header + one error line only (no raw keys, no source_context)
+    assert len(lines) == 2
+
+
+def test_render_row_verbose_diff_renders_at_bottom() -> None:
+    errors = [{"line": 1, "code": "E1", "msg": "msg"}]
+    diff = "-old line\n+new line"
+    data = {"tool": "t", "ok": False, "count": 1, "errors": errors, "duration_ms": 1, "diff": diff}
+    lines = supertool._validator_render_row(data, verbose=True)
+    assert any("[diff]" in l for l in lines)
+    assert any("-old line" in l for l in lines)
+    assert any("+new line" in l for l in lines)
+    assert any("[/diff]" in l for l in lines)
+    diff_idx = next(i for i, l in enumerate(lines) if "[diff]" in l)
+    error_idx = next(i for i, l in enumerate(lines) if "msg" in l)
+    assert diff_idx > error_idx
+
+
+def test_render_row_verbose_diff_absent_no_diff_block() -> None:
+    errors = [{"line": 1, "code": "E1", "msg": "msg"}]
+    data = {"tool": "t", "ok": False, "count": 1, "errors": errors, "duration_ms": 1}
+    lines = supertool._validator_render_row(data, verbose=True)
+    assert not any("[diff]" in l for l in lines)
+
+
+def test_render_row_non_verbose_ignores_source_context_and_diff() -> None:
+    ctx = ["40:     return foo;", "42→     bar();"]
+    errors = [{"line": 1, "code": "E1", "msg": "msg", "source_context": ctx}]
+    diff = "-old\n+new"
+    data = {"tool": "t", "ok": False, "count": 1, "errors": errors, "duration_ms": 1, "diff": diff}
+    lines = supertool._validator_render_row(data, verbose=False)
+    assert not any("42→" in l for l in lines)
+    assert not any("[diff]" in l for l in lines)
+    assert not any("-old" in l for l in lines)
+
+
 # ---------------------------------------------------------------------------
 # op_validate verbose mode
 # ---------------------------------------------------------------------------

--- a/validators/SCHEMA.md
+++ b/validators/SCHEMA.md
@@ -27,15 +27,18 @@ Universal JSON. Every adapter emits this shape. Validator core never parses tool
 | `duration_ms` | int              | yes      | Wall time. For perf tuning.                                           |
 | `metrics`     | object           | no       | Tool-specific counters (`tests_total`, `tests_passed`, etc.). Numeric values. Used by renderer for before/after diff on metric keys even when `count` is unchanged. |
 
+| `diff`        | string           | no       | Unified diff produced by the tool (e.g. rector). Rendered as a fenced block below all errors in verbose mode. Ignored in default mode. |
+
 ### Error object
 
-| Field      | Type             | Required | Notes                                              |
-|------------|------------------|----------|----------------------------------------------------|
-| `line`     | int \| null      | yes      | 1-indexed. `null` if tool gives no location.       |
-| `col`      | int \| null      | yes      | 1-indexed. `null` if not provided.                 |
-| `severity` | string           | yes      | `error` \| `warning` \| `info`                     |
-| `code`     | string \| null   | yes      | Rule id (`missingType`, `PSR12.Files...`). Nullable. |
-| `msg`      | string           | yes      | Human message. Single line preferred.              |
+| Field            | Type             | Required | Notes                                              |
+|------------------|------------------|----------|----------------------------------------------------|
+| `line`           | int \| null      | yes      | 1-indexed. `null` if tool gives no location.       |
+| `col`            | int \| null      | yes      | 1-indexed. `null` if not provided.                 |
+| `severity`       | string           | yes      | `error` \| `warning` \| `info`                     |
+| `code`           | string \| null   | yes      | Rule id (`missingType`, `PSR12.Files...`). Nullable. |
+| `msg`            | string           | yes      | Human message. Single line preferred.              |
+| `source_context` | array of strings | no       | Source lines near the error. The line containing the error uses `→` as separator; surrounding lines use `:`. Example: `["40:     return foo;", "41: ", "42→     bar();", "43: }", "44: "]`. Rendered indented under the error in verbose mode. Ignored in default mode. |
 
 ## Contract
 


### PR DESCRIPTION
## Summary

Two additive fields in the validator/formatter result schema, surfaced by verbose rendering:

- `error.source_context` — list of 5 source lines centered on the error line. Format `"42→ code"` for the error line, `"N: code"` for surrounding lines. Renders indented under each error.
- `result.diff` — top-level unified diff string. Used by rector. Renders as a fenced `[diff]` block under the errors.

Default (non-verbose) rendering ignores both — no behavior change for existing callers.

DVSI's validator wrappers (separate MR) will start emitting these fields. With both shipped, `validate:FILE:verbose` becomes actionable for autonomous LLM loops: error message + source context + (for rector) full diff in one round-trip.

## Test plan

- [x] 5 new tests in `tests/test_validators.py` covering: source_context renders, source_context absent, diff renders, diff absent, both ignored in non-verbose
- [x] Full suite 1970 passed, 8 skipped (pre-existing)
- [x] Coverage 89.49% (gate 87%)
- [x] `validators/SCHEMA.md` updated with new fields