### PR TITLE
feat: workspace op + resolve op (smart-glob go-to-definition)

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -151,6 +151,16 @@
       "syntax": "batch:@file.json",
       "description": "Run an array of ops in one call. Mix anything — read+edit+grep+phpstan in one round-trip. Payload: bare array of {op, ...fields} OR wrapper {continue_on_error, ops}. Default continue. Validators fire per mutating op. JSON only (TOML can't express bare arrays). Use @- for stdin.",
       "example": "batch:@.max/ops.json"
+    },
+    "workspace": {
+      "syntax": "workspace:PATH",
+      "description": "One-shot IDE-style view: file + symbols + validators + siblings + git + references + tests. Opt-in (heavy). Use for first-touch on unfamiliar files.",
+      "example": "workspace:src/app/Module.py"
+    },
+    "resolve": {
+      "syntax": "resolve:SYMBOL",
+      "description": "Smart-glob resolver: PHP FQN, Python dotted, JS/TS relative path → file on disk. Returns 'external' for npm/pip packages, 'not found' if no match. Used internally by workspace.",
+      "example": "resolve:foo.bar.baz"
     }
   },
   "ops": {

--- a/.supertool.json
+++ b/.supertool.json
@@ -166,6 +166,16 @@
       "syntax": "format_staged[::tool1,tool2]",
       "description": "Run formatters on all staged files. Pair with validate_staged for a normalize-then-check pass.",
       "example": "format_staged"
+    },
+    "workspace": {
+      "syntax": "workspace:PATH",
+      "description": "One-shot IDE-style view: file + symbols + validators + siblings + git + references + tests. Opt-in (heavy). Use for first-touch on unfamiliar files.",
+      "example": "workspace:src/app/Module.py"
+    },
+    "resolve": {
+      "syntax": "resolve:SYMBOL",
+      "description": "Smart-glob resolver: PHP FQN, Python dotted, JS/TS relative path → file on disk. Returns 'external' for npm/pip packages, 'not found' if no match. Used internally by workspace.",
+      "example": "resolve:foo.bar.baz"
     }
   },
   "ops": {},

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -49,5 +49,7 @@
 | `format` | `format:PATH` or `format:PATH:tool1,tool2` | Run registered formatters matching PATH (writes file in place). Optional `tool_filter` limits to named formatters. Same formatters that fire after every mutating op. |
 | `validate_staged` | `validate_staged` or `validate_staged::tool1,tool2` | Run validators on all files in `git diff --cached --name-only`. Optional `tool_filter`. Useful as a pre-commit check. |
 | `format_staged` | `format_staged` or `format_staged::tool1,tool2` | Run formatters on all staged files. Optional `tool_filter`. Pair with `validate_staged` for a full normalize-then-check pass. |
+| `workspace` | `workspace:PATH` | One-shot IDE-style view: file + symbols + validators + siblings + git + references + tests. Opt-in (heavy). Use for first-touch on unfamiliar files. |
+| `resolve` | `resolve:SYMBOL` | Smart-glob resolver: PHP FQN (`\`-separated), Python dotted import, JS/TS relative path (`./`) → file on disk. Returns `external` for npm/pip packages, `not found` if no match. Used internally by workspace's Imports section. |
 
 **LLM onboarding in one call:** `./supertool 'introduction' 'output-format' 'ops'`

--- a/supertool.py
+++ b/supertool.py
@@ -423,7 +423,7 @@ def _rtk_run(args: List[str], timeout: int = 30) -> str | None:
     return None
 
 # Built-in op names — custom ops/aliases with these names are ignored
-_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines", "paste", "vi", "validate", "format", "validate_staged", "format_staged"}
+_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines", "paste", "vi", "validate", "format", "validate_staged", "format_staged", "workspace", "resolve"}
 
 # Read-only built-in ops — safe to run in parallel across a batch.
 # Excludes mutating ops (replace, edit, replace_lines) and custom ops
@@ -431,7 +431,8 @@ _BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc
 _PARALLEL_SAFE_OPS = {
     "read", "grep", "glob", "ls", "head", "tail", "wc", "stat",
     "map", "tree", "around", "around_line", "between", "diff", "blame",
-    "version", "validate", "validate_staged", "format_staged",
+    "version", "validate", "validate_staged", "format_staged", "workspace",
+    "resolve",
 }
 
 
@@ -8077,6 +8078,434 @@ def op_validate(path: str, tool_filter: Optional[list] = None, verbose: bool = F
     return "\n".join(out) + "\n"
 
 
+# ---------------------------------------------------------------------------
+# workspace — one-shot IDE-style view of a single file
+# ---------------------------------------------------------------------------
+
+# Symbols that are too common to run an unrestricted reference search on.
+_WORKSPACE_COMMON_SYMBOLS = frozenset({
+    "index", "main", "init", "__init__", "app", "base", "utils", "helpers",
+    "helper", "config", "settings", "common", "core", "util", "test",
+    "tests", "setup", "models", "model", "views", "view", "routes",
+})
+
+
+# ---------------------------------------------------------------------------
+# op_resolve — smart-glob "go to definition" resolver
+# ---------------------------------------------------------------------------
+
+def op_resolve(symbol: str) -> str:
+    """Resolve a symbol/import string to a project file path.
+
+    Detection rules (in priority order):
+      - Contains backslash → PHP FQN  → **/<path>.class.php, fallback **/<path>.php
+      - Contains dot only (no / or ./) → Python dotted import → **/<path>.py
+      - Starts with ./ or ../ → relative path → try common extensions
+      - Bare word (no separators) → ambiguous → try multi-ext glob
+      - Otherwise → external (npm/pip/etc.)
+
+    Returns: "SYMBOL → PATH" on success, "SYMBOL → external", or "SYMBOL → not found".
+    """
+    if not symbol:
+        return "resolve: empty symbol\n"
+
+    excl = _get_exclude_paths("resolve")
+
+    # ── PHP FQN (contains backslash) ─────────────────────────────────────────
+    if "\\" in symbol:
+        fqn_path = symbol.replace("\\", "/")
+        for pat in (f"**/{fqn_path}.class.php", f"**/{fqn_path}.php"):
+            hits = _glob_files(pat, excl)
+            if hits:
+                rel = os.path.relpath(hits[0])
+                return f"{symbol} → {rel}\n"
+        return f"{symbol} → not found\n"
+
+    # ── Python dotted import (dots but no / and not starting with ./ or ../) ─
+    if "." in symbol and "/" not in symbol and not symbol.startswith("."):
+        py_path = symbol.replace(".", "/")
+        pat = f"**/{py_path}.py"
+        hits = _glob_files(pat, excl)
+        if hits:
+            rel = os.path.relpath(hits[0])
+            return f"{symbol} → {rel}\n"
+        return f"{symbol} → not found\n"
+
+    # ── Relative path (starts with ./ or ../) ────────────────────────────────
+    if symbol.startswith("./") or symbol.startswith("../"):
+        base = symbol
+        # Try adding common extensions if no extension present
+        if not os.path.splitext(base)[1]:
+            for ext in (".ts", ".tsx", ".js", ".jsx", ".py", ".php"):
+                candidate = base + ext
+                if os.path.isfile(candidate):
+                    rel = os.path.relpath(candidate)
+                    return f"{symbol} → {rel}\n"
+            # Also try .class.php
+            candidate = base + ".class.php"
+            if os.path.isfile(candidate):
+                rel = os.path.relpath(candidate)
+                return f"{symbol} → {rel}\n"
+        else:
+            if os.path.isfile(base):
+                rel = os.path.relpath(base)
+                return f"{symbol} → {rel}\n"
+        return f"{symbol} → not found\n"
+
+    # ── Bare word (no separators at all) ─────────────────────────────────────
+    if re.match(r"^[A-Za-z0-9_-]+$", symbol):
+        for pat in (
+            f"**/{symbol}.ts", f"**/{symbol}.tsx",
+            f"**/{symbol}.js", f"**/{symbol}.jsx",
+            f"**/{symbol}.py", f"**/{symbol}.php",
+            f"**/{symbol}.class.php",
+        ):
+            hits = _glob_files(pat, excl)
+            if hits:
+                rel = os.path.relpath(hits[0])
+                return f"{symbol} → {rel}\n"
+        return f"{symbol} → not found\n"
+
+    # ── Everything else — treat as external ───────────────────────────────────
+    return f"{symbol} → external\n"
+
+
+# ---------------------------------------------------------------------------
+# Import parser helpers for op_workspace
+# ---------------------------------------------------------------------------
+
+_PHP_USE_RE = re.compile(
+    r"^\s*use\s+([\w\\]+)(?:\s+as\s+(\w+))?\s*;", re.MULTILINE
+)
+_PY_FROM_RE = re.compile(
+    r"^\s*from\s+([\w.]+)\s+import\s+\S+", re.MULTILINE
+)
+_PY_IMPORT_RE = re.compile(
+    r"^\s*import\s+([\w.]+)", re.MULTILINE
+)
+_JS_FROM_RE = re.compile(
+    r"""^\s*import\s+.*?from\s+['"]([^'"]+)['"]""", re.MULTILINE
+)
+_JS_BARE_RE = re.compile(
+    r"""^\s*import\s+['"]([^'"]+)['"]""", re.MULTILINE
+)
+
+
+def _parse_imports(path: str, content: str) -> List[tuple]:
+    """Return list of (symbol, alias_or_None) pairs for the file's import statements."""
+    ext = os.path.splitext(path)[1].lower()
+    results: List[tuple] = []
+    seen: set = set()
+
+    if ext == ".php":
+        for m in _PHP_USE_RE.finditer(content):
+            sym = m.group(1)
+            alias = m.group(2)
+            key = (sym, alias)
+            if key not in seen:
+                seen.add(key)
+                results.append(key)
+    elif ext == ".py":
+        for m in _PY_FROM_RE.finditer(content):
+            sym = m.group(1)
+            key = (sym, None)
+            if key not in seen:
+                seen.add(key)
+                results.append(key)
+        for m in _PY_IMPORT_RE.finditer(content):
+            sym = m.group(1)
+            key = (sym, None)
+            if key not in seen:
+                seen.add(key)
+                results.append(key)
+    elif ext in (".js", ".jsx", ".ts", ".tsx"):
+        for m in _JS_FROM_RE.finditer(content):
+            sym = m.group(1)
+            key = (sym, None)
+            if key not in seen:
+                seen.add(key)
+                results.append(key)
+        for m in _JS_BARE_RE.finditer(content):
+            sym = m.group(1)
+            key = (sym, None)
+            if key not in seen:
+                seen.add(key)
+                results.append(key)
+
+    return results
+
+
+def op_workspace(path: str) -> str:
+    """One-shot IDE-style view: file + symbols + validators + siblings + git + references + tests.
+
+    Sections (in order):
+      ## File: PATH       full read (1000-line cap)
+      ## Symbols          map: output
+      ## Validators       op_validate output (skipped when no validators)
+      ## Siblings         ls of dirname (skipped when dirname == cwd root)
+      ## Git              branch, file status, recent commits, blame contributors
+      ## References       grep for main symbol across project
+      ## Tests            matching test file info (PHP / Python)
+    """
+    if not os.path.isfile(path):
+        return f"workspace: {path} not found\n"
+
+    out: List[str] = []
+
+    # ── Section 1: File ──────────────────────────────────────────────────────
+    out.append(f"## File: {path}\n\n")
+    # Use render_file directly with 1000-line cap (bypass rtk for consistency)
+    try:
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            raw_lines = f.read().splitlines(keepends=True)
+    except OSError as e:
+        out.append(f"ERROR: could not read {path}: {e}\n\n")
+        raw_lines = []
+        size = 0
+
+    line_count = len(raw_lines)
+    _WS_LINE_CAP = 1000
+    out.append(f"({line_count} lines, {size} bytes)\n")
+    shown = min(line_count, _WS_LINE_CAP)
+    for i in range(shown):
+        try:
+            line = raw_lines[i].decode("utf-8", errors="replace")
+        except Exception:
+            line = "<binary line>\n"
+        out.append(f"{i + 1:>6}→{line}")
+    if line_count > _WS_LINE_CAP:
+        out.append(f"... ({line_count - _WS_LINE_CAP} more lines — use read:{path}:OFFSET:LIMIT)\n")
+    else:
+        out.append("[complete file — no more lines]\n")
+    out.append("\n")
+
+    # ── Section 2: Symbols ───────────────────────────────────────────────────
+    out.append("## Symbols\n\n")
+    out.append(op_map(path))
+    out.append("\n")
+
+    # ── Section 3: Imports ───────────────────────────────────────────────────
+    # Read file content for import parsing (already read above into raw_lines)
+    try:
+        file_content = "".join(
+            ln.decode("utf-8", errors="replace") for ln in raw_lines
+        )
+    except Exception:
+        file_content = ""
+
+    _imports = _parse_imports(path, file_content)
+    if _imports:
+        _imports = _imports[:40]  # cap at 40 entries
+        out.append(f"## Imports ({len(_imports)})\n\n")
+        for sym, alias in _imports:
+            resolved_line = op_resolve(sym).strip()
+            # resolved_line is "SYMBOL → PATH" — extract just the path part
+            arrow_idx = resolved_line.find(" → ")
+            resolved_path = resolved_line[arrow_idx + 3:] if arrow_idx != -1 else resolved_line
+            label = f"{sym} (as {alias})" if alias else sym
+            out.append(f"  {label:<50} → {resolved_path}\n")
+        out.append("\n")
+
+    # ── Section 4: Validators ────────────────────────────────────────────────
+    cfg = _load_config()
+    validators = cfg.get("validators") or {}
+    if validators:
+        out.append("## Validators\n\n")
+        out.append(op_validate(path, verbose=True))
+        out.append("\n")
+
+    # ── Section 4: Siblings ──────────────────────────────────────────────────
+    dirname = os.path.dirname(os.path.abspath(path))
+    cwd = os.path.abspath(os.getcwd())
+    if dirname != cwd:
+        out.append("## Siblings\n\n")
+        # Use the relative dirname for a readable path
+        rel_dir = os.path.relpath(dirname, cwd)
+        out.append(op_ls(dirname))
+        out.append("\n")
+
+    # ── Section 5: Git ───────────────────────────────────────────────────────
+    # Check if inside a git repo
+    try:
+        git_check = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            capture_output=True, text=True, timeout=5,
+        )
+        in_git = git_check.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        in_git = False
+
+    if in_git:
+        out.append("## Git\n\n")
+
+        # Branch + ahead/behind
+        try:
+            branch_r = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True, text=True, timeout=5,
+            )
+            branch = branch_r.stdout.strip() if branch_r.returncode == 0 else "?"
+            # ahead/behind
+            ab_r = subprocess.run(
+                ["git", "rev-list", "--left-right", "--count", f"{branch}...@{{u}}"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if ab_r.returncode == 0 and ab_r.stdout.strip():
+                parts_ab = ab_r.stdout.strip().split()
+                ahead, behind = (parts_ab + ["0", "0"])[:2]
+                out.append(f"branch: {branch}  ahead {ahead}  behind {behind}\n")
+            else:
+                out.append(f"branch: {branch}\n")
+        except (subprocess.TimeoutExpired, OSError):
+            out.append("branch: (git error)\n")
+
+        # File git status
+        try:
+            status_r = subprocess.run(
+                ["git", "status", "--porcelain", path],
+                capture_output=True, text=True, timeout=5,
+            )
+            if status_r.returncode == 0:
+                status_line = status_r.stdout.strip()
+                if status_line:
+                    xy = status_line[:2]
+                    if xy[0] in "MADRC":
+                        file_status = "staged"
+                    elif xy[1] in "MD":
+                        file_status = "modified"
+                    else:
+                        file_status = status_line.strip()
+                else:
+                    file_status = "clean"
+                out.append(f"file status: {file_status}\n")
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+        # Recent commits touching PATH
+        try:
+            log_r = subprocess.run(
+                ["git", "log", "--oneline", "-5", "--", path],
+                capture_output=True, text=True, timeout=5,
+            )
+            if log_r.returncode == 0 and log_r.stdout.strip():
+                out.append("recent commits:\n")
+                for line in log_r.stdout.strip().splitlines():
+                    out.append(f"  {line}\n")
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+        # Top blame contributors
+        try:
+            blame_r = subprocess.run(
+                ["git", "blame", "--line-porcelain", path],
+                capture_output=True, text=True, timeout=15,
+            )
+            if blame_r.returncode == 0 and blame_r.stdout:
+                author_counts: Dict[str, int] = {}
+                total_blame_lines = 0
+                for bline in blame_r.stdout.splitlines():
+                    if bline.startswith("author "):
+                        author = bline[7:].strip()
+                        author_counts[author] = author_counts.get(author, 0) + 1
+                        total_blame_lines += 1
+                if author_counts and total_blame_lines > 0:
+                    top3 = sorted(author_counts.items(), key=lambda x: -x[1])[:3]
+                    out.append("top contributors:\n")
+                    for author, count in top3:
+                        pct = round(100 * count / total_blame_lines)
+                        out.append(f"  {author} ({pct}%)\n")
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+        out.append("\n")
+
+    # ── Section 6: References ────────────────────────────────────────────────
+    out.append("## References\n\n")
+    basename = os.path.basename(path)
+    ext = os.path.splitext(basename)[1]  # e.g. ".php"
+    # Strip extension. For "Foo.class.php" → "Foo.class" → strip again by splitext
+    symbol = os.path.splitext(basename)[0]  # strips last extension
+    # For "Foo.class.php" → symbol = "Foo.class"; strip another extension if still has one
+    if "." in symbol:
+        symbol = os.path.splitext(symbol)[0]
+
+    ref_limit = 20
+    noisy_note = ""
+    if symbol.lower() in _WORKSPACE_COMMON_SYMBOLS:
+        ref_limit = 10
+        noisy_note = f"  (common symbol — results may be noisy)\n"
+
+    excl = _get_exclude_paths("grep")
+    hits = _grep_recursive(symbol, ".", ref_limit, excl)
+    # Filter to same extension, exclude self
+    abs_path = os.path.abspath(path)
+    filtered_hits: List[str] = []
+    for hit in hits:
+        # hit format: "filepath:lineno:content"
+        colon1 = hit.index(":")
+        hit_file = hit[:colon1]
+        if os.path.abspath(hit_file) == abs_path:
+            continue
+        if ext and not hit_file.endswith(ext):
+            continue
+        filtered_hits.append(hit)
+
+    if noisy_note:
+        out.append(noisy_note)
+
+    if filtered_hits:
+        current_file = ""
+        for hit in filtered_hits:
+            colon1 = hit.index(":")
+            rest = hit[colon1 + 1:]
+            colon2 = rest.index(":")
+            hit_file = hit[:colon1]
+            lineno = rest[:colon2]
+            content = rest[colon2 + 1:]
+            if hit_file != current_file:
+                current_file = hit_file
+                out.append(f"{hit_file}\n")
+            out.append(f"  {lineno}:{content}\n")
+    else:
+        out.append(f"(no references to {symbol!r} found in *{ext} files)\n")
+    out.append("\n")
+
+    # ── Section 7: Tests ─────────────────────────────────────────────────────
+    _ws_test_path: Optional[str] = None
+
+    if ext == ".php":
+        # PHP: look for *Test.php matching the base symbol
+        test_pattern = f"**/{symbol}Test.php"
+        from glob import glob as _glob
+        candidates = _glob(test_pattern, recursive=True)
+        if candidates:
+            _ws_test_path = candidates[0]
+    elif ext == ".py":
+        # Python: test_*.py or *_test.py matching the symbol
+        sym_lower = symbol.lower()
+        for tpat in (f"**/test_{sym_lower}.py", f"**/{sym_lower}_test.py",
+                     f"**/test_{symbol}.py", f"**/{symbol}_test.py"):
+            from glob import glob as _glob
+            candidates = _glob(tpat, recursive=True)
+            if candidates:
+                _ws_test_path = candidates[0]
+                break
+
+    if _ws_test_path and os.path.isfile(_ws_test_path):
+        out.append("## Tests\n\n")
+        try:
+            test_lines = _count_lines(_ws_test_path)
+            test_mtime = os.path.getmtime(_ws_test_path)
+            test_mtime_str = datetime.fromtimestamp(test_mtime).strftime("%Y-%m-%d %H:%M")
+            out.append(f"{_ws_test_path}  ({test_lines} lines, last modified {test_mtime_str})\n")
+        except OSError:
+            out.append(f"{_ws_test_path}\n")
+        out.append("\n")
+
+    return "".join(out)
+
+
 def op_format(path: str, tool_filter: Optional[list] = None, verbose: bool = False) -> str:
     """Manual one-shot: run formatters on ``path``, render ok/fail + duration.
 
@@ -8850,6 +9279,12 @@ def dispatch(arg: str) -> str:
             fs_parts = [p for p in parts[1:] if p != "verbose"]
             fs_tools = [t for t in (fs_parts[0].split(",") if len(fs_parts) > 0 and fs_parts[0] else []) if t]
             body = op_format_staged(fs_tools or None, verbose=fs_verbose)
+        elif op == "resolve":
+            rs_symbol = parts[1] if len(parts) > 1 else ""
+            body = op_resolve(rs_symbol)
+        elif op == "workspace":
+            ws_path = parts[1] if len(parts) > 1 else ""
+            body = op_workspace(ws_path)
         elif op in ("introduction", "output-format", "ops", "ops-compact", "version"):
             # Meta-ops use markdown headers instead of --- header ---
             header = ""

--- a/supertool.py
+++ b/supertool.py
@@ -8089,26 +8089,67 @@ _WORKSPACE_COMMON_SYMBOLS = frozenset({
     "tests", "setup", "models", "model", "views", "view", "routes",
 })
 
+# Extension family map for workspace References scan.
+# A file with ext X searches for references in files matching any ext in the family.
+# Default: same-ext only (handled by the fallback in op_workspace).
+_EXT_FAMILIES: Dict[str, tuple] = {
+    ".ts":   (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"),
+    ".tsx":  (".ts", ".tsx", ".js", ".jsx"),
+    ".js":   (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx"),
+    ".jsx":  (".js", ".jsx", ".ts", ".tsx"),
+    ".mjs":  (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx"),
+    ".cjs":  (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx"),
+    ".php":  (".php",),  # DVSI's .class.php matched via endswith(".php")
+    ".py":   (".py", ".pyi"),
+    ".pyi":  (".py", ".pyi"),
+}
+
 
 # ---------------------------------------------------------------------------
 # op_resolve — smart-glob "go to definition" resolver
 # ---------------------------------------------------------------------------
 
-def op_resolve(symbol: str) -> str:
+def op_resolve(symbol: str, from_file: Optional[str] = None, _cache: Optional[dict] = None) -> str:
     """Resolve a symbol/import string to a project file path.
 
     Detection rules (in priority order):
       - Contains backslash → PHP FQN  → **/<path>.class.php, fallback **/<path>.php
+      - Starts with one or more dots (Python relative import, e.g. ".", ".utils") →
+        resolve relative to from_file's directory when provided; otherwise → external
       - Contains dot only (no / or ./) → Python dotted import → **/<path>.py
       - Starts with ./ or ../ → relative path → try common extensions
       - Bare word (no separators) → ambiguous → try multi-ext glob
       - Otherwise → external (npm/pip/etc.)
+
+    Args:
+        symbol: The import/symbol string to resolve.
+        from_file: Optional path to the file that contains the import (used for
+            Python relative imports like "." or ".utils"). Without this, relative
+            Python imports return "external".
+        _cache: Optional dict used as a per-call resolve cache (avoids repeated
+            full-repo globs for the same symbol within a single workspace call).
 
     Returns: "SYMBOL → PATH" on success, "SYMBOL → external", or "SYMBOL → not found".
     """
     if not symbol:
         return "resolve: empty symbol\n"
 
+    # Per-call cache: key is (symbol, from_file)
+    if _cache is not None:
+        cache_key = (symbol, from_file)
+        if cache_key in _cache:
+            return _cache[cache_key]
+
+    result = _op_resolve_inner(symbol, from_file)
+
+    if _cache is not None:
+        _cache[cache_key] = result
+
+    return result
+
+
+def _op_resolve_inner(symbol: str, from_file: Optional[str] = None) -> str:
+    """Core resolve logic — called by op_resolve (which handles caching)."""
     excl = _get_exclude_paths("resolve")
 
     # ── PHP FQN (contains backslash) ─────────────────────────────────────────
@@ -8120,6 +8161,45 @@ def op_resolve(symbol: str) -> str:
                 rel = os.path.relpath(hits[0])
                 return f"{symbol} → {rel}\n"
         return f"{symbol} → not found\n"
+
+    # ── Python relative import (starts with one or more dots, no /) ──────────
+    # Matches: ".", ".utils", "..models", ".sub.module" etc.
+    # Does NOT match "./" or "../" (those are handled below as relative paths).
+    if re.match(r"^\.+\w*(?:\.\w+)*$", symbol) or symbol in (".", ".."):
+        if not from_file:
+            return f"{symbol} → external\n"
+        base_dir = os.path.dirname(os.path.abspath(from_file))
+        # Strip leading dots to find the module name; count dots for package depth
+        # Single dot: same package. ".utils" → utils in same dir.
+        # ".." / "..models" → parent package (we resolve one level up per leading dot beyond 1)
+        m = re.match(r"^(\.+)(.*)", symbol)
+        if not m:
+            return f"{symbol} → external\n"
+        dots, rest = m.group(1), m.group(2)
+        # Each extra dot beyond the first means go up one directory
+        target_dir = base_dir
+        for _ in range(len(dots) - 1):
+            target_dir = os.path.dirname(target_dir)
+        if rest:
+            module_path = rest.replace(".", "/")
+            for ext in (".py", ".pyi"):
+                candidate = os.path.join(target_dir, module_path + ext)
+                if os.path.isfile(candidate):
+                    rel = os.path.relpath(candidate)
+                    return f"{symbol} → {rel}\n"
+            # Also try as a package (directory with __init__.py)
+            pkg_init = os.path.join(target_dir, module_path, "__init__.py")
+            if os.path.isfile(pkg_init):
+                rel = os.path.relpath(pkg_init)
+                return f"{symbol} → {rel}\n"
+            return f"{symbol} → not found\n"
+        else:
+            # Bare "." or ".." — refers to the package itself
+            pkg_init = os.path.join(target_dir, "__init__.py")
+            if os.path.isfile(pkg_init):
+                rel = os.path.relpath(pkg_init)
+                return f"{symbol} → {rel}\n"
+            return f"{symbol} → not found\n"
 
     # ── Python dotted import (dots but no / and not starting with ./ or ../) ─
     if "." in symbol and "/" not in symbol and not symbol.startswith("."):
@@ -8175,10 +8255,10 @@ def op_resolve(symbol: str) -> str:
 # ---------------------------------------------------------------------------
 
 _PHP_USE_RE = re.compile(
-    r"^\s*use\s+([\w\\]+)(?:\s+as\s+(\w+))?\s*;", re.MULTILINE
+    r"^\s*use\s+(?:function\s+|const\s+)?([\w\\]+)(?:\s+as\s+(\w+))?\s*;", re.MULTILINE
 )
 _PY_FROM_RE = re.compile(
-    r"^\s*from\s+([\w.]+)\s+import\s+\S+", re.MULTILINE
+    r"^\s*from\s+(\.+\w*(?:\.\w+)*|\w+(?:\.\w+)*)\s+import", re.MULTILINE
 )
 _PY_IMPORT_RE = re.compile(
     r"^\s*import\s+([\w.]+)", re.MULTILINE
@@ -8191,7 +8271,7 @@ _JS_BARE_RE = re.compile(
 )
 
 
-def _parse_imports(path: str, content: str) -> List[tuple]:
+def _parse_imports(path: str, content: str) -> List[tuple]:  # noqa: same signature, from_file is path
     """Return list of (symbol, alias_or_None) pairs for the file's import statements."""
     ext = os.path.splitext(path)[1].lower()
     results: List[tuple] = []
@@ -8297,9 +8377,10 @@ def op_workspace(path: str) -> str:
     _imports = _parse_imports(path, file_content)
     if _imports:
         _imports = _imports[:40]  # cap at 40 entries
+        _resolve_cache: dict = {}
         out.append(f"## Imports ({len(_imports)})\n\n")
         for sym, alias in _imports:
-            resolved_line = op_resolve(sym).strip()
+            resolved_line = op_resolve(sym, from_file=path, _cache=_resolve_cache).strip()
             # resolved_line is "SYMBOL → PATH" — extract just the path part
             arrow_idx = resolved_line.find(" → ")
             resolved_path = resolved_line[arrow_idx + 3:] if arrow_idx != -1 else resolved_line
@@ -8315,17 +8396,15 @@ def op_workspace(path: str) -> str:
         out.append(op_validate(path, verbose=True))
         out.append("\n")
 
-    # ── Section 4: Siblings ──────────────────────────────────────────────────
+    # ── Section 5: Siblings ──────────────────────────────────────────────────
     dirname = os.path.dirname(os.path.abspath(path))
     cwd = os.path.abspath(os.getcwd())
     if dirname != cwd:
         out.append("## Siblings\n\n")
-        # Use the relative dirname for a readable path
-        rel_dir = os.path.relpath(dirname, cwd)
         out.append(op_ls(dirname))
         out.append("\n")
 
-    # ── Section 5: Git ───────────────────────────────────────────────────────
+    # ── Section 6: Git ───────────────────────────────────────────────────────
     # Check if inside a git repo
     try:
         git_check = subprocess.run(
@@ -8420,7 +8499,7 @@ def op_workspace(path: str) -> str:
 
         out.append("\n")
 
-    # ── Section 6: References ────────────────────────────────────────────────
+    # ── Section 7: References ────────────────────────────────────────────────
     out.append("## References\n\n")
     basename = os.path.basename(path)
     ext = os.path.splitext(basename)[1]  # e.g. ".php"
@@ -8438,8 +8517,9 @@ def op_workspace(path: str) -> str:
 
     excl = _get_exclude_paths("grep")
     hits = _grep_recursive(symbol, ".", ref_limit, excl)
-    # Filter to same extension, exclude self
+    # Filter to family extensions (or same-ext fallback), exclude self
     abs_path = os.path.abspath(path)
+    ext_family = _EXT_FAMILIES.get(ext, (ext,)) if ext else ()
     filtered_hits: List[str] = []
     for hit in hits:
         # hit format: "filepath:lineno:content"
@@ -8447,7 +8527,7 @@ def op_workspace(path: str) -> str:
         hit_file = hit[:colon1]
         if os.path.abspath(hit_file) == abs_path:
             continue
-        if ext and not hit_file.endswith(ext):
+        if ext_family and not any(hit_file.endswith(e) for e in ext_family):
             continue
         filtered_hits.append(hit)
 
@@ -8471,7 +8551,7 @@ def op_workspace(path: str) -> str:
         out.append(f"(no references to {symbol!r} found in *{ext} files)\n")
     out.append("\n")
 
-    # ── Section 7: Tests ─────────────────────────────────────────────────────
+    # ── Section 8: Tests ─────────────────────────────────────────────────────
     _ws_test_path: Optional[str] = None
 
     if ext == ".php":

--- a/tests/fixtures/resolve/Foo/Bar.class.php
+++ b/tests/fixtures/resolve/Foo/Bar.class.php
@@ -1,0 +1,4 @@
+<?php
+namespace Foo;
+
+class Bar {}

--- a/tests/fixtures/resolve/mypkg/utils.py
+++ b/tests/fixtures/resolve/mypkg/utils.py
@@ -1,0 +1,2 @@
+class Bar:
+    pass

--- a/tests/fixtures/resolve/util.ts
+++ b/tests/fixtures/resolve/util.ts
@@ -1,0 +1,1 @@
+export function helper(): void {}

--- a/tests/test_op_resolve.py
+++ b/tests/test_op_resolve.py
@@ -1,0 +1,210 @@
+"""Tests for op_resolve and workspace ## Imports section."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FIXTURES = Path(__file__).parent / "fixtures" / "resolve"
+
+
+# ---------------------------------------------------------------------------
+# op_resolve — PHP FQN
+# ---------------------------------------------------------------------------
+
+def test_resolve_php_fqn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Foo\\Bar resolves to the fixture .class.php file."""
+    monkeypatch.chdir(FIXTURES)
+    result = supertool.op_resolve("Foo\\Bar")
+    assert "→" in result
+    assert "not found" not in result
+    assert "external" not in result
+    assert "Bar.class.php" in result
+
+
+# ---------------------------------------------------------------------------
+# op_resolve — Python dotted
+# ---------------------------------------------------------------------------
+
+def test_resolve_python_dotted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """mypkg.utils resolves to the fixture .py file."""
+    monkeypatch.chdir(FIXTURES)
+    result = supertool.op_resolve("mypkg.utils")
+    assert "→" in result
+    assert "not found" not in result
+    assert "external" not in result
+    assert "utils.py" in result
+
+
+# ---------------------------------------------------------------------------
+# op_resolve — relative path
+# ---------------------------------------------------------------------------
+
+def test_resolve_relative_ts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """./util from the fixtures dir resolves to util.ts."""
+    monkeypatch.chdir(FIXTURES)
+    result = supertool.op_resolve("./util")
+    assert "→" in result
+    assert "not found" not in result
+    assert "external" not in result
+    assert "util.ts" in result
+
+
+# ---------------------------------------------------------------------------
+# op_resolve — external package
+# ---------------------------------------------------------------------------
+
+def test_resolve_external(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A package-spec with / that isn't relative (e.g. lodash/utils) returns external."""
+    monkeypatch.chdir(tmp_path)
+    result = supertool.op_resolve("lodash/utils")
+    assert "external" in result
+
+
+def test_resolve_bare_word_not_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare word with no matching file returns 'not found'."""
+    monkeypatch.chdir(tmp_path)
+    result = supertool.op_resolve("lodash")
+    assert "not found" in result
+
+
+# ---------------------------------------------------------------------------
+# op_resolve — not found
+# ---------------------------------------------------------------------------
+
+def test_resolve_not_found_php(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A PHP FQN that has no matching file returns 'not found'."""
+    monkeypatch.chdir(FIXTURES)
+    result = supertool.op_resolve("Does\\NotExist")
+    assert "not found" in result
+
+
+def test_resolve_not_found_python(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Python dotted import that has no matching file returns 'not found'."""
+    monkeypatch.chdir(FIXTURES)
+    result = supertool.op_resolve("does.not.exist.anywhere")
+    assert "not found" in result
+
+
+# ---------------------------------------------------------------------------
+# op_resolve — dispatch round-trip
+# ---------------------------------------------------------------------------
+
+def test_resolve_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """dispatch('resolve:Foo\\\\Bar') returns the expected header + result."""
+    monkeypatch.chdir(FIXTURES)
+    out = supertool.dispatch("resolve:Foo\\Bar")
+    assert "--- resolve:" in out
+    assert "Bar.class.php" in out
+
+
+# ---------------------------------------------------------------------------
+# workspace — Imports section present for PHP with use statements
+# ---------------------------------------------------------------------------
+
+def test_workspace_imports_php(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """workspace on a PHP file with use statements emits an ## Imports section."""
+    # Create a target PHP file with use statements
+    php_file = tmp_path / "MyCommand.class.php"
+    php_file.write_text(
+        "<?php\n"
+        "use Foo\\Bar;\n"
+        "use Baz\\Qux as Q;\n"
+        "class MyCommand {}\n"
+    )
+    # Create a matching file for Foo\Bar so resolve finds it
+    foo_dir = tmp_path / "Foo"
+    foo_dir.mkdir()
+    (foo_dir / "Bar.class.php").write_text("<?php\nclass Bar {}\n")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+    monkeypatch.setattr(supertool, "_CONFIG", {})
+
+    out = supertool.op_workspace(str(php_file))
+
+    assert "## Imports" in out
+    # Both use statements should appear
+    assert "Foo\\Bar" in out or "Foo" in out
+    assert "Baz\\Qux" in out or "Qux" in out
+
+
+# ---------------------------------------------------------------------------
+# workspace — Imports section absent when no imports
+# ---------------------------------------------------------------------------
+
+def test_workspace_no_imports_section_when_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """workspace on a file with no import statements omits ## Imports."""
+    f = tmp_path / "plain.py"
+    f.write_text("x = 1\ny = 2\n")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+    monkeypatch.setattr(supertool, "_CONFIG", {})
+
+    out = supertool.op_workspace(str(f))
+    assert "## Imports" not in out
+
+
+# ---------------------------------------------------------------------------
+# workspace — Imports section present for Python with import statements
+# ---------------------------------------------------------------------------
+
+def test_workspace_imports_python(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """workspace on a Python file with imports emits ## Imports."""
+    f = tmp_path / "mymodule.py"
+    f.write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "x = 1\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+    monkeypatch.setattr(supertool, "_CONFIG", {})
+
+    out = supertool.op_workspace(str(f))
+    assert "## Imports" in out
+    assert "os" in out
+    assert "pathlib" in out
+
+
+# ---------------------------------------------------------------------------
+# Imports section ordering: after Symbols, before Validators
+# ---------------------------------------------------------------------------
+
+def test_workspace_imports_order(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """## Imports appears after ## Symbols and before ## Validators."""
+    f = tmp_path / "sample.php"
+    f.write_text("<?php\nuse Foo\\Bar;\nclass Sample {}\n")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+    monkeypatch.setattr(supertool, "_CONFIG", {
+        "validators": {
+            "phplint": {
+                "cmd": "true {file}",
+                "match": "*.php",
+                "hooks_into": [],
+                "timeout": 5,
+            }
+        }
+    })
+
+    out = supertool.op_workspace(str(f))
+    sym_pos = out.find("## Symbols")
+    imp_pos = out.find("## Imports")
+    val_pos = out.find("## Validators")
+
+    assert sym_pos != -1
+    assert imp_pos != -1
+    assert sym_pos < imp_pos
+    if val_pos != -1:
+        assert imp_pos < val_pos

--- a/tests/test_op_workspace.py
+++ b/tests/test_op_workspace.py
@@ -1,0 +1,259 @@
+"""Tests for op_workspace — one-shot IDE-style file view."""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_php(tmp_path: Path, name: str = "Foo.class.php") -> Path:
+    f = tmp_path / name
+    f.write_text(
+        "<?php\nclass Foo {\n    public function bar(): void {}\n}\n"
+    )
+    return f
+
+
+def _make_py(tmp_path: Path, name: str = "mymodule.py") -> Path:
+    f = tmp_path / name
+    f.write_text(
+        "class MyModule:\n    def run(self) -> None:\n        pass\n"
+    )
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Missing file
+# ---------------------------------------------------------------------------
+
+def test_workspace_missing_file() -> None:
+    out = supertool.op_workspace("/nonexistent/path/to/NoSuchFile.php")
+    assert "not found" in out
+
+
+def test_workspace_dispatch_missing_file() -> None:
+    out = supertool.dispatch("workspace:/nonexistent/file.py")
+    assert "not found" in out
+
+
+# ---------------------------------------------------------------------------
+# Basic invocation — sections present and in correct order
+# ---------------------------------------------------------------------------
+
+def test_workspace_sections_order(tmp_path: Path) -> None:
+    f = _make_php(tmp_path, "Widget.class.php")
+    out = supertool.op_workspace(str(f))
+
+    # All expected section headers present
+    assert "## File:" in out
+    assert "## Symbols" in out
+    assert "## References" in out
+
+    # Order: File → Symbols → References
+    file_pos = out.index("## File:")
+    sym_pos = out.index("## Symbols")
+    ref_pos = out.index("## References")
+    assert file_pos < sym_pos < ref_pos
+
+
+def test_workspace_file_section_contains_content(tmp_path: Path) -> None:
+    f = _make_php(tmp_path, "Widget.class.php")
+    out = supertool.op_workspace(str(f))
+    assert "class Foo" in out
+    assert "public function bar" in out
+
+
+def test_workspace_symbols_section_present(tmp_path: Path) -> None:
+    f = _make_py(tmp_path)
+    out = supertool.op_workspace(str(f))
+    assert "## Symbols" in out
+    # regex extraction should find the class
+    assert "MyModule" in out
+
+
+# ---------------------------------------------------------------------------
+# Validators section — present only when validators configured
+# ---------------------------------------------------------------------------
+
+def test_workspace_no_validators_section_when_none_configured(tmp_path: Path, monkeypatch) -> None:
+    """When no validators in config, ## Validators section is omitted."""
+    monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+    monkeypatch.setattr(supertool, "_CONFIG", {})
+    f = _make_py(tmp_path)
+    out = supertool.op_workspace(str(f))
+    assert "## Validators" not in out
+
+
+def test_workspace_validators_section_when_configured(tmp_path: Path, monkeypatch) -> None:
+    """When validators are configured, ## Validators section appears."""
+    f = tmp_path / "sample.json"
+    f.write_text('{"key": "value"}\n')
+    monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+    monkeypatch.setattr(supertool, "_CONFIG", {
+        "validators": {
+            "jsonlint": {
+                "cmd": "python3 -m json.tool {file}",
+                "match": "*.json",
+                "hooks_into": [],
+                "timeout": 10,
+            }
+        }
+    })
+    out = supertool.op_workspace(str(f))
+    assert "## Validators" in out
+
+
+# ---------------------------------------------------------------------------
+# Siblings section — present only when dirname != cwd
+# ---------------------------------------------------------------------------
+
+def test_workspace_siblings_present_when_in_subdir(tmp_path: Path, monkeypatch) -> None:
+    subdir = tmp_path / "src"
+    subdir.mkdir()
+    f = subdir / "Thing.py"
+    f.write_text("x = 1\n")
+    (subdir / "Other.py").write_text("y = 2\n")
+
+    monkeypatch.chdir(tmp_path)
+    out = supertool.op_workspace(str(f))
+    assert "## Siblings" in out
+    assert "Thing.py" in out or "Other.py" in out
+
+
+def test_workspace_siblings_skipped_when_in_cwd(tmp_path: Path, monkeypatch) -> None:
+    f = tmp_path / "top.py"
+    f.write_text("x = 1\n")
+    monkeypatch.chdir(tmp_path)
+    out = supertool.op_workspace(str(f))
+    assert "## Siblings" not in out
+
+
+# ---------------------------------------------------------------------------
+# Git section — omitted outside a git repo
+# ---------------------------------------------------------------------------
+
+def test_workspace_no_git_section_outside_repo(tmp_path: Path, monkeypatch) -> None:
+    """Outside a git repo the Git section must be absent."""
+    f = _make_py(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # Patch subprocess.run to simulate "not inside a git repo"
+    real_run = subprocess.run
+
+    def _fake_run(cmd, **kwargs):
+        if cmd[0] == "git" and "rev-parse" in cmd:
+            import subprocess as sp
+            result = sp.CompletedProcess(cmd, returncode=128, stdout="", stderr="")
+            return result
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    out = supertool.op_workspace(str(f))
+    assert "## Git" not in out
+
+
+# ---------------------------------------------------------------------------
+# References section — exclude paths respected
+# ---------------------------------------------------------------------------
+
+def test_workspace_references_excludes_vendor(tmp_path: Path, monkeypatch) -> None:
+    """References scan must not return hits from vendor/ directories."""
+    # Create the target file
+    src = tmp_path / "src"
+    src.mkdir()
+    target = src / "Processor.py"
+    target.write_text("class Processor:\n    pass\n")
+
+    # Create a vendor file that references the symbol
+    vendor = tmp_path / "vendor" / "lib"
+    vendor.mkdir(parents=True)
+    (vendor / "something.py").write_text("from Processor import Processor\n")
+
+    # Create a legitimate reference
+    (src / "caller.py").write_text("from Processor import Processor\n")
+
+    monkeypatch.chdir(tmp_path)
+    # Inject vendor/ into exclude paths
+    monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+    monkeypatch.setattr(supertool, "_CONFIG", {
+        "ops": {
+            "grep": {"exclude-paths": ["vendor/"]}
+        }
+    })
+
+    out = supertool.op_workspace(str(target))
+    ref_section_start = out.find("## References")
+    assert ref_section_start != -1
+    ref_section = out[ref_section_start:]
+
+    assert "vendor" not in ref_section
+    assert "caller.py" in ref_section
+
+
+# ---------------------------------------------------------------------------
+# Tests section — PHP test file detection
+# ---------------------------------------------------------------------------
+
+def test_workspace_tests_section_php(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "Widget.class.php"
+    f.write_text("<?php\nclass Widget {}\n")
+    test_f = tmp_path / "WidgetTest.php"
+    test_f.write_text("<?php\nclass WidgetTest extends TestCase {}\n")
+
+    out = supertool.op_workspace(str(f))
+    assert "## Tests" in out
+    assert "WidgetTest.php" in out
+
+
+def test_workspace_tests_section_python(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "processor.py"
+    f.write_text("class Processor:\n    pass\n")
+    test_f = tmp_path / "test_processor.py"
+    test_f.write_text("def test_run(): pass\n")
+
+    out = supertool.op_workspace(str(f))
+    assert "## Tests" in out
+    assert "test_processor.py" in out
+
+
+def test_workspace_no_tests_section_when_no_match(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "obscure_thing_xyz.py"
+    f.write_text("x = 1\n")
+    out = supertool.op_workspace(str(f))
+    assert "## Tests" not in out
+
+
+# ---------------------------------------------------------------------------
+# Common symbol — noisy note injected, limit tightened
+# ---------------------------------------------------------------------------
+
+def test_workspace_common_symbol_note(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "index.py"
+    f.write_text("x = 1\n")
+    out = supertool.op_workspace(str(f))
+    assert "common symbol" in out
+
+
+# ---------------------------------------------------------------------------
+# Dispatch round-trip
+# ---------------------------------------------------------------------------
+
+def test_workspace_dispatch_returns_header(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "sample.py"
+    f.write_text("def hello(): pass\n")
+    out = supertool.dispatch(f"workspace:{f}")
+    assert f"--- workspace:{f} ---" in out
+    assert "## File:" in out


### PR DESCRIPTION
## Summary

- **`workspace:PATH`** — one-shot IDE-style first-touch view: File, Symbols, **Imports** (new), Validators, Siblings, Git, References, Tests. Committed earlier on this branch.
- **`resolve:SYMBOL`** — new smart-glob go-to-definition primitive. Detects language from symbol shape (PHP `\`-separated FQN, Python dotted import, JS/TS relative `./`) and returns the first matching project file, `external` for package specs, or `not found`. Used standalone and internally by workspace's new Imports section.
- **Imports section in `workspace`** — parses `use`/`import` statements per language (PHP, Python, JS/TS via regex), calls `op_resolve` for each, emits a table of `Symbol → Path`. Capped at 40 entries. Omitted entirely when no imports detected.

## Test plan

- [ ] `resolve:Foo\Bar` → resolves to `tests/fixtures/resolve/Foo/Bar.class.php`
- [ ] `resolve:mypkg.utils` → resolves to `tests/fixtures/resolve/mypkg/utils.py`
- [ ] `resolve:./util` from fixtures dir → resolves to `util.ts`
- [ ] `resolve:lodash/utils` → returns `external`
- [ ] `resolve:DoesNotExist\Anywhere` → returns `not found`
- [ ] `workspace` on PHP file with `use` statements → emits `## Imports` section
- [ ] `workspace` on file with no imports → omits `## Imports` section
- [ ] `## Imports` appears after `## Symbols` and before `## Validators`
- [ ] Full pytest suite: 1998 passed, 8 skipped, 89% coverage (≥87% required)