### PR TITLE
feat: upstream psr (phpcs PSR-12) wrapper as env-configured validator

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -434,6 +434,17 @@
       ],
       "rollback_on_fail": false,
       "timeout": 30
+    },
+    "psr": {
+      "cmd": "python3 {supertool_dir}/validators/psr/psr.py {file}",
+      "match": "*.php",
+      "hooks_into": [],
+      "rollback_on_fail": false,
+      "timeout": 30,
+      "env": {
+        "PSR_STANDARD": "PSR12",
+        "PSR_SEVERITY": "9"
+      }
     }
   },
   "formatters": {

--- a/.supertool.json
+++ b/.supertool.json
@@ -174,7 +174,7 @@
     },
     "resolve": {
       "syntax": "resolve:SYMBOL",
-      "description": "Smart-glob resolver: PHP FQN, Python dotted, JS/TS relative path → file on disk. Returns 'external' for npm/pip packages, 'not found' if no match. Used internally by workspace.",
+      "description": "Smart-glob resolver: PHP FQN, Python dotted, JS/TS relative path \u2192 file on disk. Returns 'external' for npm/pip packages, 'not found' if no match. Used internally by workspace.",
       "example": "resolve:foo.bar.baz"
     }
   },
@@ -193,17 +193,6 @@
       ],
       "rollback_on_fail": true,
       "timeout": 10
-    },
-    "psr": {
-      "cmd": "python3 {supertool_dir}/validators/psr/psr.py {file}",
-      "match": "*.php",
-      "hooks_into": [],
-      "rollback_on_fail": false,
-      "timeout": 30,
-      "env": {
-        "PSR_STANDARD": "PSR12",
-        "PSR_SEVERITY": "9"
-      }
     }
   }
 }

--- a/.supertool.json
+++ b/.supertool.json
@@ -193,6 +193,17 @@
       ],
       "rollback_on_fail": true,
       "timeout": 10
+    },
+    "psr": {
+      "cmd": "python3 {supertool_dir}/validators/psr/psr.py {file}",
+      "match": "*.php",
+      "hooks_into": [],
+      "rollback_on_fail": false,
+      "timeout": 30,
+      "env": {
+        "PSR_STANDARD": "PSR12",
+        "PSR_SEVERITY": "9"
+      }
     }
   }
 }

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -70,6 +70,7 @@ Enable any of these by copying the relevant entry from `.supertool.example.json`
 | Rust                | `cargo-check`    | `cargo` (ships with Rust)          | Uses `cargo check` — full type resolution  |
 | PHP — static  | `phpstan`        | `phpstan` binary (PATH or via `PHPSTAN_BIN` env)  | Env-configured. See [README](../validators/phpstan/README.md) |
 | PHP — mess    | `phpmd`          | `phpmd` binary (PATH or via `PHPMD_BIN` env)      | Env-configured. See [README](../validators/phpmd/README.md) |
+| PHP — style   | `psr`            | `phpcs` binary (PATH or via `PSR_BIN` env)        | Env-configured. See [README](../validators/psr/README.md)  |
 
 
 ## Adding your own

--- a/tests/test_validators_psr.py
+++ b/tests/test_validators_psr.py
@@ -1,0 +1,122 @@
+"""Smoke tests for validators/psr/psr.py."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PSR_PY = Path(__file__).parent.parent / "validators" / "psr" / "psr.py"
+
+
+def test_psr_no_arg_returns_schema_error() -> None:
+    """Calling with no arg must emit a valid SCHEMA.md error dict and exit 0."""
+    r = subprocess.run(["python3", str(PSR_PY)], capture_output=True, text=True, timeout=10)
+    assert r.returncode == 0
+    data = json.loads(r.stdout.strip())
+    assert data["tool"] == "psr"
+    assert data["ok"] is False
+    assert "no file arg" in data["errors"][0]["msg"]
+
+
+def test_psr_missing_binary_returns_schema_error(tmp_path: Path) -> None:
+    """When PSR_BIN does not exist, adapter must emit ok=false with descriptive error."""
+    f = tmp_path / "clean.php"
+    f.write_text("<?php\n$x = 1;\n")
+    env = {**os.environ, "PSR_BIN": str(tmp_path / "phpcs-does-not-exist")}
+    r = subprocess.run(
+        ["python3", str(PSR_PY), str(f)],
+        capture_output=True, text=True, timeout=10, env=env,
+    )
+    assert r.returncode == 0
+    data = json.loads(r.stdout.strip())
+    assert data["tool"] == "psr"
+    assert data["ok"] is False
+    assert "PSR_BIN not found" in data["errors"][0]["msg"]
+
+
+def test_psr_clean_output_parses_to_ok(tmp_path: Path) -> None:
+    """When phpcs produces no violations, adapter emits ok=True."""
+    f = tmp_path / "clean.php"
+    f.write_text("<?php\n$x = 1;\n")
+    # Stub phpcs that exits 0 with empty JSON report.
+    stub = tmp_path / "phpcs"
+    stub.write_text('#!/usr/bin/env bash\nprintf \'{"totals":{"errors":0,"warnings":0},"files":{}}\'\nexit 0\n')
+    stub.chmod(0o755)
+    env = {**os.environ, "PSR_BIN": str(stub)}
+    r = subprocess.run(
+        ["python3", str(PSR_PY), str(f)],
+        capture_output=True, text=True, timeout=10, env=env,
+    )
+    assert r.returncode == 0
+    data = json.loads(r.stdout.strip())
+    assert data["tool"] == "psr"
+    assert data["ok"] is True
+    assert data["count"] == 0
+    assert data["errors"] == []
+
+
+def test_psr_parses_json_violations(tmp_path: Path) -> None:
+    """Adapter must parse phpcs JSON report into SCHEMA.md errors."""
+    f = tmp_path / "dirty.php"
+    f.write_text("<?php\n$x = 1;\n")
+    violation_json = json.dumps({
+        "totals": {"errors": 1, "warnings": 0},
+        "files": {
+            str(f): {
+                "errors": 1,
+                "warnings": 0,
+                "messages": [
+                    {
+                        "message": "Opening brace should be on a new line",
+                        "source": "PSR2.Classes.ClassDeclaration.OpenBraceNewLine",
+                        "severity": 5,
+                        "type": "ERROR",
+                        "line": 2,
+                        "column": 1,
+                        "fixable": True,
+                    }
+                ],
+            }
+        },
+    })
+    stub = tmp_path / "phpcs"
+    stub.write_text(f"#!/usr/bin/env bash\nprintf '%s' '{violation_json}'\nexit 1\n")
+    stub.chmod(0o755)
+    env = {**os.environ, "PSR_BIN": str(stub)}
+    r = subprocess.run(
+        ["python3", str(PSR_PY), str(f)],
+        capture_output=True, text=True, timeout=10, env=env,
+    )
+    assert r.returncode == 0
+    data = json.loads(r.stdout.strip())
+    assert data["tool"] == "psr"
+    assert data["ok"] is False
+    assert data["count"] == 1
+    err = data["errors"][0]
+    assert err["line"] == 2
+    assert err["col"] == 1
+    assert err["severity"] == "error"
+    assert err["code"] == "PSR2.Classes.ClassDeclaration.OpenBraceNewLine"
+    assert "brace" in err["msg"].lower()
+    assert "source_context" in err
+
+
+@pytest.mark.skipif(not shutil.which("phpcs"), reason="phpcs not installed")
+def test_psr_live_clean_php(tmp_path: Path) -> None:
+    """Live phpcs on a clean PHP file → ok=True, count=0."""
+    f = tmp_path / "ok.php"
+    f.write_text("<?php\n\nfunction add(int $a, int $b): int\n{\n    return $a + $b;\n}\n")
+    r = subprocess.run(
+        ["python3", str(PSR_PY), str(f)],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert r.returncode == 0
+    data = json.loads(r.stdout.strip())
+    assert data["tool"] == "psr"
+    assert isinstance(data["ok"], bool)
+    assert isinstance(data["errors"], list)
+    assert isinstance(data["duration_ms"], int)

--- a/validators/psr/README.md
+++ b/validators/psr/README.md
@@ -1,0 +1,41 @@
+# psr validator adapter
+
+Runs [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) on a single file and emits SCHEMA.md-compliant JSON.
+
+## Env vars
+
+| Var              | Default   | Description                                      |
+|------------------|-----------|--------------------------------------------------|
+| `PSR_BIN`        | `phpcs`   | Path to phpcs binary                             |
+| `PSR_STANDARD`   | `PSR12`   | Coding standard (`PSR12`, `PSR2`, or custom)     |
+| `PSR_EXCLUDE`    | _(none)_  | Comma-separated paths to ignore                  |
+| `PSR_SEVERITY`   | `9`       | Warning severity threshold (0–10)                |
+| `PSR_EXTENSIONS` | `php`     | Comma-separated file extensions to check         |
+
+## Example `.supertool.json` snippet
+
+```json
+{
+  "validators": {
+    "psr": {
+      "cmd": "python3 {supertool_dir}/validators/psr/psr.py {file}",
+      "match": "*.php",
+      "hooks_into": [],
+      "rollback_on_fail": false,
+      "timeout": 30,
+      "env": {
+        "PSR_BIN": "./vendor/bin/phpcs",
+        "PSR_STANDARD": "PSR12",
+        "PSR_SEVERITY": "9",
+        "PSR_EXCLUDE": "src/Generated/"
+      }
+    }
+  }
+}
+```
+
+`hooks_into: []` keeps this manual-only — run explicitly via `./supertool 'validate:src/Foo.php:psr'`.
+
+## Output shape
+
+Follows [SCHEMA.md](../SCHEMA.md). Each error carries `severity` (`"error"` or `"warning"`), `code` set to the phpcs source identifier (e.g. `PSR12.Files.FileHeader.SpacingAfterBlock`), `col` for the column number, and `source_context` (5-line window centered on the error line).

--- a/validators/psr/psr.py
+++ b/validators/psr/psr.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""phpcs PSR-12 validator adapter. Emits SCHEMA.md JSON.
+
+Usage: psr.py <file>
+
+Env vars:
+  PSR_BIN        phpcs binary (default: phpcs)
+  PSR_STANDARD   coding standard (default: PSR12)
+  PSR_EXCLUDE    comma-separated exclude paths (optional)
+  PSR_SEVERITY   warning severity threshold (default: 9)
+  PSR_EXTENSIONS file extensions to check (default: php)
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import pathlib
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
+from source_context import source_context
+
+
+def emit(obj: dict) -> None:
+    print(json.dumps(obj))
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({
+            "tool": "psr", "file": "", "ok": False, "count": 1,
+            "errors": [{"line": None, "col": None, "severity": "error",
+                        "code": "adapter", "msg": "no file arg"}],
+            "duration_ms": 0,
+        })
+        return
+
+    file = sys.argv[1]
+
+    psr_bin = os.environ.get("PSR_BIN", "phpcs")
+    psr_standard = os.environ.get("PSR_STANDARD", "PSR12")
+    psr_exclude = os.environ.get("PSR_EXCLUDE", "")
+    psr_severity = os.environ.get("PSR_SEVERITY", "9")
+    psr_extensions = os.environ.get("PSR_EXTENSIONS", "php")
+
+    # Guard: binary must exist
+    if not shutil.which(psr_bin) and not (pathlib.Path(psr_bin).exists() and os.access(psr_bin, os.X_OK)):
+        emit({
+            "tool": "psr", "file": file, "ok": False, "count": 1,
+            "errors": [{"line": None, "col": None, "severity": "error",
+                        "code": "adapter", "msg": f"PSR_BIN not found: {psr_bin}"}],
+            "duration_ms": 0,
+        })
+        return
+
+    cmd = [
+        psr_bin,
+        f"--standard={psr_standard}",
+        f"--warning-severity={psr_severity}",
+        f"--extensions={psr_extensions}",
+        "--report=json",
+        "--runtime-set", "ignore_warnings_on_exit", "true",
+    ]
+    if psr_exclude:
+        cmd.append(f"--ignore={psr_exclude}")
+    cmd.append(file)
+
+    start = time.time()
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except FileNotFoundError:
+        dur = int((time.time() - start) * 1000)
+        emit({
+            "tool": "psr", "file": file, "ok": False, "count": 1,
+            "errors": [{"line": None, "col": None, "severity": "error",
+                        "code": "adapter", "msg": f"PSR_BIN not found: {psr_bin}"}],
+            "duration_ms": dur,
+        })
+        return
+    except subprocess.TimeoutExpired:
+        emit({
+            "tool": "psr", "file": file, "ok": False, "count": 1,
+            "errors": [{"line": None, "col": None, "severity": "error",
+                        "code": "adapter", "msg": "timeout"}],
+            "duration_ms": 120000,
+        })
+        return
+    dur = int((time.time() - start) * 1000)
+
+    raw = r.stdout.strip()
+    try:
+        data = json.loads(raw) if raw else {"totals": {"errors": 0, "warnings": 0}, "files": {}}
+    except json.JSONDecodeError:
+        emit({
+            "tool": "psr", "file": file, "ok": False, "count": 1,
+            "errors": [{"line": None, "col": None, "severity": "error",
+                        "code": "adapter", "msg": "phpcs output not json"}],
+            "duration_ms": dur,
+        })
+        return
+
+    errors = []
+    for fdata in data.get("files", {}).values():
+        for msg in fdata.get("messages", []):
+            line = msg.get("line")
+            col = msg.get("column")
+            sev_raw = msg.get("type", "ERROR").upper()
+            severity = "warning" if sev_raw == "WARNING" else "error"
+            errors.append({
+                "line": line,
+                "col": col,
+                "severity": severity,
+                "code": msg.get("source"),
+                "msg": msg.get("message", ""),
+                "source_context": source_context(file, line),
+            })
+
+    count = len(errors)
+    emit({
+        "tool": "psr",
+        "file": file,
+        "ok": count == 0,
+        "count": count,
+        "errors": errors,
+        "duration_ms": dur,
+    })
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `validators/psr/psr.py` — thin Python adapter for PHP CodeSniffer, mirrors `phpmd`/`phpstan` pattern
- Parses `phpcs --report=json` into SCHEMA.md shape with `line`, `col`, `severity`, `code`, `msg`, `source_context`
- Binary-missing guard via `shutil.which` emits `ok=false` with `PSR_BIN not found`
- Registered in `.supertool.json` + `.supertool.example.json` with `hooks_into: []` (manual-only, mirrors phpmd in dvsi)

## Env vars

| Var | Default | Description |
|-----|---------|-------------|
| `PSR_BIN` | `phpcs` | phpcs binary path |
| `PSR_STANDARD` | `PSR12` | Coding standard |
| `PSR_EXCLUDE` | _(none)_ | Comma-separated ignore paths |
| `PSR_SEVERITY` | `9` | Warning severity threshold |
| `PSR_EXTENSIONS` | `php` | File extensions to check |

## Test plan

- [x] Full suite 2021 passed, 11 skipped, coverage 89.45%
- [x] 5 new tests (no-arg, missing-binary, clean-output, violations, live-skipif)