### PR TITLE
feat: git-status validator — line delta on every mutating op

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -168,7 +168,7 @@
     },
     "resolve": {
       "syntax": "resolve:SYMBOL",
-      "description": "Smart-glob resolver: PHP FQN, Python dotted, JS/TS relative path → file on disk. Returns 'external' for npm/pip packages, 'not found' if no match. Used internally by workspace.",
+      "description": "Smart-glob resolver: PHP FQN, Python dotted, JS/TS relative path \u2192 file on disk. Returns 'external' for npm/pip packages, 'not found' if no match. Used internally by workspace.",
       "example": "resolve:foo.bar.baz"
     }
   },
@@ -445,6 +445,19 @@
         "PSR_STANDARD": "PSR12",
         "PSR_SEVERITY": "9"
       }
+    },
+    "git-status": {
+      "cmd": "python3 {supertool_dir}/validators/git-status/git-status.py {file}",
+      "match": "*",
+      "hooks_into": [
+        "edit",
+        "replace",
+        "replace_lines",
+        "paste",
+        "vim"
+      ],
+      "rollback_on_fail": false,
+      "timeout": 5
     }
   },
   "formatters": {

--- a/.supertool.json
+++ b/.supertool.json
@@ -193,6 +193,19 @@
       ],
       "rollback_on_fail": true,
       "timeout": 10
+    },
+    "git-status": {
+      "cmd": "python3 {supertool_dir}/validators/git-status/git-status.py {file}",
+      "match": "*",
+      "hooks_into": [
+        "edit",
+        "replace",
+        "replace_lines",
+        "paste",
+        "vim"
+      ],
+      "rollback_on_fail": false,
+      "timeout": 5
     }
   }
 }

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -71,6 +71,7 @@ Enable any of these by copying the relevant entry from `.supertool.example.json`
 | PHP — static  | `phpstan`        | `phpstan` binary (PATH or via `PHPSTAN_BIN` env)  | Env-configured. See [README](../validators/phpstan/README.md) |
 | PHP — mess    | `phpmd`          | `phpmd` binary (PATH or via `PHPMD_BIN` env)      | Env-configured. See [README](../validators/phpmd/README.md) |
 | PHP — style   | `psr`            | `phpcs` binary (PATH or via `PSR_BIN` env)        | Env-configured. See [README](../validators/psr/README.md)  |
+| Git           | `git-status`     | `git` binary                                      | Reports working-tree delta (`+N -N <state>`) post-edit |
 
 
 ## Adding your own

--- a/supertool.py
+++ b/supertool.py
@@ -7814,6 +7814,12 @@ def _validator_render_row(data: Dict[str, Any], verbose: bool = False) -> list:
     dur = data.get("duration_ms", 0)
     status = "ok" if ok else f"{count} err"
     line = f"{tool:8s}: {status:12s} ({dur}ms)"
+    metrics = data.get("metrics")
+    if metrics and tool == "git-status":
+        added = metrics.get("lines_added", 0)
+        removed = metrics.get("lines_removed", 0)
+        state = metrics.get("state", "")
+        line += f"  +{added} -{removed} {state}"
     if data.get("resolved_to"):
         line += f"  → {data['resolved_to']}"
     out = [line]

--- a/tests/test_validators_git_status.py
+++ b/tests/test_validators_git_status.py
@@ -1,0 +1,124 @@
+"""Tests for validators/git-status/git-status.py."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+GIT_STATUS_PY = Path(__file__).parent.parent / "validators" / "git-status" / "git-status.py"
+
+
+def _run(file: str = "", env: dict | None = None) -> dict:
+    args = ["python3", str(GIT_STATUS_PY)]
+    if file:
+        args.append(file)
+    r = subprocess.run(args, capture_output=True, text=True, timeout=10, env=env or os.environ)
+    assert r.returncode == 0
+    return json.loads(r.stdout.strip())
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, check=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+             "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com"},
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Bootstrap a minimal git repo with one committed file."""
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@t.com")
+    _git(tmp_path, "config", "user.name", "test")
+    f = tmp_path / "base.txt"
+    f.write_text("line1\nline2\n")
+    _git(tmp_path, "add", "base.txt")
+    _git(tmp_path, "commit", "-m", "init")
+    return tmp_path
+
+
+def test_no_arg_emits_ok_zero_metrics() -> None:
+    """No file arg → ok=true, zero metrics, clean state."""
+    data = _run()
+    assert data["tool"] == "git-status"
+    assert data["ok"] is True
+    assert data["count"] == 0
+    assert data["errors"] == []
+    m = data["metrics"]
+    assert m["lines_added"] == 0
+    assert m["lines_removed"] == 0
+    assert m["state"] == "clean"
+
+
+def test_clean_file(tmp_path: Path) -> None:
+    """Committed, unmodified file → state=clean, zero deltas."""
+    repo = _init_repo(tmp_path)
+    f = repo / "base.txt"
+    data = _run(str(f))
+    assert data["ok"] is True
+    m = data["metrics"]
+    assert m["lines_added"] == 0
+    assert m["lines_removed"] == 0
+    assert m["state"] == "clean"
+    assert isinstance(data["duration_ms"], int)
+
+
+def test_modified_file(tmp_path: Path) -> None:
+    """File with unstaged edits → state=modified, lines_added/removed > 0."""
+    repo = _init_repo(tmp_path)
+    f = repo / "base.txt"
+    f.write_text("line1\nline2\nline3\n")  # +1 line (adds line3)
+    data = _run(str(f))
+    assert data["ok"] is True
+    m = data["metrics"]
+    assert m["lines_added"] >= 1
+    assert m["state"] == "modified"
+
+
+def test_staged_file(tmp_path: Path) -> None:
+    """File with all changes staged → state=staged, staged delta > 0."""
+    repo = _init_repo(tmp_path)
+    f = repo / "base.txt"
+    f.write_text("line1\nline2\nextra\n")
+    _git(repo, "add", "base.txt")
+    data = _run(str(f))
+    assert data["ok"] is True
+    m = data["metrics"]
+    assert m["lines_staged_added"] >= 1
+    assert m["state"] == "staged"
+
+
+def test_untracked_file(tmp_path: Path) -> None:
+    """New file never added → state=untracked."""
+    repo = _init_repo(tmp_path)
+    f = repo / "new.txt"
+    f.write_text("hello\n")
+    data = _run(str(f))
+    assert data["ok"] is True
+    assert data["metrics"]["state"] == "untracked"
+
+
+def test_not_in_git_repo(tmp_path: Path) -> None:
+    """File outside any git repo → ok=true, zero metrics, state=clean."""
+    f = tmp_path / "plain.txt"
+    f.write_text("hello\n")
+    data = _run(str(f))
+    assert data["ok"] is True
+    m = data["metrics"]
+    assert m["lines_added"] == 0
+    assert m["lines_removed"] == 0
+    assert m["state"] == "clean"
+
+
+def test_git_absent(tmp_path: Path) -> None:
+    """When git binary is missing → ok=true, graceful skip."""
+    f = tmp_path / "x.txt"
+    f.write_text("x\n")
+    env = {**os.environ, "GIT_BIN": "/nonexistent/git"}
+    data = _run(str(f), env=env)
+    assert data["ok"] is True
+    assert data["count"] == 0
+    assert data["errors"] == []

--- a/validators/git-status/README.md
+++ b/validators/git-status/README.md
@@ -1,0 +1,60 @@
+# git-status validator
+
+Reports the working-tree delta (lines added/removed) and file state after every mutating op.
+
+## Behavior
+
+- Runs `git diff --numstat` (unstaged) and `git diff --cached --numstat` (staged) against the edited file.
+- Runs `git status --porcelain` to determine file state.
+- Always emits `ok: true` — git status is informational, never a rollback trigger.
+- If `git` is absent or the file is not inside a git repo, emits zero metrics and exits cleanly.
+
+## Output
+
+```json
+{
+  "tool": "git-status",
+  "file": "src/Foo.php",
+  "ok": true,
+  "count": 0,
+  "errors": [],
+  "duration_ms": 5,
+  "metrics": {
+    "lines_added": 5,
+    "lines_removed": 4,
+    "lines_staged_added": 0,
+    "lines_staged_removed": 0,
+    "state": "modified"
+  }
+}
+```
+
+## State values
+
+| State       | Meaning                                      |
+|-------------|----------------------------------------------|
+| `clean`     | No changes vs HEAD                           |
+| `modified`  | Unstaged changes in working tree             |
+| `staged`    | All changes are staged (index only)          |
+| `untracked` | File not tracked by git                      |
+| `unknown`   | Porcelain output present but not recognised  |
+
+## Env vars
+
+| Var       | Default | Notes                              |
+|-----------|---------|------------------------------------|
+| `GIT_BIN` | `git`   | Override if git is not on `PATH`   |
+
+## Registration
+
+Add to `.supertool.json` under `validators`:
+
+```json
+"git-status": {
+  "cmd": "python3 {supertool_dir}/validators/git-status/git-status.py {file}",
+  "match": "*",
+  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+  "rollback_on_fail": false,
+  "timeout": 5
+}
+```

--- a/validators/git-status/git-status.py
+++ b/validators/git-status/git-status.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""git-status validator adapter. Emits SCHEMA.md JSON.
+
+Always ok=true — reports working-tree delta as metrics, never triggers rollback.
+
+Usage: git-status.py <file>
+
+Env vars:
+  GIT_BIN  git binary (default: git)
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import pathlib
+import time
+
+
+def emit(obj: dict) -> None:
+    print(json.dumps(obj))
+
+
+def _parse_numstat(output: str) -> tuple[int, int]:
+    """Parse `git diff --numstat` single-file output → (added, removed)."""
+    line = output.strip()
+    if not line:
+        return 0, 0
+    parts = line.split("\t")
+    if len(parts) < 2:
+        return 0, 0
+    try:
+        added = int(parts[0]) if parts[0] != "-" else 0
+        removed = int(parts[1]) if parts[1] != "-" else 0
+        return added, removed
+    except ValueError:
+        return 0, 0
+
+
+def _parse_state(porcelain: str) -> str:
+    """Parse `git status --porcelain` single-file output → state string."""
+    line = porcelain.rstrip("\n")
+    if not line:
+        return "clean"
+    if len(line) < 2:
+        return "unknown"
+    xy = line[:2]
+    x = xy[0]  # index (staged)
+    y = xy[1]  # worktree (unstaged)
+    if xy == "??":
+        return "untracked"
+    if x != " " and x != "?" and y == " ":
+        return "staged"
+    if y != " " and y != "?":
+        return "modified"
+    if x != " " and x != "?":
+        return "staged"
+    return "clean"
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({
+            "tool": "git-status", "file": "", "ok": True, "count": 0,
+            "errors": [], "duration_ms": 0,
+            "metrics": {"lines_added": 0, "lines_removed": 0,
+                        "lines_staged_added": 0, "lines_staged_removed": 0,
+                        "state": "clean"},
+        })
+        return
+
+    file = sys.argv[1]
+    git_bin = os.environ.get("GIT_BIN", "git")
+
+    if not shutil.which(git_bin):
+        emit({
+            "tool": "git-status", "file": file, "ok": True, "count": 0,
+            "errors": [], "duration_ms": 0,
+            "metrics": {"lines_added": 0, "lines_removed": 0,
+                        "lines_staged_added": 0, "lines_staged_removed": 0,
+                        "state": "clean"},
+        })
+        return
+
+    start = time.time()
+    file_dir = str(pathlib.Path(file).resolve().parent)
+
+    def run(*args: str) -> str:
+        try:
+            r = subprocess.run(
+                [git_bin, *args],
+                capture_output=True, text=True, timeout=5,
+                cwd=file_dir,
+            )
+            return r.stdout
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return ""
+
+    # Check we're inside a git repo (fast — runs rev-parse)
+    rev = run("rev-parse", "--is-inside-work-tree")
+    if rev.strip() != "true":
+        dur = int((time.time() - start) * 1000)
+        emit({
+            "tool": "git-status", "file": file, "ok": True, "count": 0,
+            "errors": [], "duration_ms": dur,
+            "metrics": {"lines_added": 0, "lines_removed": 0,
+                        "lines_staged_added": 0, "lines_staged_removed": 0,
+                        "state": "clean"},
+        })
+        return
+
+    worktree_out = run("diff", "--numstat", "--", file)
+    staged_out = run("diff", "--cached", "--numstat", "--", file)
+    porcelain_out = run("status", "--porcelain", "--", file)
+
+    dur = int((time.time() - start) * 1000)
+
+    added, removed = _parse_numstat(worktree_out)
+    staged_added, staged_removed = _parse_numstat(staged_out)
+    state = _parse_state(porcelain_out)
+
+    emit({
+        "tool": "git-status",
+        "file": file,
+        "ok": True,
+        "count": 0,
+        "errors": [],
+        "duration_ms": dur,
+        "metrics": {
+            "lines_added": added,
+            "lines_removed": removed,
+            "lines_staged_added": staged_added,
+            "lines_staged_removed": staged_removed,
+            "state": state,
+        },
+    })
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `validators/git-status/git-status.py` — emits SCHEMA.md JSON with `metrics: {lines_added, lines_removed, state}`. Fires post-edit (`hooks_into: ["edit","replace","replace_lines","paste","vim"]`), always `ok=true` (no rollback — git status isn't an error).

Renders in the standard validator row format:
```
git-status : ok           (5ms) +5 -4 modified
```

## Test plan

- [x] 7 new tests in `tests/test_validators_git_status.py` (clean, modified, staged, untracked, not-in-git-repo)
- [x] Full suite: 88.37% coverage