### PR TITLE
fix: workspace truncates runaway commit subjects to 120 chars

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -8530,6 +8530,10 @@ def op_workspace(path: str) -> str:
             if log_r.returncode == 0 and log_r.stdout.strip():
                 out.append("recent commits:\n")
                 for line in log_r.stdout.strip().splitlines():
+                    # Truncate runaway subjects (Kevin commits sometimes list
+                    # hundreds of files in the subject). Keep ~120 chars.
+                    if len(line) > 120:
+                        line = line[:117] + "..."
                     out.append(f"  {line}\n")
         except (subprocess.TimeoutExpired, OSError):
             pass


### PR DESCRIPTION
## Context

Kevin commits sometimes have 5KB+ subjects listing every changed file. Workspace's ## Git section currently dumps those raw, swamping the readable signal. Truncate to 117 + ellipsis.

## Test plan

- [x] Manual: workspace on a file in a repo with Kevin's long-subject commit shows truncated line.