### PR TITLE
fix: add phpstan-result-cache + phpunit/rector caches to default excludes

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -117,6 +117,7 @@ _GREP_EXTENSIONS_EFFECTIVE: Tuple[str, ...] | None = None
 _DEFAULT_EXCLUDE_PATHS: Tuple[str, ...] = (
     ".git/", "node_modules/", ".svn/", ".hg/", ".idea/", ".vscode/",
     "__pycache__/", ".venv/", "venv/", "dist/", "build/",
+    "phpstan-result-cache/", ".phpunit.cache/", ".rector/",
 )
 WILDCARD_CHARS = re.compile(r"[*?\[]")
 # Patterns for lines that are "blank or comment-only" across common languages


### PR DESCRIPTION
## Context

Workspace References section (and other traversal ops) were scanning PHPStan's result cache, polluting symbol-grep hits with binary cache files. Added `phpstan-result-cache/`, `.phpunit.cache/`, `.rector/` to `_DEFAULT_EXCLUDE_PATHS`.

Match shape is prefix-relative-to-cwd with trailing slash (same as the existing entries).