### PR TITLE
fix: brace expansion in match-glob — prettier was dead-letter

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -111,6 +111,34 @@ LOG_FILE = os.path.join(tempfile.gettempdir(), "supertool-calls.log")
 GREP_FILE_INCLUDES = ("*.php", "*.xml", "*.py", "*.js", "*.ts", "*.md")
 _GREP_EXTENSIONS_EFFECTIVE: Tuple[str, ...] | None = None
 
+def _match_glob(path: str, pattern: str) -> bool:
+    """fnmatch with brace expansion: `*.{a,b,c}` → match if any of `*.a / *.b / *.c`.
+
+    fnmatch.fnmatch doesn't understand `{a,b,c}` alternatives. This helper
+    expands them once (one level, no nesting) and tries each alternative.
+    Patterns without braces fall through to plain fnmatch unchanged.
+    """
+    import fnmatch
+    if not pattern:
+        return True
+    if "{" not in pattern or "}" not in pattern:
+        return fnmatch.fnmatch(path, pattern)
+    # Expand a single brace group `{a,b,c}` into ["a", "b", "c"]. Multiple
+    # brace groups in the same pattern aren't supported (not needed by current
+    # consumers) — fall through to plain fnmatch in that case.
+    open_i = pattern.index("{")
+    close_i = pattern.index("}", open_i)
+    if pattern.count("{") > 1 or pattern.count("}") > 1:
+        return fnmatch.fnmatch(path, pattern)
+    prefix = pattern[:open_i]
+    suffix = pattern[close_i + 1:]
+    alternatives = pattern[open_i + 1:close_i].split(",")
+    for alt in alternatives:
+        if fnmatch.fnmatch(path, f"{prefix}{alt.strip()}{suffix}"):
+            return True
+    return False
+
+
 # Default exclude-paths applied to all traversal ops (glob, grep, tree, map).
 # These are pruned at the directory-walk boundary — the dirs are never opened.
 # Match is prefix-relative-to-cwd; trailing slash is normalised in _get_exclude_paths.
@@ -7671,7 +7699,7 @@ def _applicable_validators(op: str, path: str) -> Dict[str, Dict[str, Any]]:
         if spec.get("opt_in"):
             continue
         glob = spec.get("match", "*")
-        if path and glob and not fnmatch.fnmatch(path, glob):
+        if path and glob and not _match_glob(path, glob):
             continue
         out[name] = spec
     return out
@@ -7954,7 +7982,7 @@ def _applicable_formatters(op: str, path: str) -> Dict[str, Dict[str, Any]]:
         if op not in (spec.get("hooks_into") or []):
             continue
         glob = spec.get("match", "*")
-        if path and glob and not fnmatch.fnmatch(path, glob):
+        if path and glob and not _match_glob(path, glob):
             continue
         out[name] = spec
     return out
@@ -8177,7 +8205,7 @@ def op_validate(path: str, tool_filter: Optional[list] = None, verbose: bool = F
     out = [f"validate: {path}"]
     for name, spec in validators.items():
         glob = spec.get("match", "*")
-        if path and glob and not fnmatch.fnmatch(path, glob):
+        if path and glob and not _match_glob(path, glob):
             continue
         data = _validator_run_one(name, spec, path)
         if data is None:
@@ -8760,7 +8788,7 @@ def op_format(path: str, tool_filter: Optional[list] = None, verbose: bool = Fal
         if not isinstance(spec, dict):
             continue
         glob = spec.get("match", "*")
-        if path and glob and not fnmatch.fnmatch(path, glob):
+        if path and glob and not _match_glob(path, glob):
             continue
         matched = True
         result = _formatter_run_one(name, spec, path)

--- a/tests/test_match_glob_braces.py
+++ b/tests/test_match_glob_braces.py
@@ -1,0 +1,50 @@
+"""TDD: brace expansion in match glob (`*.{a,b,c}`).
+
+The validator/formatter framework reads `spec["match"]` (e.g.
+`*.{xml,scss,css,js,json,yml,yaml,md}`) and feeds it to `fnmatch.fnmatch`,
+which doesn't expand braces — so prettier silently never fired on DVSI.
+
+These tests cover the helper that expands brace patterns before matching.
+"""
+from __future__ import annotations
+
+import supertool
+
+
+def test_brace_pattern_matches_any_alternative() -> None:
+    assert supertool._match_glob("test.json", "*.{xml,json,md}") is True
+    assert supertool._match_glob("test.xml", "*.{xml,json,md}") is True
+    assert supertool._match_glob("test.md", "*.{xml,json,md}") is True
+
+
+def test_brace_pattern_rejects_non_matching_extension() -> None:
+    assert supertool._match_glob("test.py", "*.{xml,json,md}") is False
+    assert supertool._match_glob("test.txt", "*.{xml,json,md}") is False
+
+
+def test_plain_pattern_still_works() -> None:
+    assert supertool._match_glob("test.php", "*.php") is True
+    assert supertool._match_glob("test.json", "*.php") is False
+
+
+def test_dvsi_real_world_prettier_pattern() -> None:
+    """The exact pattern from DVSI's .supertool.json prettier formatter."""
+    pat = "*.{xml,scss,css,js,json,yml,yaml,md}"
+    for ext in ("xml", "scss", "css", "js", "json", "yml", "yaml", "md"):
+        assert supertool._match_glob(f"foo.{ext}", pat) is True, f"expected match for .{ext}"
+    assert supertool._match_glob("foo.php", pat) is False
+
+
+def test_nested_path_with_braces() -> None:
+    assert supertool._match_glob("src/foo/bar.json", "*.{json,xml}") is True
+    assert supertool._match_glob("src/foo/bar.txt", "*.{json,xml}") is False
+
+
+def test_no_braces_passes_through_to_fnmatch() -> None:
+    # Should behave identically to fnmatch for non-brace patterns
+    assert supertool._match_glob("Dockerfile.dev", "Dockerfile*") is True
+    assert supertool._match_glob("config.ini", "*.ini") is True
+
+
+def test_empty_or_star_match_anything() -> None:
+    assert supertool._match_glob("anything.xyz", "*") is True


### PR DESCRIPTION
## Context

`fnmatch.fnmatch` doesn't expand `{a,b,c}` alternatives. DVSI's prettier formatter spec uses `"match": "*.{xml,scss,css,js,json,yml,yaml,md}"` — that pattern matched NOTHING. prettier silently never fired post-edit, since setup. Same for the prettier-check validator.

## Fix

`_match_glob(path, pattern)` helper expands one-level brace groups and falls back to plain fnmatch. Replaces 4 `fnmatch.fnmatch` call sites in the validator/formatter dispatch.

## Test plan

- [x] 7 TDD tests in `tests/test_match_glob_braces.py`
- [x] Live verified on DVSI: prettier-check now fires post-edit on `.json` files (previously silent)