### PR TITLE
feat: MCP config + extension routing (sub-PR 2 of MCP integration)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -9928,6 +9928,8 @@ def _mcp_route(path: str, op: str) -> Optional[Tuple[str, str]]:
     """Find (server_name, mcp_tool) for an op on this file's extension, or None."""
     if not path:
         return None
+    # Iteration order matches config insertion order (Python 3.7+ dict);
+    # first server whose `match` glob matches wins. Document at spec §6.
     for name, spec in _mcp_specs.items():
         glob = spec.get("match")
         if glob and _match_glob(path, glob):
@@ -9960,8 +9962,17 @@ def _mcp_ensure_server(name: str) -> Optional[MCPServer]:
 
 def _extract_path_from_mcp_result(result: Any) -> Optional[str]:
     """Normalize MCP response into a single file path string."""
+    from urllib.parse import urlparse, unquote
+
     if not isinstance(result, dict):
         return None
+
+    def _normalize_file_url_or_path(s: str) -> str:
+        if s.startswith("file://"):
+            parsed = urlparse(s)
+            return unquote(parsed.path)
+        return s
+
     # Shape 1: {"content": [{"type": "text", "text": "..."}]}
     content = result.get("content")
     if isinstance(content, list):
@@ -9969,16 +9980,11 @@ def _extract_path_from_mcp_result(result: Any) -> Optional[str]:
             if isinstance(item, dict) and item.get("type") == "text":
                 text = item.get("text", "")
                 if text:
-                    # Strip file:// prefix if present
-                    if text.startswith("file://"):
-                        return text[7:]
-                    return text
+                    return _normalize_file_url_or_path(text)
     # Shape 2: {"uri": "file:///path"}
     uri = result.get("uri")
     if isinstance(uri, str):
-        if uri.startswith("file://"):
-            return uri[7:]
-        return uri
+        return _normalize_file_url_or_path(uri)
     # Shape 3: {"path": "/path"}
     if isinstance(result.get("path"), str):
         return result["path"]

--- a/supertool.py
+++ b/supertool.py
@@ -167,6 +167,9 @@ _COMPACT_SKIP = re.compile(
 _CONFIG: Dict[str, Any] | None = None
 _CONFIG_CHECKED = False
 
+# MCP server specs parsed from _CONFIG["mcp"] — populated by _load_config()
+_mcp_specs: Dict[str, dict] = {}
+
 # Supertool install directory (where supertool.py actually lives, following symlinks)
 _INSTALL_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -247,9 +250,10 @@ def _merge_presets(config: Dict[str, Any], project_dir: str) -> None:
 def _load_config() -> Dict[str, Any]:
     """Load .supertool.json from cwd or parents. Cached.
 
-    After loading, merges any preset ops declared in "presets" key.
+    After loading, merges any preset ops declared in "presets" key and
+    parses the optional "mcp" block into the module-level _mcp_specs dict.
     """
-    global _CONFIG, _CONFIG_CHECKED
+    global _CONFIG, _CONFIG_CHECKED, _mcp_specs
     if _CONFIG_CHECKED:
         return _CONFIG or {}
     _CONFIG_CHECKED = True
@@ -263,6 +267,12 @@ def _load_config() -> Dict[str, Any]:
                     _CONFIG = json.load(f)
                     project_dir = d
                     _merge_presets(_CONFIG, project_dir)
+                    # Parse MCP server specs from the optional "mcp" block.
+                    mcp_block = _CONFIG.get("mcp")
+                    if isinstance(mcp_block, dict):
+                        for srv_name, spec in mcp_block.items():
+                            if isinstance(spec, dict) and "cmd" in spec:
+                                _mcp_specs[srv_name] = spec
                     return _CONFIG
             except (json.JSONDecodeError, OSError):
                 pass
@@ -8291,6 +8301,23 @@ def _op_resolve_inner(symbol: str, from_file: Optional[str] = None) -> str:
     """Core resolve logic — called by op_resolve (which handles caching)."""
     excl = _get_exclude_paths("resolve")
 
+    # MCP route (sub-PR 2): if a configured LSP MCP matches this file's extension,
+    # try it first. Falls through to heuristic glob on miss/error.
+    if from_file:
+        route = _mcp_route(from_file, "resolve")
+        if route:
+            server_name, mcp_tool = route
+            server = _mcp_ensure_server(server_name)
+            if server is not None:
+                try:
+                    result = _mcp_call(server_name, mcp_tool, {"symbol": symbol, "file": from_file})
+                    if result is not None:
+                        path = _extract_path_from_mcp_result(result)
+                        if path:
+                            return f"{symbol} → {path}\n"
+                except (MCPServerError, MCPTimeout):
+                    pass
+
     # ── PHP FQN (contains backslash) ─────────────────────────────────────────
     if "\\" in symbol:
         fqn_path = symbol.replace("\\", "/")
@@ -9894,6 +9921,71 @@ for _sig in (signal.SIGTERM, signal.SIGINT):
 
 
 # ---------------------------------------------------------------------------
+# MCP config routing helpers (sub-PR 2)
+# ---------------------------------------------------------------------------
+
+def _mcp_route(path: str, op: str) -> Optional[Tuple[str, str]]:
+    """Find (server_name, mcp_tool) for an op on this file's extension, or None."""
+    if not path:
+        return None
+    for name, spec in _mcp_specs.items():
+        glob = spec.get("match")
+        if glob and _match_glob(path, glob):
+            tool = (spec.get("tools") or {}).get(op)
+            if tool:
+                return (name, tool)
+    return None
+
+
+def _mcp_ensure_server(name: str) -> Optional[MCPServer]:
+    """Get-or-spawn MCPServer for a configured name. None on any failure."""
+    server = _mcp_get_server(name)
+    if server is not None:
+        return server
+    spec = _mcp_specs.get(name)
+    if spec is None:
+        return None
+    try:
+        server = MCPServer(
+            name=name, cmd=spec["cmd"],
+            env=spec.get("env"), timeout=int(spec.get("timeout", 30)),
+        )
+        server.spawn()
+        server.initialize()
+    except (OSError, MCPServerError, MCPTimeout, KeyError):
+        return None
+    _mcp_register(name, server)
+    return server
+
+
+def _extract_path_from_mcp_result(result: Any) -> Optional[str]:
+    """Normalize MCP response into a single file path string."""
+    if not isinstance(result, dict):
+        return None
+    # Shape 1: {"content": [{"type": "text", "text": "..."}]}
+    content = result.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text", "")
+                if text:
+                    # Strip file:// prefix if present
+                    if text.startswith("file://"):
+                        return text[7:]
+                    return text
+    # Shape 2: {"uri": "file:///path"}
+    uri = result.get("uri")
+    if isinstance(uri, str):
+        if uri.startswith("file://"):
+            return uri[7:]
+        return uri
+    # Shape 3: {"path": "/path"}
+    if isinstance(result.get("path"), str):
+        return result["path"]
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Helper API for supertool ops (sub-PR 2 entry points)
 # ---------------------------------------------------------------------------
 
@@ -9934,11 +10026,8 @@ def _mcp_call(server_name: str, tool: str, args: dict) -> Optional[dict]:
     -------------------
     This function does NOT spawn servers itself. To enable lazy-spawn, the
     caller must pre-register a server via _mcp_register() before the first
-    call. Sub-PR 2 will hook config-block parsing to do this automatically
-    (i.e. read the [mcp.*] config, build an MCPServer, call _mcp_register).
-
-    # TODO(sub-PR-2): accept an optional spawn_factory callable so the config
-    # loader can pass a factory here and avoid requiring pre-registration.
+    call. _mcp_ensure_server() handles config-block parsing, lazy-spawn,
+    and registration automatically (sub-PR 2).
     """
     server = _mcp_get_server(server_name)
     if server is None:

--- a/tests/fixtures/mock_mcp_server.py
+++ b/tests/fixtures/mock_mcp_server.py
@@ -21,7 +21,14 @@ TOOLS = [
             "type": "object",
             "properties": {"message": {"type": "string"}},
         },
-    }
+    },
+    {
+        "name": "definition",
+        "description": "Mock LSP-style definition lookup",
+        "inputSchema": {"type": "object",
+                        "properties": {"symbol": {"type": "string"},
+                                       "file": {"type": "string"}}},
+    },
 ]
 
 
@@ -83,7 +90,16 @@ def handle(msg: dict) -> None:
             })
             return
         params = msg.get("params", {})
+        tool_name = params.get("name", "")
         args = params.get("arguments", {})
+        if tool_name == "definition":
+            send({
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text",
+                                        "text": args.get("file", "/mock/resolved.php")}]},
+            })
+            return
         send({
             "jsonrpc": "2.0",
             "id": msg_id,

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -1,0 +1,89 @@
+"""Tests for MCP config + extension routing (sub-PR 2)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import supertool
+from supertool import (
+    MCPServer, _mcp_route, _mcp_ensure_server,
+    _extract_path_from_mcp_result, _MCP_SERVERS, _MCP_LOCK,
+)
+
+MOCK_SERVER = str(Path(__file__).parent / "fixtures" / "mock_mcp_server.py")
+MOCK_CMD = f"{sys.executable} {MOCK_SERVER}"
+
+
+def _set_mcp_specs(specs: dict) -> None:
+    """Inject MCP specs into the module-level _mcp_specs dict."""
+    supertool._mcp_specs.clear()
+    supertool._mcp_specs.update(specs)
+
+
+def test_route_matches_by_extension_glob() -> None:
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"resolve": "definition"}}
+    })
+    assert _mcp_route("foo.php", "resolve") == ("php-lsp", "definition")
+
+
+def test_route_returns_none_when_no_match() -> None:
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"resolve": "definition"}}
+    })
+    assert _mcp_route("foo.py", "resolve") is None
+
+
+def test_route_returns_none_when_op_not_in_tools() -> None:
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php", "tools": {"resolve": "definition"}}
+    })
+    assert _mcp_route("foo.php", "refs") is None
+
+
+def test_ensure_server_spawns_on_demand() -> None:
+    _set_mcp_specs({
+        "lsp-test": {"cmd": MOCK_CMD, "match": "*.php",
+                     "tools": {"resolve": "definition"}}
+    })
+    try:
+        srv = _mcp_ensure_server("lsp-test")
+        assert srv is not None
+        assert srv.is_alive()
+        # Second call returns same instance (cached)
+        srv2 = _mcp_ensure_server("lsp-test")
+        assert srv2 is srv
+    finally:
+        with _MCP_LOCK:
+            srv = _MCP_SERVERS.pop("lsp-test", None)
+        if srv:
+            srv.shutdown()
+
+
+def test_ensure_server_returns_none_on_bad_cmd() -> None:
+    _set_mcp_specs({
+        "broken": {"cmd": "/nonexistent/binary", "match": "*.php",
+                   "tools": {"resolve": "definition"}}
+    })
+    srv = _mcp_ensure_server("broken")
+    assert srv is None
+
+
+def test_extract_path_from_text_content() -> None:
+    result = {"content": [{"type": "text", "text": "/path/to/Foo.php"}]}
+    assert _extract_path_from_mcp_result(result) == "/path/to/Foo.php"
+
+
+def test_extract_path_from_file_uri() -> None:
+    result = {"uri": "file:///path/to/Foo.php"}
+    assert _extract_path_from_mcp_result(result) == "/path/to/Foo.php"
+
+
+def test_extract_path_returns_none_for_empty() -> None:
+    assert _extract_path_from_mcp_result({}) is None
+    assert _extract_path_from_mcp_result(None) is None

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -11,6 +11,7 @@ import supertool
 from supertool import (
     MCPServer, _mcp_route, _mcp_ensure_server,
     _extract_path_from_mcp_result, _MCP_SERVERS, _MCP_LOCK,
+    op_resolve,
 )
 
 MOCK_SERVER = str(Path(__file__).parent / "fixtures" / "mock_mcp_server.py")
@@ -87,3 +88,54 @@ def test_extract_path_from_file_uri() -> None:
 def test_extract_path_returns_none_for_empty() -> None:
     assert _extract_path_from_mcp_result({}) is None
     assert _extract_path_from_mcp_result(None) is None
+
+
+def test_extract_path_from_file_uri_text_content() -> None:
+    """file:// in text-content shape must not corrupt the path (was returning //path)."""
+    result = {"content": [{"type": "text", "text": "file:///path/to/Foo.php"}]}
+    assert _extract_path_from_mcp_result(result) == "/path/to/Foo.php"
+
+
+def test_extract_path_from_file_uri_url_decode() -> None:
+    """Percent-encoded characters in file:// URIs are decoded."""
+    result = {"content": [{"type": "text", "text": "file:///path%20with%20space.php"}]}
+    assert _extract_path_from_mcp_result(result) == "/path with space.php"
+
+
+def test_op_resolve_uses_mcp_when_configured(tmp_path: Path) -> None:
+    """op_resolve delegates to MCP server when a matching spec is configured."""
+    php_file = str(tmp_path / "bar.php")
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"resolve": "definition"}}
+    })
+    srv_name = "php-lsp"
+    try:
+        result = op_resolve("Foo", from_file=php_file)
+        # Mock server returns the from_file value as the resolved path
+        assert php_file in result
+        assert "→" in result
+    finally:
+        with _MCP_LOCK:
+            srv = _MCP_SERVERS.pop(srv_name, None)
+        if srv:
+            srv.shutdown()
+        supertool._mcp_specs.clear()
+
+
+def test_op_resolve_falls_back_to_heuristic_on_mcp_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MCP failure (bad cmd) silently falls through to heuristic glob."""
+    monkeypatch.chdir(tmp_path)
+    _set_mcp_specs({
+        "broken-lsp": {"cmd": "/nonexistent/binary", "match": "*.php",
+                       "tools": {"resolve": "definition"}}
+    })
+    php_file = str(tmp_path / "bar.php")
+    try:
+        result = op_resolve("DoesNotExist", from_file=php_file)
+        # Must not raise; heuristic returns "not found"
+        assert "not found" in result or "→" in result
+    finally:
+        supertool._mcp_specs.clear()


### PR DESCRIPTION
## Summary

Sub-PR 2 of the MCP integration plan ([docs/mcp-integration.md](../blob/master/docs/mcp-integration.md)).

- `_load_config` parses the new `mcp` block per spec §3
- `_mcp_route(path, op)` returns `(server, tool)` on extension match (first-match-wins, dict insertion order)
- `_mcp_ensure_server` lazy-spawns + initializes from config; None on failure
- `_extract_path_from_mcp_result` normalizes common MCP response shapes (uses `urllib.parse` for file:// URIs)
- `op_resolve` probes MCP first when a route matches; falls back to heuristic glob on miss/error
- Mock MCP server gained a `definition` tool for routing tests

## Out of scope (this PR)

- Workspace section integration (refs, symbols, imports) — sub-PR 3
- LLM-visible `mcp:<server>:<tool>` op — deferred
- Crash recovery + backoff — TODO from sub-PR 1

## Deferred to follow-ups

- **Cache layer** (spec §7) — keyed on `(server, tool, file_sha, args)`
- **Verbose-mode fallback logging** — note in output when MCP miss → heuristic
- **env var expansion** (`$INTELEPHENSE_LICENSE`) — config-time interpolation
- **Config validation** — currently silent on malformed `tools` / `env`

## Test plan

- [x] 10 routing tests in `tests/test_mcp_routing.py` (7 from initial + 3 from review: file:// URI, end-to-end op_resolve, heuristic fallback)
- [x] `file://` URI extraction now correct for both text-content and uri shapes
- [x] First-match-wins documented in code