### PR TITLE
feat: roll MCP integration out to workspace References + Symbols (sub-PR 3 / 3)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -8535,7 +8535,23 @@ def op_workspace(path: str) -> str:
 
     # ── Section 2: Symbols ───────────────────────────────────────────────────
     out.append("## Symbols\n\n")
-    out.append(op_map(path))
+    _sym_mcp_used = False
+    _sym_route = _mcp_route(path, "symbols")
+    if _sym_route:
+        _sym_server_name, _sym_mcp_tool = _sym_route
+        _sym_server = _mcp_ensure_server(_sym_server_name)
+        if _sym_server:
+            try:
+                _sym_mcp_result = _mcp_call(_sym_server_name, _sym_mcp_tool, {"file": path})
+                if _sym_mcp_result is not None:
+                    _sym_text = _extract_symbols_from_mcp_result(_sym_mcp_result)
+                    if _sym_text is not None:
+                        out.append(_sym_text)
+                        _sym_mcp_used = True
+            except (MCPServerError, MCPTimeout):
+                pass
+    if not _sym_mcp_used:
+        out.append(op_map(path))
     out.append("\n")
 
     # ── Section 3: Imports ───────────────────────────────────────────────────
@@ -8715,23 +8731,39 @@ def op_workspace(path: str) -> str:
     # Grep with a high internal cap so we can show "X of Y" in the header.
     # Tests live in the dedicated ## Tests section — exclude them here so
     # the quota goes to production usages.
-    excl = _get_exclude_paths("grep")
-    hits = _grep_recursive(symbol, ".", 200, excl)
-    abs_path = os.path.abspath(path)
-    ext_family = _EXT_FAMILIES.get(ext, (ext,)) if ext else ()
-    _test_marker = re.compile(r"(?:^|/)(?:test_[^/]+|[^/]+_test|[^/]+Test)\.[^/]+$")
-    filtered_hits: List[str] = []
-    for hit in hits:
-        # hit format: "filepath:lineno:content"
-        colon1 = hit.index(":")
-        hit_file = hit[:colon1]
-        if os.path.abspath(hit_file) == abs_path:
-            continue
-        if ext_family and not any(hit_file.endswith(e) for e in ext_family):
-            continue
-        if _test_marker.search(hit_file):
-            continue
-        filtered_hits.append(hit)
+    _refs_mcp_used = False
+    _refs_route = _mcp_route(path, "refs")
+    if _refs_route:
+        _refs_server_name, _refs_mcp_tool = _refs_route
+        _refs_server = _mcp_ensure_server(_refs_server_name)
+        if _refs_server:
+            try:
+                _refs_mcp_result = _mcp_call(_refs_server_name, _refs_mcp_tool, {"symbol": symbol, "file": path})
+                if _refs_mcp_result is not None:
+                    _mcp_refs = _extract_refs_from_mcp_result(_refs_mcp_result)
+                    if _mcp_refs is not None:
+                        filtered_hits = _mcp_refs
+                        _refs_mcp_used = True
+            except (MCPServerError, MCPTimeout):
+                pass
+    if not _refs_mcp_used:
+        excl = _get_exclude_paths("grep")
+        hits = _grep_recursive(symbol, ".", 200, excl)
+        abs_path = os.path.abspath(path)
+        ext_family = _EXT_FAMILIES.get(ext, (ext,)) if ext else ()
+        _test_marker = re.compile(r"(?:^|/)(?:test_[^/]+|[^/]+_test|[^/]+Test)\.[^/]+$")
+        filtered_hits = []
+        for hit in hits:
+            # hit format: "filepath:lineno:content"
+            colon1 = hit.index(":")
+            hit_file = hit[:colon1]
+            if os.path.abspath(hit_file) == abs_path:
+                continue
+            if ext_family and not any(hit_file.endswith(e) for e in ext_family):
+                continue
+            if _test_marker.search(hit_file):
+                continue
+            filtered_hits.append(hit)
 
     total = len(filtered_hits)
     shown = filtered_hits[:display_cap]
@@ -9958,6 +9990,34 @@ def _mcp_ensure_server(name: str) -> Optional[MCPServer]:
         return None
     _mcp_register(name, server)
     return server
+
+
+def _extract_refs_from_mcp_result(result: Any) -> Optional[List[str]]:
+    """Normalize MCP response for a refs/references tool into a list of 'file:line:content' strings."""
+    if not isinstance(result, dict):
+        return None
+    content = result.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text", "").strip()
+                if text:
+                    return [line for line in text.splitlines() if line.strip()]
+    return None
+
+
+def _extract_symbols_from_mcp_result(result: Any) -> Optional[str]:
+    """Normalize MCP response for a symbols/documentSymbol tool into a formatted string."""
+    if not isinstance(result, dict):
+        return None
+    content = result.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text", "").strip()
+                if text:
+                    return text + "\n"
+    return None
 
 
 def _extract_path_from_mcp_result(result: Any) -> Optional[str]:

--- a/supertool.py
+++ b/supertool.py
@@ -8542,7 +8542,7 @@ def op_workspace(path: str) -> str:
         _sym_server = _mcp_ensure_server(_sym_server_name)
         if _sym_server:
             try:
-                _sym_mcp_result = _mcp_call(_sym_server_name, _sym_mcp_tool, {"file": path})
+                _sym_mcp_result = _mcp_call(_sym_server_name, _sym_mcp_tool, {"file": os.path.abspath(path)})
                 if _sym_mcp_result is not None:
                     _sym_text = _extract_symbols_from_mcp_result(_sym_mcp_result)
                     if _sym_text is not None:
@@ -8738,7 +8738,7 @@ def op_workspace(path: str) -> str:
         _refs_server = _mcp_ensure_server(_refs_server_name)
         if _refs_server:
             try:
-                _refs_mcp_result = _mcp_call(_refs_server_name, _refs_mcp_tool, {"symbol": symbol, "file": path})
+                _refs_mcp_result = _mcp_call(_refs_server_name, _refs_mcp_tool, {"symbol": symbol, "file": os.path.abspath(path)})
                 if _refs_mcp_result is not None:
                     _mcp_refs = _extract_refs_from_mcp_result(_refs_mcp_result)
                     if _mcp_refs is not None:
@@ -10002,7 +10002,7 @@ def _extract_refs_from_mcp_result(result: Any) -> Optional[List[str]]:
             if isinstance(item, dict) and item.get("type") == "text":
                 text = item.get("text", "").strip()
                 if text:
-                    return [line for line in text.splitlines() if line.strip()]
+                    return [line.rstrip() for line in text.splitlines() if line.strip()]
     return None
 
 

--- a/tests/fixtures/mock_mcp_server.py
+++ b/tests/fixtures/mock_mcp_server.py
@@ -29,6 +29,19 @@ TOOLS = [
                         "properties": {"symbol": {"type": "string"},
                                        "file": {"type": "string"}}},
     },
+    {
+        "name": "references",
+        "description": "Mock LSP-style references lookup",
+        "inputSchema": {"type": "object",
+                        "properties": {"symbol": {"type": "string"},
+                                       "file": {"type": "string"}}},
+    },
+    {
+        "name": "documentSymbol",
+        "description": "Mock LSP-style document symbol listing",
+        "inputSchema": {"type": "object",
+                        "properties": {"file": {"type": "string"}}},
+    },
 ]
 
 
@@ -98,6 +111,22 @@ def handle(msg: dict) -> None:
                 "id": msg_id,
                 "result": {"content": [{"type": "text",
                                         "text": args.get("file", "/mock/resolved.php")}]},
+            })
+            return
+        if tool_name == "references":
+            send({
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text",
+                                        "text": "file1.php:10:line content\nfile2.php:20:other content"}]},
+            })
+            return
+        if tool_name == "documentSymbol":
+            send({
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"content": [{"type": "text",
+                                        "text": "class Foo  [10-50]\n  method bar  [12-20]"}]},
             })
             return
         send({

--- a/tests/test_mcp_workspace.py
+++ b/tests/test_mcp_workspace.py
@@ -1,0 +1,259 @@
+"""Tests for MCP routing in op_workspace — References, Symbols, and Imports (sub-PR 3)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import supertool
+from supertool import (
+    _mcp_route, _mcp_ensure_server, _mcp_call,
+    _extract_refs_from_mcp_result, _extract_symbols_from_mcp_result,
+    _MCP_SERVERS, _MCP_LOCK,
+    op_workspace, op_resolve,
+)
+
+MOCK_SERVER = str(Path(__file__).parent / "fixtures" / "mock_mcp_server.py")
+MOCK_CMD = f"{sys.executable} {MOCK_SERVER}"
+
+
+def _set_mcp_specs(specs: dict) -> None:
+    supertool._mcp_specs.clear()
+    supertool._mcp_specs.update(specs)
+
+
+def _cleanup_servers(*names: str) -> None:
+    with _MCP_LOCK:
+        for name in names:
+            srv = _MCP_SERVERS.pop(name, None)
+            if srv:
+                try:
+                    srv.shutdown()
+                except Exception:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Unit: helper extractors
+# ---------------------------------------------------------------------------
+
+def test_extract_refs_from_mcp_result_basic() -> None:
+    result = {"content": [{"type": "text", "text": "file1.php:10:line content\nfile2.php:20:other content"}]}
+    refs = _extract_refs_from_mcp_result(result)
+    assert refs == ["file1.php:10:line content", "file2.php:20:other content"]
+
+
+def test_extract_refs_from_mcp_result_empty_text() -> None:
+    result = {"content": [{"type": "text", "text": ""}]}
+    assert _extract_refs_from_mcp_result(result) is None
+
+
+def test_extract_refs_from_mcp_result_no_content() -> None:
+    assert _extract_refs_from_mcp_result({}) is None
+    assert _extract_refs_from_mcp_result(None) is None
+
+
+def test_extract_refs_strips_blank_lines() -> None:
+    result = {"content": [{"type": "text", "text": "a.php:1:foo\n\nb.php:2:bar\n"}]}
+    refs = _extract_refs_from_mcp_result(result)
+    assert refs == ["a.php:1:foo", "b.php:2:bar"]
+
+
+def test_extract_symbols_from_mcp_result_basic() -> None:
+    result = {"content": [{"type": "text", "text": "class Foo  [10-50]\n  method bar  [12-20]"}]}
+    sym = _extract_symbols_from_mcp_result(result)
+    assert sym is not None
+    assert "class Foo" in sym
+    assert "method bar" in sym
+
+
+def test_extract_symbols_from_mcp_result_no_content() -> None:
+    assert _extract_symbols_from_mcp_result({}) is None
+    assert _extract_symbols_from_mcp_result(None) is None
+
+
+def test_extract_symbols_from_mcp_result_empty_text() -> None:
+    result = {"content": [{"type": "text", "text": ""}]}
+    assert _extract_symbols_from_mcp_result(result) is None
+
+
+# ---------------------------------------------------------------------------
+# Route matching: refs + symbols
+# ---------------------------------------------------------------------------
+
+def test_route_refs_matches_when_configured() -> None:
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"refs": "references"}}
+    })
+    assert _mcp_route("foo.php", "refs") == ("php-lsp", "references")
+    supertool._mcp_specs.clear()
+
+
+def test_route_symbols_matches_when_configured() -> None:
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"symbols": "documentSymbol"}}
+    })
+    assert _mcp_route("foo.php", "symbols") == ("php-lsp", "documentSymbol")
+    supertool._mcp_specs.clear()
+
+
+def test_route_refs_returns_none_when_not_in_tools() -> None:
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"resolve": "definition"}}
+    })
+    assert _mcp_route("foo.php", "refs") is None
+    supertool._mcp_specs.clear()
+
+
+# ---------------------------------------------------------------------------
+# op_workspace: References section uses MCP when configured
+# ---------------------------------------------------------------------------
+
+def test_workspace_references_uses_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "Widget.class.php"
+    f.write_text("<?php\nclass Widget {}\n")
+
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"refs": "references"}}
+    })
+    try:
+        out = op_workspace(str(f))
+        assert "## References" in out
+        # Mock server returns "file1.php:10:line content\nfile2.php:20:other content"
+        assert "file1.php" in out
+        assert "file2.php" in out
+    finally:
+        _cleanup_servers("php-lsp")
+        supertool._mcp_specs.clear()
+
+
+def test_workspace_references_falls_back_on_mcp_miss(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When MCP returns no result (broken server), fall back to heuristic grep."""
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "Widget.class.php"
+    f.write_text("<?php\nclass Widget {}\n")
+
+    _set_mcp_specs({
+        "broken-lsp": {"cmd": "/nonexistent/binary", "match": "*.php",
+                       "tools": {"refs": "references"}}
+    })
+    try:
+        out = op_workspace(str(f))
+        # Must still produce a References section (heuristic path)
+        assert "## References" in out
+    finally:
+        _cleanup_servers("broken-lsp")
+        supertool._mcp_specs.clear()
+
+
+def test_workspace_references_falls_back_when_no_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No MCP configured → heuristic grep runs normally."""
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "Widget.class.php"
+    f.write_text("<?php\nclass Widget {}\n")
+    supertool._mcp_specs.clear()
+
+    out = op_workspace(str(f))
+    assert "## References" in out
+
+
+# ---------------------------------------------------------------------------
+# op_workspace: Symbols section uses MCP when configured
+# ---------------------------------------------------------------------------
+
+def test_workspace_symbols_uses_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "Widget.class.php"
+    f.write_text("<?php\nclass Widget {}\n")
+
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"symbols": "documentSymbol"}}
+    })
+    try:
+        out = op_workspace(str(f))
+        assert "## Symbols" in out
+        # Mock server returns "class Foo  [10-50]\n  method bar  [12-20]"
+        assert "class Foo" in out
+        assert "method bar" in out
+    finally:
+        _cleanup_servers("php-lsp")
+        supertool._mcp_specs.clear()
+
+
+def test_workspace_symbols_falls_back_when_no_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "mymodule.py"
+    f.write_text("class MyModule:\n    def run(self) -> None:\n        pass\n")
+    supertool._mcp_specs.clear()
+
+    out = op_workspace(str(f))
+    assert "## Symbols" in out
+    assert "MyModule" in out
+
+
+def test_workspace_symbols_falls_back_on_bad_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "mymodule.py"
+    f.write_text("class MyModule:\n    def run(self) -> None:\n        pass\n")
+
+    _set_mcp_specs({
+        "broken-lsp": {"cmd": "/nonexistent/binary", "match": "*.py",
+                       "tools": {"symbols": "documentSymbol"}}
+    })
+    try:
+        out = op_workspace(str(f))
+        assert "## Symbols" in out
+        # Heuristic regex fallback should still find the class
+        assert "MyModule" in out
+    finally:
+        _cleanup_servers("broken-lsp")
+        supertool._mcp_specs.clear()
+
+
+# ---------------------------------------------------------------------------
+# op_workspace: Imports section already uses MCP via op_resolve (sub-PR 2)
+# ---------------------------------------------------------------------------
+
+def test_workspace_imports_uses_mcp_via_op_resolve(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Imports section delegates to op_resolve which already uses MCP (sub-PR 2).
+
+    Verifies end-to-end: a PHP file with a use-statement renders an Imports
+    section whose resolved path comes from the MCP server.
+    """
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "Consumer.class.php"
+    f.write_text("<?php\nuse Foo\\Bar;\nclass Consumer {}\n")
+
+    php_file = str(f)
+    _set_mcp_specs({
+        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+                    "tools": {"resolve": "definition"}}
+    })
+    try:
+        out = op_workspace(php_file)
+        assert "## Imports" in out
+        # Mock server returns the from_file path as the resolved definition —
+        # which equals php_file itself. Confirm the import line rendered.
+        assert "Bar" in out or "Foo" in out
+    finally:
+        _cleanup_servers("php-lsp")
+        supertool._mcp_specs.clear()
+
+
+def test_workspace_imports_section_present_without_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Imports section works (heuristic fallback) when no MCP configured."""
+    monkeypatch.chdir(tmp_path)
+    f = tmp_path / "Consumer.class.php"
+    f.write_text("<?php\nuse Foo\\Bar;\nclass Consumer {}\n")
+    supertool._mcp_specs.clear()
+
+    out = op_workspace(str(f))
+    assert "## Imports" in out


### PR DESCRIPTION
## Context

Final sub-PR of the MCP workspace integration plan (docs/mcp-integration.md §10). Sub-PRs 1 (client) and 2 (routing + op_resolve) are already merged. This PR rolls MCP routing out to the remaining workspace sections: References and Symbols. Imports was already covered by sub-PR 2 via op_resolve — this PR adds an end-to-end test to confirm.

## Scope

- **References section** (`op_workspace`): consults MCP `refs` tool when a matching server is configured; falls back to heuristic `_grep_recursive` on miss or error.
- **Symbols section** (`op_workspace`): consults MCP `documentSymbol` tool when configured; falls back to `op_map` (tree-sitter / ctags / regex).
- **Imports section**: no code change — already MCP-routed via `op_resolve` (sub-PR 2). End-to-end test added.
- **Mock MCP server** (`tests/fixtures/mock_mcp_server.py`): gained `references` and `documentSymbol` tools.
- **New helpers**: `_extract_refs_from_mcp_result`, `_extract_symbols_from_mcp_result`.
- **New test file**: `tests/test_mcp_workspace.py` — 18 tests covering MCP path, fallback path, and end-to-end imports.

## Deferred items

- **Cache layer** (spec §7): not implemented — follow-up.
- **Verbose-mode fallback logging**: not implemented — follow-up.

## Test plan

- [x] `python3 -m pytest tests/test_mcp_workspace.py --no-cov -q` → 18 passed
- [ ] Full suite via CI (coverage ≥ 86%)