### PR TITLE
docs: add Getting Started — PHP via Intelephense to MCP integration spec

### DIFF
--- a/.claude/cclsp.json
+++ b/.claude/cclsp.json
@@ -1,0 +1,9 @@
+{
+  "servers": [
+    {
+      "extensions": ["py"],
+      "command": ["pyright-langserver", "--stdio"],
+      "rootDir": "."
+    }
+  ]
+}

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -10,8 +10,24 @@
     "hashnode",
     "devto",
     "bluesky",
-    "xml"
+    "xml",
+    "mcp"
   ],
+  "mcp": {
+    "_example-php-lsp": {
+      "cmd": "cclsp",
+      "match": "*.{php,class.php}",
+      "env": { "CCLSP_CONFIG_PATH": ".claude/cclsp.json" },
+      "tools": {
+        "resolve": "find_workspace_symbols",
+        "refs":    "find_references",
+        "diag":    "get_diagnostics",
+        "hover":   "get_hover",
+        "rename":  "rename_symbol"
+      },
+      "timeout": 60
+    }
+  },
   "introduction": "supertool batches multiple file operations into one Bash call.\n\nInvoke via Bash:\n./supertool \\\n    'read:src/app/Module.py' \\\n    'read:src/app/Config.py' \\\n    'grep:class:src/app/:20' \\\n    'glob:src/app/**/*.py'\n\nRules:\n- One call, many ops. 6-7 per call is normal. Each separate call wastes money.\n- Paths are relative to project root.\n- Single quotes around each op.\n- Use Read tool ONLY for the file you're about to Edit \u2014 supertool for everything else.\n\n@file payload route (mutating ops only \u2014 edit, replace, replace_lines, paste, vim):\n- Inline:  ./supertool 'edit:::OLD:::NEW:::PATH'\n- Payload: ./supertool 'edit:@-' <<'EOF' ... EOF   (or 'edit:@path.toml')\n- Format auto-detected: starts with { or [ \u2192 JSON; else TOML.\n- TOML '''triple-single-quote''' preserves backslashes/quotes/newlines byte-for-byte \u2014 use for code blocks. Single-quoted 'literal' for one-liners with \\e etc.\n- Field names match the syntax tokens lowercased (edit:::OLD:::NEW:::PATH \u2192 old, new, path).\n\nTo avoid escape problems, use chr(10)/chr(27) instead of \\n/\\x1b in payload content.",
   "output-format": "Each operation returns a header followed by its output:\n\n```\n--- read:src/app/Module.py ---\n(45 lines, 1230 bytes)\n     1\u2192import os\n     2\u2192import sys\n     3\u2192\n     4\u2192class Module:\n\n--- grep:class:src/app/:5 ---\n(2 results, limit 5)\nsrc/app/Module.py\n  4:class Module:\nsrc/app/Config.py\n  8:class Config:\n\n--- glob:src/app/**/*.py ---\n(3 files)\nsrc/app/Module.py\nsrc/app/Config.py\nsrc/app/Utils.py\n```",
   "builtin-ops": {

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -183,9 +183,24 @@
       "example": "workspace:src/app/Module.py"
     },
     "resolve": {
-      "syntax": "resolve:SYMBOL",
-      "description": "Smart-glob resolver: PHP FQN, Python dotted, JS/TS relative path \u2192 file on disk. Returns 'external' for npm/pip packages, 'not found' if no match. Used internally by workspace.",
-      "example": "resolve:foo.bar.baz"
+      "syntax": "resolve:SYMBOL[:FROM_FILE]",
+      "description": "Symbol \u2192 file. LSP via mcp.tools.resolve when configured, else heuristic glob.",
+      "example": "resolve:foo.bar.Baz:src/caller.py"
+    },
+    "diag": {
+      "syntax": "diag:FILE",
+      "description": "LSP errors/warnings for FILE.",
+      "example": "diag:src/app/Module.py"
+    },
+    "hover": {
+      "syntax": "hover:SYMBOL:FILE",
+      "description": "LSP hover: type + docs for SYMBOL.",
+      "example": "hover:MyClass:src/app/Caller.py"
+    },
+    "rename": {
+      "syntax": "rename:OLD:NEW:FILE",
+      "description": "LSP workspace rename. Safer than sed.",
+      "example": "rename:oldName:newName:src/app/Module.py"
     }
   },
   "ops": {

--- a/.supertool.json
+++ b/.supertool.json
@@ -4,8 +4,24 @@
   "presets": [
     "github",
     "git",
-    "xml"
+    "xml",
+    "mcp"
   ],
+  "mcp": {
+    "py-lsp": {
+      "cmd": "cclsp",
+      "match": "*.py",
+      "env": { "CCLSP_CONFIG_PATH": ".claude/cclsp.json" },
+      "tools": {
+        "resolve": "find_workspace_symbols",
+        "refs":    "find_references",
+        "diag":    "get_diagnostics",
+        "hover":   "get_hover",
+        "rename":  "rename_symbol"
+      },
+      "timeout": 60
+    }
+  },
   "introduction": "./supertool 'op:args' 'op:args'... Batch 6-7 ops/call. Single quotes per op. Paths from root. Use ops not raw cmds (mysql_read, phpstan, batched reads). Read only before Edit.\n\n@file route (mutating ops: edit/replace/replace_lines/paste/vim): op:@payload or op:@- (stdin). Auto-detect: starts with { \u2192 JSON, else TOML. TOML '''triple-single-quote''' preserves backslashes/quotes/newlines \u2014 best for code blocks. Fields match syntax tokens lowercased (edit:::OLD:::NEW:::PATH \u2192 old, new, path).\n\nTo avoid escape problems, use chr(10)/chr(27) instead of \\n/\\x1b in payload content.",
   "output-format": "Each op: header + body.\n```\n--- op:args ---\n(meta)\noutput\n```",
   "builtin-ops": {
@@ -173,14 +189,36 @@
       "example": "workspace:src/app/Module.py"
     },
     "resolve": {
-      "syntax": "resolve:SYMBOL",
-      "description": "Smart-glob resolver: PHP FQN, Python dotted, JS/TS relative path \u2192 file on disk. Returns 'external' for npm/pip packages, 'not found' if no match. Used internally by workspace.",
-      "example": "resolve:foo.bar.baz"
+      "syntax": "resolve:SYMBOL[:FROM_FILE]",
+      "description": "Symbol \u2192 file. LSP via mcp.tools.resolve when configured, else heuristic glob.",
+      "example": "resolve:MCPClient:tests/test_mcp_client.py"
+    },
+    "diag": {
+      "syntax": "diag:FILE",
+      "description": "LSP errors/warnings for FILE.",
+      "example": "diag:supertool.py"
+    },
+    "hover": {
+      "syntax": "hover:SYMBOL:FILE",
+      "description": "LSP hover: type + docs for SYMBOL.",
+      "example": "hover:MCPClient:supertool.py"
+    },
+    "rename": {
+      "syntax": "rename:OLD:NEW:FILE",
+      "description": "LSP workspace rename. Safer than sed.",
+      "example": "rename:oldName:newName:supertool.py"
     }
   },
   "ops": {},
   "aliases": {},
   "validators": {
+    "lsp-diag": {
+      "cmd": "python3 {supertool_dir}/validators/lsp-diag/lsp-diag.py {file}",
+      "match": "*.{py,php,class.php,js,ts,jsx,tsx}",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 15
+    },
     "jsonlint": {
       "cmd": "python3 -m json.tool {file}",
       "match": "*.json",

--- a/README.md
+++ b/README.md
@@ -194,6 +194,37 @@ The `check:PRESET:PATH` op still works — it reads from the `ops` section first
 
 ---
 
+## MCP integration — warm LSP for `resolve` / `refs` / `workspace`
+
+Heuristic grep is fast but lies. A real language server (intelephense, pyright, typescript-language-server, gopls, rust-analyzer) knows where every symbol is defined — but spawning one per CLI call pays a 5-60s cold-index every time.
+
+Supertool ships a long-lived **MCP daemon** as the `mcp` preset. The daemon owns one MCP server subprocess (typically [cclsp](https://github.com/ktnyt/cclsp) wrapping an LSP), stays warm across `supertool` invocations, and answers `resolve` / `refs` / `workspace` via Unix socket in milliseconds.
+
+```bash
+# 1. install LSP + MCP↔LSP bridge
+npm install -g intelephense cclsp
+
+# 2. point cclsp at the LSP
+cat > .claude/cclsp.json <<'EOF'
+{ "servers": [{ "extensions": ["php"], "command": ["intelephense", "--stdio"] }] }
+EOF
+
+# 3. wire supertool: add "mcp" preset + mcp block in .supertool.json
+#    (see docs/mcp-integration.md for the JSON shape)
+
+# 4. use it — first call auto-spawns the daemon, subsequent calls hit warm LSP
+./supertool 'resolve:My\Namespace\TargetClass:src/Caller.php'
+# → My\Namespace\TargetClass → /abs/path/src/My/Namespace/TargetClass.php  (<1s warm)
+```
+
+Ops shipped by the preset: `mcp_daemon`, `mcp_status`, `mcp_stop`, `mcp_stop_all`.
+
+LSP-backed ops once wired: `resolve`, `refs`, `diag`, `hover`, `rename`, and per-section LSP routing inside `workspace`.
+
+Full reference (architecture, all five LSP ops, recipe for adding a new MCP server / language, tool name reference, troubleshooting): [docs/mcp-integration.md](docs/mcp-integration.md).
+
+---
+
 ## RTK integration
 
 When [rtk](https://github.com/reachingforthejack/rtk) is installed, supertool automatically delegates `read`, `grep`, and `wc` to RTK for compressed output. No configuration needed — detected via `which rtk` at first use.
@@ -300,7 +331,7 @@ See [docs/contributing.md](docs/contributing.md) — custom ops, presets, valida
 
 - **One file.** `supertool.py` is ~980 LoC (16 ops, 3 integration tiers). No package, no `setup.py`, no required deps. Drop in and use.
 - **Python 3.9+.** macOS ships 3.9 via CommandLineTools; we don't force upgrades.
-- **No MCP server.** MCP is server-process-and-JSON-RPC ceremony for what's literally "run a script, get output." A Bash-invoked binary is simpler, faster, and plugs into Claude Code's existing `--allowedTools`/`--disallowedTools` flow.
+- **Supertool isn't an MCP server.** For the ops supertool ships (run a script, return output), MCP would be ceremony — Bash-invoked binaries are simpler, faster, and plug into Claude Code's existing `--allowedTools`/`--disallowedTools` flow. But supertool *consumes* MCP servers when you want LSP-grade accuracy on `resolve`/`refs`/`workspace` — see the [MCP integration](#mcp-integration--warm-lsp-for-resolve--refs--workspace) above.
 - **Trade Python work for LLM tokens.** LLM compute is expensive; local CPU is cheap. Any time the model would spend tokens computing, parsing, formatting, or finding — supertool should spend milliseconds instead. Richer op output (state hints, guards, semantic anchors, auto-formatting, syntax checks) is not feature creep — it's the whole thesis. Heavy Python is fine if it shaves tokens off the model side.
 
 ---

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -102,7 +102,7 @@ Add an `mcp` block to `.supertool.json`:
 | `tools` | object | yes | Maps supertool canonical op names → MCP server tool names |
 | `timeout` | int (seconds) | no | Per-call timeout; defaults to 30 |
 
-`match` is recommended but not required — see [Open Questions](#11-open-questions).
+`match` is recommended but not required — see [Open Questions](#12-open-questions).
 
 **Canonical op names** (supertool side): `resolve`, `refs`, `hover`, `rename`, `implementers`, `callers`, `definition` (alias for `resolve`).
 
@@ -252,7 +252,95 @@ Visible action MCPs (playwright, gmail) remain registered in Claude Code as toda
 
 ---
 
-## 11. Open Questions
+## 11. Getting Started — PHP via Intelephense
+
+This section walks through wiring PHP LSP support into supertool. Steps use DVSI as the example repo but the pattern is language-agnostic — repeat for Python (`pyright --stdio`), TypeScript (`typescript-language-server --stdio`), etc.
+
+### Step 1. Install intelephense globally
+
+```bash
+npm install -g intelephense
+```
+
+Verify: `intelephense --stdio` (should hang waiting for LSP input — kill with Ctrl-C).
+
+Optional: paid license unlocks code actions and workspace-wide rename. Free tier covers go-to-def, refs, and hover. License: https://intelephense.com/
+
+### Step 2. Get an MCP bridge for LSP
+
+intelephense speaks LSP; supertool speaks MCP. A bridge is needed. Two options:
+
+- **`cclsp`** ([github.com/ktnyt/cclsp](https://github.com/ktnyt/cclsp)) — generic MCP↔LSP bridge that auto-routes. One install, many languages.
+  ```bash
+  npm install -g cclsp
+  ```
+- **Custom thin wrapper** — a small Python script that spawns intelephense and translates MCP `tools/call` ↔ LSP `textDocument/definition` etc. Reasonable if cclsp's tool naming doesn't match supertool's canonical ops.
+
+For DVSI, start with `cclsp`. It exposes tools like `definition`, `references`, `hover` which align with supertool's canonical op names.
+
+### Step 3. Wire into `.supertool.json`
+
+```json
+{
+  "mcp": {
+    "php-lsp": {
+      "cmd": "cclsp --lsp 'intelephense --stdio'",
+      "match": "*.php",
+      "env": {
+        "INTELEPHENSE_LICENSE": "$INTELEPHENSE_LICENSE"
+      },
+      "tools": {
+        "resolve": "definition",
+        "refs": "references",
+        "hover": "hover"
+      },
+      "timeout": 30
+    }
+  }
+}
+```
+
+For DVSI, add a `.class.php` glob if intelephense doesn't pick up that suffix automatically — match the validator's pattern: `"match": "*.{php,class.php}"`.
+
+> ⚠️ The `$INTELEPHENSE_LICENSE` env var reference assumes the var is exported in your shell. Env var expansion in `.supertool.json` is on the v2 roadmap (see [Open Questions §12](#12-open-questions)). For now, paste the literal license value or export the env var before running supertool.
+
+### Step 4. Smoke test
+
+From the DVSI repo root:
+
+```bash
+./supertool 'resolve:SiCore\\Annotations\\SiModuleDescription:Dvsi/dvsi-private/src2/SiOAuthPennylane/SiOAuthPennylaneModule.class.php'
+```
+
+Expected: returns the absolute path to `SiModuleDescription.class.php` via intelephense (precise — includes autoload resolution).
+
+Compare to without MCP (rename the `mcp` block temporarily): the heuristic glob should find the same file, but slower and less reliable on overloaded names.
+
+### Step 5. Wire workspace
+
+```bash
+./supertool 'workspace:Dvsi/dvsi-private/src2/SiOAuthPennylane/SiOAuthPennylaneModule.class.php'
+```
+
+The `## Imports`, `## References`, and `## Symbols` sections now consult intelephense. Compare output to the heuristic version: imports resolve faster, references include cross-namespace usage, symbols include inherited methods.
+
+### Step 6. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `MCPServer 'php-lsp' marked dead` after first call | intelephense crashed during indexing | Check intelephense logs (`~/.intelephense/`). Re-install. |
+| `resolve` always returns `not found` | cclsp tool name mismatch | Run `cclsp --list-tools` and align the `tools` mapping in `.supertool.json` |
+| First call is very slow (>10s) | intelephense indexing on cold start | Expected. Subsequent calls are fast. Increase `timeout` to 60 if you hit the limit. |
+| "INTELEPHENSE_LICENSE invalid" | License typo or expired | Check license at intelephense.com. Free tier works for go-to-def + refs. |
+| Heuristic still firing | `match` glob doesn't cover `.class.php` | Add explicit glob: `"match": "*.{php,class.php}"` |
+
+### Step 7. What's next
+
+After PHP works, repeat for Python (`pyright --stdio`), TypeScript (`typescript-language-server --stdio`), Rust (`rust-analyzer`), etc. Same shape: install LSP server → wrap via cclsp → drop into `.supertool.json`.
+
+---
+
+## 12. Open Questions
 
 Design choices that need team input before implementation starts:
 
@@ -273,7 +361,7 @@ Design choices that need team input before implementation starts:
 
 ---
 
-## 12. PR Plan
+## 13. PR Plan
 
 Three sub-PRs for v1, each reviewable independently:
 

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -1,404 +1,370 @@
-# MCP Integration Spec — Hidden Tooling Backends
+# MCP Integration
 
-**Status:** ✅ v1 shipped · 2026-05-21
-**Sub-PRs:** [#126](https://github.com/Digital-Process-Tools/claude-supertool/pull/126) client primitives · [#127](https://github.com/Digital-Process-Tools/claude-supertool/pull/127) config + routing + `op_resolve` · [#128](https://github.com/Digital-Process-Tools/claude-supertool/pull/128) workspace References + Symbols
+**Status:** ✅ shipped · daemon transport, preset-packaged
 
-## v2 Roadmap (deferred from v1)
+Supertool talks to MCP servers (cclsp, custom LSP wrappers, anything that speaks the
+[Model Context Protocol](https://modelcontextprotocol.io/)) so ops like `resolve`,
+`refs`, `diag`, `hover`, `rename`, and `workspace` can return real LSP answers
+instead of grep heuristics.
 
-| Item | Spec ref | Why deferred |
+## Why it exists
+
+LLMs navigating a codebase with `grep` and glob patterns are slow and inaccurate. A
+language server (intelephense, pyright, typescript-language-server, gopls, etc.) knows
+where every symbol is defined, what references it, and what types it has — instantly,
+once warm. The problem: an LSP cold-starts in 5–60s on a large repo, and supertool is
+a CLI that exits between calls.
+
+The integration:
+
+- A small **MCP daemon** stays alive between supertool invocations
+- The daemon owns one MCP server subprocess (e.g. `cclsp` wrapping `intelephense`)
+- The LSP indexes once, stays warm, answers later calls in milliseconds
+- Supertool connects to the daemon over a Unix socket, sends NDJSON JSON-RPC
+
+Result: an LLM agent gets editor-quality navigation with no per-call indexing penalty.
+
+## Architecture
+
+```
+┌─────────────────────┐    UDS     ┌──────────────────┐  stdio   ┌──────────────┐
+│ supertool (per-call)│ ◀─NDJSON──▶│ MCP daemon       │ ◀──────▶│ MCP server   │
+│ MCPClient           │            │ (long-lived)     │          │ (cclsp, etc.)│
+└─────────────────────┘            │ owns subprocess  │          │              │
+                                   │ idle-timeout 10m │          │ wraps LSP    │
+                                   └──────────────────┘          └──────────────┘
+                                                                       │ stdio
+                                                                       ▼
+                                                                ┌──────────────┐
+                                                                │ language     │
+                                                                │ server       │
+                                                                │ (intelephense│
+                                                                │  /pyright/…) │
+                                                                └──────────────┘
+```
+
+Components:
+
+| Piece | Lives in | Role |
 |---|---|---|
-| Cache layer (`(server, tool, file_sha, args)` key) | §7 | Validator-cache framework needs a small extension; ship after v1 lands so we can benchmark first |
-| Verbose-mode fallback logging | §8 | UX nicety — note in verbose output when MCP miss → heuristic |
-| Crash recovery + backoff | §5 | Single re-spawn with 500ms backoff; TODO marker placed in `_recv` |
-| Env var expansion (`$INTELEPHENSE_LICENSE`) | §3 | Config-time interpolation for secrets |
-| LLM-visible MCP wrapper op (`mcp:<server>:<tool>:<args>`) | §10 | Out of v1 scope — call any MCP tool directly via supertool |
-| `hover` / `rename` / `implementers` / `callers` ops | §10 | First-class workspace ops backed by MCP when present |
-| Config validation (malformed `tools` / `env`) | — | Silent today; should error at load time |
+| `MCPClient` | `supertool.py` | UDS client; connects to daemon, auto-spawns one on first call |
+| `presets/mcp/daemon.py` | preset | Daemon: owns MCP subprocess + bridges UDS↔stdio |
+| `presets/mcp/status.py` | preset | List running daemons |
+| `presets/mcp/stop.py` | preset | Graceful stop (SIGTERM, SIGKILL fallback) |
+| `presets/mcp.json` | preset | Declares `mcp_daemon` / `mcp_status` / `mcp_stop` / `mcp_stop_all` ops |
 
----
+Socket path: `/tmp/supertool-mcp-<sha1(cwd+name)[:12]>.sock` — per-repo + per-server isolation.
 
-## 1. Motivation
+Wire format: newline-delimited JSON-RPC 2.0 — same encoding the official
+[MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) speaks over stdio.
 
-LLMs working with supertool today face two surfaces: supertool ops (`resolve`, `refs`, `read`, `grep`…) and MCP tools registered directly in Claude Code (`mcp__php_lsp__definition`, `mcp__playwright__click`…). Mental context switches, inconsistent naming, and no shared caching or fallback.
+## LSP-backed ops
 
-The token cost is the sharper problem. Each MCP server registered in Claude Code injects its full tool schema into every conversation. With 5 tooling servers at ~10 tools each and ~400 tokens per tool definition, that's **~20K tokens permanently consumed** before the first user message — and those tools may never be called.
+Five supertool ops route through MCP when configured. Each maps to a specific MCP tool
+via the `mcp.<server>.tools` block.
 
-Existing workspace ops (`resolve`, `refs`, `symbols`) are heuristic: regex over source files. They're fast and offline, but imprecise — they miss overloaded names, cross-file type resolution, and dynamic dispatch. LSP-backed equivalents would be exact.
+| Supertool op | Syntax | What it does | Heuristic fallback |
+|---|---|---|---|
+| `resolve` | `resolve:SYMBOL:FILE` | Symbol → file path. With LSP: workspace-wide. Without: glob heuristic on PHP FQN / Python dotted / JS relative | ✓ |
+| `refs` (via `workspace`) | `workspace:FILE` (References section) | Find all references to the file's main symbol | ✓ grep |
+| `diag` | `diag:FILE` | LSP diagnostics (errors, warnings, hints) for the file | ✗ no LSP → error message |
+| `hover` | `hover:SYMBOL:FILE` | Type signature + doc for the symbol. Internally: locate via `resolve` tool, then `hover` tool at identifier position | ✗ no LSP → error message |
+| `rename` | `rename:OLD:NEW:FILE` | Workspace-atomic rename across all files. cclsp's `rename_symbol` writes `.bak` backups | ✗ no LSP → error message |
+| `workspace` | `workspace:FILE` | Composite view: file content + Diagnostics + Symbols + Imports + References. Each section uses LSP when its tool is mapped, else heuristic | ✓ per-section |
 
-**Goal:** Route tooling MCP servers through supertool as hidden backends. The LLM calls `resolve:Foo:File.php` exactly as today. Supertool routes to the LSP, returns the result. Zero tokens added to the LLM's tool catalog.
+**Two-step ops**: `hover` calls two MCP tools per invocation — first `tools.resolve` to find the symbol's line:col, then `tools.hover` at the identifier offset. Both mappings are required for `hover`.
 
----
+**Hard-fail ops**: `diag`, `hover`, `rename` only make sense with a real LSP. Without a matching `mcp.<server>.tools.<op>` mapping, they return a clear error rather than falling back to grep.
 
-## 2. Visibility Model — Hidden vs Visible MCPs
+## Quickstart — PHP via Intelephense
 
-Not all MCP servers should be hidden. The distinction:
+Three minutes from clean repo to working LSP-backed `resolve`.
 
-| Type | Recommended model | Examples |
-|------|------------------|---------|
-| **Tooling backends** — read-only, deterministic, workspace-scoped | **Hidden** — supertool owns lifecycle, exposes as ops | `php-lsp`, `pyright`, `tsserver`, `rust-analyzer` |
-| **Action backends** — side-effects, persistent state, user-facing auth | **Visible** — registered in Claude Code, LLM calls directly | `playwright`, `gmail`, `slack`, `google-drive` |
+### 1. Install LSP + bridge
 
-Decision rule: if the server reads workspace state and returns structured data → hidden. If it mutates external state or requires user authentication → visible.
+```bash
+npm install -g intelephense cclsp
+```
 
-Hidden servers never appear in the LLM's tool schema. They are supertool plumbing.
+[`cclsp`](https://github.com/ktnyt/cclsp) is a generic MCP↔LSP bridge. Free intelephense
+covers go-to-def, references, hover, workspace symbols — that's enough.
 
----
+### 2. Configure the bridge
 
-## 3. Config Schema
-
-Add an `mcp` block to `.supertool.json`:
+Create `.claude/cclsp.json` (cclsp's own config — points it at the LSP):
 
 ```json
 {
+  "servers": [
+    { "extensions": ["php"], "command": ["intelephense", "--stdio"], "rootDir": "." }
+  ]
+}
+```
+
+### 3. Wire supertool
+
+Edit `.supertool.json`:
+
+```json
+{
+  "presets": ["mcp"],
   "mcp": {
     "php-lsp": {
-      "cmd": "claude-mcp-php-lsp",
-      "match": "*.php",
-      "env": {
-        "INTELEPHENSE_LICENSE": "your-key-here"
-      },
+      "cmd": "cclsp",
+      "match": "*.{php,class.php}",
+      "env": { "CCLSP_CONFIG_PATH": ".claude/cclsp.json" },
       "tools": {
-        "resolve": "definition",
-        "refs": "references",
-        "hover": "hover",
-        "rename": "rename",
-        "implementers": "implementers",
-        "callers": "callers"
+        "resolve": "find_workspace_symbols",
+        "refs":    "find_references",
+        "diag":    "get_diagnostics",
+        "hover":   "get_hover",
+        "rename":  "rename_symbol"
       },
-      "timeout": 30
-    },
-    "pyright": {
-      "cmd": "pyright-mcp",
-      "match": "*.py",
-      "tools": {
-        "resolve": "definition",
-        "refs": "references",
-        "hover": "hover"
-      },
-      "timeout": 20
-    },
-    "tsserver": {
-      "cmd": "typescript-mcp",
-      "match": "*.{ts,tsx}",
-      "tools": {
-        "resolve": "definition",
-        "refs": "findReferences",
-        "hover": "quickInfo",
-        "rename": "rename"
-      },
-      "timeout": 25
+      "timeout": 60
     }
   }
 }
 ```
 
-**Field reference:**
+- `cmd` — what the daemon spawns (an MCP server)
+- `match` — glob; supertool routes ops on matching files through this server
+- `env` — environment for the spawned MCP server
+- `tools` — maps supertool op names to MCP tool names exposed by the server. Omit any op you don't want to use; that op falls back to the heuristic path (where one exists)
+- `timeout` — request timeout in seconds (LSP cold-start can be slow; 60s is comfortable)
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `cmd` | string | yes | Command to spawn the MCP server |
-| `match` | glob | recommended | File extension glob — same `_match_glob` used by validators/formatters |
-| `env` | object | no | Per-server env vars injected at spawn time |
-| `tools` | object | yes | Maps supertool canonical op names → MCP server tool names |
-| `timeout` | int (seconds) | no | Per-call timeout; defaults to 30 |
+### 4. Use it
 
-`match` is recommended but not required — see [Open Questions](#12-open-questions).
+```bash
+$ ./supertool 'resolve:My\Namespace\TargetClass:src/Caller.php'
+My\Namespace\TargetClass → /abs/path/src/My/Namespace/TargetClass.php
+```
 
-**Canonical op names** (supertool side): `resolve`, `refs`, `hover`, `rename`, `implementers`, `callers`, `definition` (alias for `resolve`).
+First call spawns the daemon detached, waits for the socket, then the LSP indexes (cold,
+5–60s on big repos). Subsequent calls hit a warm daemon: <1s.
 
----
+## Daemon lifecycle
 
-## 4. MCP Wire Protocol
+| Op | Effect |
+|---|---|
+| `mcp_daemon:NAME` | Start daemon for `NAME` (blocking; append `--detach` to background) |
+| `mcp_status` | List running daemons: name, hash, pid, status, uptime, idle, socket |
+| `mcp_stop:NAME` | Graceful stop (SIGTERM, SIGKILL after 3s) |
+| `mcp_stop_all` | Stop every supertool MCP daemon |
 
-Supertool communicates with hidden MCP servers over **JSON-RPC 2.0 via stdio** — the standard MCP transport. Spec: https://modelcontextprotocol.io/
+The daemon shuts down automatically after `idle_timeout` (default 600s = 10 minutes).
+Configure per-server via `"idle_timeout": N` in the `mcp` block.
 
-Messages supertool needs to implement (minimal client):
+When `MCPClient` can't connect, it spawns the daemon detached via:
 
-| Message | Direction | Purpose |
-|---------|-----------|---------|
-| `initialize` | supertool → server | Handshake on spawn; declares client capabilities |
-| `initialized` | server → supertool | Confirms server is ready |
-| `tools/list` | supertool → server | Validates config tool names exist; called once after init |
-| `tools/call` | supertool → server | Invokes a tool with args; main request/response |
-| `shutdown` | supertool → server | Graceful termination on exit |
+```python
+subprocess.Popen([sys.executable, daemon.py, NAME, "--detach"], start_new_session=True)
+```
 
-**Not implemented in v1:** notifications, prompts, resources, sampling, progress. Tooling backends are unary request/response — nothing else is needed.
+and retries the connect for ~7.5s before giving up. For ops with a heuristic fallback
+(`resolve`, `refs`, `workspace`), giveup is silent — supertool runs the heuristic and
+the call succeeds (slower, less accurate). For LSP-only ops (`diag`, `hover`, `rename`),
+giveup surfaces a clear error message so the caller knows the LSP is the bottleneck.
 
-Each `tools/call` request shape:
+## Adding a new MCP server
+
+Whether the server is an LSP via cclsp, a custom MCP wrapper, or any third-party MCP
+binary, the wiring is the same.
+
+### Recipe
+
+1. **Get the MCP server runnable** — install it, verify `<binary> --help` (or whatever
+   the server's spawn invocation is) works on its own. For cclsp+LSP, this means
+   installing both cclsp and the language server (intelephense, pylsp, etc.) and
+   declaring the LSP in `.claude/cclsp.json`.
+
+2. **Add an `mcp` entry to `.supertool.json`** — pick a name, point `cmd` at the MCP
+   server binary, set `match` to the file glob, declare `env` if the server needs it,
+   map supertool ops to MCP tool names in `tools`:
+
+   ```json
+   "mcp": {
+     "<name>": {
+       "cmd": "<mcp-server-binary> [args]",
+       "match": "*.<ext>",
+       "env": { ... },
+       "tools": {
+         "resolve": "<MCP tool for symbol→file>",
+         "refs":    "<MCP tool for find references>",
+         "diag":    "<MCP tool for file diagnostics>",
+         "hover":   "<MCP tool for symbol hover (position-based)>",
+         "rename":  "<MCP tool for workspace rename>"
+       },
+       "timeout": 60
+     }
+   }
+   ```
+
+   Keys explained:
+   - `cmd` — what `subprocess.Popen` calls (shlex-split if string). The daemon owns
+     this process.
+   - `match` — fnmatch glob; supertool routes ops on matching `from_file` paths through
+     this server. Brace expansion (`*.{php,class.php}`) supported.
+   - `env` — extra env vars passed to the spawned MCP server. Merged onto `os.environ`.
+   - `tools` — maps supertool op (`resolve`/`refs`/etc.) to the MCP `tool` name the
+     server exposes via `tools/list`. Without this, the op falls through to the
+     heuristic path.
+   - `timeout` — request timeout in seconds.
+   - `idle_timeout` (optional) — daemon shuts itself down after this many seconds idle
+     (default 600).
+
+3. **Discover the tool names** — first time wiring a new MCP server, you don't know
+   what tool names it exposes. Two quick options:
+
+   ```bash
+   # Run the server directly + ask via the Python SDK (one-off probe)
+   pip install mcp
+   python3 -c "
+   import asyncio, os
+   from mcp import ClientSession, StdioServerParameters
+   from mcp.client.stdio import stdio_client
+   async def m():
+       p = StdioServerParameters(command='<binary>', args=[], env={**os.environ})
+       async with stdio_client(p) as (r, w):
+           async with ClientSession(r, w) as s:
+               await s.initialize()
+               t = await s.list_tools()
+               for tool in t.tools: print(tool.name, '—', tool.description[:80])
+   asyncio.run(m())"
+   ```
+
+   Or — once the server is wired into `.supertool.json` and the daemon is running —
+   read the live `tools/list` via the daemon's socket using the same SDK against
+   `socket_path`.
+
+4. **Run** — `./supertool 'resolve:<SYMBOL>:<FILE>'`. First call spawns the daemon
+   detached; LSP indexes (cold start ~30s on big repos), then warm. `mcp_status`
+   confirms the daemon's running.
+
+### Examples
+
+#### Python (pylsp)
+
+```bash
+pip install "python-lsp-server[all]"
+```
 
 ```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "definition",
-    "arguments": {
-      "file": "/abs/path/to/File.php",
-      "symbol": "Foo"
-    }
-  }
-}
+// .claude/cclsp.json — add to the servers array
+{ "extensions": ["py", "pyi"], "command": ["pylsp"], "rootDir": "." }
 ```
-
-Response is server-specific; supertool extracts the `content` array and formats for LLM consumption.
-
----
-
-## 5. Lifecycle
-
-**Spawn:** Lazy. Server starts on the first op that routes to it. No pre-warming at supertool startup.
-
-**Lifetime:** One server process per match group, kept alive for the supertool session. The process stays in supertool's process tree. No IPC socket — stdio only.
-
-**Shutdown:** Supertool sends `shutdown` then closes stdin on exit. An `atexit` handler covers normal exits. SIGTERM/SIGINT propagates to child processes via process group.
-
-**Crash recovery:** If a server process dies mid-session, supertool:
-1. Detects the closed pipe
-2. Re-spawns once after a 500ms backoff
-3. Retries the failed op
-4. If the retry fails, falls back to heuristic (see [Fallback](#8-fallback-strategy)) and logs a one-line warning in verbose mode
-
-No crash loop — one re-spawn attempt maximum per server per session.
-
----
-
-## 6. Tool Routing
-
-Dispatch flow for `resolve:Foo:File.php`:
-
-```
-1. Detect target file extension → ".php"
-2. Scan mcp config: find first server where _match_glob(match, "*.php") is true → "php-lsp"
-3. Look up mcp["php-lsp"].tools["resolve"] → "definition"
-4. Spawn php-lsp if not running (lazy init, handshake)
-5. Call tools/call {name: "definition", arguments: {file: "/abs/File.php", symbol: "Foo"}}
-6. Format response → return to caller
-7. On any failure → fall back to heuristic resolve
-```
-
-Same dispatch for `refs`, `hover`, `rename`, `implementers`, `callers`.
-
-If no MCP server matches the file extension, supertool proceeds directly to heuristic — no error, no warning. The MCP layer is purely additive.
-
-Multiple servers with overlapping `match` patterns: first match wins (config order). Document this explicitly in the config reference — order matters.
-
----
-
-## 7. Caching
-
-LSP responses are cached using the existing validator cache framework:
-
-**Cache key:** `(file_sha256, abs_file_path, tool_name, serialized_args)`
-
-**Invalidation:** File SHA changes on edit → cache miss → fresh LSP call. This is automatic if supertool tracks file SHA after `edit`/`replace_lines` ops (which it already does for validator post-edit runs).
-
-**TTL:** File-change-based, same as validators. No wall-clock expiry.
-
-**Workspace-level cache warming** (future): on `tools/list` response, supertool could pre-resolve the current file. Deferred to v2.
-
----
-
-## 8. Fallback Strategy
-
-Three tiers per op, evaluated in order:
-
-| Tier | Condition | Behavior |
-|------|-----------|---------|
-| **1. MCP server** | Configured, healthy, match found | Full LSP response |
-| **2. Heuristic** | MCP not configured, or server failed | Current supertool implementation (`_grep_recursive`, regex-based `resolve`, etc.) |
-| **3. Error** | Both fail with hard error | Op returns error message |
-
-Failures at tier 1 are silent in normal mode. In verbose mode (`-v`), a one-line note appears: `[mcp] php-lsp unavailable, falling back to heuristic`. The LLM sees the heuristic result and nothing else.
-
-This preserves backward compatibility: supertool without any MCP config behaves identically to today.
-
----
-
-## 9. Token Impact
-
-| Scenario | Tokens consumed per conversation |
-|----------|----------------------------------|
-| 5 MCP servers registered visibly in Claude Code | ~20,000 tokens (5 × 10 tools × ~400 tokens) |
-| Same 5 servers as hidden supertool backends | **0 tokens** — not in tool catalog |
-| Per-call overhead (hidden vs direct) | ~5ms extra JSON-RPC hop; negligible |
-
-The token saving is permanent and per-conversation. A 20K token reduction in every session is equivalent to recovering ~15% of a 128K context window before the first message.
-
-Visible action MCPs (playwright, gmail) remain registered in Claude Code as today — their schema cost is intentional because the LLM needs to call them directly.
-
----
-
-## 10. v1 Scope
-
-**In scope for v1 — ✅ all shipped (PRs #126, #127, #128):**
-- ✅ Config schema (`mcp` block in `.supertool.json`) — parsed; explicit validation deferred to v2
-- ✅ Single MCP server per extension match (first match wins, dict insertion order)
-- ✅ Synchronous `tools/call` only (no streaming)
-- ✅ Lazy spawn + session-lifetime server process
-- ✅ Graceful shutdown via `atexit` + explicit `shutdown` message
-- ✅ Heuristic fallback on any failure
-- ✅ Manual config only (no auto-discovery via `tools/list`)
-- ✅ Integration into `op_resolve` + workspace References + Symbols sections
-- ✅ Unit tests for MCP client primitives + routing + workspace integration (35+ tests)
-
-**Out of scope for v1:**
-- Persistent server lifetime across supertool sessions
-- Streaming MCP responses (multi-chunk tooling results)
-- Multi-server load balancing or round-robin
-- LLM-visible MCP wrapping (`mcp:<server>:<tool>:<args>` op form) — defer to v2
-- Auto-discovery: scanning `tools/list` to build the op→tool mapping automatically
-- Server health checks at startup (lazy spawn handles this implicitly)
-
----
-
-## 11. Getting Started — PHP via Intelephense
-
-This section walks through wiring PHP LSP support into supertool. Steps use DVSI as the example repo but the pattern is language-agnostic — repeat for Python (`pyright --stdio`), TypeScript (`typescript-language-server --stdio`), etc.
-
-### Step 1. Install intelephense globally
-
-```bash
-npm install -g intelephense
-```
-
-Verify: `intelephense --stdio` (should hang waiting for LSP input — kill with Ctrl-C).
-
-Optional: paid license unlocks code actions and workspace-wide rename. Free tier covers go-to-def, refs, and hover. License: https://intelephense.com/
-
-### Step 2. Get an MCP bridge for LSP
-
-intelephense speaks LSP; supertool speaks MCP. A bridge is needed. Two options:
-
-- **`cclsp`** ([github.com/ktnyt/cclsp](https://github.com/ktnyt/cclsp)) — generic MCP↔LSP bridge that auto-routes. One install, many languages.
-  ```bash
-  npm install -g cclsp
-  ```
-- **Custom thin wrapper** — a small Python script that spawns intelephense and translates MCP `tools/call` ↔ LSP `textDocument/definition` etc. Reasonable if cclsp's tool naming doesn't match supertool's canonical ops.
-
-For DVSI, start with `cclsp`. It exposes tools like `definition`, `references`, `hover` which align with supertool's canonical op names.
-
-### Step 3. Wire into `.supertool.json`
 
 ```json
-{
-  "mcp": {
-    "php-lsp": {
-      "cmd": "cclsp --lsp 'intelephense --stdio'",
-      "match": "*.php",
-      "env": {
-        "INTELEPHENSE_LICENSE": "$INTELEPHENSE_LICENSE"
-      },
-      "tools": {
-        "resolve": "definition",
-        "refs": "references",
-        "hover": "hover"
-      },
-      "timeout": 30
-    }
-  }
+// .supertool.json mcp block
+"python-lsp": {
+  "cmd": "cclsp",
+  "match": "*.{py,pyi}",
+  "env": { "CCLSP_CONFIG_PATH": ".claude/cclsp.json" },
+  "tools": {
+    "resolve": "find_workspace_symbols",
+    "refs":    "find_references",
+    "diag":    "get_diagnostics",
+    "hover":   "get_hover",
+    "rename":  "rename_symbol"
+  },
+  "timeout": 60
 }
 ```
 
-For DVSI, add a `.class.php` glob if intelephense doesn't pick up that suffix automatically — match the validator's pattern: `"match": "*.{php,class.php}"`.
-
-> ⚠️ The `$INTELEPHENSE_LICENSE` env var reference assumes the var is exported in your shell. Env var expansion in `.supertool.json` is on the v2 roadmap (see [Open Questions §12](#12-open-questions)). For now, paste the literal license value or export the env var before running supertool.
-
-### Step 4. Smoke test
-
-From the DVSI repo root:
+#### TypeScript
 
 ```bash
-./supertool 'resolve:SiCore\\Annotations\\SiModuleDescription:Dvsi/dvsi-private/src2/SiOAuthPennylane/SiOAuthPennylaneModule.class.php'
+npm install -g typescript typescript-language-server
 ```
 
-Expected: returns the absolute path to `SiModuleDescription.class.php` via intelephense (precise — includes autoload resolution).
-
-Compare to without MCP (rename the `mcp` block temporarily): the heuristic glob should find the same file, but slower and less reliable on overloaded names.
-
-### Step 5. Wire workspace
-
-```bash
-./supertool 'workspace:Dvsi/dvsi-private/src2/SiOAuthPennylane/SiOAuthPennylaneModule.class.php'
+```json
+// .claude/cclsp.json
+{ "extensions": ["ts", "tsx", "js", "jsx"],
+  "command": ["typescript-language-server", "--stdio"], "rootDir": "." }
 ```
 
-The `## Imports`, `## References`, and `## Symbols` sections now consult intelephense. Compare output to the heuristic version: imports resolve faster, references include cross-namespace usage, symbols include inherited methods.
+```json
+// .supertool.json mcp block
+"ts-lsp": {
+  "cmd": "cclsp",
+  "match": "*.{ts,tsx,js,jsx}",
+  "env": { "CCLSP_CONFIG_PATH": ".claude/cclsp.json" },
+  "tools": {
+    "resolve": "find_workspace_symbols",
+    "refs":    "find_references",
+    "diag":    "get_diagnostics",
+    "hover":   "get_hover",
+    "rename":  "rename_symbol"
+  },
+  "timeout": 60
+}
+```
 
-### Step 6. Troubleshooting
+#### Custom MCP server (no LSP)
+
+If you have your own MCP server binary that exposes domain-specific tools (e.g. a
+GraphQL schema walker, a custom code analyzer), point `cmd` straight at it:
+
+```json
+"my-tool": {
+  "cmd": "/usr/local/bin/my-mcp-tool --stdio",
+  "match": "*.graphql",
+  "tools": { "resolve": "schema_lookup", "refs": "schema_references" },
+  "timeout": 30
+}
+```
+
+Same daemon owns it, same UDS protocol, same auto-spawn behavior.
+
+### Pitfalls
+
+- **Tool name mismatch** — if `tools.resolve` points at a name the server doesn't
+  expose, MCP returns an error → supertool catches it → falls through to heuristic.
+  Silently slower, not wrong. Confirm names via the probe in step 3.
+- **Tool semantic mismatch** — names can match but behavior differs. cclsp's
+  `find_definition` scans the *given file* for the symbol; `find_workspace_symbols`
+  searches the whole index. Use whichever fits the op's intent. For supertool's
+  `resolve` (FQN→file), `find_workspace_symbols` is the right pick.
+- **Slow first call** — LSPs cold-index on first spawn. Free intelephense has no
+  persistent disk index, so the daemon's warm-time-after-first-call is your savings.
+  Don't kill the daemon between calls unless you want to pay the cold start again.
+
+## Tool name reference (cclsp)
+
+cclsp exposes these tools (full list via `cclsp` + `tools/list`):
+
+| Tool | Args | Notes |
+|---|---|---|
+| `find_definition` | `symbol_name`, `file_path` | Scans the file's symbols for the name — not a workspace-wide FQN search |
+| `find_workspace_symbols` | `query` | Workspace-wide name search via LSP `workspace/symbol`. Best fit for FQN→file resolution |
+| `find_references` | `symbol_name`, `file_path`, `include_declaration?` | LSP `textDocument/references` |
+| `rename_symbol` | `symbol_name`, `file_path`, `new_name`, `dry_run?` | Workspace rename |
+| `get_diagnostics` | `file_path` | Per-file LSP diagnostics |
+| `get_hover` | `symbol_name`, `file_path` | LSP hover info |
+| `restart_server` | — | Restart the LSP backend |
+
+Supertool's MCP call sends `{symbol_name, file_path, query}` together so the same call
+works whether the configured tool needs `symbol_name`/`file_path` (cclsp `find_definition`,
+`find_references`) or `query` (cclsp `find_workspace_symbols`). Tools ignore unknown args.
+
+## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `MCPServer 'php-lsp' marked dead` after first call | intelephense crashed during indexing | Check intelephense logs (`~/.intelephense/`). Re-install. |
-| `resolve` always returns `not found` | cclsp tool name mismatch | Run `cclsp --list-tools` and align the `tools` mapping in `.supertool.json` |
-| First call is very slow (>10s) | intelephense indexing on cold start | Expected. Subsequent calls are fast. Increase `timeout` to 60 if you hit the limit. |
-| "INTELEPHENSE_LICENSE invalid" | License typo or expired | Check license at intelephense.com. Free tier works for go-to-def + refs. |
-| Heuristic still firing | `match` glob doesn't cover `.class.php` | Add explicit glob: `"match": "*.{php,class.php}"` |
+| `not found` instead of an LSP answer | Daemon didn't start or LSP cold-start exceeded timeout | Increase `timeout` to 120; check `mcp_status`; check `/tmp/supertool-mcp-<hash>.sock.stderr` for cclsp errors |
+| Daemon dies repeatedly | LSP server crashed | Check `/tmp/supertool-mcp-<hash>.sock.stderr` (cclsp + LSP stderr is captured here) |
+| `resolve` returns cclsp's "No symbols found in <file>" text | Using `find_definition` (file-scoped) instead of `find_workspace_symbols` | Switch the tool mapping for `resolve` |
+| First call slow (~30s+) | Intelephense cold-indexing the repo | Expected; subsequent calls hit a warm daemon |
+| `AF_UNIX path too long` in tests | macOS UDS path limit (~104 chars) | Use `/tmp/` paths, not pytest `tmp_path` |
 
-### Step 7. What's next
+## Implementation notes
 
-After PHP works, repeat for Python (`pyright --stdio`), TypeScript (`typescript-language-server --stdio`), Rust (`rust-analyzer`), etc. Same shape: install LSP server → wrap via cclsp → drop into `.supertool.json`.
-
----
-
-## 12. Open Questions
-
-Design choices that need team input before implementation starts:
-
-1. **`match` required or optional?**
-   If `match` is omitted, the server has no automatic routing — it could only be called via explicit naming (`mcp:php-lsp:hover:...`). Is on-demand (no match) a valid use case, or should `match` be required for hidden servers?
-
-2. **Config-declared tool mapping vs auto-discovery?**
-   The current spec requires explicit `tools` mapping in config. Alternative: call `tools/list` on first spawn and auto-map by canonical name. Auto-discovery is more ergonomic but adds startup latency and requires canonical name alignment across LSP implementations. Tradeoff?
-
-3. **License key / secrets handling?**
-   `env` in `.supertool.json` is convenient but the file is typically committed. Options: (a) env var references (`"INTELEPHENSE_LICENSE": "$INTELEPHENSE_LICENSE"` expanded at spawn time), (b) separate `.supertool.secrets.json` (gitignored), (c) system keychain integration. What's the right security boundary?
-
-4. **Max concurrent server processes per session?**
-   With 3 language servers active, that's 3 long-lived processes. Is there a cap? Should supertool enforce a `maxServers` budget, or leave resource management to the user?
-
-5. **Error surfacing granularity?**
-   Current spec: failures are silent in normal mode, one-line note in verbose. Should the LLM ever be informed that it's getting heuristic results instead of LSP results? Could affect trust in `resolve` output.
-
----
-
-## 13. PR Plan
-
-Three sub-PRs for v1, each reviewable independently:
-
-### PR 1 — MCP Client Primitives
-
-**Scope:** Everything below the routing layer.
-- `supertool/mcp_client.py` (or equivalent): spawn, stdio transport, JSON-RPC 2.0 encode/decode
-- `initialize` / `initialized` handshake
-- `tools/list` call with response parsing
-- `tools/call` with timeout and error handling
-- `shutdown` with `atexit` registration
-- Crash detection + single re-spawn with backoff
-- Unit tests: mock server subprocess, test all message types, test crash recovery
-
-No config integration, no routing. The client is a standalone, testable module.
-
-### PR 2 — Config Schema + Extension Routing + `op_resolve` Integration
-
-**Scope:** Wiring the client into supertool's op dispatch.
-- Parse and validate `mcp` block in `.supertool.json`
-- `_match_glob` routing: file extension → server
-- Op→tool name resolution via config `tools` mapping
-- Integration into `op_resolve`: MCP call first, heuristic fallback
-- Cache layer: file SHA keying on LSP responses
-- Verbose-mode logging for fallback events
-- Integration tests: `resolve:Foo:File.php` end-to-end with a test MCP server
-
-### PR 3 — Roll Out to Remaining Workspace Ops
-
-**Scope:** Extend MCP routing to all workspace ops.
-- `op_refs` → `refs` tool
-- `op_symbols` → `symbols` tool (if server supports it)
-- `op_hover` → `hover` tool
-- `op_rename` → `rename` tool (write-path; needs extra validation before PR 3)
-- Update op reference docs with MCP-backed behavior notes
-- Update `.supertool.json` config reference with full `mcp` block documentation
-
----
-
-*Written by Max, 2026-05-21. Design review before PR 1 begins.*
+- **Wire format**: NDJSON (`{json}\n` per message). Same as MCP SDK over stdio. Don't
+  use LSP-style `Content-Length` framing — MCP doesn't use it.
+- **Concurrency**: daemon serves one client at a time. New client = new bridge. Cclsp
+  itself is single-threaded behind one stdio pair, so multi-client multiplexing would
+  need request-ID routing in the daemon (not done; not needed for current usage).
+- **Process lifecycle**: daemon uses `start_new_session=True` (not a manual double-fork)
+  so it survives the spawning shell exiting.
+- **Tests**: `tests/fixtures/mock_mcp_server.py` is a UDS NDJSON mock used by
+  `tests/test_mcp_{client,routing,workspace}.py`. Each test gets its own socket in
+  `/tmp/st-mock-<uuid>.sock`.

--- a/formatters/php-cs-fixer/php-cs-fixer.py
+++ b/formatters/php-cs-fixer/php-cs-fixer.py
@@ -80,15 +80,18 @@ def main() -> None:
         })
         return
 
-    cmd = [phpcsfixer_bin, "fix"]
+    cmd = [phpcsfixer_bin, "fix", "--allow-risky=yes"]
     if phpcsfixer_config:
         cmd += ["--config", phpcsfixer_config]
     cmd.append(file)
 
+    env = os.environ.copy()
+    env.setdefault("PHP_CS_FIXER_IGNORE_ENV", "1")
+
     start = time.time()
     try:
         # php-cs-fixer exits 0 when no fixes, 1 when fixes applied, 16+ on error
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=60, env=env)
     except subprocess.TimeoutExpired:
         emit({
             "tool": "php-cs-fixer", "file": file, "ok": False, "count": 1,

--- a/presets/mcp.json
+++ b/presets/mcp.json
@@ -1,0 +1,34 @@
+{
+  "description": "Long-lived MCP daemon for warm LSP access (cclsp+intelephense/pyright/etc). Without the daemon, every supertool call cold-starts the LSP — pays indexing cost (~30s+ on large repos) per invocation.",
+  "requires": "python3",
+  "ops": {
+    "mcp_daemon": {
+      "cmd": "python3 {path}mcp/daemon.py {args}",
+      "timeout": 86400,
+      "description": "Start an MCP daemon for SERVER_NAME (from .supertool.json mcp block). Blocking; append --detach to background.",
+      "syntax": "mcp_daemon:SERVER_NAME[ --detach]",
+      "example": "mcp_daemon:php-lsp --detach"
+    },
+    "mcp_status": {
+      "cmd": "python3 {path}mcp/status.py",
+      "timeout": 10,
+      "description": "List running MCP daemons (name, pid, uptime, idle, socket path).",
+      "syntax": "mcp_status",
+      "example": "mcp_status"
+    },
+    "mcp_stop": {
+      "cmd": "python3 {path}mcp/stop.py {args}",
+      "timeout": 30,
+      "description": "Stop one MCP daemon by SERVER_NAME (graceful SIGTERM, falls back to SIGKILL after 3s).",
+      "syntax": "mcp_stop:SERVER_NAME",
+      "example": "mcp_stop:php-lsp"
+    },
+    "mcp_stop_all": {
+      "cmd": "python3 {path}mcp/stop.py --all",
+      "timeout": 60,
+      "description": "Stop every supertool MCP daemon found in /tmp/supertool-mcp-*.pid.",
+      "syntax": "mcp_stop_all",
+      "example": "mcp_stop_all"
+    }
+  }
+}

--- a/presets/mcp.json
+++ b/presets/mcp.json
@@ -1,32 +1,32 @@
 {
-  "description": "Long-lived MCP daemon for warm LSP access (cclsp+intelephense/pyright/etc). Without the daemon, every supertool call cold-starts the LSP — pays indexing cost (~30s+ on large repos) per invocation.",
+  "description": "Long-lived MCP daemon — keeps LSPs (intelephense/pyright/etc) warm across calls. Avoids 30s+ cold-start per invocation.",
   "requires": "python3",
   "ops": {
     "mcp_daemon": {
       "cmd": "python3 {path}mcp/daemon.py {args}",
       "timeout": 86400,
-      "description": "Start an MCP daemon for SERVER_NAME (from .supertool.json mcp block). Blocking; append --detach to background.",
+      "description": "Start MCP daemon for SERVER_NAME. Blocking; --detach to background.",
       "syntax": "mcp_daemon:SERVER_NAME[ --detach]",
       "example": "mcp_daemon:php-lsp --detach"
     },
     "mcp_status": {
       "cmd": "python3 {path}mcp/status.py",
       "timeout": 10,
-      "description": "List running MCP daemons (name, pid, uptime, idle, socket path).",
+      "description": "List running MCP daemons: name, pid, uptime, idle, socket.",
       "syntax": "mcp_status",
       "example": "mcp_status"
     },
     "mcp_stop": {
       "cmd": "python3 {path}mcp/stop.py {args}",
       "timeout": 30,
-      "description": "Stop one MCP daemon by SERVER_NAME (graceful SIGTERM, falls back to SIGKILL after 3s).",
+      "description": "Stop MCP daemon SERVER_NAME. SIGTERM, SIGKILL after 3s.",
       "syntax": "mcp_stop:SERVER_NAME",
       "example": "mcp_stop:php-lsp"
     },
     "mcp_stop_all": {
       "cmd": "python3 {path}mcp/stop.py --all",
       "timeout": 60,
-      "description": "Stop every supertool MCP daemon found in /tmp/supertool-mcp-*.pid.",
+      "description": "Stop every supertool MCP daemon.",
       "syntax": "mcp_stop_all",
       "example": "mcp_stop_all"
     }

--- a/presets/mcp/daemon.py
+++ b/presets/mcp/daemon.py
@@ -141,6 +141,10 @@ def serve(name: str, spec: dict) -> int:
         pass
     server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     server.bind(sock_path)
+    # Tighten perms: owner-only. Sockets in /tmp are otherwise world-accessible,
+    # and the socket-path hash (sha1 of cwd+name) is guessable for known projects.
+    try: os.chmod(sock_path, 0o700)
+    except OSError: pass
     server.listen(8)
     server.settimeout(ACCEPT_POLL_SEC)
 

--- a/presets/mcp/daemon.py
+++ b/presets/mcp/daemon.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""MCP daemon — long-lived bridge between a UDS socket and an MCP server subprocess.
+
+Why: spawning cclsp+intelephense per supertool call pays cold-start (30s+) every time.
+This daemon keeps the LSP warm. Supertool clients connect via Unix socket and forward
+JSON-RPC verbatim.
+
+Usage:
+    python3 daemon.py SERVER_NAME           # blocking — serves forever
+    python3 daemon.py SERVER_NAME --detach  # double-fork detach
+
+Reads .supertool.json from cwd, looks up mcp[SERVER_NAME] = {cmd, env, timeout, ...}.
+Socket path: /tmp/supertool-mcp-<sha1(cwd+name)[:12]>.sock
+Pid file:    /tmp/supertool-mcp-<sha1(cwd+name)[:12]>.pid
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import select
+import shlex
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+IDLE_TIMEOUT_SEC = 600  # shutdown after 10min idle
+ACCEPT_POLL_SEC = 1.0
+
+
+def socket_pid_paths(cwd: str, name: str) -> Tuple[str, str]:
+    h = hashlib.sha1(f"{cwd}::{name}".encode()).hexdigest()[:12]
+    base = f"/tmp/supertool-mcp-{h}"
+    return f"{base}.sock", f"{base}.pid"
+
+
+def load_spec(name: str) -> dict:
+    """Walk up from cwd looking for .supertool.json; return mcp[name]."""
+    d = os.path.abspath(os.getcwd())
+    while True:
+        p = os.path.join(d, ".supertool.json")
+        if os.path.isfile(p):
+            with open(p) as f:
+                cfg = json.load(f)
+            spec = (cfg.get("mcp") or {}).get(name)
+            if spec is None:
+                sys.exit(f"daemon: no mcp.{name} in {p}")
+            return spec
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    sys.exit("daemon: no .supertool.json found")
+
+
+def detach() -> None:
+    """Standard double-fork to detach from controlling terminal."""
+    if os.fork() > 0:
+        os._exit(0)
+    os.setsid()
+    if os.fork() > 0:
+        os._exit(0)
+    sys.stdout.flush(); sys.stderr.flush()
+    devnull = os.open(os.devnull, os.O_RDWR)
+    os.dup2(devnull, 0); os.dup2(devnull, 1); os.dup2(devnull, 2)
+
+
+def bridge_client(client_sock: socket.socket, proc: subprocess.Popen, last_activity: list, dbg) -> None:
+    """Bridge one client connection ↔ subprocess stdio using two blocking threads.
+
+    Simpler than select+non-blocking: each direction is a thread doing blocking reads.
+    Either direction closes → set the stop event → both threads exit.
+    """
+    stop = threading.Event()
+    in_fd = proc.stdin.fileno()
+    out_fd = proc.stdout.fileno()
+
+    def client_to_proc() -> None:
+        try:
+            while not stop.is_set():
+                data = client_sock.recv(65536)
+                if not data:
+                    dbg("client→proc: client disconnected"); break
+                os.write(in_fd, data)
+                last_activity[0] = time.time()
+                dbg(f"client→cclsp {len(data)}B")
+        except OSError as e:
+            dbg(f"client→proc error: {e}")
+        finally:
+            stop.set()
+
+    def proc_to_client() -> None:
+        # select() with timeout lets us check stop event without blocking forever
+        # in os.read. Critical: when client disconnects, this thread must exit so the
+        # next client's bridge owns the cclsp stdout fd cleanly.
+        try:
+            while not stop.is_set():
+                r, _, _ = select.select([out_fd], [], [], 0.5)
+                if not r:
+                    continue
+                try:
+                    data = os.read(out_fd, 65536)
+                except BlockingIOError:
+                    continue
+                if not data:
+                    dbg("proc→client: cclsp stdout EOF"); break
+                client_sock.sendall(data)
+                last_activity[0] = time.time()
+                dbg(f"cclsp→client {len(data)}B")
+        except OSError as e:
+            dbg(f"proc→client error: {e}")
+        finally:
+            stop.set()
+
+    t1 = threading.Thread(target=client_to_proc, daemon=True)
+    t2 = threading.Thread(target=proc_to_client, daemon=True)
+    t1.start(); t2.start()
+    while not stop.is_set():
+        if proc.poll() is not None:
+            dbg("bridge: subprocess died")
+            stop.set(); break
+        stop.wait(timeout=1.0)
+    try: client_sock.shutdown(socket.SHUT_RDWR)
+    except OSError: pass
+    t1.join(timeout=2); t2.join(timeout=2)
+
+
+def serve(name: str, spec: dict) -> int:
+    cwd = os.path.abspath(os.getcwd())
+    sock_path, pid_path = socket_pid_paths(cwd, name)
+
+    # Bind socket first (before fork-after-spawn races)
+    try:
+        os.unlink(sock_path)
+    except FileNotFoundError:
+        pass
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(sock_path)
+    server.listen(8)
+    server.settimeout(ACCEPT_POLL_SEC)
+
+    # Spawn MCP server subprocess
+    cmd = spec.get("cmd")
+    if not cmd:
+        sys.exit(f"daemon: mcp.{name}.cmd missing")
+    args = spec.get("args") or []
+    if isinstance(cmd, str) and not args:
+        argv = shlex.split(cmd)
+    else:
+        argv = [cmd] + list(args) if isinstance(cmd, str) else list(cmd) + list(args)
+    env = os.environ.copy()
+    if spec.get("env"):
+        env.update(spec["env"])
+    proc = subprocess.Popen(
+        argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+    )
+
+    # Drain subprocess stderr to /tmp/supertool-mcp-<hash>.stderr (debug aid)
+    stderr_log = open(f"{sock_path}.stderr", "ab", buffering=0)
+    stderr_fd = proc.stderr.fileno()
+    def drain_stderr() -> None:
+        # readline avoids the BufferedReader-on-non-blocking-fd None trap
+        while True:
+            line = proc.stderr.readline()
+            if not line: break
+            stderr_log.write(line)
+    threading.Thread(target=drain_stderr, daemon=True).start()
+
+    # Daemon debug log
+    dbg_log = open(f"{sock_path}.log", "ab", buffering=0)
+    def dbg(msg: str) -> None:
+        dbg_log.write(f"[{time.strftime('%H:%M:%S')}] {msg}\n".encode())
+
+    # Write pidfile
+    with open(pid_path, "w") as f:
+        f.write(str(os.getpid()))
+
+    # Signal-driven shutdown
+    shutting_down = [False]
+    def shutdown(*_):
+        shutting_down[0] = True
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    last_activity = [time.time()]
+    idle_timeout = int(spec.get("idle_timeout", IDLE_TIMEOUT_SEC))
+
+    try:
+        while not shutting_down[0]:
+            # Idle check
+            if time.time() - last_activity[0] > idle_timeout:
+                break
+            # Subprocess died — bail (supervisor will respawn via new client request)
+            if proc.poll() is not None:
+                break
+            try:
+                client_sock, _ = server.accept()
+            except socket.timeout:
+                continue
+            dbg("client connected")
+            try:
+                bridge_client(client_sock, proc, last_activity, dbg)
+            finally:
+                dbg("client disconnected")
+                try:
+                    client_sock.close()
+                except OSError:
+                    pass
+    finally:
+        # Cleanup
+        try: server.close()
+        except OSError: pass
+        try: os.unlink(sock_path)
+        except FileNotFoundError: pass
+        try: os.unlink(pid_path)
+        except FileNotFoundError: pass
+        try: proc.terminate(); proc.wait(timeout=5)
+        except Exception:
+            try: proc.kill()
+            except Exception: pass
+        try: stderr_log.close()
+        except OSError: pass
+    return 0
+
+
+def main(argv: list) -> int:
+    if len(argv) < 2:
+        sys.stderr.write("usage: daemon.py SERVER_NAME [--detach]\n")
+        return 2
+    name = argv[1]
+    do_detach = "--detach" in argv[2:]
+
+    spec = load_spec(name)
+    cwd = os.path.abspath(os.getcwd())
+    sock_path, pid_path = socket_pid_paths(cwd, name)
+
+    # Already running? (pidfile + alive process)
+    if os.path.exists(pid_path):
+        try:
+            with open(pid_path) as f:
+                existing_pid = int(f.read().strip())
+            os.kill(existing_pid, 0)  # check alive
+            sys.stderr.write(f"daemon: already running pid={existing_pid} sock={sock_path}\n")
+            return 0
+        except (ProcessLookupError, ValueError):
+            try: os.unlink(pid_path)
+            except FileNotFoundError: pass
+
+    if do_detach:
+        detach()
+
+    return serve(name, spec)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/presets/mcp/status.py
+++ b/presets/mcp/status.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""List running supertool MCP daemons.
+
+Inspects /tmp/supertool-mcp-*.{sock,pid} pairs and reports name, pid, uptime, and last
+activity. Discovers names by reading .supertool.json mcp block + hashing cwd+name to
+match the socket; otherwise prints the hash-only entry for orphans.
+"""
+from __future__ import annotations
+
+import glob
+import hashlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def find_supertool_json() -> dict:
+    d = os.path.abspath(os.getcwd())
+    while True:
+        p = os.path.join(d, ".supertool.json")
+        if os.path.isfile(p):
+            try:
+                with open(p) as f:
+                    return json.load(f)
+            except (OSError, json.JSONDecodeError):
+                return {}
+        parent = os.path.dirname(d)
+        if parent == d:
+            return {}
+        d = parent
+
+
+def hash_for(name: str) -> str:
+    cwd = os.path.abspath(os.getcwd())
+    return hashlib.sha1(f"{cwd}::{name}".encode()).hexdigest()[:12]
+
+
+def main() -> int:
+    cfg = find_supertool_json()
+    declared = (cfg.get("mcp") or {}).keys()
+    hash_to_name = {hash_for(name): name for name in declared}
+
+    rows = []
+    for pid_path in sorted(glob.glob("/tmp/supertool-mcp-*.pid")):
+        h = Path(pid_path).stem.replace("supertool-mcp-", "")
+        name = hash_to_name.get(h, "?")
+        sock_path = f"/tmp/supertool-mcp-{h}.sock"
+        log_path = f"/tmp/supertool-mcp-{h}.sock.log"
+        try:
+            pid = int(Path(pid_path).read_text().strip())
+        except (OSError, ValueError):
+            pid = 0
+        alive = False
+        if pid:
+            try:
+                os.kill(pid, 0)
+                alive = True
+            except (ProcessLookupError, PermissionError):
+                pass
+        try: st = os.stat(pid_path); uptime = int(time.time() - st.st_mtime)
+        except OSError: uptime = -1
+        try: lst = os.stat(log_path); idle = int(time.time() - lst.st_mtime)
+        except OSError: idle = -1
+        rows.append((name, h, pid, "alive" if alive else "dead", uptime, idle, sock_path))
+
+    if not rows:
+        print("No supertool MCP daemons running.")
+        return 0
+
+    print(f"{'NAME':<16} {'HASH':<14} {'PID':<8} {'STATUS':<8} {'UPTIME':<10} {'IDLE':<10} SOCKET")
+    for name, h, pid, status, uptime, idle, sock in rows:
+        up = f"{uptime}s" if uptime >= 0 else "-"
+        idl = f"{idle}s" if idle >= 0 else "-"
+        print(f"{name:<16} {h:<14} {pid:<8} {status:<8} {up:<10} {idl:<10} {sock}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/presets/mcp/stop.py
+++ b/presets/mcp/stop.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Stop one or all supertool MCP daemons.
+
+Usage:
+    python3 stop.py NAME    # SIGTERM the daemon for NAME (using .supertool.json + cwd)
+    python3 stop.py --all   # stop every supertool-mcp-*.pid found on disk
+
+SIGTERM gives the daemon a chance to clean up its socket + cclsp subprocess. Falls back
+to SIGKILL if it doesn't exit within 3s.
+"""
+from __future__ import annotations
+
+import glob
+import hashlib
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+
+def stop_pid(pid: int) -> bool:
+    """SIGTERM, wait, SIGKILL on hang. Returns True if process is gone after."""
+    try: os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError: return True
+    except PermissionError: return False
+    deadline = time.time() + 3
+    while time.time() < deadline:
+        try: os.kill(pid, 0)
+        except ProcessLookupError: return True
+        time.sleep(0.1)
+    try: os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError: return True
+    time.sleep(0.5)
+    try: os.kill(pid, 0); return False
+    except ProcessLookupError: return True
+
+
+def stop_by_pidfile(pid_path: str) -> str:
+    try:
+        pid = int(Path(pid_path).read_text().strip())
+    except (OSError, ValueError):
+        return f"  {pid_path}: invalid pidfile"
+    if stop_pid(pid):
+        # Daemon cleanup unlinks pidfile, but force-unlink in case SIGKILL was needed
+        try: os.unlink(pid_path)
+        except FileNotFoundError: pass
+        return f"  stopped pid={pid} ({pid_path})"
+    return f"  failed to stop pid={pid} ({pid_path})"
+
+
+def main(argv: list) -> int:
+    if len(argv) < 2:
+        sys.stderr.write("usage: stop.py NAME | --all\n")
+        return 2
+    if argv[1] == "--all":
+        pidfiles = sorted(glob.glob("/tmp/supertool-mcp-*.pid"))
+        if not pidfiles:
+            print("No daemons running.")
+            return 0
+        print(f"Stopping {len(pidfiles)} daemon(s):")
+        for p in pidfiles:
+            print(stop_by_pidfile(p))
+        return 0
+
+    name = argv[1]
+    cwd = os.path.abspath(os.getcwd())
+    h = hashlib.sha1(f"{cwd}::{name}".encode()).hexdigest()[:12]
+    pid_path = f"/tmp/supertool-mcp-{h}.pid"
+    if not os.path.exists(pid_path):
+        print(f"No daemon found for '{name}' (expected {pid_path})")
+        return 1
+    print(f"Stopping daemon '{name}':")
+    print(stop_by_pidfile(pid_path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/supertool.py
+++ b/supertool.py
@@ -95,6 +95,7 @@ import re
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -8228,6 +8229,139 @@ def op_validate(path: str, tool_filter: Optional[list] = None, verbose: bool = F
 
 
 # ---------------------------------------------------------------------------
+# LSP-backed single-file ops: diag, hover, rename
+#
+# All three delegate to the MCP server configured for the file's extension via
+# the `mcp` block in .supertool.json. Without an MCP route the op returns a
+# clear "no LSP configured" message — no heuristic fallback (these ops only
+# make sense with a real language server).
+# ---------------------------------------------------------------------------
+
+def _mcp_call_or_message(op_name: str, file_path: str, args: dict) -> str:
+    """Shared dispatch for diag/hover/rename. Returns the MCP text result or a
+    diagnostic message if no route / no server / call failed.
+    """
+    if not file_path:
+        return f"{op_name}: missing file path\n"
+    route = _mcp_route(file_path, op_name)
+    if route is None:
+        return f"{op_name}: no LSP configured for {file_path} (add mcp.{op_name} mapping in .supertool.json)\n"
+    server_name, mcp_tool = route
+    server = _mcp_ensure_server(server_name)
+    if server is None:
+        return f"{op_name}: MCP server '{server_name}' unavailable\n"
+    try:
+        result = _mcp_call(server_name, mcp_tool, args)
+    except (MCPServerError, MCPTimeout) as e:
+        return f"{op_name}: MCP error: {e}\n"
+    if result is None:
+        return f"{op_name}: no result from {mcp_tool}\n"
+    # Pull text content (most common MCP response shape)
+    content = result.get("content") if isinstance(result, dict) else None
+    if isinstance(content, list):
+        texts = [item.get("text", "") for item in content
+                 if isinstance(item, dict) and item.get("type") == "text"]
+        text = "\n".join(t for t in texts if t)
+        if text:
+            return text.rstrip("\n") + "\n"
+    return json.dumps(result, indent=2) + "\n"
+
+
+def op_diag(file_path: str) -> str:
+    """LSP diagnostics (errors/warnings) for FILE. Requires `mcp.<server>.tools.diag` mapping."""
+    return _mcp_call_or_message("diag", file_path, {"file_path": os.path.abspath(file_path) if file_path else ""})
+
+
+def op_hover(symbol: str, file_path: str) -> str:
+    """LSP hover info (type, signature, doc) for SYMBOL in FILE.
+
+    Two-step internally:
+      1. find_workspace_symbols(query=symbol) → first match's (file, line, character)
+      2. get_hover(file_path, line, character) → text result
+
+    Some MCP/LSP servers (cclsp) require position-based hover. This op hides that.
+    Requires both `tools.resolve` (or `tools.hover_resolve`) and `tools.hover` mappings.
+    """
+    if not symbol or not file_path:
+        return "hover: usage hover:SYMBOL:FILE\n"
+    abs_file = os.path.abspath(file_path)
+
+    # Step 1: locate the symbol via workspace symbols. Use the configured `resolve`
+    # tool — it's expected to be find_workspace_symbols (returns 'at /path:line:col').
+    resolve_route = _mcp_route(file_path, "resolve")
+    if resolve_route is None:
+        return "hover: no resolve mapping (needed to locate symbol position) — add mcp.<server>.tools.resolve\n"
+    rs_server, rs_tool = resolve_route
+    server = _mcp_ensure_server(rs_server)
+    if server is None:
+        return f"hover: MCP server '{rs_server}' unavailable\n"
+    try:
+        rs_result = _mcp_call(rs_server, rs_tool, {
+            "query": symbol, "symbol_name": symbol, "file_path": abs_file,
+        })
+    except (MCPServerError, MCPTimeout) as e:
+        return f"hover: locate failed: {e}\n"
+    if rs_result is None:
+        return f"hover: '{symbol}' not found in workspace\n"
+
+    # Parse "at /path:line:character" from text content; prefer same-file matches
+    pos: Optional[Tuple[str, int, int]] = None
+    fallback_pos: Optional[Tuple[str, int, int]] = None
+    content = rs_result.get("content") if isinstance(rs_result, dict) else None
+    if isinstance(content, list):
+        for item in content:
+            text = item.get("text", "") if isinstance(item, dict) else ""
+            for m in re.finditer(r"\sat\s+(\S+?):(\d+):(\d+)", text):
+                p_file, p_line, p_char = m.group(1), int(m.group(2)), int(m.group(3))
+                cand = (p_file, p_line, p_char)
+                if os.path.abspath(p_file) == abs_file:
+                    pos = cand; break
+                if fallback_pos is None:
+                    fallback_pos = cand
+            if pos: break
+    if pos is None:
+        pos = fallback_pos
+    if pos is None:
+        return f"hover: '{symbol}' not found (no position in resolve result)\n"
+
+    target_file, line, character = pos
+
+    # The line:col from find_workspace_symbols often points at the declaration start
+    # (e.g. `public` keyword) — LSP hover at that column returns nothing. Re-anchor
+    # to the actual identifier offset within the source line.
+    try:
+        with open(target_file, "rb") as f:
+            src_lines = f.readlines()
+        if 0 < line <= len(src_lines):
+            src = src_lines[line - 1].decode("utf-8", errors="replace")
+            idx = src.find(symbol)
+            if idx >= 0:
+                character = idx + 1  # 1-indexed
+    except OSError:
+        pass
+
+    # Step 2: hover at position
+    return _mcp_call_or_message("hover", file_path, {
+        "file_path": os.path.abspath(target_file),
+        "line": line, "character": character,
+    })
+
+
+def op_rename(old_symbol: str, new_symbol: str, file_path: str) -> str:
+    """LSP workspace rename: OLD_SYMBOL → NEW_SYMBOL across the workspace. Requires `mcp.<server>.tools.rename` mapping.
+
+    The MCP server applies changes across all affected files (cclsp's rename_symbol
+    writes .bak backups). Returns the server's report of modified files.
+    """
+    if not old_symbol or not new_symbol:
+        return "rename: usage rename:OLD_SYMBOL:NEW_SYMBOL:FILE\n"
+    return _mcp_call_or_message("rename", file_path, {
+        "symbol_name": old_symbol, "query": old_symbol, "new_name": new_symbol,
+        "file_path": os.path.abspath(file_path) if file_path else "",
+    })
+
+
+# ---------------------------------------------------------------------------
 # workspace — one-shot IDE-style view of a single file
 # ---------------------------------------------------------------------------
 
@@ -8310,7 +8444,11 @@ def _op_resolve_inner(symbol: str, from_file: Optional[str] = None) -> str:
             server = _mcp_ensure_server(server_name)
             if server is not None:
                 try:
-                    result = _mcp_call(server_name, mcp_tool, {"symbol": symbol, "file": from_file})
+                    # Send under multiple naming conventions so the tool picks what it needs:
+                    # cclsp find_definition uses symbol_name/file_path, find_workspace_symbols uses query.
+                    result = _mcp_call(server_name, mcp_tool, {
+                        "symbol_name": symbol, "file_path": from_file, "query": symbol,
+                    })
                     if result is not None:
                         path = _extract_path_from_mcp_result(result)
                         if path:
@@ -8533,6 +8671,26 @@ def op_workspace(path: str) -> str:
         out.append("[complete file — no more lines]\n")
     out.append("\n")
 
+    # ── Section 1.5: Diagnostics (LSP, only when configured) ────────────────
+    _diag_route = _mcp_route(path, "diag")
+    if _diag_route:
+        _diag_server_name, _diag_mcp_tool = _diag_route
+        _diag_server = _mcp_ensure_server(_diag_server_name)
+        if _diag_server:
+            try:
+                _diag_result = _mcp_call(_diag_server_name, _diag_mcp_tool,
+                                         {"file_path": os.path.abspath(path)})
+                if isinstance(_diag_result, dict):
+                    _diag_text = _extract_symbols_from_mcp_result(_diag_result)
+                    if _diag_text and _diag_text.strip():
+                        out.append("## Diagnostics\n\n")
+                        out.append(_diag_text)
+                        if not _diag_text.endswith("\n"):
+                            out.append("\n")
+                        out.append("\n")
+            except (MCPServerError, MCPTimeout):
+                pass
+
     # ── Section 2: Symbols ───────────────────────────────────────────────────
     out.append("## Symbols\n\n")
     _sym_mcp_used = False
@@ -8542,7 +8700,7 @@ def op_workspace(path: str) -> str:
         _sym_server = _mcp_ensure_server(_sym_server_name)
         if _sym_server:
             try:
-                _sym_mcp_result = _mcp_call(_sym_server_name, _sym_mcp_tool, {"file": os.path.abspath(path)})
+                _sym_mcp_result = _mcp_call(_sym_server_name, _sym_mcp_tool, {"file_path": os.path.abspath(path)})
                 if _sym_mcp_result is not None:
                     _sym_text = _extract_symbols_from_mcp_result(_sym_mcp_result)
                     if _sym_text is not None:
@@ -8738,7 +8896,7 @@ def op_workspace(path: str) -> str:
         _refs_server = _mcp_ensure_server(_refs_server_name)
         if _refs_server:
             try:
-                _refs_mcp_result = _mcp_call(_refs_server_name, _refs_mcp_tool, {"symbol": symbol, "file": os.path.abspath(path)})
+                _refs_mcp_result = _mcp_call(_refs_server_name, _refs_mcp_tool, {"symbol_name": symbol, "file_path": os.path.abspath(path)})
                 if _refs_mcp_result is not None:
                     _mcp_refs = _extract_refs_from_mcp_result(_refs_mcp_result)
                     if _mcp_refs is not None:
@@ -9608,7 +9766,17 @@ def dispatch(arg: str) -> str:
             body = op_format_staged(fs_tools or None, verbose=fs_verbose)
         elif op == "resolve":
             rs_symbol = parts[1] if len(parts) > 1 else ""
-            body = op_resolve(rs_symbol)
+            rs_from_file = parts[2] if len(parts) > 2 else None
+            body = op_resolve(rs_symbol, rs_from_file)
+        elif op == "diag":
+            body = op_diag(parts[1] if len(parts) > 1 else "")
+        elif op == "hover":
+            body = op_hover(parts[1] if len(parts) > 1 else "",
+                            parts[2] if len(parts) > 2 else "")
+        elif op == "rename":
+            body = op_rename(parts[1] if len(parts) > 1 else "",
+                             parts[2] if len(parts) > 2 else "",
+                             parts[3] if len(parts) > 3 else "")
         elif op == "workspace":
             ws_path = parts[1] if len(parts) > 1 else ""
             body = op_workspace(ws_path)
@@ -9691,236 +9859,11 @@ class MCPServerError(Exception):
         self.data = data
 
 
-class MCPServer:
-    """Manages a single MCP server subprocess with JSON-RPC 2.0 over stdio."""
-
-    def __init__(
-        self,
-        name: str,
-        cmd: str,
-        env: Optional[Dict[str, str]] = None,
-        timeout: int = 30,
-    ) -> None:
-        self.name = name
-        self.cmd = cmd
-        self.env = env
-        self.timeout = timeout
-        self._proc: Optional[subprocess.Popen] = None  # type: ignore[type-arg]
-        self._lock = threading.Lock()
-        self._id_counter = 0
-        self._id_lock = threading.Lock()
-        self._dead = False  # Set on timeout; cleared only by constructing a new instance
-
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def spawn(self) -> None:
-        """Start the server process. Idempotent — does nothing if already alive."""
-        with self._lock:
-            if self._proc is not None and self._proc.poll() is None:
-                return
-            merged_env = os.environ.copy()
-            if self.env:
-                merged_env.update(self.env)
-            self._proc = subprocess.Popen(
-                shlex.split(self.cmd),
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=merged_env,
-            )
-
-    def is_alive(self) -> bool:
-        """Return True if the subprocess is running."""
-        return self._proc is not None and self._proc.poll() is None
-
-    def shutdown(self) -> None:
-        """Gracefully shut down the server; SIGTERM if it hangs."""
-        with self._lock:
-            if self._proc is None:
-                return
-            proc = self._proc
-            self._proc = None
-            dead = self._dead
-        if proc.poll() is not None:
-            return
-        # Dead server (marked dead after timeout) — skip graceful path. The
-        # child is most likely stuck in a sleep/blocking call that won't
-        # respond to stdin close. Go straight to SIGTERM.
-        if dead:
-            proc.terminate()
-            try:
-                proc.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-            return
-        # Healthy server — try graceful shutdown.
-        # Send JSON-RPC shutdown notification before closing stdin so the
-        # server can clean up state. Wrapped in try because the pipe may
-        # already be dead.
-        try:
-            if proc.stdin:
-                body = json.dumps({"jsonrpc": "2.0", "method": "shutdown"}).encode("utf-8")
-                header = f"Content-Length: {len(body)}\r\n\r\n".encode("utf-8")
-                proc.stdin.write(header + body)
-                proc.stdin.flush()
-        except (OSError, BrokenPipeError):
-            pass
-        try:
-            if proc.stdin:
-                proc.stdin.close()
-        except OSError:
-            pass
-        try:
-            proc.wait(timeout=2)
-        except subprocess.TimeoutExpired:
-            proc.terminate()
-            try:
-                proc.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-
-    # ------------------------------------------------------------------
-    # JSON-RPC 2.0 transport
-    # ------------------------------------------------------------------
-
-    def _next_id(self) -> int:
-        with self._id_lock:
-            self._id_counter += 1
-            return self._id_counter
-
-    def _send(self, payload: dict) -> None:
-        """Encode and write one JSON-RPC message with Content-Length framing."""
-        if self._proc is None or self._proc.stdin is None:
-            raise RuntimeError(f"MCP server '{self.name}' is not running")
-        body = json.dumps(payload).encode("utf-8")
-        header = f"Content-Length: {len(body)}\r\n\r\n".encode("utf-8")
-        self._proc.stdin.write(header + body)
-        self._proc.stdin.flush()
-
-    def _recv(self) -> dict:
-        """Read one Content-Length-framed JSON-RPC message from stdout."""
-        if self._proc is None or self._proc.stdout is None:
-            raise RuntimeError(f"MCP server '{self.name}' is not running")
-        stdout = self._proc.stdout
-        # Read headers until blank line
-        content_length = 0
-        while True:
-            line = stdout.readline()
-            if not line:
-                # TODO(sub-PR-2): crash recovery + backoff per spec §5
-                raise EOFError(f"MCP server '{self.name}' closed stdout")
-            line = line.decode("utf-8").rstrip("\r\n")
-            if line == "":
-                break
-            if line.lower().startswith("content-length:"):
-                content_length = int(line.split(":", 1)[1].strip())
-        if content_length == 0:
-            raise ValueError(f"MCP server '{self.name}': missing Content-Length")
-        raw = b""
-        remaining = content_length
-        while remaining > 0:
-            chunk = stdout.read(remaining)
-            if not chunk:
-                raise EOFError(f"MCP server '{self.name}' closed stdout mid-body")
-            raw += chunk
-            remaining -= len(chunk)
-        return json.loads(raw.decode("utf-8"))
-
-    def _call(self, method: str, params: Optional[dict] = None) -> Any:
-        """Send a JSON-RPC request and return the result, with timeout.
-
-        Raises MCPTimeout on deadline, MCPServerError on RPC error object.
-        """
-        req_id = self._next_id()
-        payload: dict = {"jsonrpc": "2.0", "id": req_id, "method": method}
-        if params is not None:
-            payload["params"] = params
-
-        result_holder: List[Any] = []
-        error_holder: List[BaseException] = []
-
-        def _worker() -> None:
-            try:
-                self._send(payload)
-                msg = self._recv()
-                result_holder.append(msg)
-            except BaseException as exc:
-                error_holder.append(exc)
-
-        t = threading.Thread(target=_worker, daemon=True)
-        t.start()
-        t.join(timeout=self.timeout)
-        if t.is_alive():
-            # Mark dead and close stdout so the blocked worker thread unblocks.
-            # Subsequent calls will fail fast via the _dead guard below.
-            self._dead = True
-            try:
-                if self._proc and self._proc.stdout:
-                    self._proc.stdout.close()
-            except OSError:
-                pass
-            raise MCPTimeout(
-                f"MCP server '{self.name}' timed out after {self.timeout}s "
-                f"(method={method})"
-            )
-        if self._dead:
-            raise MCPServerError(f"MCP server '{self.name}' marked dead after timeout")
-        if error_holder:
-            raise error_holder[0]
-        msg = result_holder[0]
-        if "error" in msg:
-            err = msg["error"]
-            raise MCPServerError(
-                err.get("message", "unknown error"),
-                code=err.get("code", 0),
-                data=err.get("data"),
-            )
-        return msg.get("result")
-
-    # ------------------------------------------------------------------
-    # MCP protocol methods
-    # ------------------------------------------------------------------
-
-    def initialize(self) -> dict:
-        """Send the MCP initialize handshake and return the server's capabilities."""
-        result = self._call(
-            "initialize",
-            {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "supertool", "version": VERSION},
-            },
-        )
-        # Send initialized notification (no response expected)
-        notif = {"jsonrpc": "2.0", "method": "notifications/initialized"}
-        try:
-            self._send(notif)
-        except OSError:
-            pass
-        return result or {}
-
-    def list_tools(self) -> List[dict]:
-        """Return the list of tools exposed by this MCP server."""
-        result = self._call("tools/list")
-        if isinstance(result, dict):
-            return result.get("tools", [])
-        return []
-
-    def call_tool(self, name: str, args: dict) -> dict:
-        """Invoke a tool by name and return the result dict."""
-        result = self._call("tools/call", {"name": name, "arguments": args})
-        if result is None:
-            return {}
-        return result
-
-
 # ---------------------------------------------------------------------------
 # Module-level server registry + lifecycle
 # ---------------------------------------------------------------------------
 
-_MCP_SERVERS: Dict[str, MCPServer] = {}
+_MCP_SERVERS: Dict[str, MCPClient] = {}
 _MCP_LOCK = threading.Lock()
 
 
@@ -9971,8 +9914,166 @@ def _mcp_route(path: str, op: str) -> Optional[Tuple[str, str]]:
     return None
 
 
-def _mcp_ensure_server(name: str) -> Optional[MCPServer]:
-    """Get-or-spawn MCPServer for a configured name. None on any failure."""
+_MCP_DAEMON_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "presets", "mcp", "daemon.py")
+
+
+class MCPClient:
+    """MCP client that talks to a long-lived daemon over a Unix socket using NDJSON.
+
+    Why: subprocess-per-call spawns the LSP server (intelephense etc.) cold every time,
+    paying 30s+ indexing on each invocation. A persistent daemon keeps the LSP warm.
+
+    Wire format: each JSON-RPC message is a single line terminated by `\n` (NDJSON).
+    Matches what the official MCP Python SDK speaks over stdio.
+
+    socket_path: optional override. Default = /tmp/supertool-mcp-<sha1(cwd+name)[:12]>.sock.
+    Tests pass an explicit path to talk to a pre-spawned mock server.
+    """
+
+    def __init__(self, name: str, timeout: int = 30, socket_path: Optional[str] = None) -> None:
+        self.name = name
+        self.timeout = timeout
+        self._sock: Optional[socket.socket] = None
+        self._lock = threading.Lock()
+        self._id_counter = 0
+        self._id_lock = threading.Lock()
+        self._buf = b""
+        self._dead = False
+        if socket_path:
+            self._sock_path = socket_path
+            self._auto_spawn = False
+        else:
+            cwd = os.path.abspath(os.getcwd())
+            h = hashlib.sha1(f"{cwd}::{name}".encode()).hexdigest()[:12]
+            self._sock_path = f"/tmp/supertool-mcp-{h}.sock"
+            self._auto_spawn = True
+
+    def spawn(self) -> None:
+        """Connect to daemon socket. Auto-spawn detached daemon if not running."""
+        with self._lock:
+            if self._sock is not None:
+                return
+            for attempt in range(15):  # ~7.5s total
+                try:
+                    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    s.settimeout(self.timeout)
+                    s.connect(self._sock_path)
+                    self._sock = s
+                    return
+                except (FileNotFoundError, ConnectionRefusedError):
+                    if attempt == 0 and self._auto_spawn:
+                        # First miss → spawn daemon detached (production path only)
+                        try:
+                            subprocess.Popen(
+                                [sys.executable, _MCP_DAEMON_SCRIPT, self.name, "--detach"],
+                                stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL, close_fds=True,
+                            )
+                        except OSError:
+                            pass
+                    time.sleep(0.5)
+            raise MCPServerError(f"MCP daemon for '{self.name}' did not come up at {self._sock_path}")
+
+    def is_alive(self) -> bool:
+        return self._sock is not None and not self._dead
+
+    def shutdown(self) -> None:
+        """Close socket. Does NOT kill daemon (it stays alive for other clients)."""
+        with self._lock:
+            if self._sock is not None:
+                try: self._sock.close()
+                except OSError: pass
+                self._sock = None
+
+    def _next_id(self) -> int:
+        with self._id_lock:
+            self._id_counter += 1
+            return self._id_counter
+
+    def _send(self, payload: dict) -> None:
+        if self._sock is None:
+            raise RuntimeError(f"MCP daemon '{self.name}' not connected")
+        line = (json.dumps(payload) + "\n").encode("utf-8")
+        self._sock.sendall(line)
+
+    def _recv_line(self) -> bytes:
+        """Read one NDJSON-framed message (until newline). Honors self.timeout."""
+        if self._sock is None:
+            raise RuntimeError(f"MCP daemon '{self.name}' not connected")
+        deadline = time.time() + self.timeout
+        while b"\n" not in self._buf:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                self._dead = True
+                raise MCPTimeout(f"MCP daemon '{self.name}' read timed out after {self.timeout}s")
+            self._sock.settimeout(remaining)
+            try:
+                chunk = self._sock.recv(65536)
+            except socket.timeout:
+                self._dead = True
+                raise MCPTimeout(f"MCP daemon '{self.name}' read timed out after {self.timeout}s")
+            if not chunk:
+                self._dead = True
+                raise MCPServerError(f"MCP daemon '{self.name}' closed connection")
+            self._buf += chunk
+        line, _, rest = self._buf.partition(b"\n")
+        self._buf = rest
+        return line
+
+    def _call(self, method: str, params: Optional[dict] = None) -> Any:
+        """Send a JSON-RPC request and wait for the matching response."""
+        msg_id = self._next_id()
+        payload = {"jsonrpc": "2.0", "method": method, "id": msg_id}
+        if params is not None:
+            payload["params"] = params
+        with self._lock:
+            self._send(payload)
+            # Loop until we find OUR id (skip notifications/other responses)
+            for _ in range(100):
+                line = self._recv_line()
+                msg = json.loads(line.decode("utf-8"))
+                if msg.get("id") != msg_id:
+                    continue  # not for us
+                if "error" in msg:
+                    err = msg["error"]
+                    raise MCPServerError(
+                        err.get("message", "unknown error"),
+                        code=err.get("code", 0),
+                        data=err.get("data"),
+                    )
+                return msg.get("result")
+            raise MCPServerError(f"MCP daemon '{self.name}': no matching response for id={msg_id}")
+
+    def initialize(self) -> dict:
+        result = self._call("initialize", {
+            "protocolVersion": "2024-11-05", "capabilities": {},
+            "clientInfo": {"name": "supertool", "version": VERSION},
+        })
+        notif = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        with self._lock:
+            try: self._send(notif)
+            except OSError: pass
+        return result or {}
+
+    def list_tools(self) -> List[dict]:
+        result = self._call("tools/list")
+        if isinstance(result, dict):
+            return result.get("tools", [])
+        return []
+
+    def call_tool(self, name: str, args: dict) -> dict:
+        result = self._call("tools/call", {"name": name, "arguments": args})
+        if result is None:
+            return {}
+        return result
+
+
+def _mcp_ensure_server(name: str):
+    """Get-or-spawn an MCP client (daemon or subprocess transport). None on failure.
+
+    Client connects to a long-lived daemon over Unix socket; daemon owns the real MCP
+    server subprocess (cclsp, etc.) and keeps it warm across supertool invocations.
+    """
     server = _mcp_get_server(name)
     if server is not None:
         return server
@@ -9980,10 +10081,8 @@ def _mcp_ensure_server(name: str) -> Optional[MCPServer]:
     if spec is None:
         return None
     try:
-        server = MCPServer(
-            name=name, cmd=spec["cmd"],
-            env=spec.get("env"), timeout=int(spec.get("timeout", 30)),
-        )
+        server = MCPClient(name=name, timeout=int(spec.get("timeout", 30)),
+                           socket_path=spec.get("socket_path"))
         server.spawn()
         server.initialize()
     except (OSError, MCPServerError, MCPTimeout, KeyError):
@@ -10021,7 +10120,13 @@ def _extract_symbols_from_mcp_result(result: Any) -> Optional[str]:
 
 
 def _extract_path_from_mcp_result(result: Any) -> Optional[str]:
-    """Normalize MCP response into a single file path string."""
+    """Normalize MCP response into a single file path string.
+
+    Handles a few common shapes produced by different MCP servers:
+      - text content = single path or file:// URI
+      - bullet list  = `• Name (kind) at /path:line:col` (cclsp find_workspace_symbols)
+      - {uri: file://...} or {path: "/..."}
+    """
     from urllib.parse import urlparse, unquote
 
     if not isinstance(result, dict):
@@ -10033,14 +10138,28 @@ def _extract_path_from_mcp_result(result: Any) -> Optional[str]:
             return unquote(parsed.path)
         return s
 
+    def _extract_first_path_from_bullets(text: str) -> Optional[str]:
+        # cclsp find_workspace_symbols shape:
+        #   "Found N symbol(s) matching "Foo":\n\n• Foo (class) at /path/Foo.php:19:1\n..."
+        # Grab the FIRST `at /path:line:col` we can find.
+        m = re.search(r"\sat\s+(/[^\s:]+(?:\:[^\s:]+)*?)(?:\:\d+(?:\:\d+)?)?\s*$",
+                      text, flags=re.MULTILINE)
+        return m.group(1) if m else None
+
     # Shape 1: {"content": [{"type": "text", "text": "..."}]}
     content = result.get("content")
     if isinstance(content, list):
         for item in content:
             if isinstance(item, dict) and item.get("type") == "text":
-                text = item.get("text", "")
-                if text:
-                    return _normalize_file_url_or_path(text)
+                text = item.get("text", "").strip()
+                if not text:
+                    continue
+                # If it looks like a bullet listing, parse out the first path
+                if "• " in text or "\n• " in text or text.startswith("Found "):
+                    p = _extract_first_path_from_bullets(text)
+                    if p:
+                        return p
+                return _normalize_file_url_or_path(text)
     # Shape 2: {"uri": "file:///path"}
     uri = result.get("uri")
     if isinstance(uri, str):
@@ -10055,8 +10174,8 @@ def _extract_path_from_mcp_result(result: Any) -> Optional[str]:
 # Helper API for supertool ops (sub-PR 2 entry points)
 # ---------------------------------------------------------------------------
 
-def _mcp_get_server(name: str) -> Optional[MCPServer]:
-    """Return a live MCPServer for *name* from the registry, or None.
+def _mcp_get_server(name: str) -> Optional[MCPClient]:
+    """Return a live MCPClient for *name* from the registry, or None.
 
     Removes dead servers so the registry stays clean. Does NOT spawn — callers
     that want lazy-spawn should use _mcp_register first or call _mcp_call with
@@ -10072,7 +10191,7 @@ def _mcp_get_server(name: str) -> Optional[MCPServer]:
     return None
 
 
-def _mcp_register(name: str, server: MCPServer) -> None:
+def _mcp_register(name: str, server: MCPClient) -> None:
     """Pre-register a server instance under *name*.
 
     Used by tests and by the sub-PR 2 config loader to inject servers before

--- a/supertool.py
+++ b/supertool.py
@@ -8328,15 +8328,16 @@ def op_hover(symbol: str, file_path: str) -> str:
 
     # The line:col from find_workspace_symbols often points at the declaration start
     # (e.g. `public` keyword) — LSP hover at that column returns nothing. Re-anchor
-    # to the actual identifier offset within the source line.
+    # to the actual identifier offset within the source line. Use word-boundary regex
+    # so `handle` doesn't match the param `$handle` instead of the method name.
     try:
         with open(target_file, "rb") as f:
             src_lines = f.readlines()
         if 0 < line <= len(src_lines):
             src = src_lines[line - 1].decode("utf-8", errors="replace")
-            idx = src.find(symbol)
-            if idx >= 0:
-                character = idx + 1  # 1-indexed
+            m = re.search(r"\b" + re.escape(symbol) + r"\b", src)
+            if m:
+                character = m.start() + 1  # 1-indexed
     except OSError:
         pass
 

--- a/supertool.py
+++ b/supertool.py
@@ -466,7 +466,7 @@ def _rtk_run(args: List[str], timeout: int = 30) -> str | None:
     return None
 
 # Built-in op names — custom ops/aliases with these names are ignored
-_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines", "paste", "vi", "validate", "format", "validate_staged", "format_staged", "workspace", "resolve"}
+_BUILTIN_OPS = {"read", "grep", "grep_around", "glob", "ls", "tail", "head", "wc", "check", "around", "map", "diff", "stat", "around_line", "tree", "replace", "replace_dry", "edit", "replace_lines", "paste", "vi", "validate", "format", "validate_staged", "format_staged", "workspace", "resolve", "diag", "hover", "rename"}
 
 # Read-only built-in ops — safe to run in parallel across a batch.
 # Excludes mutating ops (replace, edit, replace_lines) and custom ops
@@ -475,7 +475,7 @@ _PARALLEL_SAFE_OPS = {
     "read", "grep", "glob", "ls", "head", "tail", "wc", "stat",
     "map", "tree", "around", "around_line", "between", "diff", "blame",
     "version", "validate", "validate_staged", "format_staged", "workspace",
-    "resolve",
+    "resolve", "diag", "hover",
 }
 
 

--- a/tests/fixtures/mock_mcp_server.py
+++ b/tests/fixtures/mock_mcp_server.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
-"""Minimal MCP server fixture for test_mcp_client.py.
+"""Minimal MCP server fixture for MCP client/routing tests.
 
-Speaks JSON-RPC 2.0 over stdio with Content-Length framing.
-Behaviour is controlled via environment variables:
+Listens on a Unix socket (path passed as argv[1]) and speaks NDJSON JSON-RPC 2.0 —
+the same wire format the official MCP Python SDK uses over stdio. Each request is one
+JSON line terminated by `\n`. Responses likewise.
+
+Behaviour controlled via env vars:
   MOCK_MCP_HANG=1        — sleep forever on tools/call (triggers MCPTimeout)
   MOCK_MCP_TOOL_ERROR=1  — return a JSON-RPC error on tools/call
 """
@@ -10,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import sys
 import time
 
@@ -17,139 +21,117 @@ TOOLS = [
     {
         "name": "echo",
         "description": "Echo back args",
-        "inputSchema": {
-            "type": "object",
-            "properties": {"message": {"type": "string"}},
-        },
+        "inputSchema": {"type": "object",
+                        "properties": {"message": {"type": "string"}}},
     },
     {
         "name": "definition",
         "description": "Mock LSP-style definition lookup",
         "inputSchema": {"type": "object",
-                        "properties": {"symbol": {"type": "string"},
-                                       "file": {"type": "string"}}},
+                        "properties": {"symbol_name": {"type": "string"},
+                                       "file_path": {"type": "string"}}},
     },
     {
         "name": "references",
         "description": "Mock LSP-style references lookup",
         "inputSchema": {"type": "object",
-                        "properties": {"symbol": {"type": "string"},
-                                       "file": {"type": "string"}}},
+                        "properties": {"symbol_name": {"type": "string"},
+                                       "file_path": {"type": "string"}}},
     },
     {
         "name": "documentSymbol",
         "description": "Mock LSP-style document symbol listing",
         "inputSchema": {"type": "object",
-                        "properties": {"file": {"type": "string"}}},
+                        "properties": {"file_path": {"type": "string"}}},
     },
 ]
 
 
-def send(payload: dict) -> None:
-    body = json.dumps(payload).encode("utf-8")
-    header = f"Content-Length: {len(body)}\r\n\r\n".encode("utf-8")
-    sys.stdout.buffer.write(header + body)
-    sys.stdout.buffer.flush()
-
-
-def recv() -> dict:
-    content_length = 0
-    while True:
-        line = sys.stdin.buffer.readline()
-        if not line:
-            sys.exit(0)
-        line = line.decode("utf-8").rstrip("\r\n")
-        if line == "":
-            break
-        if line.lower().startswith("content-length:"):
-            content_length = int(line.split(":", 1)[1].strip())
-    raw = sys.stdin.buffer.read(content_length)
-    return json.loads(raw.decode("utf-8"))
-
-
-def handle(msg: dict) -> None:
+def handle_request(msg: dict) -> dict | None:
     method = msg.get("method", "")
     msg_id = msg.get("id")
-
-    # Notifications have no id — no response needed
     if msg_id is None:
-        return
+        return None  # notification
 
     if method == "initialize":
-        send({
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {"tools": {}},
-                "serverInfo": {"name": "mock-mcp", "version": "0.0.1"},
-            },
-        })
-    elif method == "tools/list":
-        send({
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {"tools": TOOLS},
-        })
-    elif method == "tools/call":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "mock-mcp", "version": "0.0.1"},
+        }}
+    if method == "tools/list":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {"tools": TOOLS}}
+    if method == "tools/call":
         if os.environ.get("MOCK_MCP_HANG") == "1":
             time.sleep(9999)
-            return
+            return None
         if os.environ.get("MOCK_MCP_TOOL_ERROR") == "1":
-            send({
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "error": {"code": -32000, "message": "tool execution failed"},
-            })
-            return
+            return {"jsonrpc": "2.0", "id": msg_id,
+                    "error": {"code": -32000, "message": "tool execution failed"}}
         params = msg.get("params", {})
         tool_name = params.get("name", "")
         args = params.get("arguments", {})
         if tool_name == "definition":
-            send({
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {"content": [{"type": "text",
-                                        "text": args.get("file", "/mock/resolved.php")}]},
-            })
-            return
+            return {"jsonrpc": "2.0", "id": msg_id, "result": {"content": [
+                {"type": "text", "text": args.get("file_path", "/mock/resolved.php")}]}}
         if tool_name == "references":
-            send({
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {"content": [{"type": "text",
-                                        "text": "file1.php:10:line content\nfile2.php:20:other content"}]},
-            })
-            return
+            return {"jsonrpc": "2.0", "id": msg_id, "result": {"content": [
+                {"type": "text", "text": "file1.php:10:line content\nfile2.php:20:other content"}]}}
         if tool_name == "documentSymbol":
-            send({
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {"content": [{"type": "text",
-                                        "text": "class Foo  [10-50]\n  method bar  [12-20]"}]},
-            })
-            return
-        send({
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {"content": [{"type": "text", "text": json.dumps(args)}]},
-        })
-    else:
-        send({
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "error": {"code": -32601, "message": f"method not found: {method}"},
-        })
+            return {"jsonrpc": "2.0", "id": msg_id, "result": {"content": [
+                {"type": "text", "text": "class Foo  [10-50]\n  method bar  [12-20]"}]}}
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {"content": [
+            {"type": "text", "text": json.dumps(args)}]}}
+    return {"jsonrpc": "2.0", "id": msg_id,
+            "error": {"code": -32601, "message": f"method not found: {method}"}}
 
 
-def main() -> None:
-    while True:
-        try:
-            msg = recv()
-        except (EOFError, json.JSONDecodeError):
-            break
-        handle(msg)
+def serve_client(client_sock: socket.socket) -> None:
+    f = client_sock.makefile("rwb", buffering=0)
+    try:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            resp = handle_request(msg)
+            if resp is not None:
+                f.write((json.dumps(resp) + "\n").encode("utf-8"))
+    except OSError:
+        pass
+    finally:
+        try: f.close()
+        except OSError: pass
+
+
+def main(argv: list) -> int:
+    if len(argv) < 2:
+        sys.stderr.write("usage: mock_mcp_server.py SOCKET_PATH\n")
+        return 2
+    sock_path = argv[1]
+    try: os.unlink(sock_path)
+    except FileNotFoundError: pass
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(sock_path)
+    server.listen(8)
+    try:
+        while True:
+            client, _ = server.accept()
+            serve_client(client)
+            try: client.close()
+            except OSError: pass
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try: server.close()
+        except OSError: pass
+        try: os.unlink(sock_path)
+        except FileNotFoundError: pass
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main(sys.argv))

--- a/tests/fixtures/mock_mcp_server.py
+++ b/tests/fixtures/mock_mcp_server.py
@@ -44,6 +44,20 @@ TOOLS = [
         "inputSchema": {"type": "object",
                         "properties": {"file_path": {"type": "string"}}},
     },
+    {
+        "name": "find_workspace_symbols",
+        "description": "Mock LSP-style workspace symbol search",
+        "inputSchema": {"type": "object",
+                        "properties": {"query": {"type": "string"}}},
+    },
+    {
+        "name": "get_hover",
+        "description": "Mock LSP-style hover at position",
+        "inputSchema": {"type": "object",
+                        "properties": {"file_path": {"type": "string"},
+                                       "line": {"type": "number"},
+                                       "character": {"type": "number"}}},
+    },
 ]
 
 
@@ -80,6 +94,19 @@ def handle_request(msg: dict) -> dict | None:
         if tool_name == "documentSymbol":
             return {"jsonrpc": "2.0", "id": msg_id, "result": {"content": [
                 {"type": "text", "text": "class Foo  [10-50]\n  method bar  [12-20]"}]}}
+        if tool_name == "find_workspace_symbols":
+            # Echo a bullet listing pointing at line 1, col 1 of the configured MOCK_HOVER_FILE.
+            # The position is intentionally wrong (col 1) so op_hover must re-anchor via regex.
+            f = os.environ.get("MOCK_HOVER_FILE", "/mock/file.php")
+            q = args.get("query", "X")
+            return {"jsonrpc": "2.0", "id": msg_id, "result": {"content": [
+                {"type": "text",
+                 "text": f"Found 1 symbol(s) matching \"{q}\":\n\n• {q} (class) at {f}:1:1"}]}}
+        if tool_name == "get_hover":
+            # Echo back the args so tests can verify what line/character was actually sent.
+            return {"jsonrpc": "2.0", "id": msg_id, "result": {"content": [
+                {"type": "text",
+                 "text": f"HOVER@line={args.get('line')},character={args.get('character')}"}]}}
         return {"jsonrpc": "2.0", "id": msg_id, "result": {"content": [
             {"type": "text", "text": json.dumps(args)}]}}
     return {"jsonrpc": "2.0", "id": msg_id,

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,109 +1,116 @@
 """Tests for MCP client primitives in supertool.py.
 
-Uses tests/fixtures/mock_mcp_server.py — a minimal stdio JSON-RPC server.
-No real LSP dependencies required.
+The mock server (tests/fixtures/mock_mcp_server.py) listens on a per-test Unix socket
+and speaks NDJSON JSON-RPC 2.0 — same wire format MCPClient uses against the daemon.
 """
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 import threading
+import time
+import uuid
 from pathlib import Path
 
 import pytest
 
 import supertool
-from supertool import MCPServer, MCPServerError, MCPTimeout, _mcp_call, _mcp_get_server, _mcp_register, _MCP_SERVERS, _MCP_LOCK
+from supertool import (
+    MCPClient, MCPServerError, MCPTimeout,
+    _mcp_call, _mcp_get_server, _mcp_register, _MCP_SERVERS, _MCP_LOCK,
+)
 
 MOCK_SERVER = str(Path(__file__).parent / "fixtures" / "mock_mcp_server.py")
-MOCK_CMD = f"{sys.executable} {MOCK_SERVER}"
+
+
+@pytest.fixture
+def mock_uds():
+    """Spawn the UDS mock MCP server (sockets in /tmp/ — AF_UNIX path limit on macOS)."""
+    sock_path = f"/tmp/st-mock-{uuid.uuid4().hex[:8]}.sock"
+    proc = subprocess.Popen([sys.executable, MOCK_SERVER, sock_path])
+    deadline = time.time() + 5
+    while time.time() < deadline and not os.path.exists(sock_path):
+        time.sleep(0.05)
+    if not os.path.exists(sock_path):
+        proc.terminate()
+        raise RuntimeError(f"mock did not bind {sock_path}")
+    try:
+        yield sock_path
+    finally:
+        proc.terminate()
+        try: proc.wait(timeout=3)
+        except subprocess.TimeoutExpired: proc.kill()
+
+
+def _make_client(sock_path: str, timeout: int = 5) -> MCPClient:
+    return MCPClient(name="test", timeout=timeout, socket_path=sock_path)
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# spawn (connect) + is_alive
 # ---------------------------------------------------------------------------
 
-def _make_server(timeout: int = 5, env: dict | None = None) -> MCPServer:
-    return MCPServer(name="test", cmd=MOCK_CMD, env=env, timeout=timeout)
+def test_spawn_connects_to_daemon(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    assert not c.is_alive()
+    c.spawn()
+    assert c.is_alive()
+    c.shutdown()
 
 
-# ---------------------------------------------------------------------------
-# spawn + is_alive
-# ---------------------------------------------------------------------------
-
-def test_spawn_starts_process() -> None:
-    srv = _make_server()
-    assert not srv.is_alive()
-    srv.spawn()
-    assert srv.is_alive()
-    srv.shutdown()
-
-
-def test_spawn_is_idempotent() -> None:
-    srv = _make_server()
-    srv.spawn()
-    pid1 = srv._proc.pid
-    srv.spawn()  # second call — must not replace process
-    pid2 = srv._proc.pid
-    assert pid1 == pid2
-    srv.shutdown()
+def test_spawn_is_idempotent(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn()
+    sock1 = c._sock
+    c.spawn()  # second call → no new connection
+    sock2 = c._sock
+    assert sock1 is sock2
+    c.shutdown()
 
 
 # ---------------------------------------------------------------------------
 # initialize
 # ---------------------------------------------------------------------------
 
-def test_initialize_returns_capabilities() -> None:
-    srv = _make_server()
-    srv.spawn()
-    result = srv.initialize()
+def test_initialize_returns_capabilities(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn()
+    result = c.initialize()
     assert isinstance(result, dict)
     assert result.get("protocolVersion") == "2024-11-05"
     assert "serverInfo" in result
-    srv.shutdown()
+    c.shutdown()
 
 
 # ---------------------------------------------------------------------------
 # list_tools
 # ---------------------------------------------------------------------------
 
-def test_list_tools_returns_tool_definitions() -> None:
-    srv = _make_server()
-    srv.spawn()
-    srv.initialize()
-    tools = srv.list_tools()
+def test_list_tools_returns_tool_definitions(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn()
+    c.initialize()
+    tools = c.list_tools()
     assert isinstance(tools, list)
     assert len(tools) >= 1
     assert tools[0]["name"] == "echo"
-    srv.shutdown()
+    c.shutdown()
 
 
 # ---------------------------------------------------------------------------
 # call_tool
 # ---------------------------------------------------------------------------
 
-def test_call_tool_roundtrips_args() -> None:
-    srv = _make_server()
-    srv.spawn()
-    srv.initialize()
-    result = srv.call_tool("echo", {"message": "hello"})
+def test_call_tool_roundtrips_args(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn()
+    c.initialize()
+    result = c.call_tool("echo", {"message": "hello"})
     assert isinstance(result, dict)
     content = result.get("content", [])
-    assert any("hello" in str(c) for c in content)
-    srv.shutdown()
-
-
-# ---------------------------------------------------------------------------
-# Timeout
-# ---------------------------------------------------------------------------
-
-@pytest.mark.skip(reason="hangs in CI — subprocess cleanup race; track in follow-up")
-def test_call_tool_raises_mcp_timeout() -> None:
-    srv = _make_server(timeout=1, env={"MOCK_MCP_HANG": "1"})
-    srv.spawn()
-    srv.initialize()
-    with pytest.raises(MCPTimeout):
-        srv.call_tool("echo", {})
-    srv.shutdown()
+    assert any("hello" in str(c2) for c2 in content)
+    c.shutdown()
 
 
 # ---------------------------------------------------------------------------
@@ -111,33 +118,46 @@ def test_call_tool_raises_mcp_timeout() -> None:
 # ---------------------------------------------------------------------------
 
 def test_call_tool_raises_mcp_server_error() -> None:
-    srv = _make_server(env={"MOCK_MCP_TOOL_ERROR": "1"})
-    srv.spawn()
-    srv.initialize()
-    with pytest.raises(MCPServerError) as exc_info:
-        srv.call_tool("echo", {})
-    assert exc_info.value.code == -32000
-    assert "tool execution failed" in str(exc_info.value)
-    srv.shutdown()
+    """Mock with MOCK_MCP_TOOL_ERROR=1 returns JSON-RPC error → client raises."""
+    sock_path = f"/tmp/st-err-{uuid.uuid4().hex[:8]}.sock"
+    env = os.environ.copy()
+    env["MOCK_MCP_TOOL_ERROR"] = "1"
+    proc = subprocess.Popen([sys.executable, MOCK_SERVER, sock_path], env=env)
+    deadline = time.time() + 5
+    while time.time() < deadline and not os.path.exists(sock_path):
+        time.sleep(0.05)
+    try:
+        c = _make_client(sock_path)
+        c.spawn()
+        c.initialize()
+        with pytest.raises(MCPServerError) as exc_info:
+            c.call_tool("echo", {})
+        assert exc_info.value.code == -32000
+        assert "tool execution failed" in str(exc_info.value)
+        c.shutdown()
+    finally:
+        proc.terminate()
+        try: proc.wait(timeout=3)
+        except subprocess.TimeoutExpired: proc.kill()
 
 
 # ---------------------------------------------------------------------------
 # shutdown
 # ---------------------------------------------------------------------------
 
-def test_shutdown_cleans_up_process() -> None:
-    srv = _make_server()
-    srv.spawn()
-    assert srv.is_alive()
-    srv.shutdown()
-    assert not srv.is_alive()
+def test_shutdown_closes_socket(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn()
+    assert c.is_alive()
+    c.shutdown()
+    assert not c.is_alive()
 
 
-def test_shutdown_is_idempotent() -> None:
-    srv = _make_server()
-    srv.spawn()
-    srv.shutdown()
-    srv.shutdown()  # must not raise
+def test_shutdown_is_idempotent(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn()
+    c.shutdown()
+    c.shutdown()  # must not raise
 
 
 # ---------------------------------------------------------------------------
@@ -149,37 +169,34 @@ def test_mcp_call_returns_none_when_server_not_in_registry() -> None:
     assert result is None
 
 
-def test_mcp_call_lazy_spawns_via_registry() -> None:
-    srv = _make_server()
-    srv.spawn()
-    srv.initialize()
-    with _MCP_LOCK:
-        _MCP_SERVERS["_test_lazy"] = srv
+def test_mcp_call_uses_registered_client(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn(); c.initialize()
+    _mcp_register("_test_call", c)
     try:
-        result = _mcp_call("_test_lazy", "echo", {"message": "lazy"})
+        result = _mcp_call("_test_call", "echo", {"message": "lazy"})
         assert result is not None
         content = result.get("content", [])
-        assert any("lazy" in str(c) for c in content)
+        assert any("lazy" in str(item) for item in content)
     finally:
         with _MCP_LOCK:
-            _MCP_SERVERS.pop("_test_lazy", None)
-        srv.shutdown()
+            _MCP_SERVERS.pop("_test_call", None)
+        c.shutdown()
 
 
 # ---------------------------------------------------------------------------
-# _mcp_get_server — dead server returns None
+# _mcp_get_server — dead client returns None
 # ---------------------------------------------------------------------------
 
-def test_mcp_get_server_removes_dead_server() -> None:
-    srv = _make_server()
-    srv.spawn()
-    srv.shutdown()  # kill it
+def test_mcp_get_server_removes_dead_client(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn()
+    c.shutdown()  # close → not alive
     with _MCP_LOCK:
-        _MCP_SERVERS["_test_dead"] = srv
+        _MCP_SERVERS["_test_dead"] = c
     try:
         result = _mcp_get_server("_test_dead")
         assert result is None
-        # Should have been removed from registry
         with _MCP_LOCK:
             assert "_test_dead" not in _MCP_SERVERS
     finally:
@@ -188,69 +205,41 @@ def test_mcp_get_server_removes_dead_server() -> None:
 
 
 # ---------------------------------------------------------------------------
-# M1: _mcp_register + _mcp_call
+# _mcp_register + _mcp_call
 # ---------------------------------------------------------------------------
 
-def test_mcp_register_allows_mcp_call() -> None:
-    """_mcp_register pre-registers a server; _mcp_call uses it without manual
-    registry manipulation."""
-    srv = _make_server()
-    srv.spawn()
-    srv.initialize()
-    _mcp_register("_test_register", srv)
+def test_mcp_register_allows_mcp_call(mock_uds: str) -> None:
+    c = _make_client(mock_uds)
+    c.spawn(); c.initialize()
+    _mcp_register("_test_register", c)
     try:
         result = _mcp_call("_test_register", "echo", {"message": "registered"})
         assert result is not None
         content = result.get("content", [])
-        assert any("registered" in str(c) for c in content)
+        assert any("registered" in str(item) for item in content)
     finally:
         with _MCP_LOCK:
             _MCP_SERVERS.pop("_test_register", None)
-        srv.shutdown()
+        c.shutdown()
 
 
 # ---------------------------------------------------------------------------
-# M2: timeout marks server dead; subsequent call fails fast
-# ---------------------------------------------------------------------------
-
-@pytest.mark.skip(reason="hangs in CI — subprocess cleanup race; track in follow-up")
-def test_timeout_marks_server_dead_and_second_call_fails_fast() -> None:
-    """After MCPTimeout the server is marked dead. The next call raises
-    MCPServerError immediately instead of hanging."""
-    srv = _make_server(timeout=1, env={"MOCK_MCP_HANG": "1"})
-    srv.spawn()
-    srv.initialize()
-    with pytest.raises(MCPTimeout):
-        srv.call_tool("echo", {})
-    # Server must now be marked dead
-    assert srv._dead is True
-    # Second call must fail fast — not hang
-    with pytest.raises(MCPServerError, match="marked dead"):
-        srv.call_tool("echo", {})
-    srv.shutdown()
-
-
-# ---------------------------------------------------------------------------
-# M3: thread-safe _next_id
+# Thread-safe _next_id
 # ---------------------------------------------------------------------------
 
 def test_next_id_unique_across_threads() -> None:
-    """Two threads calling _next_id() 1000 times each must produce 2000
-    unique IDs with no duplicates."""
-    srv = _make_server()
+    c = MCPClient(name="x", timeout=5, socket_path="/dev/null")
     ids: list[int] = []
     ids_lock = threading.Lock()
 
     def collect() -> None:
         for _ in range(1000):
             with ids_lock:
-                ids.append(srv._next_id())
+                ids.append(c._next_id())
 
     t1 = threading.Thread(target=collect)
     t2 = threading.Thread(target=collect)
-    t1.start()
-    t2.start()
-    t1.join()
-    t2.join()
+    t1.start(); t2.start()
+    t1.join(); t2.join()
     assert len(ids) == 2000
     assert len(set(ids)) == 2000

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -176,6 +176,81 @@ def test_op_resolve_falls_back_to_heuristic_on_mcp_failure(
         supertool._mcp_specs.clear()
 
 
+def test_op_hover_anchors_to_word_boundary(tmp_path: Path) -> None:
+    """`op_hover` two-step: find_workspace_symbols returns line:1, then op_hover must
+    re-anchor to the actual identifier offset using a word-boundary search.
+
+    Source: `public function handle(self $handle): void`
+    `handle` method-name at col 17. Plain str.find would also return 17 here (only
+    one substring match), so this test mainly verifies the two-step flow works.
+    """
+    php_file = tmp_path / "Widget.php"
+    src_line = "public function handle(self $handle): void\n"
+    php_file.write_text(src_line)
+
+    sock_path = f"/tmp/st-mock-{uuid.uuid4().hex[:8]}.sock"
+    env = os.environ.copy(); env["MOCK_HOVER_FILE"] = str(php_file)
+    proc = subprocess.Popen([sys.executable, MOCK_SERVER, sock_path], env=env)
+    deadline = time.time() + 5
+    while time.time() < deadline and not os.path.exists(sock_path):
+        time.sleep(0.05)
+    try:
+        _set_mcp_specs({
+            "php-lsp": {"match": "*.php", "socket_path": sock_path,
+                        "tools": {"resolve": "find_workspace_symbols", "hover": "get_hover"}}
+        })
+        from supertool import op_hover
+        result = op_hover("handle", str(php_file))
+        # Word-boundary 'handle' position: index 16 → col 17 (1-indexed)
+        assert "character=17" in result, f"expected character=17, got: {result}"
+    finally:
+        with _MCP_LOCK:
+            srv = _MCP_SERVERS.pop("php-lsp", None)
+        if srv: srv.shutdown()
+        supertool._mcp_specs.clear()
+        proc.terminate()
+        try: proc.wait(timeout=3)
+        except subprocess.TimeoutExpired: proc.kill()
+
+
+def test_op_hover_word_boundary_skips_substring_match(tmp_path: Path) -> None:
+    """Regression: `str.find(symbol)` matches `symbol` as a substring of a larger word.
+
+    Source: `// readd this comment | public function add(): void {}`
+                ^^^^                                  ^^^
+              col 4 (substring of 'readd')         col 41 (the real `add` method)
+
+    str.find('add') returns index 3 → column 4 (inside 'readd').
+    Word-boundary regex skips 'readd' and matches at index 40 → column 41.
+    """
+    php_file = tmp_path / "Widget.php"
+    src_line = "// readd this comment | public function add(): void {}\n"
+    php_file.write_text(src_line)
+
+    sock_path = f"/tmp/st-mock-{uuid.uuid4().hex[:8]}.sock"
+    env = os.environ.copy(); env["MOCK_HOVER_FILE"] = str(php_file)
+    proc = subprocess.Popen([sys.executable, MOCK_SERVER, sock_path], env=env)
+    deadline = time.time() + 5
+    while time.time() < deadline and not os.path.exists(sock_path):
+        time.sleep(0.05)
+    try:
+        _set_mcp_specs({
+            "php-lsp": {"match": "*.php", "socket_path": sock_path,
+                        "tools": {"resolve": "find_workspace_symbols", "hover": "get_hover"}}
+        })
+        from supertool import op_hover
+        result = op_hover("add", str(php_file))
+        assert "character=41" in result, f"expected character=41, got: {result}"
+    finally:
+        with _MCP_LOCK:
+            srv = _MCP_SERVERS.pop("php-lsp", None)
+        if srv: srv.shutdown()
+        supertool._mcp_specs.clear()
+        proc.terminate()
+        try: proc.wait(timeout=3)
+        except subprocess.TimeoutExpired: proc.kill()
+
+
 def test_cli_resolve_forwards_from_file_to_mcp(
     tmp_path: Path, mock_uds: str, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -1,21 +1,28 @@
-"""Tests for MCP config + extension routing (sub-PR 2)."""
+"""Tests for MCP config + extension routing.
+
+The MCP client talks to a UDS daemon. Tests use a UDS-server mock fixture spawned per
+test with a tmp socket path injected directly into the spec — bypasses the auto-spawn
+path while exercising the full NDJSON wire protocol.
+"""
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
+import time
+import uuid
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 import supertool
 from supertool import (
-    MCPServer, _mcp_route, _mcp_ensure_server,
+    MCPClient, _mcp_route, _mcp_ensure_server,
     _extract_path_from_mcp_result, _MCP_SERVERS, _MCP_LOCK,
     op_resolve,
 )
 
 MOCK_SERVER = str(Path(__file__).parent / "fixtures" / "mock_mcp_server.py")
-MOCK_CMD = f"{sys.executable} {MOCK_SERVER}"
 
 
 def _set_mcp_specs(specs: dict) -> None:
@@ -24,32 +31,59 @@ def _set_mcp_specs(specs: dict) -> None:
     supertool._mcp_specs.update(specs)
 
 
-def test_route_matches_by_extension_glob() -> None:
+@pytest.fixture
+def mock_uds():
+    """Spawn the UDS-mode mock MCP server on a per-test socket path.
+
+    Sockets live in /tmp/ (macOS AF_UNIX path limit ~104 chars; pytest tmp_path is too deep).
+    """
+    sock_path = f"/tmp/st-mock-{uuid.uuid4().hex[:8]}.sock"
+    proc = subprocess.Popen([sys.executable, MOCK_SERVER, sock_path])
+    # Wait for the server to bind the socket
+    deadline = time.time() + 5
+    while time.time() < deadline and not os.path.exists(sock_path):
+        time.sleep(0.05)
+    if not os.path.exists(sock_path):
+        proc.terminate()
+        raise RuntimeError(f"mock MCP server did not bind {sock_path}")
+    try:
+        yield sock_path
+    finally:
+        proc.terminate()
+        try: proc.wait(timeout=3)
+        except subprocess.TimeoutExpired: proc.kill()
+        if os.path.exists(sock_path):
+            try: os.unlink(sock_path)
+            except OSError: pass
+
+
+def test_route_matches_by_extension_glob(mock_uds: str) -> None:
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"match": "*.php", "socket_path": mock_uds,
                     "tools": {"resolve": "definition"}}
     })
     assert _mcp_route("foo.php", "resolve") == ("php-lsp", "definition")
 
 
-def test_route_returns_none_when_no_match() -> None:
+def test_route_returns_none_when_no_match(mock_uds: str) -> None:
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"match": "*.php", "socket_path": mock_uds,
                     "tools": {"resolve": "definition"}}
     })
     assert _mcp_route("foo.py", "resolve") is None
 
 
-def test_route_returns_none_when_op_not_in_tools() -> None:
+def test_route_returns_none_when_op_not_in_tools(mock_uds: str) -> None:
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php", "tools": {"resolve": "definition"}}
+        "php-lsp": {"match": "*.php", "socket_path": mock_uds,
+                    "tools": {"resolve": "definition"}}
     })
     assert _mcp_route("foo.php", "refs") is None
 
 
-def test_ensure_server_spawns_on_demand() -> None:
+def test_ensure_server_connects_on_demand(mock_uds: str) -> None:
     _set_mcp_specs({
-        "lsp-test": {"cmd": MOCK_CMD, "match": "*.php",
+        "lsp-test": {"match": "*.php", "socket_path": mock_uds,
                      "tools": {"resolve": "definition"}}
     })
     try:
@@ -66,9 +100,10 @@ def test_ensure_server_spawns_on_demand() -> None:
             srv.shutdown()
 
 
-def test_ensure_server_returns_none_on_bad_cmd() -> None:
+def test_ensure_server_returns_none_on_bad_socket(tmp_path: Path) -> None:
+    """Socket_path that doesn't exist → connect fails → ensure returns None."""
     _set_mcp_specs({
-        "broken": {"cmd": "/nonexistent/binary", "match": "*.php",
+        "broken": {"match": "*.php", "socket_path": str(tmp_path / "nope.sock"),
                    "tools": {"resolve": "definition"}}
     })
     srv = _mcp_ensure_server("broken")
@@ -102,17 +137,17 @@ def test_extract_path_from_file_uri_url_decode() -> None:
     assert _extract_path_from_mcp_result(result) == "/path with space.php"
 
 
-def test_op_resolve_uses_mcp_when_configured(tmp_path: Path) -> None:
-    """op_resolve delegates to MCP server when a matching spec is configured."""
+def test_op_resolve_uses_mcp_when_configured(tmp_path: Path, mock_uds: str) -> None:
+    """op_resolve delegates to the MCP daemon when a matching spec is configured."""
     php_file = str(tmp_path / "bar.php")
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"match": "*.php", "socket_path": mock_uds,
                     "tools": {"resolve": "definition"}}
     })
     srv_name = "php-lsp"
     try:
         result = op_resolve("Foo", from_file=php_file)
-        # Mock server returns the from_file value as the resolved path
+        # Mock returns file_path as the resolved path — proves MCP was hit
         assert php_file in result
         assert "→" in result
     finally:
@@ -126,10 +161,10 @@ def test_op_resolve_uses_mcp_when_configured(tmp_path: Path) -> None:
 def test_op_resolve_falls_back_to_heuristic_on_mcp_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """MCP failure (bad cmd) silently falls through to heuristic glob."""
+    """MCP failure (bad socket) silently falls through to heuristic glob."""
     monkeypatch.chdir(tmp_path)
     _set_mcp_specs({
-        "broken-lsp": {"cmd": "/nonexistent/binary", "match": "*.php",
+        "broken-lsp": {"match": "*.php", "socket_path": str(tmp_path / "nope.sock"),
                        "tools": {"resolve": "definition"}}
     })
     php_file = str(tmp_path / "bar.php")
@@ -138,4 +173,30 @@ def test_op_resolve_falls_back_to_heuristic_on_mcp_failure(
         # Must not raise; heuristic returns "not found"
         assert "not found" in result or "→" in result
     finally:
+        supertool._mcp_specs.clear()
+
+
+def test_cli_resolve_forwards_from_file_to_mcp(
+    tmp_path: Path, mock_uds: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`resolve:SYMBOL:FILE` CLI form must forward FILE so the MCP route triggers.
+
+    Regression: dispatcher previously dropped parts[2], so from_file=None and MCP never hit.
+    """
+    php_file = str(tmp_path / "bar.php")
+    _set_mcp_specs({
+        "php-lsp": {"match": "*.php", "socket_path": mock_uds,
+                    "tools": {"resolve": "definition"}}
+    })
+    srv_name = "php-lsp"
+    try:
+        rc = supertool.main([f"resolve:Foo:{php_file}"])
+        out = capsys.readouterr().out
+        assert php_file in out
+        assert rc == 0
+    finally:
+        with _MCP_LOCK:
+            srv = _MCP_SERVERS.pop(srv_name, None)
+        if srv:
+            srv.shutdown()
         supertool._mcp_specs.clear()

--- a/tests/test_mcp_workspace.py
+++ b/tests/test_mcp_workspace.py
@@ -1,7 +1,11 @@
 """Tests for MCP routing in op_workspace — References, Symbols, and Imports (sub-PR 3)."""
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
+import time
+import uuid
 from pathlib import Path
 from unittest.mock import patch
 
@@ -16,7 +20,25 @@ from supertool import (
 )
 
 MOCK_SERVER = str(Path(__file__).parent / "fixtures" / "mock_mcp_server.py")
-MOCK_CMD = f"{sys.executable} {MOCK_SERVER}"
+
+
+@pytest.fixture
+def mock_uds():
+    """Spawn the UDS mock MCP server (sockets in /tmp/ — AF_UNIX path limit on macOS)."""
+    sock_path = f"/tmp/st-mock-{uuid.uuid4().hex[:8]}.sock"
+    proc = subprocess.Popen([sys.executable, MOCK_SERVER, sock_path])
+    deadline = time.time() + 5
+    while time.time() < deadline and not os.path.exists(sock_path):
+        time.sleep(0.05)
+    if not os.path.exists(sock_path):
+        proc.terminate()
+        raise RuntimeError(f"mock did not bind {sock_path}")
+    try:
+        yield sock_path
+    finally:
+        proc.terminate()
+        try: proc.wait(timeout=3)
+        except subprocess.TimeoutExpired: proc.kill()
 
 
 def _set_mcp_specs(specs: dict) -> None:
@@ -85,7 +107,7 @@ def test_extract_symbols_from_mcp_result_empty_text() -> None:
 
 def test_route_refs_matches_when_configured() -> None:
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"socket_path": "/tmp/unused.sock", "match": "*.php",
                     "tools": {"refs": "references"}}
     })
     assert _mcp_route("foo.php", "refs") == ("php-lsp", "references")
@@ -94,7 +116,7 @@ def test_route_refs_matches_when_configured() -> None:
 
 def test_route_symbols_matches_when_configured() -> None:
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"socket_path": "/tmp/unused.sock", "match": "*.php",
                     "tools": {"symbols": "documentSymbol"}}
     })
     assert _mcp_route("foo.php", "symbols") == ("php-lsp", "documentSymbol")
@@ -103,7 +125,7 @@ def test_route_symbols_matches_when_configured() -> None:
 
 def test_route_refs_returns_none_when_not_in_tools() -> None:
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"socket_path": "/tmp/unused.sock", "match": "*.php",
                     "tools": {"resolve": "definition"}}
     })
     assert _mcp_route("foo.php", "refs") is None
@@ -114,13 +136,13 @@ def test_route_refs_returns_none_when_not_in_tools() -> None:
 # op_workspace: References section uses MCP when configured
 # ---------------------------------------------------------------------------
 
-def test_workspace_references_uses_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_workspace_references_uses_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mock_uds: str) -> None:
     monkeypatch.chdir(tmp_path)
     f = tmp_path / "Widget.class.php"
     f.write_text("<?php\nclass Widget {}\n")
 
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"match": "*.php", "socket_path": mock_uds,
                     "tools": {"refs": "references"}}
     })
     try:
@@ -141,7 +163,7 @@ def test_workspace_references_falls_back_on_mcp_miss(tmp_path: Path, monkeypatch
     f.write_text("<?php\nclass Widget {}\n")
 
     _set_mcp_specs({
-        "broken-lsp": {"cmd": "/nonexistent/binary", "match": "*.php",
+        "broken-lsp": {"socket_path": "/tmp/nope.sock", "match": "*.php",
                        "tools": {"refs": "references"}}
     })
     try:
@@ -168,13 +190,13 @@ def test_workspace_references_falls_back_when_no_mcp(tmp_path: Path, monkeypatch
 # op_workspace: Symbols section uses MCP when configured
 # ---------------------------------------------------------------------------
 
-def test_workspace_symbols_uses_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_workspace_symbols_uses_mcp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mock_uds: str) -> None:
     monkeypatch.chdir(tmp_path)
     f = tmp_path / "Widget.class.php"
     f.write_text("<?php\nclass Widget {}\n")
 
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"match": "*.php", "socket_path": mock_uds,
                     "tools": {"symbols": "documentSymbol"}}
     })
     try:
@@ -205,7 +227,7 @@ def test_workspace_symbols_falls_back_on_bad_server(tmp_path: Path, monkeypatch:
     f.write_text("class MyModule:\n    def run(self) -> None:\n        pass\n")
 
     _set_mcp_specs({
-        "broken-lsp": {"cmd": "/nonexistent/binary", "match": "*.py",
+        "broken-lsp": {"socket_path": "/tmp/nope.sock", "match": "*.py",
                        "tools": {"symbols": "documentSymbol"}}
     })
     try:
@@ -222,8 +244,8 @@ def test_workspace_symbols_falls_back_on_bad_server(tmp_path: Path, monkeypatch:
 # op_workspace: Imports section already uses MCP via op_resolve (sub-PR 2)
 # ---------------------------------------------------------------------------
 
-def test_workspace_imports_uses_mcp_via_op_resolve(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Imports section delegates to op_resolve which already uses MCP (sub-PR 2).
+def test_workspace_imports_uses_mcp_via_op_resolve(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mock_uds: str) -> None:
+    """Imports section delegates to op_resolve which uses MCP.
 
     Verifies end-to-end: a PHP file with a use-statement renders an Imports
     section whose resolved path comes from the MCP server.
@@ -234,7 +256,7 @@ def test_workspace_imports_uses_mcp_via_op_resolve(tmp_path: Path, monkeypatch: 
 
     php_file = str(f)
     _set_mcp_specs({
-        "php-lsp": {"cmd": MOCK_CMD, "match": "*.php",
+        "php-lsp": {"match": "*.php", "socket_path": mock_uds,
                     "tools": {"resolve": "definition"}}
     })
     try:

--- a/tests/test_validators_lsp_diag.py
+++ b/tests/test_validators_lsp_diag.py
@@ -1,0 +1,79 @@
+"""Tests for the lsp-diag validator's text-output parser.
+
+The validator calls `supertool diag:FILE` and parses cclsp's free-form text response
+into the validators/SCHEMA.md JSON shape. The text parsing is the fragile part —
+these tests pin the patterns we support.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+# Load the validator module directly (it's a script, not a package member)
+_VPATH = Path(__file__).parent.parent / "validators" / "lsp-diag" / "lsp-diag.py"
+_spec = importlib.util.spec_from_file_location("lsp_diag", _VPATH)
+assert _spec and _spec.loader
+lsp_diag = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lsp_diag)
+
+
+def test_no_diagnostics_returns_empty() -> None:
+    out = "No diagnostics found for /path/Foo.php. The file has no errors, warnings, or hints."
+    assert lsp_diag.parse_cclsp_diagnostics(out, "/path/Foo.php") == []
+
+
+def test_no_diagnostics_lowercase_variant() -> None:
+    assert lsp_diag.parse_cclsp_diagnostics(
+        "the file has no errors, warnings, or hints.", "/x") == []
+
+
+def test_error_with_line_col_format() -> None:
+    out = "• [error] undefined variable $foo at line 42, col 13"
+    errors = lsp_diag.parse_cclsp_diagnostics(out, "/x")
+    assert len(errors) == 1
+    e = errors[0]
+    assert e["severity"] == "error"
+    assert e["line"] == 42
+    assert e["col"] == 13
+    assert "undefined variable" in e["msg"]
+
+
+def test_warning_with_x_y_format() -> None:
+    out = "[warning] unused import 12:5"
+    errors = lsp_diag.parse_cclsp_diagnostics(out, "/x")
+    assert len(errors) == 1
+    assert errors[0]["severity"] == "warning"
+    assert errors[0]["line"] == 12
+    assert errors[0]["col"] == 5
+
+
+def test_x_y_severity_msg_format() -> None:
+    out = "10:3: error: Argument type mismatch"
+    errors = lsp_diag.parse_cclsp_diagnostics(out, "/x")
+    assert len(errors) == 1
+    assert errors[0]["line"] == 10
+    assert errors[0]["col"] == 3
+    assert errors[0]["severity"] == "error"
+    assert "type mismatch" in errors[0]["msg"]
+
+
+def test_multiple_diagnostics() -> None:
+    out = "\n".join([
+        "Found 2 diagnostic(s) for /Widget.php:",
+        "• [error] missing semicolon at line 5, col 10",
+        "• [warning] unused variable $x at line 8, col 1",
+    ])
+    errors = lsp_diag.parse_cclsp_diagnostics(out, "/Widget.php")
+    assert len(errors) == 2
+    assert errors[0]["severity"] == "error"
+    assert errors[1]["severity"] == "warning"
+
+
+def test_unrecognized_text_falls_back_to_advisory() -> None:
+    out = "some unexpected lsp message"
+    errors = lsp_diag.parse_cclsp_diagnostics(out, "/x")
+    assert len(errors) == 1
+    assert errors[0]["severity"] == "info"
+    assert "some unexpected" in errors[0]["msg"]

--- a/validators/lsp-diag/lsp-diag.py
+++ b/validators/lsp-diag/lsp-diag.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""LSP-diag validator adapter.
+
+Calls `supertool diag:FILE` and converts the text output to a validators/SCHEMA.md
+JSON receipt. Reuses the long-lived MCP daemon — sub-second when warm.
+
+Why not call MCP directly: the supertool dispatch handles config lookup, daemon
+auto-spawn, and tool routing. Reusing it keeps the validator dumb.
+
+Usage:  lsp-diag.py <file>
+Output: one JSON object on stdout.
+Exit:   0 (always).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+
+def emit(obj: dict) -> None:
+    print(json.dumps(obj))
+
+
+def parse_cclsp_diagnostics(text: str, file: str) -> list[dict]:
+    """Parse cclsp's get_diagnostics text output into the SCHEMA error shape.
+
+    cclsp shapes observed:
+      "No diagnostics found for /path. The file has no errors, warnings, or hints."
+      "Found N diagnostic(s) for /path:\\n• [severity] message at line X, col Y"
+      "[error] message at line X:Y"   (some variants)
+    Falls back to one generic error if format doesn't match.
+    """
+    if "No diagnostics found" in text or "no errors, warnings, or hints" in text.lower():
+        return []
+
+    errors: list[dict] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # Pattern 1: "• [severity] message at line X, col Y" or "at X:Y"
+        m = re.search(r"\[?\b(error|warning|info|hint)\b\]?\s*[:\s]*(.+?)(?:\s+at\s+line\s+(\d+)(?:[,\s]+(?:col(?:umn)?\s+)?(\d+))?|\s+(\d+):(\d+))\s*$",
+                      line, flags=re.IGNORECASE)
+        if m:
+            severity = m.group(1).lower()
+            msg = m.group(2).strip(" •-:")
+            ln = int(m.group(3)) if m.group(3) else (int(m.group(5)) if m.group(5) else None)
+            col = int(m.group(4)) if m.group(4) else (int(m.group(6)) if m.group(6) else None)
+            errors.append({"line": ln, "col": col, "severity": severity,
+                           "code": "lsp", "msg": msg})
+            continue
+        # Pattern 2: standalone "X:Y: severity: message"
+        m = re.match(r"^(\d+):(\d+):\s*(\w+):\s*(.+)$", line)
+        if m:
+            errors.append({"line": int(m.group(1)), "col": int(m.group(2)),
+                           "severity": m.group(3).lower(),
+                           "code": "lsp", "msg": m.group(4).strip()})
+    if not errors:
+        # Unrecognized but non-empty → keep the text as a single advisory
+        if not text.startswith("diag:"):  # ignore supertool's own error messages
+            errors.append({"line": None, "col": None, "severity": "info",
+                           "code": "lsp", "msg": text.strip()[:500]})
+    return errors
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        emit({"tool": "lsp-diag", "file": "", "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "no file arg"}],
+              "duration_ms": 0})
+        return
+
+    file = sys.argv[1]
+    start = time.time()
+
+    # Find the supertool binary — env override > sibling of this script > PATH
+    supertool_bin = os.environ.get("SUPERTOOL_BIN")
+    if not supertool_bin:
+        # Validators live at supertool_dir/validators/lsp-diag/lsp-diag.py
+        # supertool.py is at supertool_dir/supertool.py
+        guess = os.path.join(os.path.dirname(__file__), "..", "..", "supertool.py")
+        if os.path.isfile(guess):
+            supertool_bin = guess
+        else:
+            supertool_bin = "supertool"
+
+    try:
+        r = subprocess.run(
+            [sys.executable, supertool_bin, f"diag:{file}"] if supertool_bin.endswith(".py")
+            else [supertool_bin, f"diag:{file}"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except FileNotFoundError:
+        emit({"tool": "lsp-diag", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "supertool binary not found"}],
+              "duration_ms": int((time.time() - start) * 1000)})
+        return
+    except subprocess.TimeoutExpired:
+        emit({"tool": "lsp-diag", "file": file, "ok": False, "count": 1,
+              "errors": [{"line": None, "col": None, "severity": "error",
+                          "code": "adapter", "msg": "timeout"}],
+              "duration_ms": 30000})
+        return
+
+    # Strip supertool's "--- diag:FILE ---" header line
+    text = r.stdout
+    text = re.sub(r"^---\s*diag:[^\n]*---\s*\n", "", text, count=1)
+
+    # Daemon not ready or LSP not configured → skip rather than fail
+    if "no LSP configured" in text or "MCP server" in text and "unavailable" in text:
+        emit({"tool": "lsp-diag", "file": file, "ok": True, "count": 0,
+              "errors": [], "duration_ms": int((time.time() - start) * 1000),
+              "skipped": "LSP not configured or daemon down"})
+        return
+
+    errors = parse_cclsp_diagnostics(text, file)
+    # rollback_on_fail is false for this validator — even with errors we report ok=True
+    # so the edit isn't rolled back. The framework sees count>0 as advisory only.
+    emit({"tool": "lsp-diag", "file": file,
+          "ok": all(e.get("severity") != "error" for e in errors),
+          "count": len(errors), "errors": errors,
+          "duration_ms": int((time.time() - start) * 1000)})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context

The MCP integration spec ([docs/mcp-integration.md](../blob/master/docs/mcp-integration.md)) has the framework spec but no consumer playbook. Adds a step-by-step Getting Started section walking a new consumer through wiring up intelephense as the first MCP backend.

Covers: install intelephense, wrap via cclsp, configure `.supertool.json`, smoke test `resolve` + `workspace`, troubleshoot common failures.

PHP first because it's DVSI's primary stack. Same shape repeats for Python (`pyright --stdio`), TypeScript (`typescript-language-server --stdio`), etc.