### PR TITLE
fix(map): show real names for PHP typed properties (was '<anonymous>')

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -1493,6 +1493,17 @@ def _ts_node_name(node: Any, lang_name: str) -> str:
     if node.type == "const_element" and node.children:
         return node.children[0].text.decode("utf-8", errors="replace")
 
+    # PHP property_declaration (typed props since 7.4): nested
+    # property_element → variable_name → $name. Walk down to find the variable.
+    if node.type == "property_declaration":
+        for child in node.children:
+            if child.type == "property_element":
+                for grandchild in child.children:
+                    if grandchild.type == "variable_name":
+                        # variable_name → "$" + name child; strip the leading $
+                        text = grandchild.text.decode("utf-8", errors="replace")
+                        return text.lstrip("$")
+
     # Fallback: first identifier-like child
     for child in node.children:
         if child.type in ("identifier", "name", "type_identifier",

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -399,6 +399,36 @@ class MyClass {
     assert "method doSomething" in out
 
 
+@pytest.mark.skipif(
+    not _has_any_tree_sitter(),
+    reason="no tree-sitter package installed"
+)
+def test_map_php_typed_property_names(tmp_path: Path, enable_tree_sitter) -> None:
+    """PHP typed properties (PHP 7.4+) should show their real name, not <anonymous>.
+
+    Regression: tree-sitter's property_declaration node nests the name inside
+    property_element → variable_name, one level deeper than _ts_node_name walked.
+    """
+    f = tmp_path / "Helper.php"
+    f.write_text("""<?php
+class Helper {
+    private static array $repoPerKey = [];
+    protected static int $callerIndex = 2;
+    private static ?string $agency = null;
+    public string $simple;
+    public ?int $optional = null;
+}
+""")
+    out = supertool.op_map(str(f))
+    assert "tier: tree-sitter" in out
+    assert "property repoPerKey" in out
+    assert "property callerIndex" in out
+    assert "property agency" in out
+    assert "property simple" in out
+    assert "property optional" in out
+    assert "<anonymous>" not in out
+
+
 # ---------------------------------------------------------------------------
 # map — additional coverage for branches and error paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- tree-sitter's PHP grammar nests typed-property names two levels deep (`property_declaration` → `property_element` → `variable_name`); `_ts_node_name` only walked one level, so PHP 7.4+ typed properties like `private static array $foo = [];` rendered as `property <anonymous>` in `map:` output.
- Fix: when `node.type == "property_declaration"`, descend to `variable_name` and strip the leading `$`.
- Untyped legacy properties (`public $bar;`) already worked because `variable_name` was a direct child.

## Test plan

- [x] New `test_map_php_typed_property_names` covers 5 typed-property variants (static array, static int, static nullable, public string, public nullable int) + asserts `<anonymous>` never appears.
- [x] Test was confirmed failing before the fix, passing after.
- [x] Full `tests/test_map.py` suite (56 tests) green.
- [x] Real-world DVSI smoke: `BusinessEntityHelper.class.php` now shows `property repoPerKey`, `property callerIndex`, `property agency` etc. instead of `<anonymous>`.