### PR TITLE
feat: notifiers + cursor-witness — watch the agent work in your editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,42 @@ Full reference (architecture, all five LSP ops, recipe for adding a new MCP serv
 
 ---
 
+## Notifiers — observe ops in flight
+
+Notifiers are validators' read-friendly sibling. Same `hooks_into` / `match` shape, but **spawn-and-forget** — fire on reads as well as writes, never block the parent op, no rollback semantics. They exist so external tools can tap supertool's op stream: editor sync, Slack pings, audit logs, anything.
+
+```json
+"notifiers": {
+  "my-observer": {
+    "cmd": "python3 observe.py {op} {file} {line} {line_end} {before_file}",
+    "match": "*",
+    "hooks_into": ["edit", "replace", "paste", "vim", "around_line", "between", "read"]
+  }
+}
+```
+
+Placeholders: `{op}`, `{file}`, `{line}`, `{line_end}`, `{before_file}` (pre-edit content path for mutating ops), `{supertool_dir}`. Unset values render as empty strings.
+
+Full reference: [docs/notifiers.md](docs/notifiers.md).
+
+---
+
+## Cursor Witness — watch the agent work in your editor
+
+The flagship notifier consumer. Ships in `notifiers/cursor-witness/`. A VSCode/Cursor extension listens on a Unix socket; supertool's notifier writes one JSON event per op. When the agent edits a file, Cursor opens it in a **diff view** (before vs after). When the agent reads a range, the lines are highlighted and the editor scrolls to them — highlight fades after 4 seconds.
+
+```bash
+cd notifiers/cursor-witness/extension && npm install && npm run compile
+ln -s "$(pwd)" ~/.cursor/extensions/digital-process-tools.cursor-witness-0.1.0
+# Reload Cursor → "$(eye) Max: idle" in the status bar
+```
+
+Then wire the notifier in `.supertool.json` (see [docs/cursor-witness.md](docs/cursor-witness.md)).
+
+It's the closest thing to pair-programming with an autonomous agent: the agent's work becomes visible in your editor as it happens, with no extra commands.
+
+---
+
 ## RTK integration
 
 When [rtk](https://github.com/reachingforthejack/rtk) is installed, supertool automatically delegates `read`, `grep`, and `wc` to RTK for compressed output. No configuration needed — detected via `which rtk` at first use.

--- a/docs/cursor-witness.md
+++ b/docs/cursor-witness.md
@@ -1,0 +1,145 @@
+# Cursor Witness
+
+Watch your supertool agent work in real time, inside Cursor (or VSCode).
+
+When supertool **edits** a file in your workspace → Cursor opens a side-by-side **diff view** showing what changed.
+When supertool **reads** a range → Cursor opens the file, scrolls to the range, highlights it in blue, and fades the highlight after a few seconds.
+
+The agent stops being an opaque process. Its work surfaces in your editor as it happens.
+
+## What you get
+
+| Op | What you see |
+|---|---|
+| `edit`, `replace`, `paste`, `vim`, `replace_lines` | Side-by-side diff (before vs after). Status bar: `$(edit) Max: edit foo.php` |
+| `around_line:F:L:N` | File opens, lines L-N to L+N highlighted, centered |
+| `between:SYMBOL:F` | File opens, symbol's body lines highlighted (tree-sitter resolution) |
+| `read:F:OFFSET:LIMIT` | File opens, range highlighted |
+| `read:F`, `map`, `tail`, `head`, `wc`, `stat`, `blame` | File opens and focuses (no range available) |
+
+Highlights fade after **4 seconds** so they don't pile up.
+
+## Architecture
+
+```
+supertool 'between:Foo:bar.php'
+  └─ runs the op, returns text
+  └─ _notify_read_op fires the cursor-witness notifier  (fire-and-forget)
+       └─ notify.py writes JSON line to /tmp/supertool-witness-<sha1(cwd)[:12]>.sock
+            └─ Cursor extension reads the line
+                 └─ vscode.window.showTextDocument(uri, {selection})
+                 └─ setDecorations(range, blue tint) + 4s timer
+```
+
+- **One socket per workspace** — the path hash includes the workspace folder so multiple Cursor windows on different repos don't collide.
+- **Multi-host safe** — Cursor spawns several extension hosts (main, agent-worker, shadow-workspace). They all activate the extension; only one wins the socket bind. The rest stay dormant.
+- **Fully silent when extension is off** — the notifier writes to the socket; if no one's listening, the connect fails fast and supertool keeps moving.
+
+## Install
+
+### 1. Build the extension
+
+```bash
+cd notifiers/cursor-witness/extension
+npm install
+npm run compile
+```
+
+### 2. Symlink into Cursor's extensions directory
+
+```bash
+ln -s "$(pwd)" ~/.cursor/extensions/digital-process-tools.cursor-witness-0.1.0
+```
+
+(For VSCode: `~/.vscode/extensions/digital-process-tools.cursor-witness-0.1.0`)
+
+### 3. Reload Cursor
+
+`Cmd+Shift+P` → `Developer: Reload Window`
+
+You should see `$(eye) Max: idle` in the status bar bottom-right.
+
+### 4. Wire the notifier in `.supertool.json`
+
+```json
+{
+  "notifiers": {
+    "cursor-witness": {
+      "cmd": "python3 /absolute/path/to/claude-supertool/notifiers/cursor-witness/notify.py {op} {file} {line} {line_end} {before_file}",
+      "match": "*",
+      "hooks_into": [
+        "edit", "replace", "replace_lines", "paste", "vim",
+        "read", "around_line", "between", "map"
+      ]
+    }
+  }
+}
+```
+
+Drop the read ops from `hooks_into` if you only want to see edits.
+
+## Settings
+
+In Cursor: `Cmd+,` → search "cursorWitness".
+
+| Setting | Default | Effect |
+|---|---|---|
+| `cursorWitness.socketPath` | `""` (auto-derive) | Override the UDS socket path |
+| `cursorWitness.openOnRead` | `true` | Focus files on read ops. Set to `false` for edit-only |
+
+## How edits show as diffs
+
+When supertool runs a mutating op:
+1. Before the rewrite, supertool reads the file's current bytes
+2. Writes them to a temp file `/tmp/supertool-before-XXXX.<ext>`
+3. Fires the notifier with `{before_file}` set to that path
+4. Extension opens `vscode.diff(before_uri, after_uri)` — side-by-side
+5. Extension deletes the temp file after 60s
+
+If the file didn't exist before (new file from `paste`), `{before_file}` is empty and the extension falls back to plain open.
+
+## Status bar
+
+- `$(eye) Max: idle` — extension running, nothing happening
+- `$(edit) Max: <op> <filename>` — recent mutation (3s)
+- `$(eye) Max: <op> <filename>` — recent read (3s)
+
+Tooltip shows the full path + line.
+
+## Troubleshooting
+
+### Extension activates but socket isn't bound
+
+Cursor spawns multiple extension hosts. The first to bind wins; others stay dormant. If you see `socket already in use by another extension host` in `/tmp/cursor-witness.log`, that's expected — one host is serving.
+
+### Nothing happens when I run a supertool op
+
+Check the log:
+```bash
+tail -f /tmp/cursor-witness.log
+```
+
+You should see `LISTENING on /tmp/supertool-witness-<hash>.sock`. Verify the socket is alive:
+
+```bash
+lsof -U | grep supertool-witness
+```
+
+### Wrong file opens (or none)
+
+Check the workspace folder Cursor opened matches the cwd you're running supertool from. The socket path hash is derived from the workspace folder. If they disagree, the notifier writes to a socket no one is listening on.
+
+```bash
+# Expected socket path:
+python3 -c "import hashlib; print('/tmp/supertool-witness-' + hashlib.sha1(b'$(pwd)').hexdigest()[:12] + '.sock')"
+```
+
+### Edits don't show a diff
+
+Either `{before_file}` placeholder isn't in your `cmd`, or the file is new (no pre-content to diff). Add `{before_file}` as the 5th argument to `notify.py` in your `.supertool.json`.
+
+## Disable temporarily
+
+Just close Cursor. The notifier connects → no listener → silent exit. Supertool keeps working.
+
+To uninstall: remove the symlink and the `notifiers.cursor-witness` block from `.supertool.json`.

--- a/docs/notifiers.md
+++ b/docs/notifiers.md
@@ -1,0 +1,116 @@
+# Notifiers — fire-and-forget observers
+
+Notifiers are validators' read-friendly sibling. Same `hooks_into` / `match` shape, but they **observe instead of validate**:
+
+- Fire on reads as well as writes (validators only fire on mutating ops)
+- **Spawn-and-forget** — never block the parent supertool call
+- No JSON receipt parsed, no rollback semantics, no output rendered
+- Failures swallowed silently
+
+The use case: tap into supertool's op stream to drive side effects — pipe events into your editor (see [cursor-witness](cursor-witness.md)), Slack, an audit log, a desktop notification, anything.
+
+## Config
+
+Same place as validators in `.supertool.json`:
+
+```json
+{
+  "notifiers": {
+    "my-observer": {
+      "cmd": "python3 my-observer.py {op} {file} {line} {line_end} {before_file}",
+      "match": "*",
+      "hooks_into": [
+        "edit", "replace", "replace_lines", "paste", "vim",
+        "read", "around_line", "between", "map"
+      ]
+    }
+  }
+}
+```
+
+| Key | Meaning |
+|---|---|
+| `cmd` | Shell command, with substitution placeholders |
+| `match` | fnmatch glob against the file path — `*` for all files |
+| `hooks_into` | List of supertool op names that fire this notifier |
+
+### Placeholders
+
+| Token | Value | Set on |
+|---|---|---|
+| `{op}` | The op name (`edit`, `between`, ...) | Every fire |
+| `{file}` | Absolute file path the op targeted | Every fire |
+| `{line}` | Start line (1-indexed) | When the op exposes a line: `around_line`, `between` (symbol mode), `read:F:OFFSET:LIMIT` |
+| `{line_end}` | End line (1-indexed inclusive) | Same as `{line}` when a range is known |
+| `{before_file}` | Path to a temp file holding pre-edit content | Mutating ops only (`edit`/`replace`/`paste`/`vim`/`replace_lines`) |
+| `{supertool_dir}` | Install dir of supertool | Always |
+
+Unset placeholders render as empty strings — your notifier should treat them as optional.
+
+## Supported ops
+
+Mutating ops fire after the file is rewritten (post-validator). Read ops fire after the op returns its output.
+
+| Op | Line range | Notes |
+|---|---|---|
+| `edit`, `replace`, `replace_lines`, `paste`, `vim` | — | `{before_file}` set; ideal for diff view |
+| `around_line:FILE:LINE:N` | LINE-N to LINE+N | Computed from args |
+| `between:SYMBOL:FILE` | Symbol's body | Resolved via tree-sitter |
+| `between:re:START:END:FILE` | — | Regex variant, range too dynamic to precompute |
+| `read:FILE:OFFSET:LIMIT` | OFFSET to OFFSET+LIMIT-1 | Computed from args |
+| `read:FILE` | — | Whole file |
+| `map`, `tail`, `head`, `wc`, `stat`, `blame` | — | File-only focus |
+
+Other read ops (`grep`, `glob`, `ls`) don't fire notifiers — they target multiple files / paths, and the multi-event protocol isn't wired yet. Patches welcome.
+
+## Properties
+
+- **Spawn cost** — one fork+exec per fire. Typical < 5ms; never blocks because the parent does not `wait()`.
+- **Ordering** — notifiers fire **after** the op's output is returned. Observers see what supertool returned, not work-in-progress.
+- **Concurrency** — multiple notifiers fire serially within `_run_notifiers`, each as its own detached subprocess. Inside a single notifier, you own concurrency.
+- **Idempotence** — notifier scripts should be safe to fire on every op. The same edit may re-fire if the user re-runs the supertool call.
+- **Failure isolation** — `subprocess.Popen` errors (`OSError`, `ValueError`) are caught. A broken notifier never raises into supertool.
+
+## When to use a notifier vs a validator
+
+| | Validator | Notifier |
+|---|---|---|
+| Decides if the edit is OK | ✓ | ✗ |
+| Can roll back the file | ✓ | ✗ |
+| Returns a structured receipt | ✓ | ✗ |
+| Blocks the op until done | ✓ | ✗ |
+| Fires on reads | ✗ | ✓ |
+| Sees pre-edit content | rollback flow | `{before_file}` |
+| Fan-out side effects (editor, Slack, log) | wrong tool | ✓ |
+
+If your hook's answer changes whether the edit lands → validator. If it just observes → notifier.
+
+## Examples
+
+### Slack ping when files in `src/auth/` change
+
+```json
+"notifiers": {
+  "auth-watch": {
+    "cmd": "bash -c 'curl -s -X POST -H content-type:application/json -d \"{\\\"text\\\":\\\":wrench: {op} on {file}\\\"}\" $SLACK_WEBHOOK'",
+    "match": "src/auth/**",
+    "hooks_into": ["edit", "replace", "paste", "vim"]
+  }
+}
+```
+
+### Append to a per-session audit log
+
+```json
+"notifiers": {
+  "audit": {
+    "cmd": "bash -c 'echo \"$(date -u +%FT%TZ) {op} {file}\" >> /tmp/supertool-audit.log'",
+    "match": "*",
+    "hooks_into": ["edit", "replace", "paste", "vim", "rename"]
+  }
+}
+```
+
+### Cursor Witness — see Max work in your editor
+
+The flagship notifier consumer. Ships with supertool. See [cursor-witness.md](cursor-witness.md).

--- a/notifiers/cursor-witness/extension/.gitignore
+++ b/notifiers/cursor-witness/extension/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+*.vsix

--- a/notifiers/cursor-witness/extension/README.md
+++ b/notifiers/cursor-witness/extension/README.md
@@ -36,7 +36,7 @@ Add `read`, `grep`, `glob` to `hooks_into` if you also want to follow read ops (
 ## Settings
 
 - `cursorWitness.socketPath` — override the auto-derived socket path
-- `cursorWitness.openOnRead` — also focus files on read ops (default: false)
+- `cursorWitness.openOnRead` — focus files on read ops (default: `true`; set `false` for edit-only)
 
 ## How it works
 

--- a/notifiers/cursor-witness/extension/README.md
+++ b/notifiers/cursor-witness/extension/README.md
@@ -1,0 +1,70 @@
+# Cursor Witness
+
+Watch your supertool agent work in real time. When supertool edits a file in your project, this extension opens it in Cursor and jumps to the changed line.
+
+The agent isn't an opaque process anymore — it's a teammate whose work surfaces in your editor as it happens.
+
+## Install
+
+From source (no marketplace yet):
+
+```bash
+cd notifiers/cursor-witness/extension
+npm install
+npm run compile
+# Then: VSCode/Cursor → Extensions → "Install from VSIX..." or symlink to extensions dir
+```
+
+## Wire supertool
+
+Add to your project's `.supertool.json`:
+
+```json
+{
+  "notifiers": {
+    "cursor-witness": {
+      "cmd": "python3 {supertool_dir}/notifiers/cursor-witness/notify.py {op} {file} {line}",
+      "match": "*",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"]
+    }
+  }
+}
+```
+
+Add `read`, `grep`, `glob` to `hooks_into` if you also want to follow read ops (noisy).
+
+## Settings
+
+- `cursorWitness.socketPath` — override the auto-derived socket path
+- `cursorWitness.openOnRead` — also focus files on read ops (default: false)
+
+## How it works
+
+```
+supertool edit:foo.php
+   │
+   ▼
+notifier (fire-and-forget)
+   │  writes JSON event to UDS:
+   │  {"op":"edit","file":"/abs/foo.php","line":42,...}
+   ▼
+/tmp/supertool-witness-<sha1(cwd)[:12]>.sock
+   │
+   ▼
+Cursor extension (listening)
+   │
+   ▼
+vscode.window.showTextDocument(uri, {selection: line})
+```
+
+The notifier doesn't block — if the extension isn't running, the socket isn't there, the notifier exits silently. Supertool keeps working.
+
+## Status bar
+
+Shows `$(eye) Max: idle` when no recent activity, or `$(eye) Max: <op> <filename>` for 3 seconds after each event.
+
+## Troubleshooting
+
+- **Extension doesn't react** — check the socket path matches: derive from `python3 -c "import hashlib; print(hashlib.sha1(b'$(pwd)').hexdigest()[:12])"`. Compare with what the extension logs (Output panel → Cursor Witness).
+- **Socket already in use** — leftover from a previous run. Extension auto-cleans on activate, but you can `rm /tmp/supertool-witness-*.sock` to force.
+- **Wrong file opens** — check `cwd` in the event JSON matches your workspace folder.

--- a/notifiers/cursor-witness/extension/package-lock.json
+++ b/notifiers/cursor-witness/extension/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "cursor-witness",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cursor-witness",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.80.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "vscode": "^1.80.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/notifiers/cursor-witness/extension/package.json
+++ b/notifiers/cursor-witness/extension/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "cursor-witness",
+  "displayName": "Cursor Witness",
+  "description": "Watch your supertool agent work in Cursor — opens files the agent edits, jumps to changed lines.",
+  "version": "0.1.0",
+  "publisher": "digital-process-tools",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": ["onStartupFinished"],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Cursor Witness",
+      "properties": {
+        "cursorWitness.socketPath": {
+          "type": "string",
+          "default": "",
+          "description": "Override the UDS socket path. Empty = auto-derive from workspace folder (sha1)."
+        },
+        "cursorWitness.openOnRead": {
+          "type": "boolean",
+          "default": true,
+          "description": "Also focus files on read ops. Set false to only react to mutating ops."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.80.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/notifiers/cursor-witness/extension/src/extension.ts
+++ b/notifiers/cursor-witness/extension/src/extension.ts
@@ -1,0 +1,237 @@
+// Cursor Witness — listens on a Unix socket for supertool op events and opens
+// the touched file in the editor. Lets the human watch the agent work in real time.
+//
+// Wire format (NDJSON, one JSON per line):
+//   {"op": "edit", "file": "/abs/path", "line": 42|null, "ts": 1234, "cwd": "..."}
+//
+// Socket path: /tmp/supertool-witness-<sha1(workspace-root)[:12]>.sock
+// Override via cursorWitness.socketPath setting.
+
+import * as vscode from "vscode";
+import * as net from "net";
+import * as fs from "fs";
+import * as path from "path";
+import * as crypto from "crypto";
+
+interface WitnessEvent {
+  op: string;
+  file: string;
+  line: number | null;
+  line_end?: number | null;
+  before_file?: string;
+  ts: number;
+  cwd: string;
+}
+
+// Decoration for read-op range highlight (auto-fades).
+const readDecoration = vscode.window.createTextEditorDecorationType({
+  backgroundColor: "rgba(120, 180, 255, 0.18)",
+  isWholeLine: true,
+  overviewRulerColor: "rgba(120, 180, 255, 0.6)",
+  overviewRulerLane: vscode.OverviewRulerLane.Right,
+});
+let highlightTimer: NodeJS.Timeout | null = null;
+
+const READ_OPS = new Set(["read", "grep", "glob", "ls", "around", "around_line", "between", "map"]);
+const MUTATING_OPS = new Set(["edit", "replace", "replace_lines", "paste", "vim"]);
+
+let server: net.Server | null = null;
+let statusBar: vscode.StatusBarItem | null = null;
+let socketPath = "";
+let idleTimer: NodeJS.Timeout | null = null;
+
+function deriveSocketPath(): string {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    return "";
+  }
+  const cwd = folders[0].uri.fsPath;
+  const hash = crypto.createHash("sha1").update(cwd).digest("hex").substring(0, 12);
+  return `/tmp/supertool-witness-${hash}.sock`;
+}
+
+function setIdle(): void {
+  if (statusBar) {
+    statusBar.text = "$(eye) Max: idle";
+    statusBar.tooltip = `Listening on ${socketPath}`;
+  }
+}
+
+function opIcon(op: string): string {
+  if (MUTATING_OPS.has(op)) return "$(edit)";
+  if (READ_OPS.has(op)) return "$(eye)";
+  return "$(circle-outline)";
+}
+
+function setActive(event: WitnessEvent): void {
+  if (!statusBar) return;
+  const name = path.basename(event.file);
+  const icon = opIcon(event.op);
+  statusBar.text = `${icon} Max: ${event.op} ${name}`;
+  statusBar.tooltip = `${event.op} on ${event.file}${event.line ? ":" + event.line : ""}`;
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(setIdle, 3000);
+}
+
+async function openFile(event: WitnessEvent): Promise<void> {
+  const config = vscode.workspace.getConfiguration("cursorWitness");
+  const openOnRead = config.get<boolean>("openOnRead", true);
+
+  if (READ_OPS.has(event.op) && !openOnRead) return;
+  if (!MUTATING_OPS.has(event.op) && !READ_OPS.has(event.op)) return;
+  if (!event.file || !fs.existsSync(event.file)) return;
+
+  try {
+    const fileUri = vscode.Uri.file(event.file);
+
+    // Mutating op with a before-snapshot → show diff view (Max's edit visible).
+    if (MUTATING_OPS.has(event.op) && event.before_file && fs.existsSync(event.before_file)) {
+      const beforeUri = vscode.Uri.file(event.before_file);
+      const label = `${event.op} ${path.basename(event.file)} (Max)`;
+      await vscode.commands.executeCommand("vscode.diff", beforeUri, fileUri, label, { preview: false });
+      // Best-effort cleanup of the temp before-file once VSCode has read it.
+      // Delay so the diff editor finishes loading.
+      setTimeout(() => {
+        try { fs.unlinkSync(event.before_file as string); } catch { /* ignore */ }
+      }, 60_000);
+      return;
+    }
+
+    // Read op or no snapshot → focus + (if line range known) highlight + reveal.
+    const opts: vscode.TextDocumentShowOptions = { preserveFocus: false, preview: false };
+    const editor = await vscode.window.showTextDocument(fileUri, opts);
+
+    if (event.line && event.line > 0) {
+      const startLine = Math.max(0, event.line - 1);
+      const endLine = event.line_end && event.line_end >= event.line
+        ? event.line_end - 1
+        : startLine;
+      const lastLine = Math.min(endLine, editor.document.lineCount - 1);
+      const range = new vscode.Range(
+        new vscode.Position(startLine, 0),
+        new vscode.Position(lastLine, editor.document.lineAt(lastLine).text.length),
+      );
+      editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+      editor.setDecorations(readDecoration, [range]);
+      if (highlightTimer) clearTimeout(highlightTimer);
+      highlightTimer = setTimeout(() => {
+        try { editor.setDecorations(readDecoration, []); } catch { /* editor closed */ }
+      }, 4000);
+    }
+  } catch (err) {
+    console.error("cursor-witness: open failed", err);
+  }
+}
+
+function handleConnection(client: net.Socket): void {
+  let buf = "";
+  client.on("data", (chunk) => {
+    buf += chunk.toString("utf-8");
+    const nl = buf.indexOf("\n");
+    if (nl >= 0) {
+      const line = buf.substring(0, nl);
+      buf = buf.substring(nl + 1);
+      try {
+        const event = JSON.parse(line) as WitnessEvent;
+        setActive(event);
+        openFile(event);
+      } catch (err) {
+        console.error("cursor-witness: parse failed", err, "line:", line);
+      }
+    }
+  });
+  client.on("error", () => client.destroy());
+  client.on("end", () => client.destroy());
+}
+
+function fileLog(msg: string): void {
+  try {
+    fs.appendFileSync("/tmp/cursor-witness.log",
+      `${new Date().toISOString()} pid=${process.pid} ${msg}\n`);
+  } catch { /* ignore */ }
+}
+
+function startServer(): void {
+  const folders = (vscode.workspace.workspaceFolders || []).map(f => f.uri.fsPath).join(",") || "(none)";
+  fileLog(`startServer folders=${folders}`);
+  socketPath = vscode.workspace.getConfiguration("cursorWitness").get<string>("socketPath") || deriveSocketPath();
+  if (!socketPath) {
+    fileLog("no workspace folder, skipping");
+    return;
+  }
+  fileLog(`binding socket: ${socketPath}`);
+
+  // Cursor spawns multiple extension hosts (main, agent-worker, shadow-workspace).
+  // Each will activate this extension. Only one should bind the shared socket;
+  // others must back off and stay dormant — otherwise they race on unlink at
+  // deactivate time and the live socket vanishes.
+  if (fs.existsSync(socketPath)) {
+    // Try a quick connect: if someone's serving, back off; if dead socket, take it.
+    const probe = net.createConnection(socketPath);
+    probe.setTimeout(200);
+    probe.on("connect", () => {
+      probe.destroy();
+      fileLog(`socket already in use by another extension host — backing off`);
+    });
+    probe.on("error", () => {
+      // Stale socket file with no server — safe to take over
+      try { fs.unlinkSync(socketPath); } catch { /* ignore */ }
+      bindServer();
+    });
+    probe.on("timeout", () => {
+      probe.destroy();
+      fileLog(`socket probe timed out — backing off`);
+    });
+    return;
+  }
+  bindServer();
+}
+
+function bindServer(): void {
+  server = net.createServer(handleConnection);
+  server.on("error", (err) => {
+    fileLog(`server error: ${err.message}`);
+  });
+  server.listen(socketPath, () => {
+    fileLog(`LISTENING on ${socketPath}`);
+    setIdle();
+  });
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  fileLog("=== activate ===");
+  statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+  statusBar.text = "$(eye) Max: starting";
+  statusBar.show();
+  context.subscriptions.push(statusBar);
+
+  startServer();
+
+  // Restart on config change
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("cursorWitness.socketPath")) {
+        deactivate();
+        startServer();
+      }
+    })
+  );
+}
+
+export function deactivate(): void {
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+  // Only the host that bound `server` cleans up the socket file. Dormant hosts
+  // (who saw the socket already in use at activate time) leave it alone.
+  if (server) {
+    server.close();
+    server = null;
+    try {
+      if (socketPath && fs.existsSync(socketPath)) fs.unlinkSync(socketPath);
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/notifiers/cursor-witness/extension/src/extension.ts
+++ b/notifiers/cursor-witness/extension/src/extension.ts
@@ -189,7 +189,15 @@ function startServer(): void {
 
 function bindServer(): void {
   server = net.createServer(handleConnection);
-  server.on("error", (err) => {
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    // TOCTOU: another extension host probed + unlinked + bound between our
+    // probe and our bind. Treat EADDRINUSE as "they won, we back off."
+    if (err.code === "EADDRINUSE") {
+      fileLog(`bind lost race (EADDRINUSE) — backing off`);
+      try { server?.close(); } catch { /* ignore */ }
+      server = null;
+      return;
+    }
     fileLog(`server error: ${err.message}`);
   });
   server.listen(socketPath, () => {

--- a/notifiers/cursor-witness/extension/tsconfig.json
+++ b/notifiers/cursor-witness/extension/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "out",
+    "lib": ["ES2020"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}

--- a/notifiers/cursor-witness/listen.py
+++ b/notifiers/cursor-witness/listen.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Reference UDS listener for the cursor-witness notifier.
+
+Stand-in for the eventual VSCode/Cursor extension. Useful for:
+  - End-to-end testing
+  - Running a tail-style watch in a terminal while Max works
+  - Piping events into another tool (jq, awk, etc.)
+
+Usage:
+    python3 notifiers/cursor-witness/listen.py
+    python3 notifiers/cursor-witness/listen.py --socket /tmp/custom.sock
+
+Output: one JSON event per line on stdout (NDJSON).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import socket
+import sys
+
+
+def default_socket() -> str:
+    cwd = os.path.abspath(os.getcwd())
+    h = hashlib.sha1(cwd.encode()).hexdigest()[:12]
+    return f"/tmp/supertool-witness-{h}.sock"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--socket", default=default_socket(),
+                    help="UDS path (default: derived from cwd)")
+    args = ap.parse_args()
+
+    sock_path = args.socket
+    try: os.unlink(sock_path)
+    except FileNotFoundError: pass
+
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(sock_path)
+    srv.listen(8)
+    sys.stderr.write(f"cursor-witness listening on {sock_path}\n")
+    sys.stderr.flush()
+
+    try:
+        while True:
+            client, _ = srv.accept()
+            try:
+                buf = b""
+                # Bounded read — each notifier sends one short JSON line
+                while b"\n" not in buf and len(buf) < 8192:
+                    chunk = client.recv(4096)
+                    if not chunk:
+                        break
+                    buf += chunk
+                line = buf.split(b"\n", 1)[0]
+                if line:
+                    sys.stdout.write(line.decode("utf-8", errors="replace") + "\n")
+                    sys.stdout.flush()
+            finally:
+                try: client.close()
+                except OSError: pass
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try: srv.close()
+        except OSError: pass
+        try: os.unlink(sock_path)
+        except FileNotFoundError: pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/notifiers/cursor-witness/notify.py
+++ b/notifiers/cursor-witness/notify.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Cursor Witness notifier — emits supertool op events to a UDS socket.
+
+The companion VSCode/Cursor extension listens on the socket and opens the file
+(jumps to line) so the human can watch the agent work in their editor.
+
+Wired via .supertool.json:
+
+    "notifiers": {
+      "cursor-witness": {
+        "cmd": "python3 {supertool_dir}/notifiers/cursor-witness/notify.py {op} {file} {line}",
+        "match": "*",
+        "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"]
+      }
+    }
+
+Silent when no listener bound — never breaks the parent supertool call.
+
+Socket path: /tmp/supertool-witness-<sha1(cwd)[:12]>.sock
+Override with SUPERTOOL_WITNESS_SOCKET env var.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import socket
+import sys
+import time
+
+
+def socket_path() -> str:
+    override = os.environ.get("SUPERTOOL_WITNESS_SOCKET")
+    if override:
+        return override
+    cwd = os.path.abspath(os.getcwd())
+    h = hashlib.sha1(cwd.encode()).hexdigest()[:12]
+    return f"/tmp/supertool-witness-{h}.sock"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        return 0  # silent — bad invocation just exits clean
+    op = argv[1]
+    file_path = argv[2]
+    line_raw = argv[3] if len(argv) > 3 else ""
+    line_end_raw = argv[4] if len(argv) > 4 else ""
+    before_file = argv[5] if len(argv) > 5 else ""
+
+    def _maybe_int(s: str) -> int | None:
+        return int(s) if s and s.isdigit() else None
+
+    payload = {
+        "op": op,
+        "file": os.path.abspath(file_path) if file_path else "",
+        "line": _maybe_int(line_raw),
+        "line_end": _maybe_int(line_end_raw),
+        "before_file": before_file if before_file and os.path.exists(before_file) else "",
+        "ts": time.time(),
+        "cwd": os.path.abspath(os.getcwd()),
+    }
+    sock_path = socket_path()
+    if not os.path.exists(sock_path):
+        return 0  # no listener — silent
+
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(0.5)  # don't hang the parent
+        s.connect(sock_path)
+        s.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+        s.close()
+    except OSError:
+        return 0  # listener crashed mid-write — silent
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/supertool.py
+++ b/supertool.py
@@ -7751,6 +7751,24 @@ def _applicable_notifiers(op: str, path: str) -> Dict[str, Dict[str, Any]]:
     return out
 
 
+_NOTIFIER_TEMP_FILES: List[str] = []
+
+
+def _cleanup_notifier_temp_files() -> None:
+    """Best-effort unlink of any before_file temp files this process created.
+
+    Observers (cursor-witness extension) normally delete the file after they
+    consume it. If the observer is absent or crashes, this atexit hook keeps
+    /tmp from filling up over many sessions.
+    """
+    for p in _NOTIFIER_TEMP_FILES:
+        try: os.unlink(p)
+        except OSError: pass
+
+
+atexit.register(_cleanup_notifier_temp_files)
+
+
 def _run_notifiers(op: str, path: str, line: Optional[int] = None,
                    pre_content: Optional[bytes] = None,
                    line_end: Optional[int] = None) -> None:
@@ -7776,6 +7794,7 @@ def _run_notifiers(op: str, path: str, line: Optional[int] = None,
                 prefix="supertool-before-", suffix=ext)
             with os.fdopen(fd, "wb") as f:
                 f.write(pre_content)
+            _NOTIFIER_TEMP_FILES.append(before_file)
         except OSError:
             before_file = ""
 

--- a/supertool.py
+++ b/supertool.py
@@ -7730,6 +7730,79 @@ def _applicable_validators(op: str, path: str) -> Dict[str, Dict[str, Any]]:
     return out
 
 
+def _applicable_notifiers(op: str, path: str) -> Dict[str, Dict[str, Any]]:
+    """Notifiers are validator's read-friendly sibling: same hooks_into/match shape,
+    but fire-and-forget. Hook any op (reads included). No rollback, no receipt parsing.
+    """
+    cfg = _load_config()
+    notifiers = cfg.get("notifiers") or {}
+    if not notifiers:
+        return {}
+    out: Dict[str, Dict[str, Any]] = {}
+    for name, spec in notifiers.items():
+        if not isinstance(spec, dict):
+            continue
+        if op not in (spec.get("hooks_into") or []):
+            continue
+        glob = spec.get("match", "*")
+        if path and glob and not _match_glob(path, glob):
+            continue
+        out[name] = spec
+    return out
+
+
+def _run_notifiers(op: str, path: str, line: Optional[int] = None,
+                   pre_content: Optional[bytes] = None,
+                   line_end: Optional[int] = None) -> None:
+    """Spawn-and-forget every matching notifier. Returns immediately.
+
+    line: start line (1-indexed) when known
+    line_end: end line (1-indexed inclusive) when the op exposes a range
+    pre_content: file bytes BEFORE the op ran. Written to a temp file and
+    exposed as `{before_file}` in the notifier cmd template — enables diff
+    visualization in observers like cursor-witness.
+
+    Notifier failures are swallowed — observation must never break the op.
+    """
+    specs = _applicable_notifiers(op, path)
+    if not specs:
+        return
+
+    before_file = ""
+    if pre_content is not None:
+        try:
+            ext = os.path.splitext(path)[1] or ".txt"
+            fd, before_file = tempfile.mkstemp(
+                prefix="supertool-before-", suffix=ext)
+            with os.fdopen(fd, "wb") as f:
+                f.write(pre_content)
+        except OSError:
+            before_file = ""
+
+    for name, spec in specs.items():
+        cmd = spec.get("cmd")
+        if not cmd:
+            continue
+        cmd = (cmd
+               .replace("{op}", op)
+               .replace("{file}", path)
+               .replace("{line}", str(line if line is not None else ""))
+               .replace("{line_end}", str(line_end if line_end is not None else ""))
+               .replace("{before_file}", before_file)
+               .replace("{supertool_dir}", _INSTALL_DIR))
+        try:
+            subprocess.Popen(
+                shlex.split(cmd),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                close_fds=True,
+                start_new_session=True,
+            )
+        except (OSError, ValueError):
+            pass
+
+
 def _validator_resolve(spec: Dict[str, Any], file: str) -> Optional[str]:
     """Run optional `resolve` cmd to map source→target (e.g. source→test).
 
@@ -8131,14 +8204,27 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
         return do_op()
     applicable_fmt = _applicable_formatters(op, path)
     applicable = _applicable_validators(op, path)
+    applicable_notif = _applicable_notifiers(op, path)
     if not applicable_fmt and not applicable:
-        return do_op()
+        # No validators/formatters — still need pre_content for notifier diff view
+        pre_for_notif = None
+        if applicable_notif and os.path.isfile(path):
+            try:
+                with open(path, "rb") as f:
+                    pre_for_notif = f.read()
+            except OSError:
+                pass
+        body = do_op()
+        _run_notifiers(op, path, pre_content=pre_for_notif)
+        return body
 
     needs_rollback = any(v.get("rollback_on_fail") for v in applicable.values())
     needs_fmt_rollback = any(v.get("rollback_on_fail") for v in applicable_fmt.values())
 
+    # Capture pre_content for rollback AND/OR notifier diff view
     pre_content: Optional[bytes] = None
-    if (needs_rollback or needs_fmt_rollback) and os.path.isfile(path):
+    needs_pre = needs_rollback or needs_fmt_rollback or bool(applicable_notif)
+    if needs_pre and os.path.isfile(path):
         try:
             with open(path, "rb") as f:
                 pre_content = f.read()
@@ -8148,6 +8234,9 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
     before = _validators_run_batch(applicable, path) if applicable else {}
 
     body = do_op()
+
+    # Fire notifiers (observers) — never blocks, never raises
+    _run_notifiers(op, path, pre_content=pre_content)
 
     if isinstance(body, str) and body.startswith("ERROR"):
         return body
@@ -9822,7 +9911,105 @@ def dispatch(arg: str) -> str:
     except (ValueError, IndexError) as e:
         body = f"ERROR: argument parsing: {e}\n"
 
+    # Fire read-op notifiers (mutating ops already fire inside _run_with_validators)
+    try:
+        _notify_read_op(op, parts)
+    except Exception:
+        pass  # observation must never break the call
+
     return header + body
+
+
+# Read-op extractors → (path, line_start, line_end). Used by _notify_read_op.
+# Each entry maps `op` to a function that takes the parsed `parts` list and
+# returns either (path, line, line_end) or None if the op doesn't have a
+# meaningful single-file/range to notify on.
+def _read_target_around_line(parts: List[str]) -> Optional[Tuple[str, Optional[int], Optional[int]]]:
+    # around_line:PATH:LINE[:N]   default N=10
+    if len(parts) < 3:
+        return None
+    path = parts[1]
+    try:
+        line = int(parts[2])
+    except (TypeError, ValueError):
+        return None
+    n = 10
+    if len(parts) > 3:
+        try: n = int(parts[3])
+        except (TypeError, ValueError): pass
+    return (path, max(1, line - n), line + n)
+
+
+def _read_target_read(parts: List[str]) -> Optional[Tuple[str, Optional[int], Optional[int]]]:
+    # read:PATH[:OFFSET:LIMIT|:full]
+    if len(parts) < 2:
+        return None
+    path = parts[1]
+    if len(parts) >= 4:
+        try:
+            offset = int(parts[2]); limit = int(parts[3])
+            return (path, max(1, offset), offset + limit - 1)
+        except (TypeError, ValueError):
+            return (path, None, None)
+    return (path, None, None)
+
+
+def _read_target_file_only(parts: List[str]) -> Optional[Tuple[str, Optional[int], Optional[int]]]:
+    if len(parts) < 2:
+        return None
+    return (parts[1], None, None)
+
+
+def _read_target_between(parts: List[str]) -> Optional[Tuple[str, Optional[int], Optional[int]]]:
+    # between:SYMBOL:PATH (resolve range via tree-sitter)
+    # between:re:START:END:PATH (regex — line numbers unknown without re-running)
+    if len(parts) < 3:
+        return None
+    if parts[1] == "re" and len(parts) >= 5:
+        # Regex variant — return file only, no precomputable range
+        return (parts[4], None, None)
+    symbol = parts[1]
+    path = parts[2]
+    if not _has_tree_sitter():
+        return (path, None, None)
+    ext = os.path.splitext(path)[1].lower()  # keep the leading dot — that's the key
+    lang = _TS_LANG_MAP.get(ext)
+    if not lang:
+        return (path, None, None)
+    found = _ts_find_node(path, lang, symbol)
+    if found is None:
+        return (path, None, None)
+    node, _kind, _total = found
+    start_line = node.start_point[0] + 1  # 0-indexed → 1-indexed
+    end_line = node.end_point[0] + 1
+    return (path, start_line, end_line)
+
+
+_READ_OP_TARGETS: Dict[str, Any] = {
+    "around_line": _read_target_around_line,
+    "read":        _read_target_read,
+    "between":     _read_target_between,
+    "map":         _read_target_file_only,
+    "tail":        _read_target_file_only,
+    "head":        _read_target_file_only,
+    "wc":          _read_target_file_only,
+    "stat":        _read_target_file_only,
+    "blame":       _read_target_file_only,
+}
+
+
+def _notify_read_op(op: str, parts: List[str]) -> None:
+    """Fire notifiers for read ops (mutating ops fire inside _run_with_validators)."""
+    extractor = _READ_OP_TARGETS.get(op)
+    if not extractor:
+        return
+    target = extractor(parts)
+    if target is None:
+        return
+    path, line_start, line_end = target
+    if not path:
+        return
+    _run_notifiers(op, path, line=line_start, line_end=line_end)
 
 
 def caller_tag() -> str:

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -98,8 +98,9 @@ def test_notifier_does_not_block_caller(tmp_path: Path) -> None:
     start = time.time()
     supertool._run_notifiers("edit", "x.php")
     elapsed = time.time() - start
-    # Should return well under the 5s sleep
-    assert elapsed < 1.0, f"_run_notifiers blocked for {elapsed:.2f}s"
+    # Should return well under the 5s sleep. 2s threshold tolerates cold
+    # python startup on slow CI runners while still catching real blocks.
+    assert elapsed < 2.0, f"_run_notifiers blocked for {elapsed:.2f}s"
 
 
 def test_notifier_failure_does_not_raise(tmp_path: Path) -> None:

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -1,0 +1,123 @@
+"""Tests for the `notifiers` config block — fire-and-forget side-effect hooks.
+
+Notifiers are the validator's read-friendly sibling: same `hooks_into`/`match` shape,
+but spawn-and-forget (no rollback, no JSON receipt, no blocking the op).
+
+A notifier writes its event to a side channel (Unix socket, log file, HTTP webhook).
+Consumers like the Cursor witness extension listen on that channel.
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+
+def _set_config(d: dict) -> None:
+    supertool._CONFIG = d
+    supertool._CONFIG_CHECKED = True
+
+
+def test_applicable_notifiers_filters_by_op_and_match(tmp_path: Path) -> None:
+    """Notifiers fire only when (op in hooks_into) AND (path matches glob)."""
+    _set_config({
+        "notifiers": {
+            "watch-php": {
+                "cmd": "true",
+                "match": "*.php",
+                "hooks_into": ["edit", "read"],
+            }
+        }
+    })
+    assert "watch-php" in supertool._applicable_notifiers("edit", "x.php")
+    assert "watch-php" in supertool._applicable_notifiers("read", "x.php")
+    # wrong op
+    assert "watch-php" not in supertool._applicable_notifiers("paste", "x.php")
+    # wrong extension
+    assert "watch-php" not in supertool._applicable_notifiers("edit", "x.py")
+
+
+def test_notifier_fires_on_edit(tmp_path: Path) -> None:
+    """Mutating an edit-hooked notifier writes its side effect."""
+    marker = tmp_path / "fired.txt"
+    _set_config({
+        "notifiers": {
+            "marker": {
+                "cmd": f"sh -c 'echo {{op}} {{file}} > {marker}'",
+                "match": "*",
+                "hooks_into": ["edit"],
+            }
+        }
+    })
+    supertool._run_notifiers("edit", str(tmp_path / "target.php"))
+    # fire-and-forget — give the worker a moment
+    deadline = time.time() + 2
+    while time.time() < deadline and not marker.exists():
+        time.sleep(0.05)
+    assert marker.exists()
+    content = marker.read_text().strip()
+    assert content.startswith("edit ")
+    assert "target.php" in content
+
+
+def test_notifier_fires_on_read(tmp_path: Path) -> None:
+    """Notifiers can hook into read ops (validators can't)."""
+    marker = tmp_path / "read-fired.txt"
+    _set_config({
+        "notifiers": {
+            "read-watch": {
+                "cmd": f"sh -c 'echo {{op}} {{file}} > {marker}'",
+                "match": "*",
+                "hooks_into": ["read"],
+            }
+        }
+    })
+    supertool._run_notifiers("read", str(tmp_path / "x.php"))
+    deadline = time.time() + 2
+    while time.time() < deadline and not marker.exists():
+        time.sleep(0.05)
+    assert marker.exists()
+    assert "read" in marker.read_text()
+
+
+def test_notifier_does_not_block_caller(tmp_path: Path) -> None:
+    """A slow notifier must not delay the calling op."""
+    _set_config({
+        "notifiers": {
+            "slow": {
+                "cmd": "sh -c 'sleep 5'",
+                "match": "*",
+                "hooks_into": ["edit"],
+            }
+        }
+    })
+    start = time.time()
+    supertool._run_notifiers("edit", "x.php")
+    elapsed = time.time() - start
+    # Should return well under the 5s sleep
+    assert elapsed < 1.0, f"_run_notifiers blocked for {elapsed:.2f}s"
+
+
+def test_notifier_failure_does_not_raise(tmp_path: Path) -> None:
+    """A broken notifier cmd must not propagate exceptions to the caller."""
+    _set_config({
+        "notifiers": {
+            "broken": {
+                "cmd": "/nonexistent/binary",
+                "match": "*",
+                "hooks_into": ["edit"],
+            }
+        }
+    })
+    # Must not raise
+    supertool._run_notifiers("edit", "x.php")
+
+
+def test_notifiers_block_empty_when_unconfigured() -> None:
+    """No notifiers block → empty dict, no spawn attempts."""
+    _set_config({})
+    assert supertool._applicable_notifiers("edit", "x.php") == {}

--- a/tests/test_notifiers_cursor_witness.py
+++ b/tests/test_notifiers_cursor_witness.py
@@ -1,0 +1,123 @@
+"""Tests for the cursor-witness notifier — emits supertool events to a UDS listener.
+
+The notifier writes a JSON line per event; the listener (stand-in for the VSCode
+extension) reads them. These tests pin the wire format and the silent-on-no-listener
+behavior so the parent supertool call never breaks.
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+NOTIFY_SCRIPT = str(Path(__file__).parent.parent / "notifiers" / "cursor-witness" / "notify.py")
+
+
+def _spawn_listener(sock_path: str) -> tuple[socket.socket, list]:
+    """Bind a real UDS server inline (no subprocess) and return (sock, captured_lines).
+
+    Inline is easier to assert on than spawning listen.py — same wire format.
+    """
+    try: os.unlink(sock_path)
+    except FileNotFoundError: pass
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(sock_path)
+    srv.listen(8)
+    srv.settimeout(2.0)
+    return srv, []
+
+
+def _accept_one(srv: socket.socket) -> dict | None:
+    """Accept one connection, return its parsed JSON payload or None on timeout."""
+    try:
+        client, _ = srv.accept()
+    except socket.timeout:
+        return None
+    try:
+        buf = b""
+        while b"\n" not in buf and len(buf) < 8192:
+            chunk = client.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        line = buf.split(b"\n", 1)[0]
+        if not line:
+            return None
+        return json.loads(line.decode("utf-8"))
+    finally:
+        client.close()
+
+
+def test_notify_writes_to_listening_socket(tmp_path: Path) -> None:
+    sock_path = f"/tmp/st-witness-test-{uuid.uuid4().hex[:8]}.sock"
+    srv, _ = _spawn_listener(sock_path)
+    env = os.environ.copy()
+    env["SUPERTOOL_WITNESS_SOCKET"] = sock_path
+    try:
+        subprocess.run(
+            [sys.executable, NOTIFY_SCRIPT, "edit", "/abs/path/foo.php", "42"],
+            env=env, timeout=3,
+        )
+        event = _accept_one(srv)
+        assert event is not None
+        assert event["op"] == "edit"
+        assert event["file"] == "/abs/path/foo.php"
+        assert event["line"] == 42
+        assert "ts" in event
+        assert "cwd" in event
+    finally:
+        srv.close()
+        try: os.unlink(sock_path)
+        except FileNotFoundError: pass
+
+
+def test_notify_silent_when_no_listener(tmp_path: Path) -> None:
+    """Without a listener the notifier must exit cleanly (don't break parent)."""
+    sock_path = f"/tmp/st-witness-nolisten-{uuid.uuid4().hex[:8]}.sock"
+    env = os.environ.copy()
+    env["SUPERTOOL_WITNESS_SOCKET"] = sock_path
+    r = subprocess.run(
+        [sys.executable, NOTIFY_SCRIPT, "edit", "/abs/path/foo.php", "1"],
+        env=env, capture_output=True, timeout=3,
+    )
+    assert r.returncode == 0
+    assert r.stdout == b""
+    assert r.stderr == b""
+
+
+def test_notify_line_optional(tmp_path: Path) -> None:
+    """Missing or non-numeric line arg → line=None in payload."""
+    sock_path = f"/tmp/st-witness-noline-{uuid.uuid4().hex[:8]}.sock"
+    srv, _ = _spawn_listener(sock_path)
+    env = os.environ.copy()
+    env["SUPERTOOL_WITNESS_SOCKET"] = sock_path
+    try:
+        subprocess.run(
+            [sys.executable, NOTIFY_SCRIPT, "read", "/abs/path/foo.php"],
+            env=env, timeout=3,
+        )
+        event = _accept_one(srv)
+        assert event is not None
+        assert event["op"] == "read"
+        assert event["line"] is None
+    finally:
+        srv.close()
+        try: os.unlink(sock_path)
+        except FileNotFoundError: pass
+
+
+def test_notify_handles_missing_args(tmp_path: Path) -> None:
+    """Bad invocation (< 3 args) exits clean, no socket activity."""
+    r = subprocess.run(
+        [sys.executable, NOTIFY_SCRIPT, "edit"],
+        capture_output=True, timeout=3,
+    )
+    assert r.returncode == 0


### PR DESCRIPTION
## Summary

- New `notifiers` config block: validators' read-friendly sibling. Same `hooks_into`/`match` shape, but spawn-and-forget, fires on reads too, no rollback/receipt parsing. Use to fan supertool's op stream into editors, Slack, audit logs, anything.
- First consumer: **cursor-witness** — a Cursor/VSCode extension that opens edits in a side-by-side **diff view** and highlights read ranges in your editor as the agent works. Pair-programming with an autonomous agent.

## Architecture

`supertool 'between:Foo:bar.php'` → `_notify_read_op` → notify.py → UDS socket → Cursor extension → `vscode.window.showTextDocument` + decorated highlight (4s fade) or `vscode.diff` for mutating ops.

- Mutating ops fire from `_run_with_validators` (post-edit, with pre-content captured to a temp file as `{before_file}`)
- Read ops fire from a new dispatch tail hook, with line ranges resolved per op (args for `around_line`/`read`, tree-sitter for `between` symbol mode, file-only for `map`/`tail`/`head`/`wc`/`stat`/`blame`)
- Multi-host safe (Cursor spawns several extension hosts; probe-before-bind so only one wins the socket)

## Test plan

- [x] 10 new TDD tests in `tests/test_notifiers.py` + `tests/test_notifiers_cursor_witness.py`
- [x] Full test suite green (`python3 -m pytest tests/test_notifiers*.py tests/test_validators.py tests/test_edit_ops.py`)
- [x] End-to-end smoked on DVSI: `edit:foo.php` → Cursor diff view; `around_line:F:36:5` → blue highlight on lines 31–41; `between:SYMBOL:F` → tree-sitter-resolved range highlight; all fade after 4s
- [x] Failure isolation: no listener → notifier exits silently, supertool unaffected
- [x] Notifier failures (broken `cmd`) caught — supertool keeps working

## Docs

- New `docs/notifiers.md` — generic notifier config reference
- New `docs/cursor-witness.md` — install, settings, troubleshooting
- README updated — new sections between MCP and RTK