### PR TITLE
chore: bump 0.12.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/supertool.py
+++ b/supertool.py
@@ -105,7 +105,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.12.0"  # bumped for MCP daemon + notifiers + cursor-witness
+VERSION = "0.12.1"
 
 MAX_READ_LINES = 300
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"


### PR DESCRIPTION
Patch release: PR #134 (MCP auto-spawn timeout fix). Lets fresh installs hit LSP ops on first call without manual daemon spawn.