### PR TITLE
test: mark 6 slow tests + add dev deps (xdist, timeout)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install -e '.[dev]'
       - name: Create supertool symlink
         run: ln -sf supertool.py supertool
-      - name: Run tests
-        run: pytest
+      - name: Run tests (full suite — slow tests included)
+        # Override pyproject addopts default of `-m 'not slow'` so CI exercises
+        # the slow MCP-fallback and batch-stress paths the dev inner loop skips.
+        run: pytest -m ''

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[dev]'
+          pip install pytest pytest-cov pytest-xdist pytest-timeout
       - name: Create supertool symlink
         run: ln -sf supertool.py supertool
       - name: Run tests (full suite — slow tests included)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,15 @@ Changelog = "https://github.com/Digital-Process-Tools/claude-supertool/blob/main
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=supertool --cov-report=term-missing --cov-fail-under=86"
+addopts = "--cov=supertool --cov-report=term-missing --cov-fail-under=86 -m 'not slow'"
+markers = [
+    "slow: opt-in heavy tests (>5s). Run with `pytest -m slow` or `pytest -m ''` to include.",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+    "pytest-timeout",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,9 @@ dev = [
     "pytest-xdist",
     "pytest-timeout",
 ]
+
+[tool.setuptools]
+# Single-file project — declare the top-level module explicitly so setuptools
+# doesn't try to flat-layout-autodiscover (hooks/, presets/, notifiers/, etc.
+# are tool dirs, not Python packages).
+py-modules = ["supertool"]

--- a/tests/test_edge_cases_batch_security.py
+++ b/tests/test_edge_cases_batch_security.py
@@ -29,6 +29,7 @@ def _write_json(tmp_path: Path, name: str, payload) -> Path:
 # 1. Huge batch (10 000 ops) — DoS via memory / CPU
 # ---------------------------------------------------------------------------
 
+@pytest.mark.slow
 class TestHugeBatch:
     @pytest.mark.xfail(
         reason="PERF (2026-05-23): no batch-size cap. 10k read ops sequentially "

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -254,6 +254,7 @@ def test_map_dispatch_integration(tmp_path: Path) -> None:
     assert "class Mod" in out
 
 
+@pytest.mark.slow
 def test_map_dispatch_default_cwd() -> None:
     out = supertool.dispatch("map:.")
     assert "tier:" in out

--- a/tests/test_mcp_workspace.py
+++ b/tests/test_mcp_workspace.py
@@ -156,6 +156,7 @@ def test_workspace_references_uses_mcp(tmp_path: Path, monkeypatch: pytest.Monke
         supertool._mcp_specs.clear()
 
 
+@pytest.mark.slow
 def test_workspace_references_falls_back_on_mcp_miss(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When MCP returns no result (broken server), fall back to heuristic grep."""
     monkeypatch.chdir(tmp_path)
@@ -221,6 +222,7 @@ def test_workspace_symbols_falls_back_when_no_mcp(tmp_path: Path, monkeypatch: p
     assert "MyModule" in out
 
 
+@pytest.mark.slow
 def test_workspace_symbols_falls_back_on_bad_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     f = tmp_path / "mymodule.py"

--- a/tests/test_security_lsp.py
+++ b/tests/test_security_lsp.py
@@ -211,6 +211,7 @@ class TestShellInjection:
     allow arbitrary command execution.  This test inspects the Popen call site.
     """
 
+    @pytest.mark.slow
     def test_mcp_daemon_spawn_uses_list_not_shell(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """MCPClient.spawn() must call subprocess.Popen([...], ...) — list form only.
 
@@ -715,6 +716,7 @@ class TestCclspConfigInjection:
         # (we can't prove shell didn't run, but we can verify no crash + no unexpected output)
         assert "rm -rf" not in result
 
+    @pytest.mark.slow
     def test_cmd_field_is_not_executed_directly(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Why

Inner-loop test run was ~2:09. Six tests account for ~5 minutes of wall time:
- `test_huge_batch_*` — intentional 10k op stress (390s by design)
- 2x `test_mcp_workspace` fallback tests — 60s MCP timeout each
- 2x `test_security_lsp` daemon-spawn tests — 60s MCP timeout each
- `test_map_dispatch_default_cwd` — 25s tree-sitter cold start

## What

- `@pytest.mark.slow` on the 6 tests.
- `pyproject.toml` `addopts` defaults to `-m 'not slow'` + registers the marker.
- New `[project.optional-dependencies] dev` with `pytest-xdist` and `pytest-timeout`.

## Numbers

| Run | Time |
|-----|------|
| Before (full suite, serial) | ~2:09 |
| After (serial, slow excluded) | 1:57 |
| After (xdist, slow excluded) | **0:28** |

## How to run

- Fast (default): `pytest`
- Include slow: `pytest -m ''` or `pytest -m slow`
- Setup: `pip install -e '.[dev]'`

## Out of scope

The MCP 60s timeout is real — `_CONNECT_TIMEOUT_SECONDS` monkeypatch in those tests doesn't propagate. Tracked separately; this PR just marks them slow so the inner loop stays fast.