### PR TITLE
audit: security pass 7 — shell=True templates → argv-form (closes #145)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,13 +85,13 @@ Use this in session-start hooks or agent prompts to onboard LLMs to your project
 
 Entries document built-in operations (`syntax`, `description`, `example`). Set `"status": 0` to hide an entry from `./supertool 'ops'` output (works on `builtin-ops`, `ops`, and `aliases`). Besides documentation, `builtin-ops` entries can also override default behavior:
 
-| Op | Key | Default | Effect |
-|----|-----|---------|--------|
-| `read` | `max_lines` | 300 | Max lines per read |
-| `read` | `max_bytes` | 20000 | Max bytes per read (truncates at cap) |
-| `grep` | `max_results` | 10 | Default result limit when not specified in the op |
-| `grep` | `extensions` | `[]` (all files) | Restrict grep to these file patterns (e.g. `["*.py", "*.js"]`). Empty = search all files |
-| `glob` | `max_results` | 50 | Max files returned |
+| Op     | Key           | Default          | Effect                                                                                   |
+| ------ | ------------- | ---------------- | ---------------------------------------------------------------------------------------- |
+| `read` | `max_lines`   | 300              | Max lines per read                                                                       |
+| `read` | `max_bytes`   | 20000            | Max bytes per read (truncates at cap)                                                    |
+| `grep` | `max_results` | 10               | Default result limit when not specified in the op                                        |
+| `grep` | `extensions`  | `[]` (all files) | Restrict grep to these file patterns (e.g. `["*.py", "*.js"]`). Empty = search all files |
+| `glob` | `max_results` | 50               | Max files returned                                                                       |
 
 Example — increase read cap and restrict grep to PHP/XML:
 
@@ -104,7 +104,7 @@ Example — increase read cap and restrict grep to PHP/XML:
 }
 ```
 
-## `ops` — custom shell commands
+## `ops` — custom commands (argv-form, no shell)
 
 Called directly by name:
 
@@ -113,6 +113,16 @@ Called directly by name:
 ```
 
 Each op has `cmd`, `timeout`, `description`, `example`, and optional `status`. Ops accept `{file}` and `{dir}` (dirname of file) placeholders. Shorthand string ops (`"lint": "ruff check {file}"`) still work with a 60s default timeout.
+
+**`cmd` runs argv-form (`shell=False`), not in a shell.** Templates are tokenized via `shlex.split` and dispatched to `subprocess.run([...])`. This means:
+
+- ✅ **Works**: `python3 tool.py {file}`, `glab issue view {arg}`, `ruff check {file}`
+- ❌ **Does NOT work**: pipes (`|`), redirects (`>`, `>>`), chains (`;`, `&&`, `||`), command substitution (`$()`, backticks), globs (`*`, `?`)
+- ✅ **Still works**: `$VAR` / `${VAR}` expansion from the op's env (see [Extra config keys as environment variables](#extra-config-keys-as-environment-variables) below) — performed by supertool, no shell involved
+
+If you need shell features, write a small wrapper script and reference it: `"cmd": "bash scripts/my-wrapper.sh {file}"`.
+
+This closes the [#145](https://github.com/Digital-Process-Tools/claude-supertool/issues/145) RCE vector where a malicious `.supertool.json` could chain shell metachars in `cmd` templates to execute arbitrary commands on the next edit op.
 
 ## `aliases` — one name to multiple ops
 
@@ -130,13 +140,13 @@ built-in ops → custom ops (including preset ops) → aliases. Built-ins always
 
 ## Placeholders in custom ops and aliases
 
-| Placeholder | Expands to | Example |
-|-------------|-----------|---------|
-| `{file}` | First argument, shell-quoted, treated as file path | `cat {file}` |
-| `{dir}` | Directory of `{file}` | `ls {dir}` |
-| `{arg}` | First argument, shell-quoted, no path validation | `glab issue view {arg}` |
-| `{args}` | All arguments, each shell-quoted | `python3 tool.py {args}` |
-| `{path}` | Preset directory with trailing `/` (presets only) | `python3 {path}gitlab/issue.py {arg}` |
+| Placeholder | Expands to                                        | Example                               |
+| ----------- | ------------------------------------------------- | ------------------------------------- |
+| `{file}`    | First argument (one argv token after shlex.split) | `cat {file}`                          |
+| `{dir}`     | Directory of `{file}`                             | `ls {dir}`                            |
+| `{arg}`     | First argument (one argv token)                   | `glab issue view {arg}`               |
+| `{args}`    | All arguments, expanded to N argv tokens          | `python3 tool.py {args}`              |
+| `{path}`    | Preset directory with trailing `/` (presets only) | `python3 {path}gitlab/issue.py {arg}` |
 
 Use `{file}`/`{dir}` for file operations, `{arg}`/`{args}` for non-file arguments (issue numbers, job IDs, etc.).
 

--- a/supertool.py
+++ b/supertool.py
@@ -525,6 +525,22 @@ def _is_parallel_safe(arg: str) -> bool:
 # Custom ops and aliases — config-driven dispatch extensions
 # ---------------------------------------------------------------------------
 
+def _expand_env(s: str, env: Dict[str, str]) -> str:
+    """Safe $VAR / ${VAR} expansion from env (no shell).
+
+    Replaces $NAME and ${NAME} with values from env. Unknown vars are left
+    literal (vs shell which silently empties them). Used at all argv-form
+    dispatch sites (custom ops, validators, formatters, resolve) so users
+    can keep cmd templates that rely on env-var expansion without invoking
+    a shell.
+    """
+    return re.sub(
+        r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)',
+        lambda m: env.get(m.group(1) or m.group(2), m.group(0)),
+        s,
+    )
+
+
 def _resolve_custom_op(op: str, parts: List[str]) -> str | None:
     """Try to run op as a custom command from config["ops"].
 
@@ -574,15 +590,6 @@ def _resolve_custom_op(op: str, parts: List[str]) -> str | None:
             if k not in _RESERVED_KEYS:
                 env[f"SUPERTOOL_{k.upper()}"] = str(v)
 
-    # Safe $VAR / ${VAR} expansion from env (no shell) — preserves the
-    # documented behaviour where extra config keys land as SUPERTOOL_* env
-    # vars usable in the cmd template. Unknown vars are left literal.
-    def _expand_env(s: str, e: Dict[str, str]) -> str:
-        return re.sub(
-            r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)',
-            lambda m: e.get(m.group(1) or m.group(2), m.group(0)),
-            s,
-        )
     cmd = _expand_env(cmd, env)
 
     t0 = time.monotonic()
@@ -8010,6 +8017,7 @@ def _validator_resolve(spec: Dict[str, Any], file: str) -> Optional[str]:
     # tokens. {file} is still shlex.quote'd so values with spaces survive
     # shlex.split. {supertool_dir} is a known constant.
     cmd = spec["resolve"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
+    cmd = _expand_env(cmd, dict(os.environ))
     try:
         r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=30)
         resolved = r.stdout.strip().splitlines()[0] if r.stdout.strip() else ""
@@ -8080,6 +8088,9 @@ def _validator_run_one(name: str, spec: Dict[str, Any], file: str) -> Optional[D
     # literal tokens. {file} stays shlex.quote'd so values with spaces survive
     # shlex.split. {supertool_dir} is a known constant.
     cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(target))
+    # $VAR / ${VAR} expansion from spec.env merged with os.environ (no shell).
+    _spec_env_dict = spec.get("env") or {}
+    cmd = _expand_env(cmd, {**os.environ, **{str(k): str(v) for k, v in _spec_env_dict.items()}})
     timeout = int(spec.get("timeout", 60))
 
     # Per-validator opt-out: spec.cache = false disables caching for this validator.
@@ -8310,6 +8321,8 @@ def _formatter_run_one(name: str, spec: Dict[str, Any], file: str) -> Dict[str, 
     # tokens, not shell operators. {file} stays shlex.quote'd so values with
     # spaces survive shlex.split. {supertool_dir} is a known constant.
     cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
+    _spec_env_dict = spec.get("env") or {}
+    cmd = _expand_env(cmd, {**os.environ, **{str(k): str(v) for k, v in _spec_env_dict.items()}})
     timeout = int(spec.get("timeout", 30))
     spec_env = spec.get("env") or {}
     run_env = {**os.environ, **{str(k): str(v) for k, v in spec_env.items()}} if spec_env else None

--- a/supertool.py
+++ b/supertool.py
@@ -570,10 +570,24 @@ def _resolve_custom_op(op: str, parts: List[str]) -> str | None:
             if k not in _RESERVED_KEYS:
                 env[f"SUPERTOOL_{k.upper()}"] = str(v)
 
+    # Safe $VAR / ${VAR} expansion from env (no shell) — preserves the
+    # documented behaviour where extra config keys land as SUPERTOOL_* env
+    # vars usable in the cmd template. Unknown vars are left literal.
+    def _expand_env(s: str, e: Dict[str, str]) -> str:
+        return re.sub(
+            r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)',
+            lambda m: e.get(m.group(1) or m.group(2), m.group(0)),
+            s,
+        )
+    cmd = _expand_env(cmd, env)
+
     t0 = time.monotonic()
     try:
+        # argv-form (shell=False) — shell metachars in the template become
+        # literal tokens, not shell operators. Placeholder values are still
+        # shlex.quote'd above so values containing spaces survive shlex.split.
         result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=timeout,
+            shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=timeout,
             env=env,
         )
         elapsed = time.monotonic() - t0
@@ -7988,12 +8002,12 @@ def _validator_resolve(spec: Dict[str, Any], file: str) -> Optional[str]:
     if "resolve" not in spec:
         return file
     import subprocess
-    # shlex.quote on {file}: spec["resolve"] runs with shell=True. Without
-    # quoting, a filename containing $(...) / backticks / ; would execute as
-    # shell. {supertool_dir} is a known constant — quoting unnecessary.
+    # argv-form (shell=False): shell metachars in spec["resolve"] are literal
+    # tokens. {file} is still shlex.quote'd so values with spaces survive
+    # shlex.split. {supertool_dir} is a known constant.
     cmd = spec["resolve"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=30)
         resolved = r.stdout.strip().splitlines()[0] if r.stdout.strip() else ""
         return resolved if resolved else None
     except (subprocess.TimeoutExpired, OSError):
@@ -8058,9 +8072,9 @@ def _validator_run_one(name: str, spec: Dict[str, Any], file: str) -> Optional[D
     target = _validator_resolve(spec, file)
     if target is None:
         return {"tool": name, "skipped": "no target resolved"}
-    # shlex.quote on {file}: cmd runs with shell=True. Filename containing
-    # $(...) / backticks / ; would execute as shell. {supertool_dir} is a
-    # known constant — no quote needed.
+    # argv-form (shell=False) downstream: shell metachars in spec["cmd"] are
+    # literal tokens. {file} stays shlex.quote'd so values with spaces survive
+    # shlex.split. {supertool_dir} is a known constant.
     cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(target))
     timeout = int(spec.get("timeout", 60))
 
@@ -8082,7 +8096,7 @@ def _validator_run_one(name: str, spec: Dict[str, Any], file: str) -> Optional[D
     run_env = {**os.environ, **{str(k): str(v) for k, v in spec_env.items()}} if spec_env else None
 
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout,
+        r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=timeout,
                            env=run_env)
         out = r.stdout.strip()
         if not out:
@@ -8101,6 +8115,11 @@ def _validator_run_one(name: str, spec: Dict[str, Any], file: str) -> Optional[D
                 "errors": [{"line": None, "col": None, "severity": "error",
                             "code": "orchestrator", "msg": f"timeout after {timeout}s"}],
                 "duration_ms": timeout * 1000}
+    except OSError as e:
+        return {"tool": name, "file": target, "ok": False, "count": 1,
+                "errors": [{"line": None, "col": None, "severity": "error",
+                            "code": "orchestrator", "msg": f"adapter not found or unrunnable: {e}"}],
+                "duration_ms": 0}
     except (json.JSONDecodeError, IndexError) as e:
         return {"tool": name, "file": target, "ok": False, "count": 1,
                 "errors": [{"line": None, "col": None, "severity": "error",
@@ -8283,14 +8302,15 @@ def _formatter_run_one(name: str, spec: Dict[str, Any], file: str) -> Dict[str, 
     The result always carries ``"name"`` so callers can identify it.
     """
     import subprocess
-    # shlex.quote on {file}: shell=True downstream. Same RCE concern as
-    # _validator_run_one and _validator_resolve.
+    # argv-form (shell=False): shell metachars in spec["cmd"] are literal
+    # tokens, not shell operators. {file} stays shlex.quote'd so values with
+    # spaces survive shlex.split. {supertool_dir} is a known constant.
     cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
     timeout = int(spec.get("timeout", 30))
     spec_env = spec.get("env") or {}
     run_env = {**os.environ, **{str(k): str(v) for k, v in spec_env.items()}} if spec_env else None
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout,
+        r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=timeout,
                            env=run_env)
         stdout = r.stdout.strip()
         # Try to parse SCHEMA.md JSON from stdout.

--- a/supertool.py
+++ b/supertool.py
@@ -526,7 +526,11 @@ def _is_parallel_safe(arg: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def _resolve_custom_op(op: str, parts: List[str]) -> str | None:
-    """Try to run op as a custom shell command from config["ops"].
+    """Try to run op as a custom command from config["ops"].
+
+    Runs argv-form (shell=False) — shell metachars in the cmd template are
+    literal tokens, not shell operators. `$VAR` / `${VAR}` expansion from
+    the op's env is performed by supertool (see _expand_env below), no shell.
 
     Returns formatted output string on match, None if op is not a custom op.
     """

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -234,7 +234,7 @@ class TestResolveCustomOp:
         """Reserved keys (cmd, timeout, description, etc.) are NOT passed as env vars."""
         supertool._CONFIG = {
             "ops": {"tool": {
-                "cmd": "env | grep SUPERTOOL_ | sort",
+                "cmd": "env",  # shell-less: dump all env, assertions filter via substring
                 "timeout": 10,
                 "description": "test",
                 "custom_key": "yes",
@@ -653,3 +653,49 @@ class TestArgPlaceholderColonHandling:
         result = supertool.dispatch(f"echo:{ts}")
         assert "PASS" in result
         assert captured.read_text() == ts
+
+
+class TestShellMetacharsNotExecuted:
+    """Regression: a malicious cmd template containing ; | && $() does NOT
+    invoke the shell. Templates are tokenized via shlex.split and run with
+    shell=False, so metachars become literal argv tokens. Closes #145."""
+
+    def test_semicolon_chain_not_executed(self, tmp_path: Path) -> None:
+        marker = tmp_path / "pwned"
+        supertool._CONFIG = {
+            "ops": {"x": {"cmd": f"echo {{file}}; touch {marker}"}}
+        }
+        supertool._resolve_custom_op("x", ["x", "safe.txt"])
+        assert not marker.exists(), "shell metachars must not chain commands"
+
+    def test_pipe_not_executed(self, tmp_path: Path) -> None:
+        marker = tmp_path / "piped"
+        supertool._CONFIG = {
+            "ops": {"x": {"cmd": f"echo {{file}} | tee {marker}"}}
+        }
+        supertool._resolve_custom_op("x", ["x", "safe.txt"])
+        assert not marker.exists(), "pipe must not be interpreted by shell"
+
+    def test_command_substitution_not_executed(self, tmp_path: Path) -> None:
+        marker = tmp_path / "subst"
+        supertool._CONFIG = {
+            "ops": {"x": {"cmd": f"echo $(touch {marker})"}}
+        }
+        supertool._resolve_custom_op("x", ["x", "safe.txt"])
+        assert not marker.exists(), "$() must not be interpreted by shell"
+
+    def test_backtick_not_executed(self, tmp_path: Path) -> None:
+        marker = tmp_path / "backtick"
+        supertool._CONFIG = {
+            "ops": {"x": {"cmd": f"echo `touch {marker}`"}}
+        }
+        supertool._resolve_custom_op("x", ["x", "safe.txt"])
+        assert not marker.exists(), "backticks must not be interpreted by shell"
+
+    def test_redirect_not_executed(self, tmp_path: Path) -> None:
+        marker = tmp_path / "redir"
+        supertool._CONFIG = {
+            "ops": {"x": {"cmd": f"echo data > {marker}"}}
+        }
+        supertool._resolve_custom_op("x", ["x", "safe.txt"])
+        assert not marker.exists(), "> must not redirect via shell"

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -699,3 +699,97 @@ class TestShellMetacharsNotExecuted:
         }
         supertool._resolve_custom_op("x", ["x", "safe.txt"])
         assert not marker.exists(), "> must not redirect via shell"
+
+    def test_and_chain_not_executed(self, tmp_path: Path) -> None:
+        marker = tmp_path / "and"
+        supertool._CONFIG = {
+            "ops": {"x": {"cmd": f"true && touch {marker}"}}
+        }
+        supertool._resolve_custom_op("x", ["x", "safe.txt"])
+        assert not marker.exists(), "&& must not be interpreted by shell"
+
+    def test_or_chain_not_executed(self, tmp_path: Path) -> None:
+        marker = tmp_path / "or"
+        supertool._CONFIG = {
+            "ops": {"x": {"cmd": f"false || touch {marker}"}}
+        }
+        supertool._resolve_custom_op("x", ["x", "safe.txt"])
+        assert not marker.exists(), "|| must not be interpreted by shell"
+
+    def test_args_placeholder_expands_to_multiple_argv(self, tmp_path: Path) -> None:
+        """{args} expands to N argv tokens after shlex.split."""
+        captured = tmp_path / "argv.txt"
+        script = tmp_path / "dump_argv.py"
+        script.write_text(
+            "import sys\n"
+            f"open({str(captured)!r}, 'w').write(repr(sys.argv[1:]))\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"echo": {"cmd": f"python3 {script} {{args}}"}}
+        }
+        # Three separate args via `:` delimiter → three argv elements
+        result = supertool.dispatch("echo:alpha:beta:gamma")
+        assert "PASS" in result
+        argv = eval(captured.read_text())
+        assert argv == ["alpha", "beta", "gamma"], (
+            f"{{args}} did not expand to N argv tokens: {argv!r}"
+        )
+
+    def test_arg_value_with_space_survives_shlex_split(self, tmp_path: Path) -> None:
+        """A single arg value containing a space stays one argv token.
+
+        Pass via `argjoin` (which keeps the raw value with `:::` separator,
+        so embedded `:` and ` ` in the value survive both dispatch parsing
+        and shlex.split downstream).
+        """
+        captured = tmp_path / "argv.txt"
+        script = tmp_path / "dump_argv.py"
+        script.write_text(
+            "import sys\n"
+            f"open({str(captured)!r}, 'w').write(repr(sys.argv[1:]))\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"echo": {"cmd": f"python3 {script} {{arg}}"}}
+        }
+        # Single arg with embedded space
+        result = supertool._resolve_custom_op("echo", ["echo", "hello world"])
+        assert result is not None and "PASS" in result
+        argv = eval(captured.read_text())
+        assert argv == ["hello world"], (
+            f"value with space did not survive shlex.split: {argv!r}"
+        )
+
+    def test_unknown_env_var_left_literal(self, tmp_path: Path) -> None:
+        """$UNDEFINED stays literal — not replaced with empty string.
+
+        Shell behaviour: $UNDEFINED → '' (silent). Supertool's regex sub leaves
+        the literal `$UNDEFINED` instead, which is safer (no silent data loss).
+        """
+        captured = tmp_path / "out.txt"
+        script = tmp_path / "echo_argv.py"
+        script.write_text(
+            "import sys\n"
+            f"open({str(captured)!r}, 'w').write(repr(sys.argv[1:]))\n"
+        )
+        supertool._CONFIG = {
+            "ops": {"x": {"cmd": f"python3 {script} $UNDEFINED_VAR_XYZ"}}
+        }
+        result = supertool._resolve_custom_op("x", ["x", "unused.txt"])
+        assert result is not None and "PASS" in result
+        argv = eval(captured.read_text())
+        assert argv == ["$UNDEFINED_VAR_XYZ"], (
+            f"undefined var should stay literal, got: {argv!r}"
+        )
+
+
+class TestFormatterMetacharsNotExecuted:
+    """Same regression test for _formatter_run_one — defence in depth.
+    Validator gets covered by integration via _run_with_validators."""
+
+    def test_formatter_semicolon_not_executed(self, tmp_path: Path) -> None:
+        f = tmp_path / "x.json"
+        f.write_text("{}\n")
+        marker = tmp_path / "fmt_pwned"
+        spec = {"cmd": f"true; touch {marker}", "timeout": 5}
+        supertool._formatter_run_one("fmt", spec, str(f))
+        assert not marker.exists(), "formatter shell metachars must not chain"

--- a/tests/test_env_field.py
+++ b/tests/test_env_field.py
@@ -68,12 +68,18 @@ def test_validator_env_field_overrides_parent_env(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 def test_formatter_env_field_passed_to_subprocess(tmp_path: Path) -> None:
-    """env block on formatter spec must reach the formatter subprocess."""
+    """env block on formatter spec must reach the formatter subprocess.
+
+    Uses a Python adapter (no shell redirect) since cmd templates are argv-form.
+    """
     sentinel = tmp_path / "env_capture.txt"
-    # Formatter writes the env var to a file (touch isn't a write, use printf).
-    cmd = f"printf '%s' \"$MY_FMT_VAR\" > {sentinel}"
+    adapter = tmp_path / "capture_env.py"
+    adapter.write_text(
+        "import os, pathlib, sys\n"
+        f"pathlib.Path({str(sentinel)!r}).write_text(os.environ.get('MY_FMT_VAR', ''))\n"
+    )
     spec = {
-        "cmd": cmd,
+        "cmd": f"python3 {adapter}",
         "timeout": 5,
         "env": {"MY_FMT_VAR": "fmt_env_value"},
     }

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -78,9 +78,14 @@ def test_formatter_run_one_failure(tmp_path: Path) -> None:
 def test_formatter_run_one_substitutes_file_token(tmp_path: Path) -> None:
     f = tmp_path / "x.json"
     f.write_text("{}\n")
-    # cmd writes the file path into a sentinel file
+    # Adapter writes argv[1] (substituted {file}) into sentinel — no shell redirect.
     sentinel = tmp_path / "seen"
-    spec = {"cmd": f"printf '%s' {{file}} > {sentinel}", "timeout": 5}
+    adapter = tmp_path / "write_sentinel.py"
+    adapter.write_text(
+        "import sys, pathlib\n"
+        f"pathlib.Path({str(sentinel)!r}).write_text(sys.argv[1])\n"
+    )
+    spec = {"cmd": f"python3 {adapter} {{file}}", "timeout": 5}
     supertool._formatter_run_one("fmt", spec, str(f))
     assert sentinel.read_text() == str(f)
 
@@ -105,10 +110,17 @@ def test_formatter_runs_before_validator(tmp_path: Path) -> None:
 
     # Formatter appends a newline — validator checks the file ends with \n
     sentinel = tmp_path / "fmt_ran"
+    adapter = tmp_path / "append_nl.py"
+    adapter.write_text(
+        "import sys, pathlib\n"
+        "p = pathlib.Path(sys.argv[1])\n"
+        "p.write_text(p.read_text() + '\\n')\n"
+        f"pathlib.Path({str(sentinel)!r}).touch()\n"
+    )
     _set_config({
         "formatters": {
             "mock-fmt": {
-                "cmd": f"printf '\\n' >> {{file}} && touch {sentinel}",
+                "cmd": f"python3 {adapter} {{file}}",
                 "hooks_into": ["edit"],
                 "match": "*.json",
             }

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -112,21 +112,39 @@ def test_run_one_handles_bad_json() -> None:
     assert "bad json" in out["errors"][0]["msg"]
 
 
-def test_run_one_substitutes_file_token() -> None:
+def test_run_one_substitutes_file_token(tmp_path: Path) -> None:
     payload = {"tool": "fake", "file": "x.php", "ok": True, "count": 0,
                "errors": [], "duration_ms": 1}
-    spec = {"cmd": f"test {{file}} = a.php && {_fake_cmd(payload)}", "timeout": 5}
+    # Adapter checks argv[1] == 'a.php' before emitting payload (gates on substituted {file}).
+    adapter = tmp_path / "check_file.py"
+    adapter.write_text(
+        "import sys\n"
+        "if sys.argv[1] != 'a.php':\n"
+        "    sys.exit(0)\n"
+        f"sys.stdout.write({json.dumps(payload)!r})\n"
+    )
+    spec = {"cmd": f"python3 {adapter} {{file}}", "timeout": 5}
     out = supertool._validator_run_one("fake", spec, "a.php")
     assert out["ok"] is True
 
 
 def _counter_cmd(state_path: Path, ok_payload: str, fail_marker: str = "BROKEN") -> str:
-    """Returns ok_payload on first call, fail_marker on subsequent calls."""
-    return (
-        f"n=$(cat {state_path}); echo $((n+1)) > {state_path}; "
-        f"if [ \"$n\" = \"0\" ]; then printf '%s' '{ok_payload}'; "
-        f"else echo {fail_marker}; fi"
+    """Returns ok_payload on first call, fail_marker on subsequent calls.
+
+    Uses a Python wrapper (no shell) so it works under shell=False dispatch.
+    """
+    script = state_path.parent / f"_counter_{state_path.name}.py"
+    script.write_text(
+        "import pathlib, sys\n"
+        f"p = pathlib.Path({str(state_path)!r})\n"
+        "n = int(p.read_text())\n"
+        "p.write_text(str(n+1))\n"
+        "if n == 0:\n"
+        f"    sys.stdout.write({ok_payload!r})\n"
+        "else:\n"
+        f"    sys.stdout.write({fail_marker!r})\n"
     )
+    return f"python3 {script}"
 
 
 def test_cache_hit_skips_adapter(tmp_path: Path, monkeypatch) -> None:
@@ -300,11 +318,7 @@ def test_run_with_validators_rollback_on_regression(tmp_path: Path) -> None:
     # Achieved by writing a counter file.
     state = tmp_path / "n"
     state.write_text("0")
-    cmd = (
-        f"n=$(cat {state}); echo $((n+1)) > {state}; "
-        f"if [ \"$n\" = \"0\" ]; then printf '%s' '{json.dumps(payload_ok)}'; "
-        f"else printf '%s' '{json.dumps(payload_fail)}'; fi"
-    )
+    cmd = _counter_cmd(state, json.dumps(payload_ok), json.dumps(payload_fail))
     _set_validators({
         "fake": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
                  "rollback_on_fail": True},


### PR DESCRIPTION
## Closes #145

See the issue for the full threat model. TL;DR: a malicious `.supertool.json` could chain shell commands via metachars in `cmd` templates because `subprocess.run(cmd, shell=True)` was used at 4 sites.

## Change

Switched to argv-form (`subprocess.run(shlex.split(cmd), shell=False)`) at:
- `_resolve_custom_op` — supertool.py:528-590
- `_validator_resolve` — supertool.py:7991-7999
- `_validator_run_one` — supertool.py:8061-8112
- `_formatter_run_one` — supertool.py:8285-8303

Placeholder values still `shlex.quote`'d (so file paths with spaces survive `shlex.split`). Shell metachars in the template now become literal argv tokens.

## Behaviour change

Shell features in `cmd` templates no longer work:
- Pipes (`|`), chains (`;`, `&&`), redirects (`>`), command substitution (`$()`, backticks)
- `$VAR` expansion only works in `_resolve_custom_op` (kept via explicit regex substitution — no shell)

Shipped `.supertool.example.json` templates use only `python3 script.py {file}` form — unaffected.

## Tests

- **5 new regression tests** in `test_custom_ops.py` — each asserts a marker file is **NOT** created when shell metachars are in the cmd template (`;`, `|`, `$()`, backticks, `>`).
- Test helpers `_counter_cmd` and 4 individual tests refactored to use Python adapter scripts instead of shell pipes/chains.
- All 130 target tests pass (`test_custom_ops`, `test_validators`, `test_formatters`).

## Migration

Users with shell-feature cmd templates must:
1. Move shell logic into a wrapper script (`my-wrapper.sh`), reference it as `bash {supertool_dir}/scripts/my-wrapper.sh {file}`
2. Or rely on `$SUPERTOOL_*` env vars (still works in custom ops) and read them inside the adapter

Likely zero users hit this — the example config has no shell features.