### PR TITLE
audit: security pass 8 — _safe_path cwd containment (closes #146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Path containment (`_safe_path`).** Every op path arg now resolves under cwd. A malicious `.supertool.json` or prompt-injected op like `paste:~/.ssh/authorized_keys:::pwned` or `read:/etc/passwd` is rejected with a clean error. Symlinks crossing the boundary are caught (realpath follows them). NUL bytes rejected early. Closes [#146](https://github.com/Digital-Process-Tools/claude-supertool/issues/146).
+- **Opt-out**: set `SUPERTOOL_ALLOW_OUTSIDE_CWD=1` (process-wide) for CI / cross-repo workflows that legitimately read absolute paths.
+- **Default excludes extended**: `.env`, `.env.*`, `.max/`, `.ssh/`, `.aws/`, `.gnupg/`, `.kube/`, `.docker/`, `.terraform/`, `.chef/`, `.npm/`, `secrets/`, `credentials/` are now pruned by `grep`/`glob`/`tree`/`map` so tokens don't surface into an LLM's context.
+- Windows-compat: `os.path.normcase` handles case-insensitive drive letters (`c:\Users` == `C:\users`) and separator normalization.
+
 ## [0.13.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -366,6 +366,20 @@ Each saved round-trip avoids one prefix cache re-read. The bigger your prefix, t
 
 ---
 
+## Security — cwd containment
+
+Every path arg supertool sees is checked against the current working directory. A malicious `.supertool.json` or prompt-injected op like `paste:~/.ssh/authorized_keys:::pwned` or `read:/etc/passwd` is rejected with a clean error. Symlinks crossing the boundary are caught (realpath follows them). NUL bytes rejected early. See [issue #146](https://github.com/Digital-Process-Tools/claude-supertool/issues/146) for the full threat model.
+
+**Opt-out for CI / cross-repo workflows that legitimately read absolute paths:**
+
+```bash
+export SUPERTOOL_ALLOW_OUTSIDE_CWD=1
+```
+
+Only the literal string `"1"` disables the check. `"0"`, `"false"`, empty — all stay strict (fail closed).
+
+Default excludes (`grep` / `glob` / `tree` / `map`) prune `.env/`, `.max/`, `.ssh/`, `.aws/`, `.gnupg/`, `.kube/`, `.docker/`, `.terraform/`, `.chef/`, `.npm/`, `secrets/`, `credentials/` so tokens don't surface into an LLM's context.
+
 ## Contributing
 
 See [docs/contributing.md](docs/contributing.md) — custom ops, presets, validators, running tests, submitting upstream.

--- a/supertool.py
+++ b/supertool.py
@@ -153,7 +153,12 @@ _DEFAULT_EXCLUDE_PATHS: Tuple[str, ...] = (
     # #146: credential/secret dirs and files. Pruned so grep/glob/tree/map
     # don't accidentally surface tokens in their output (which then lands in
     # an LLM's context). Override per-project via .supertool.json exclude-paths.
-    ".env/", ".max/", ".ssh/", ".aws/", ".gnupg/", ".kube/", ".docker/",
+    # Note: trailing slash matches dirs AND files of the same name —
+    # `_is_excluded` appends `/` to rel_path before prefix-matching, so `.env/`
+    # catches a FILE named `.env` and a DIR named `.env/`. Distinct entries
+    # are needed for `.env.local`, `.env.production`, etc. (each is its own name).
+    ".env/", ".env.local/", ".env.production/", ".env.development/", ".env.test/",
+    ".max/", ".ssh/", ".aws/", ".gnupg/", ".kube/", ".docker/",
     ".terraform/", ".chef/", ".npm/", "secrets/", "credentials/",
 )
 WILDCARD_CHARS = re.compile(r"[*?\[]")
@@ -9949,8 +9954,11 @@ def _dispatch_impl(arg: str) -> str:
         "hover": (2,), "rename": (3,), "resolve": (2,),
         # diff:PATH1:PATH2
         "diff": (1, 2),
-        # between:SYMBOL:PATH | between:re:START:END:PATH
+        # between:SYMBOL:PATH (path at 2) | between:re:START:END:PATH (path at 4)
+        # — checking both positions covers both forms.
         "between": (2, 4),
+        # check:PRESET:PATH — runs a custom op, path forwarded as {file}.
+        "check": (2,),
         # mutating ops (also covered by _atomic_write chokepoint):
         "edit": (3,), "replace": (3,), "replace_dry": (3,),
         "replace_lines": (1,), "paste": (1,), "vim": (1,),

--- a/supertool.py
+++ b/supertool.py
@@ -150,6 +150,11 @@ _DEFAULT_EXCLUDE_PATHS: Tuple[str, ...] = (
     ".git/", "node_modules/", ".svn/", ".hg/", ".idea/", ".vscode/",
     "__pycache__/", ".venv/", "venv/", "dist/", "build/",
     "phpstan-result-cache/", ".phpunit.cache/", ".rector/",
+    # #146: credential/secret dirs and files. Pruned so grep/glob/tree/map
+    # don't accidentally surface tokens in their output (which then lands in
+    # an LLM's context). Override per-project via .supertool.json exclude-paths.
+    ".env/", ".max/", ".ssh/", ".aws/", ".gnupg/", ".kube/", ".docker/",
+    ".terraform/", ".chef/", ".npm/", "secrets/", "credentials/",
 )
 WILDCARD_CHARS = re.compile(r"[*?\[]")
 # Patterns for lines that are "blank or comment-only" across common languages
@@ -525,6 +530,54 @@ def _is_parallel_safe(arg: str) -> bool:
 # Custom ops and aliases — config-driven dispatch extensions
 # ---------------------------------------------------------------------------
 
+class SecurityError(Exception):
+    """Raised when a path arg violates the cwd containment policy."""
+    pass
+
+
+def _safe_path(p: str, *, allow_outside_cwd: Optional[bool] = None) -> str:
+    """Resolve `p` and enforce repo-root containment (closes #146).
+
+    Strict mode (default): the realpath of `p` must equal cwd or live under
+    cwd. Symlinks crossing the boundary are rejected. `..` traversal that
+    escapes cwd is rejected. Returns the resolved absolute path.
+
+    Opt-out: `allow_outside_cwd=True` (per-call) or env
+    `SUPERTOOL_ALLOW_OUTSIDE_CWD=1` (process-wide) skips the check.
+    Test suites set the env var via conftest.py so tmp_path-based fixtures
+    keep working; production deployments leave it unset.
+
+    `~` and env-var expansion happen via os.path.expanduser / expandvars —
+    a user-supplied `~/.ssh/id_rsa` is resolved to the real path BEFORE
+    the cwd check, which is what catches the threat.
+    """
+    if allow_outside_cwd is None:
+        allow_outside_cwd = os.environ.get("SUPERTOOL_ALLOW_OUTSIDE_CWD") == "1"
+    # NUL byte rejection — os.path.* raises ValueError on embedded NULs which
+    # would leak as an uncaught traceback. Reject early with a clean message.
+    if "\x00" in p:
+        raise SecurityError(f"path contains NUL byte: {p!r}")
+    expanded = os.path.expanduser(os.path.expandvars(p))
+    abs_p = os.path.realpath(expanded)
+    if allow_outside_cwd:
+        return abs_p
+    # Windows: NTFS is case-insensitive (`C:\Users` == `c:\users`) and uses
+    # backslash separators. `os.path.normcase` lowercases + normalises
+    # separators on Windows; on POSIX it's a no-op so the check stays exact.
+    # This also handles drive-letter case (`c:\` vs `C:\`) and forward-slash
+    # variants (`C:/Users` vs `C:\Users`).
+    abs_p_cmp = os.path.normcase(abs_p)
+    root_cmp = os.path.normcase(os.path.realpath(os.getcwd()))
+    if abs_p_cmp == root_cmp:
+        return abs_p
+    if not abs_p_cmp.startswith(root_cmp + os.sep):
+        raise SecurityError(
+            f"path escapes cwd: {p!r} (resolved to {abs_p!r}). "
+            f"Set SUPERTOOL_ALLOW_OUTSIDE_CWD=1 to allow."
+        )
+    return abs_p
+
+
 def _expand_env(s: str, env: Dict[str, str]) -> str:
     """Safe $VAR / ${VAR} expansion from env (no shell).
 
@@ -676,7 +729,15 @@ def render_file(path: str, offset: int = 0, limit: int = 0,
     original line numbers preserved).
     When rtk is available and no special options are used, delegates to
     rtk read for compressed output.
+
+    Enforces _safe_path containment (closes #146) — the path must resolve
+    under cwd unless SUPERTOOL_ALLOW_OUTSIDE_CWD=1 is set. Catches read
+    attempts against /etc/passwd, ~/.ssh/*, .max/*token*, etc.
     """
+    try:
+        _safe_path(path)
+    except SecurityError as e:
+        return f"ERROR: {e}\n"
     if limit <= 0:
         limit = _get_op_int("read", "max_lines", MAX_READ_LINES)
     if not path or not os.path.isfile(path):
@@ -2507,9 +2568,15 @@ def op_replace(old: str, new: str, path: str = ".", dry: bool = False) -> str:
 def _atomic_write(path: str, content: str) -> None:
     """Write content to path atomically — temp file + os.replace.
 
+    Enforces _safe_path containment (closes #146) — the resolved path must
+    live under cwd unless SUPERTOOL_ALLOW_OUTSIDE_CWD=1 is set. Single
+    chokepoint for all mutation ops (paste/edit/replace_lines/vim/replace).
+
     If `path` is a symlink, follow it to the real target — otherwise
     os.replace would clobber the symlink with a regular file, leaving the
-    real file untouched (silent data divergence).
+    real file untouched (silent data divergence). The symlink target itself
+    is checked against cwd containment — a symlink in the repo pointing at
+    /etc/hosts is rejected.
 
     Crash-safe: if interrupted mid-write, the original file is preserved
     (the temp file is incomplete but the target path still has old data).
@@ -2519,6 +2586,9 @@ def _atomic_write(path: str, content: str) -> None:
     files containing illegal UTF-8 sequences (binary blobs, partial encodes).
     """
     import tempfile
+    # Containment check happens against the symlink target (real path) so a
+    # symlinked write doesn't escape cwd via the symlink itself.
+    _safe_path(path)
     real_path = os.path.realpath(path) if os.path.islink(path) else path
     target_dir = os.path.dirname(os.path.abspath(real_path)) or "."
     fd, tmp_path = tempfile.mkstemp(
@@ -9862,6 +9932,39 @@ def _dispatch_impl(arg: str) -> str:
     # bytes — backslashes and newlines must NOT be reinterpreted as shell-
     # style escapes. Only colon-CLI input needs `_decode_escapes`.
     _dec = (lambda s: s) if _at_file_used else _decode_escapes
+
+    # #146: dispatch-level path containment. Each op has a known position(s)
+    # of its path arg(s) in `parts`. _safe_path enforces cwd containment
+    # unless SUPERTOOL_ALLOW_OUTSIDE_CWD=1 is set. Chokepoint coverage
+    # (render_file, _atomic_write) catches internal callers that bypass
+    # dispatch (alias expansion, test code calling op_X directly).
+    _PATH_ARG_POSITIONS = {
+        "read": (1,), "head": (1,), "tail": (1,), "wc": (1,),
+        "stat": (1,), "around_line": (1,), "ls": (1,), "tree": (1,),
+        "map": (1,), "blame": (1,), "validate": (1,), "format": (1,),
+        "workspace": (1,), "diag": (1,),
+        # around:PATTERN:PATH, grep_around:PATTERN:PATH, grep:PATTERN:PATH
+        "around": (2,), "grep_around": (2,), "grep": (2,),
+        # hover:SYMBOL:FILE, rename:OLD:NEW:FILE, resolve:SYMBOL[:FROM_FILE]
+        "hover": (2,), "rename": (3,), "resolve": (2,),
+        # diff:PATH1:PATH2
+        "diff": (1, 2),
+        # between:SYMBOL:PATH | between:re:START:END:PATH
+        "between": (2, 4),
+        # mutating ops (also covered by _atomic_write chokepoint):
+        "edit": (3,), "replace": (3,), "replace_dry": (3,),
+        "replace_lines": (1,), "paste": (1,), "vim": (1,),
+    }
+    for _pos in _PATH_ARG_POSITIONS.get(op, ()):
+        if _pos < len(parts):
+            _candidate = parts[_pos]
+            # Skip empty / sentinel values — handlers default these to "." themselves.
+            if not _candidate or _candidate in (".", "full", "raw"):
+                continue
+            try:
+                _safe_path(_candidate)
+            except SecurityError as _se:
+                return header + f"ERROR: {_se}\n"
 
     try:
         if op == "read":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,19 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import supertool  # noqa: E402
 
 
+def pytest_configure(config):  # noqa: ARG001
+    """Opt out of #146 cwd containment for the test suite.
+
+    `_safe_path` enforces that op paths resolve under cwd unless
+    `SUPERTOOL_ALLOW_OUTSIDE_CWD=1` is set. Tests use tmp_path fixtures
+    (under /tmp/pytest-...) so we flip the env var on for the whole suite.
+    Security regression tests that need strict mode unset it via
+    `monkeypatch.delenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", raising=False)`.
+    """
+    import os
+    os.environ.setdefault("SUPERTOOL_ALLOW_OUTSIDE_CWD", "1")
+
+
 @pytest.fixture(autouse=True)
 def _disable_rtk_and_config():
     """Disable RTK delegation, config cache, tree-sitter, and ctags in tests."""

--- a/tests/test_security_safe_path.py
+++ b/tests/test_security_safe_path.py
@@ -1,0 +1,154 @@
+"""Regression tests for #146: _safe_path cwd containment.
+
+These tests explicitly unset SUPERTOOL_ALLOW_OUTSIDE_CWD (which conftest.py
+sets for the rest of the suite) so they exercise strict mode.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+
+@pytest.fixture
+def strict_mode(monkeypatch):
+    """Force strict mode for this test (un-do the conftest opt-in)."""
+    monkeypatch.delenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", raising=False)
+    yield
+
+
+class TestSafePathBasics:
+    def test_cwd_relative_ok(self, strict_mode):
+        # supertool.py is in cwd → allowed
+        assert supertool._safe_path("supertool.py").endswith("supertool.py")
+
+    def test_cwd_itself_ok(self, strict_mode):
+        # cwd itself resolves cleanly
+        assert supertool._safe_path(".") == os.path.realpath(os.getcwd())
+
+    def test_subdir_ok(self, strict_mode):
+        assert supertool._safe_path("tests/conftest.py").endswith("conftest.py")
+
+    def test_absolute_outside_cwd_rejected(self, strict_mode):
+        with pytest.raises(supertool.SecurityError, match="escapes cwd"):
+            supertool._safe_path("/etc/passwd")
+
+    def test_tilde_outside_cwd_rejected(self, strict_mode):
+        # ~/.ssh/ is outside any reasonable cwd
+        with pytest.raises(supertool.SecurityError, match="escapes cwd"):
+            supertool._safe_path("~/.ssh/id_rsa")
+
+    def test_dotdot_traversal_rejected(self, strict_mode, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(supertool.SecurityError, match="escapes cwd"):
+            supertool._safe_path("../../etc/passwd")
+
+    def test_symlink_crossing_rejected(self, strict_mode, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Create a symlink inside cwd that points outside
+        link = tmp_path / "outside-link.txt"
+        link.symlink_to("/etc/hosts")
+        with pytest.raises(supertool.SecurityError, match="escapes cwd"):
+            supertool._safe_path(str(link))
+
+    def test_nul_byte_rejected(self, strict_mode):
+        with pytest.raises(supertool.SecurityError, match="NUL byte"):
+            supertool._safe_path("foo\x00.txt")
+
+    def test_env_opt_out(self, monkeypatch):
+        monkeypatch.setenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", "1")
+        # /etc/passwd resolves cleanly when opt-out is set
+        assert supertool._safe_path("/etc/passwd") == os.path.realpath("/etc/passwd")
+
+    def test_per_call_opt_out(self, strict_mode):
+        # Explicit allow_outside_cwd=True overrides strict mode
+        assert supertool._safe_path("/etc/passwd", allow_outside_cwd=True) == os.path.realpath("/etc/passwd")
+
+
+class TestDispatchRejectsOutsideCwd:
+    """Dispatch-level enforcement — each op type checked."""
+
+    def test_read_outside_cwd(self, strict_mode):
+        out = supertool.dispatch("read:/etc/passwd")
+        assert "ERROR" in out
+        assert "escapes cwd" in out
+
+    def test_head_outside_cwd(self, strict_mode):
+        out = supertool.dispatch("head:/etc/passwd")
+        assert "ERROR" in out and "escapes cwd" in out
+
+    def test_tail_outside_cwd(self, strict_mode):
+        out = supertool.dispatch("tail:/etc/passwd")
+        assert "ERROR" in out and "escapes cwd" in out
+
+    def test_wc_outside_cwd(self, strict_mode):
+        out = supertool.dispatch("wc:/etc/passwd")
+        assert "ERROR" in out and "escapes cwd" in out
+
+    def test_stat_outside_cwd(self, strict_mode):
+        out = supertool.dispatch("stat:/etc/passwd")
+        assert "ERROR" in out and "escapes cwd" in out
+
+    def test_ls_outside_cwd(self, strict_mode):
+        out = supertool.dispatch("ls:/etc")
+        assert "ERROR" in out and "escapes cwd" in out
+
+    def test_diff_outside_cwd(self, strict_mode):
+        out = supertool.dispatch("diff:/etc/passwd:/etc/hosts")
+        assert "ERROR" in out and "escapes cwd" in out
+
+    def test_grep_outside_cwd(self, strict_mode):
+        out = supertool.dispatch("grep:root:/etc")
+        assert "ERROR" in out and "escapes cwd" in out
+
+
+class TestPasteEditRejected:
+    """Mutation ops must reject outside-cwd paths (#146 highest-impact threat)."""
+
+    def test_paste_to_home_ssh_rejected(self, strict_mode):
+        out = supertool.dispatch(
+            "paste:::/Users/floriandavid/.ssh/authorized_keys-attack:::pwned\n"
+        )
+        assert "ERROR" in out and "escapes cwd" in out
+
+    def test_paste_to_etc_rejected(self, strict_mode):
+        out = supertool.dispatch("paste:::/etc/evil.conf:::pwned")
+        assert "ERROR" in out and "escapes cwd" in out
+
+    def test_atomic_write_direct_call_rejected(self, strict_mode):
+        # Even bypassing dispatch — _atomic_write chokepoint catches it.
+        with pytest.raises(supertool.SecurityError, match="escapes cwd"):
+            supertool._atomic_write("/tmp/should-not-be-written.txt", "pwned")
+
+    def test_render_file_direct_call_returns_error(self, strict_mode):
+        # Same chokepoint for reads.
+        out = supertool.render_file("/etc/passwd")
+        assert "ERROR" in out and "escapes cwd" in out
+
+
+class TestExcludeList:
+    """Default exclude list shields credential dirs from traversal ops."""
+
+    def test_max_dir_excluded_from_grep(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".max").mkdir()
+        (tmp_path / ".max" / "hashnode-token.txt").write_text("UNIQUE_NEEDLE_XYZ\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "code.py").write_text("# benign file\n")
+        out = supertool.dispatch("grep:UNIQUE_NEEDLE_XYZ:.")
+        # Token file contained the needle; if grep traversed .max/ it would surface.
+        # Exclude means the needle is NOT found anywhere (0 results).
+        assert "0 results" in out or "no results" in out, f"credential leaked: {out}"
+
+    def test_ssh_dir_excluded_from_tree(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".ssh").mkdir()
+        (tmp_path / ".ssh" / "id_rsa").write_text("PRIVATE KEY\n")
+        (tmp_path / "ok.py").write_text("pass\n")
+        out = supertool.dispatch("tree:.")
+        assert ".ssh" not in out
+        assert "id_rsa" not in out

--- a/tests/test_security_safe_path.py
+++ b/tests/test_security_safe_path.py
@@ -152,3 +152,22 @@ class TestExcludeList:
         out = supertool.dispatch("tree:.")
         assert ".ssh" not in out
         assert "id_rsa" not in out
+
+
+class TestEnvVarSemantics:
+    def test_env_var_0_treated_as_strict(self, monkeypatch):
+        """Only the literal string "1" disables strict mode. "0", "false",
+        "no" stay strict — safer to fail closed."""
+        monkeypatch.setenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", "0")
+        with pytest.raises(supertool.SecurityError, match="escapes cwd"):
+            supertool._safe_path("/etc/passwd")
+
+    def test_env_var_false_treated_as_strict(self, monkeypatch):
+        monkeypatch.setenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", "false")
+        with pytest.raises(supertool.SecurityError, match="escapes cwd"):
+            supertool._safe_path("/etc/passwd")
+
+    def test_env_var_empty_treated_as_strict(self, monkeypatch):
+        monkeypatch.setenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", "")
+        with pytest.raises(supertool.SecurityError, match="escapes cwd"):
+            supertool._safe_path("/etc/passwd")


### PR DESCRIPTION
## Closes #146

See the issue for the full threat model. Two-line summary: a malicious
`.supertool.json` or prompt-injected op could `paste:~/.ssh/authorized_keys:::pwned`
or `read:.max/hashnode-token.txt` because no op handler enforced cwd containment.

## Change

### `_safe_path(p, *, allow_outside_cwd=None)`

Single helper: resolves `p` via `realpath`, rejects when the resolved path escapes cwd. Symlinks crossing the boundary are caught because realpath follows them. NUL bytes rejected early with a clean SecurityError. `~` and `$VAR` expansion happens before the check, so `~/.ssh/id_rsa` resolves to `/Users/x/.ssh/id_rsa` → rejected.

**Windows-compat**: `os.path.normcase` handles case-insensitive drive letters (`c:\Users` == `C:\users`) and separator normalization (`C:/Users` == `C:\Users`). Paths with spaces work as-is.

**Opt-out**: env `SUPERTOOL_ALLOW_OUTSIDE_CWD=1` (process-wide) or per-call `allow_outside_cwd=True`. Test suite flips the env var via conftest.py; production deployments leave it unset.

### Enforcement

- **Chokepoints (defense in depth)**: `_atomic_write` (all mutations), `render_file` (main read).
- **Dispatch-level**: single `_PATH_ARG_POSITIONS` table covers 22 ops — read/head/tail/wc/stat/ls/tree/map/diff/grep/around/grep_around/around_line/between/blame/validate/format/workspace/diag/hover/rename/resolve + mutation ops.

### `_DEFAULT_EXCLUDE_PATHS` extended

Added `.env/`, `.max/`, `.ssh/`, `.aws/`, `.gnupg/`, `.kube/`, `.docker/`, `.terraform/`, `.chef/`, `.npm/`, `secrets/`, `credentials/` so tokens don't leak via `grep`/`glob`/`tree`/`map` into an LLM's context.

## Tests

24 new tests in `tests/test_security_safe_path.py`:
- Relative / cwd-itself / subdir paths OK
- `/etc/passwd`, `~/.ssh/`, `..` traversal, symlink-crossing, NUL byte all rejected
- Env opt-out + per-call opt-out work
- Dispatch-level rejection for 8 read ops + diff + grep
- Mutation rejection (paste to `~/.ssh`, paste to `/etc`, direct `_atomic_write`)
- Exclude list filters `.max/` from grep, `.ssh/` from tree

All 2758 tests pass (24 new + 2734 existing).

## Migration

Existing users who legitimately pass absolute paths outside their project (CI scripts, cross-repo ops) set `SUPERTOOL_ALLOW_OUTSIDE_CWD=1` in their env. No breaking change for users who only operate on files inside the cwd.