### PR TITLE
audit: lift KEY=VAL shell env-prefix into argv-form (#145 regression)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -8126,9 +8126,13 @@ def _validator_resolve(spec: Dict[str, Any], file: str) -> Optional[str]:
     # shlex.split. {supertool_dir} is a known constant.
     cmd = spec["resolve"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
     _prefix_env, cmd = _extract_env_prefix(cmd)
-    cmd = _expand_env(cmd, {**os.environ, **_prefix_env})
+    _merged_env = {**os.environ, **_prefix_env}
+    cmd = _expand_env(cmd, _merged_env)
+    # Pass merged env to child so prefix vars actually reach the subprocess.
+    _run_env = _merged_env if _prefix_env else None
     try:
-        r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=30,
+                           env=_run_env)
         resolved = r.stdout.strip().splitlines()[0] if r.stdout.strip() else ""
         return resolved if resolved else None
     except (subprocess.TimeoutExpired, OSError):

--- a/supertool.py
+++ b/supertool.py
@@ -583,6 +583,37 @@ def _safe_path(p: str, *, allow_outside_cwd: Optional[bool] = None) -> str:
     return abs_p
 
 
+def _extract_env_prefix(cmd: str) -> Tuple[Dict[str, str], str]:
+    """Split a leading `KEY=VAL KEY2=VAL2 ...` shell env-prefix off `cmd`.
+
+    Returns ({KEY:VAL,...}, remaining_cmd_without_prefix). Mirrors POSIX shell
+    semantics: a `KEY=VAL` token before the command sets KEY in the child's
+    env. Stops at the first non-assignment token. Tokens are parsed via
+    shlex.split, so quoted values (`KEY='one two'`) work.
+
+    Needed because the argv-form fix (#145) broke shipped cmd templates that
+    set env this way — `subprocess.run(shlex.split(cmd), shell=False)` treats
+    the assignment as a literal argv[0], yielding ENOENT.
+    """
+    env: Dict[str, str] = {}
+    tokens = shlex.split(cmd, posix=True)
+    idx = 0
+    _kv = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+    while idx < len(tokens):
+        m = _kv.match(tokens[idx])
+        if not m:
+            break
+        env[m.group(1)] = m.group(2)
+        idx += 1
+    if not env:
+        return {}, cmd
+    # Rebuild remaining cmd as shell-safe string so callers can keep using
+    # shlex.split on it (the placeholder-substituted file path already
+    # passed through shlex.quote upstream, so it survives a second pass).
+    remaining = " ".join(shlex.quote(t) for t in tokens[idx:])
+    return env, remaining
+
+
 def _expand_env(s: str, env: Dict[str, str]) -> str:
     """Safe $VAR / ${VAR} expansion from env (no shell).
 
@@ -648,6 +679,8 @@ def _resolve_custom_op(op: str, parts: List[str]) -> str | None:
             if k not in _RESERVED_KEYS:
                 env[f"SUPERTOOL_{k.upper()}"] = str(v)
 
+    _prefix_env, cmd = _extract_env_prefix(cmd)
+    env.update(_prefix_env)
     cmd = _expand_env(cmd, env)
 
     t0 = time.monotonic()
@@ -8092,7 +8125,8 @@ def _validator_resolve(spec: Dict[str, Any], file: str) -> Optional[str]:
     # tokens. {file} is still shlex.quote'd so values with spaces survive
     # shlex.split. {supertool_dir} is a known constant.
     cmd = spec["resolve"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
-    cmd = _expand_env(cmd, dict(os.environ))
+    _prefix_env, cmd = _extract_env_prefix(cmd)
+    cmd = _expand_env(cmd, {**os.environ, **_prefix_env})
     try:
         r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=30)
         resolved = r.stdout.strip().splitlines()[0] if r.stdout.strip() else ""
@@ -8163,9 +8197,13 @@ def _validator_run_one(name: str, spec: Dict[str, Any], file: str) -> Optional[D
     # literal tokens. {file} stays shlex.quote'd so values with spaces survive
     # shlex.split. {supertool_dir} is a known constant.
     cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(target))
-    # $VAR / ${VAR} expansion from spec.env merged with os.environ (no shell).
-    _spec_env_dict = spec.get("env") or {}
-    cmd = _expand_env(cmd, {**os.environ, **{str(k): str(v) for k, v in _spec_env_dict.items()}})
+    # Lift leading `KEY=VAL` shell env-prefix into env dict (shipped cmd
+    # templates use this to set MCP_*_WORKING_DIR before the python invocation).
+    _prefix_env, cmd = _extract_env_prefix(cmd)
+    # $VAR / ${VAR} expansion + child env both need spec.env + prefix env.
+    _spec_env_dict = {**_prefix_env, **(spec.get("env") or {})}
+    _merged_env = {**os.environ, **{str(k): str(v) for k, v in _spec_env_dict.items()}}
+    cmd = _expand_env(cmd, _merged_env)
     timeout = int(spec.get("timeout", 60))
 
     # Per-validator opt-out: spec.cache = false disables caching for this validator.
@@ -8182,8 +8220,8 @@ def _validator_run_one(name: str, spec: Dict[str, Any], file: str) -> Optional[D
             if cached is not None:
                 return cached
 
-    spec_env = spec.get("env") or {}
-    run_env = {**os.environ, **{str(k): str(v) for k, v in spec_env.items()}} if spec_env else None
+    # Use _merged_env (built above) so the prefix env-vars reach the child too.
+    run_env = _merged_env if _spec_env_dict else None
 
     try:
         r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=timeout,
@@ -8396,11 +8434,12 @@ def _formatter_run_one(name: str, spec: Dict[str, Any], file: str) -> Dict[str, 
     # tokens, not shell operators. {file} stays shlex.quote'd so values with
     # spaces survive shlex.split. {supertool_dir} is a known constant.
     cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
-    _spec_env_dict = spec.get("env") or {}
-    cmd = _expand_env(cmd, {**os.environ, **{str(k): str(v) for k, v in _spec_env_dict.items()}})
+    _prefix_env, cmd = _extract_env_prefix(cmd)
+    _spec_env_dict = {**_prefix_env, **(spec.get("env") or {})}
+    _merged_env = {**os.environ, **{str(k): str(v) for k, v in _spec_env_dict.items()}}
+    cmd = _expand_env(cmd, _merged_env)
     timeout = int(spec.get("timeout", 30))
-    spec_env = spec.get("env") or {}
-    run_env = {**os.environ, **{str(k): str(v) for k, v in spec_env.items()}} if spec_env else None
+    run_env = _merged_env if _spec_env_dict else None
     try:
         r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=timeout,
                            env=run_env)

--- a/tests/test_env_field.py
+++ b/tests/test_env_field.py
@@ -93,3 +93,44 @@ def test_formatter_env_field_absent_does_not_break(tmp_path: Path) -> None:
     spec = {"cmd": "true", "timeout": 5}
     result = supertool._formatter_run_one("fmt", spec, "any.php")
     assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Shell env-prefix lift (KEY=VAL cmd args) — argv-form compat (#145 regression)
+# ---------------------------------------------------------------------------
+
+def test_extract_env_prefix_basic() -> None:
+    env, cmd = supertool._extract_env_prefix("FOO=bar BAZ=qux python3 script.py")
+    assert env == {"FOO": "bar", "BAZ": "qux"}
+    assert cmd == "python3 script.py"
+
+
+def test_extract_env_prefix_no_prefix() -> None:
+    env, cmd = supertool._extract_env_prefix("python3 script.py")
+    assert env == {}
+    assert cmd == "python3 script.py"
+
+
+def test_extract_env_prefix_quoted_value() -> None:
+    env, cmd = supertool._extract_env_prefix("KEY='one two' python3 script.py")
+    assert env == {"KEY": "one two"}
+    assert "python3 script.py" in cmd
+
+
+def test_validator_env_prefix_reaches_child(tmp_path: Path) -> None:
+    """Closes the regression: shipped DVSI cmd templates use `KEY=VAL python3 ...`
+    shell env-prefix syntax. Argv-form must lift that into env=.
+    """
+    adapter = tmp_path / "capture.py"
+    payload = '{"tool":"t","file":"x","ok":true,"count":0,"errors":[],"duration_ms":1,"working_dir":"' + str(tmp_path) + '"}'
+    adapter.write_text(
+        "import os, sys\n"
+        f"if os.environ.get('MCP_PHPSTAN_WORKING_DIR') == {str(tmp_path)!r}:\n"
+        f"    sys.stdout.write({payload!r})\n"
+        "else:\n"
+        "    sys.stdout.write('{\"tool\":\"t\",\"file\":\"x\",\"ok\":false,\"count\":1,\"errors\":[{\"line\":null,\"col\":null,\"severity\":\"error\",\"code\":\"x\",\"msg\":\"env not set\"}],\"duration_ms\":1}')\n"
+    )
+    cmd = f"MCP_PHPSTAN_WORKING_DIR={tmp_path} python3 {adapter}"
+    spec = {"cmd": cmd, "timeout": 5, "cache": False}
+    out = supertool._validator_run_one("t", spec, "any.php")
+    assert out.get("ok") is True, f"env-prefix did not reach child: {out}"

--- a/tests/test_env_field.py
+++ b/tests/test_env_field.py
@@ -134,3 +134,21 @@ def test_validator_env_prefix_reaches_child(tmp_path: Path) -> None:
     spec = {"cmd": cmd, "timeout": 5, "cache": False}
     out = supertool._validator_run_one("t", spec, "any.php")
     assert out.get("ok") is True, f"env-prefix did not reach child: {out}"
+
+
+def test_spec_env_wins_over_prefix(tmp_path: Path) -> None:
+    """When both shell prefix and spec.env set the same key, spec.env wins."""
+    adapter = tmp_path / "capture.py"
+    adapter.write_text(
+        "import os, sys, json\n"
+        "val = os.environ.get('SHARED_VAR', '<unset>')\n"
+        "sys.stdout.write(json.dumps({'tool':'t','file':'x','ok': val == 'from_spec', 'count':0,'errors':[],'duration_ms':1,'captured':val}))\n"
+    )
+    spec = {
+        "cmd": f"SHARED_VAR=from_prefix python3 {adapter}",
+        "timeout": 5,
+        "cache": False,
+        "env": {"SHARED_VAR": "from_spec"},
+    }
+    out = supertool._validator_run_one("t", spec, "any.php")
+    assert out.get("captured") == "from_spec", f"spec.env did not win: {out}"


### PR DESCRIPTION
## What

Hotfix for a regression introduced by #145.

Shipped cmd templates (Kevin / DVSI / others) use POSIX-shell env-prefix:

```
"cmd": "MCP_PHPSTAN_WORKING_DIR=/path python3 adapter.py {file}"
```

With `shell=True` (pre-#145), bash parsed the assignment and set the env. With argv-form (#145), `shlex.split` turns it into `argv[0]` → `ENOENT`.

Kevin reported this morning:

```
phpstan : 1 err  orchestrator  adapter not found or unrunnable: [Errno 2] No such file or directory: 'MCP_PHPSTAN_WORKING_DIR=/Users/floriandavid/Documents/dvsi'
phpunit : 1 err  ...
rector  : 1 err  ...
```

## Fix

New `_extract_env_prefix(cmd) -> (env_dict, remaining_cmd)` helper. Parses leading `KEY=VAL` tokens via `shlex.split`, stops at first non-assignment token. Lifted env vars merge with `spec.env` (spec.env wins) and reach the child via `subprocess.run(..., env=)`.

Applied at all 4 argv-form sites: `_resolve_custom_op`, `_validator_resolve`, `_validator_run_one`, `_formatter_run_one`.

## Tests

- 3 unit tests for `_extract_env_prefix` (basic, no-prefix, quoted-value)
- 1 end-to-end test: shipped DVSI-style cmd `MCP_PHPSTAN_WORKING_DIR=path python3 ...` reaches the child with MCP_PHPSTAN_WORKING_DIR set in `os.environ`.

All 2765 tests pass.

## Migration

No action needed. The fix is fully backwards-compatible — cmd templates without env-prefix behave as before.