### PR TITLE
audit: security pass 11 — hardening bundle (closes #150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Hardening bundle.** Smaller defence-in-depth items from the audit (closes [#150](https://github.com/Digital-Process-Tools/claude-supertool/issues/150)):
+  - **Gitcli flag smuggling**: `git-checkout REF`, `git-merge REF`, `git-blame PATH` reject refs/paths starting with `-` (e.g. `--orphan=evil`, `--abort`, `-X theirs`). `git-blame` uses `--` separator to keep a path-with-dash from being parsed as a flag.
+  - **Regex ReDoS guards** on `grep`: pattern length capped at 1000 chars; nested unbounded quantifiers (`(a+)+`, `(.+)*`) rejected before they touch file content.
+  - **`validate_staged` / `format_staged`** use `git diff -z --diff-filter=ACMR` (filenames with newlines/quotes survive) and reject symlinks — a staged symlink to `/etc/hosts` would otherwise be REWRITTEN by formatters.
+  - **`xmllint` validator** runs with `--nonet --noent` so libxml2 can't fetch external entities or follow URI references during validation (XXE defence-in-depth).
+  - **Validator cache HMAC** at `~/.cache/supertool/.cache_key` (mode 0600, 32 random bytes, generated on first use). Each cache entry wrapped with HMAC-SHA256 of its body. Attacker with write access to `~/.cache/supertool/validators/` cannot forge a passing `ok: true` entry without also reading the secret. Legacy unwrapped entries treated as miss.
 - **Social publishing safety.** Three guards for the dev.to / bluesky publish + comment ops (closes [#149](https://github.com/Digital-Process-Tools/claude-supertool/issues/149)):
   - `file://` body must resolve under `.max/`, `drafts/`, `posts/`, or `blog/` (relative to cwd). Closes the credential-exfil vector: `bluesky_publish:file:///Users/.../app_password` now rejected before the file is read. Extend additively via `$SUPERTOOL_PUBLISH_BODY_ALLOWLIST=path1:path2` or `"publish_body_allowlist": [...]` in `.supertool.json`.
   - Confirm-default — `bluesky_publish` / `devto_publish` refuse to run without `|force`, `SUPERTOOL_NO_PUBLISH_CONFIRM=1` env, or `"no_publish_confirm": true` in `.supertool.json`. Blocks single-shot publish from a prompt-injected op.

--- a/presets/git/blame.py
+++ b/presets/git/blame.py
@@ -49,7 +49,9 @@ def main() -> int:
     end = line + n
     try:
         result = subprocess.run(
-            ["git", "blame", "-L", f"{start},{end}", "--date=short", path],
+            # #150: `--` separator so a PATH starting with `-` (e.g. literal
+            # file named `-foo`) is treated as a path, not a CLI flag.
+            ["git", "blame", "-L", f"{start},{end}", "--date=short", "--", path],
             capture_output=True, text=True, timeout=10,
         )
     except subprocess.TimeoutExpired:

--- a/presets/git/checkout.py
+++ b/presets/git/checkout.py
@@ -24,6 +24,13 @@ def main() -> int:
         return 1
 
     ref = sys.argv[1]
+    # #150: reject refs that look like CLI flags. `--orphan`, `--detach`,
+    # `--track=…` are valid git invocations that change semantics — a
+    # prompt-injected REF would silently do something other than switch
+    # branches. `-` (previous branch) is legitimate; allow it.
+    if ref.startswith("-") and ref != "-":
+        print(f"ERROR: ref starts with '-' (refusing for safety): {ref!r}")
+        return 1
 
     prev_branch = ""
     prev = _git(["rev-parse", "--abbrev-ref", "HEAD"])

--- a/presets/git/merge.py
+++ b/presets/git/merge.py
@@ -71,6 +71,11 @@ def main() -> int:
         return 1
 
     ref = sys.argv[1]
+    # #150: a REF like `--abort` would call `git merge --abort` (state-mutating).
+    # `-X theirs` smuggles a strategy option. Refuse leading-dash refs.
+    if ref.startswith("-"):
+        print(f"ERROR: ref starts with '-' (refusing for safety): {ref!r}")
+        return 1
     preview = int(os.environ.get("SUPERTOOL_PREVIEW_LINES", str(DEFAULT_PREVIEW_LINES)))
 
     if _git(["rev-parse", "--verify", "--quiet", ref]).returncode != 0:

--- a/supertool.py
+++ b/supertool.py
@@ -971,6 +971,21 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
     if not pattern:
         return "ERROR: empty pattern\n"
 
+    # #150 ReDoS guards. Python's stdlib `re` has no execution timeout, so
+    # we reject patterns that are obvious candidates for catastrophic
+    # backtracking before they touch any file content.
+    if len(pattern) > 1000:
+        return f"ERROR: pattern too long ({len(pattern)} > 1000 chars)\n"
+    # Nested unbounded quantifiers like `(a+)+`, `(a*)*`, `(.+)*` — the
+    # classic ReDoS shape. The check is intentionally loose; users with a
+    # legitimate need can split into simpler greps.
+    if re.search(r"\([^)]*[+*][^)]*\)[+*?]", pattern):
+        return (
+            "ERROR: pattern contains nested unbounded quantifiers "
+            f"({pattern!r}) — would risk catastrophic backtracking. "
+            "Rewrite without `(...+)+`-style nesting.\n"
+        )
+
     # Auto-convert bash grep BRE alternation (\|) to Python regex (|)
     if "\\|" in pattern:
         pattern = pattern.replace("\\|", "|")
@@ -8244,23 +8259,77 @@ def _validator_cache_path(key: str) -> Path:
     return Path.home() / ".cache" / "supertool" / "validators" / f"{key}.json"
 
 
+def _validator_cache_secret() -> bytes:
+    """Per-user HMAC secret for cache integrity (closes #150 cache-poison).
+
+    32-byte random secret stored at `~/.cache/supertool/.cache_key`, mode
+    0600. Attacker with write access to the cache dir (compromised account,
+    malicious npm postinstall) cannot forge a passing `ok: true` entry
+    without also reading the secret.
+    """
+    secret_path = Path.home() / ".cache" / "supertool" / ".cache_key"
+    try:
+        if secret_path.is_file():
+            data = secret_path.read_bytes()
+            if len(data) == 32:
+                return data
+    except OSError:
+        pass
+    secret = os.urandom(32)
+    try:
+        secret_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(secret_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(fd, secret)
+        finally:
+            os.close(fd)
+        return secret
+    except FileExistsError:
+        try:
+            return secret_path.read_bytes()
+        except OSError:
+            return secret
+    except OSError:
+        return secret
+
+
 def _validator_cache_read(key: str) -> Optional[Dict[str, Any]]:
+    """Read + HMAC-verify a cache entry. Returns None on missing / tampered.
+
+    Legacy unwrapped entries (pre-HMAC) treated as miss — they get rewritten
+    in wrapped form next time the validator runs.
+    """
+    import hashlib
+    import hmac
     import json
     p = _validator_cache_path(key)
     if not p.exists():
         return None
     try:
-        return json.loads(p.read_text())
+        wrapped = json.loads(p.read_text())
     except (OSError, json.JSONDecodeError):
         return None
+    if not isinstance(wrapped, dict) or "data" not in wrapped or "mac" not in wrapped:
+        return None  # legacy unwrapped — don't trust ok=True
+    payload = json.dumps(wrapped["data"], sort_keys=True).encode("utf-8")
+    expected = hmac.new(_validator_cache_secret(), payload, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, str(wrapped.get("mac", ""))):
+        return None  # tampered or written by another machine's secret
+    return wrapped["data"] if isinstance(wrapped["data"], dict) else None
 
 
 def _validator_cache_write(key: str, data: Dict[str, Any]) -> None:
+    """Write a cache entry wrapped with HMAC over its JSON body."""
+    import hashlib
+    import hmac
     import json
     p = _validator_cache_path(key)
+    payload = json.dumps(data, sort_keys=True).encode("utf-8")
+    mac = hmac.new(_validator_cache_secret(), payload, hashlib.sha256).hexdigest()
+    wrapped = {"data": data, "mac": mac}
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(json.dumps(data))
+        p.write_text(json.dumps(wrapped))
     except OSError:
         pass
 
@@ -9566,11 +9635,15 @@ def op_validate_staged(tool_filter: Optional[list] = None, verbose: bool = False
 
     verbose=True: passed through to op_validate for each file — shows all errors
     and raw adapter output instead of the compact capped form.
+
+    #150: uses `git diff -z` for NUL-separated names (filenames with newlines /
+    quotes survive intact) and rejects symlinks (staged symlink to /etc/passwd
+    would otherwise be passed to validators that could process it).
     """
     import subprocess
     try:
         r = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
+            ["git", "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMR"],
             capture_output=True, text=True, timeout=15,
         )
         if r.returncode != 0:
@@ -9579,7 +9652,17 @@ def op_validate_staged(tool_filter: Optional[list] = None, verbose: bool = False
     except (subprocess.TimeoutExpired, OSError) as e:
         return f"ERROR: git unavailable: {e}\n"
 
-    staged = [p for p in r.stdout.splitlines() if p and os.path.isfile(p)]
+    # Split on NUL (git diff -z), reject empty + symlinks + paths outside cwd.
+    staged = []
+    for p in r.stdout.split("\x00"):
+        if not p or os.path.islink(p) or not os.path.isfile(p):
+            continue
+        # Reject paths that resolve outside cwd (symlink-following could leak).
+        real = os.path.realpath(p)
+        root = os.path.realpath(os.getcwd())
+        if real != root and not real.startswith(root + os.sep):
+            continue
+        staged.append(p)
     if not staged:
         return "no staged files\n"
 
@@ -9598,11 +9681,15 @@ def op_format_staged(tool_filter: Optional[list] = None, verbose: bool = False) 
 
     verbose=True: passed through to op_format for each file — shows full error
     messages and a [verbose] marker instead of the compact truncated form.
+
+    #150: uses `git diff -z` for NUL-separated names and rejects symlinks —
+    a staged symlink to /etc/hosts would otherwise be REWRITTEN by formatters
+    (prettier, php-cs-fixer, etc.).
     """
     import subprocess
     try:
         r = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
+            ["git", "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMR"],
             capture_output=True, text=True, timeout=15,
         )
         if r.returncode != 0:
@@ -9611,7 +9698,15 @@ def op_format_staged(tool_filter: Optional[list] = None, verbose: bool = False) 
     except (subprocess.TimeoutExpired, OSError) as e:
         return f"ERROR: git unavailable: {e}\n"
 
-    staged = [p for p in r.stdout.splitlines() if p and os.path.isfile(p)]
+    staged = []
+    for p in r.stdout.split("\x00"):
+        if not p or os.path.islink(p) or not os.path.isfile(p):
+            continue
+        real = os.path.realpath(p)
+        root = os.path.realpath(os.getcwd())
+        if real != root and not real.startswith(root + os.sep):
+            continue
+        staged.append(p)
     if not staged:
         return "no staged files\n"
 

--- a/tests/test_security_hardening_150.py
+++ b/tests/test_security_hardening_150.py
@@ -1,0 +1,159 @@
+"""Regression tests for #150: hardening bundle.
+
+Covers:
+- gitcli flag smuggling — checkout / merge / blame
+- regex ReDoS guards on op_grep
+- format_staged / validate_staged reject symlinks
+- xmllint --nonet --noent
+- validator cache HMAC integrity
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+PRESETS_GIT = Path(__file__).parent.parent / "presets" / "git"
+
+
+def _run_git_preset(script: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["python3", str(PRESETS_GIT / script), *args],
+        capture_output=True, text=True, timeout=10,
+    )
+
+
+class TestGitcliFlagSmuggling:
+    def test_checkout_rejects_leading_dash_ref(self):
+        r = _run_git_preset("checkout.py", "--orphan=evil")
+        assert "refusing for safety" in r.stdout
+        assert r.returncode != 0
+
+    def test_checkout_allows_dash_alone(self):
+        # "-" = previous branch in git checkout, allow it.
+        r = _run_git_preset("checkout.py", "-")
+        # May succeed or fail depending on repo state — the key is we
+        # don't refuse it for the leading-dash reason.
+        assert "refusing for safety" not in r.stdout
+
+    def test_merge_rejects_dash_abort(self):
+        r = _run_git_preset("merge.py", "--abort")
+        assert "refusing for safety" in r.stdout
+        assert r.returncode != 0
+
+    def test_merge_rejects_strategy_smuggle(self):
+        r = _run_git_preset("merge.py", "-X")
+        assert "refusing for safety" in r.stdout
+
+    def test_blame_uses_dash_separator(self):
+        """The git invocation must include `--` so a path starting with
+        `-` is treated as a path, not a flag. Inspect the source."""
+        src = (PRESETS_GIT / "blame.py").read_text()
+        assert '"--",' in src or '"--"' in src, "blame.py must include `--` separator"
+
+
+class TestRegexReDoS:
+    def test_long_pattern_rejected(self):
+        out = supertool.op_grep("a" * 1001, ".")
+        assert "pattern too long" in out
+
+    def test_nested_unbounded_quantifier_rejected(self):
+        out = supertool.op_grep("(a+)+", ".")
+        assert "nested unbounded quantifiers" in out
+
+    def test_classic_redos_pattern_rejected(self):
+        out = supertool.op_grep("(.+)*", ".")
+        assert "nested unbounded quantifiers" in out
+
+    def test_normal_pattern_passes(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "foo.txt").write_text("hello world\n")
+        out = supertool.op_grep("hello", ".")
+        assert "hello" in out
+        assert "ERROR" not in out
+
+
+class TestStagedSymlinkRejected:
+    def test_format_staged_skips_symlinks(self, tmp_path, monkeypatch):
+        """A staged symlink must not reach formatters that could rewrite it.
+
+        We can't easily fake `git diff --cached` output without a real repo,
+        so we check that the implementation rejects symlinks at the filter
+        step. The dispatch logic uses `os.path.islink` — verified by source.
+        """
+        src = Path(supertool.__file__).read_text()
+        # Both staged ops must check islink before isfile.
+        # (Loose grep — exact line could shift.)
+        assert "os.path.islink(p)" in src
+        # And use `-z` for NUL-separated names.
+        assert '"-z"' in src and '"--name-only"' in src
+
+
+class TestXmllintFlags:
+    def test_xmllint_uses_nonet_noent(self):
+        adapter = Path(__file__).parent.parent / "validators" / "xmllint" / "xmllint.py"
+        src = adapter.read_text()
+        assert '"--nonet"' in src
+        assert '"--noent"' in src
+
+
+class TestValidatorCacheHmac:
+    @pytest.fixture
+    def cache_dir(self, tmp_path, monkeypatch):
+        """Point cache to tmp_path so tests don't pollute real ~/.cache."""
+        # Patch Path.home() to return tmp_path so all cache paths land there.
+        original_home = Path.home
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        yield tmp_path / ".cache" / "supertool" / "validators"
+        monkeypatch.setattr(Path, "home", original_home)
+
+    def test_write_then_read_roundtrip(self, cache_dir):
+        data = {"tool": "fake", "ok": True, "count": 0}
+        supertool._validator_cache_write("k1", data)
+        roundtrip = supertool._validator_cache_read("k1")
+        assert roundtrip == data
+
+    def test_tampered_entry_rejected(self, cache_dir, tmp_path):
+        data = {"tool": "fake", "ok": False, "count": 5}
+        supertool._validator_cache_write("k2", data)
+        cache_path = supertool._validator_cache_path("k2")
+        # Tamper: flip ok=False to ok=True while keeping old mac.
+        wrapped = json.loads(cache_path.read_text())
+        wrapped["data"]["ok"] = True
+        cache_path.write_text(json.dumps(wrapped))
+        # Read must reject — mac no longer matches.
+        assert supertool._validator_cache_read("k2") is None
+
+    def test_legacy_unwrapped_treated_as_miss(self, cache_dir, tmp_path):
+        """Pre-#150 cache entries (raw dict, no mac) are not trusted."""
+        # Write raw legacy form directly.
+        supertool._validator_cache_path("k3").parent.mkdir(parents=True, exist_ok=True)
+        supertool._validator_cache_path("k3").write_text(
+            json.dumps({"tool": "fake", "ok": True, "count": 0})
+        )
+        assert supertool._validator_cache_read("k3") is None
+
+    def test_secret_file_is_mode_600(self, cache_dir):
+        # Force secret generation.
+        supertool._validator_cache_secret()
+        secret_path = Path.home() / ".cache" / "supertool" / ".cache_key"
+        assert secret_path.is_file()
+        import stat as _stat
+        mode = _stat.S_IMODE(secret_path.stat().st_mode)
+        assert mode == 0o600, f"secret must be 0600, got {oct(mode)}"
+
+    def test_different_secret_invalidates_cache(self, cache_dir, tmp_path):
+        """If the .cache_key is rotated, old entries fail HMAC verification."""
+        data = {"tool": "fake", "ok": True, "count": 0}
+        supertool._validator_cache_write("k4", data)
+        # Rotate the secret.
+        (Path.home() / ".cache" / "supertool" / ".cache_key").unlink()
+        # Force regeneration with a fresh secret.
+        supertool._validator_cache_secret()
+        assert supertool._validator_cache_read("k4") is None

--- a/validators/xmllint/xmllint.py
+++ b/validators/xmllint/xmllint.py
@@ -32,8 +32,14 @@ def main() -> None:
     file = sys.argv[1]
     start = time.time()
     try:
-        r = subprocess.run(["xmllint", "--noout", file],
-                           capture_output=True, text=True, timeout=30)
+        # #150 XXE defence-in-depth: `--nonet` blocks network access during
+        # entity resolution (DTDs, external entities); `--noent` resolves
+        # entities to their text rather than fetching them. Both narrow what
+        # libxml2 will do with attacker-influenced XML during validation.
+        r = subprocess.run(
+            ["xmllint", "--noout", "--nonet", "--noent", file],
+            capture_output=True, text=True, timeout=30,
+        )
     except FileNotFoundError:
         emit({"tool": "xmllint", "file": file, "ok": False, "count": 1,
               "errors": [{"line": None, "col": None, "severity": "error",


### PR DESCRIPTION
## Closes #150

Five defence-in-depth items from the audit, batched.

### 1. Gitcli flag smuggling
- `git-checkout REF`, `git-merge REF` reject leading-dash refs (`--orphan=evil`, `--abort`, `-X theirs`). `checkout -` (previous branch) still allowed.
- `git-blame` uses `--` separator before PATH.

### 2. Regex ReDoS guards on `grep`
- Pattern length cap (1000 chars).
- Reject nested unbounded quantifiers (`(a+)+`, `(.+)*`) before they touch file content.

### 3. `validate_staged` / `format_staged` hardening
- `git diff -z --diff-filter=ACMR` — filenames with newlines/quotes survive intact.
- Reject symlinks (staged symlink to `/etc/hosts` would be **rewritten** by formatters).
- Reject paths resolving outside cwd.

### 4. `xmllint` validator: `--nonet --noent`
XXE defence-in-depth — libxml2 can't fetch external entities during validation.

### 5. Validator cache HMAC
- 32-byte random secret at `~/.cache/supertool/.cache_key` (mode 0600, `O_EXCL` TOCTOU-safe).
- Each entry wrapped: `{"data": ..., "mac": HMAC-SHA256(data, key)}`.
- Read verifies HMAC; legacy unwrapped entries treated as miss.
- Attacker with write access to `~/.cache/supertool/validators/` (npm postinstall, etc.) now needs ALSO to read the secret to forge passing `ok: true` entries.

## Tests

16 new in `tests/test_security_hardening_150.py`:
- gitcli leading-dash reject (checkout, merge), `-` alone allowed, blame uses `--`
- ReDoS guards (long, nested quantifiers, normal pattern passes)
- staged source check verifies `islink` + `-z` flags present
- xmllint flags present
- cache roundtrip, tampered entry rejected, legacy treated as miss, secret 0600, rotated secret invalidates

All 2829 tests pass.

## Migration

No action needed. The HMAC cache is a clean migration — legacy entries become misses and regenerate wrapped on next run.