### PR TITLE
feat(glob): brace expansion `*.{a,b,c}` (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`glob` brace expansion.** `glob:src/**/*.{json,xml}` now fans out into `*.json` + `*.xml` (shell/fd/ripgrep semantics) and dedupes results, instead of silently returning 0 files. Supports multiple groups (`{a,b}.{x,y}` → 4) and nesting (`{a,b{1,2}}` → 3). Patterns without braces are unchanged. Closes [#161](https://github.com/Digital-Process-Tools/claude-supertool/issues/161).
+
 ## [0.14.0] — 2026-05-23
 
 ### Added

--- a/supertool.py
+++ b/supertool.py
@@ -143,6 +143,54 @@ def _match_glob(path: str, pattern: str) -> bool:
     return False
 
 
+def _expand_braces(pattern: str) -> List[str]:
+    """Expand shell-style brace groups `{a,b,c}` into a list of patterns.
+
+    Supports multiple groups (`*.{a,b}.{x,y}` → 4 patterns) and nesting
+    (`{a,b{1,2}}` → `[a, b1, b2]`). Patterns without braces return `[pattern]`.
+    Unbalanced braces are returned unchanged (treated as a literal).
+    """
+    if "{" not in pattern:
+        return [pattern]
+    open_i = pattern.index("{")
+    depth = 0
+    close_i = -1
+    for i in range(open_i, len(pattern)):
+        c = pattern[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                close_i = i
+                break
+    if close_i == -1:
+        return [pattern]
+    prefix = pattern[:open_i]
+    suffix = pattern[close_i + 1:]
+    inner = pattern[open_i + 1:close_i]
+    parts: List[str] = []
+    depth = 0
+    last = 0
+    for i, c in enumerate(inner):
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        elif c == "," and depth == 0:
+            parts.append(inner[last:i])
+            last = i + 1
+    parts.append(inner[last:])
+    out: List[str] = []
+    seen = set()
+    for alt in parts:
+        for sub in _expand_braces(prefix + alt + suffix):
+            if sub not in seen:
+                seen.add(sub)
+                out.append(sub)
+    return out
+
+
 # Default exclude-paths applied to all traversal ops (glob, grep, tree, map).
 # These are pruned at the directory-walk boundary — the dirs are never opened.
 # Match is prefix-relative-to-cwd; trailing slash is normalised in _get_exclude_paths.
@@ -2341,6 +2389,20 @@ def _glob_files(
     glob.glob and filters results post-hoc (no subtree to prune anyway).
     """
     max_results = _get_op_int("glob", "max_results", MAX_GLOB_RESULTS)
+
+    # Brace expansion: `*.{json,xml}` → fan out + dedupe. Shell/fd semantics.
+    expanded = _expand_braces(pattern)
+    if expanded != [pattern]:
+        seen: set = set()
+        results: List[str] = []
+        for sub_pattern in expanded:
+            for f in _glob_files(sub_pattern, exclude_paths):
+                if f not in seen:
+                    seen.add(f)
+                    results.append(f)
+                    if len(results) >= max_results:
+                        return results
+        return results
 
     if exclude_paths and "**" in pattern and pattern.count("**") == 1:
         # Walk-based implementation for recursive globs with exclusions.

--- a/tests/test_glob_braces.py
+++ b/tests/test_glob_braces.py
@@ -1,0 +1,105 @@
+"""Brace expansion in glob op (issue #161).
+
+`glob:src/**/*.{json,xml}` previously returned 0 files because Python's
+`glob.glob` doesn't expand braces. Caller expected shell/fd/ripgrep semantics.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+
+# ---------------------------------------------------------------------------
+# _expand_braces helper
+# ---------------------------------------------------------------------------
+
+
+def test_expand_no_braces_passthrough() -> None:
+    assert supertool._expand_braces("*.php") == ["*.php"]
+
+
+def test_expand_single_group() -> None:
+    assert supertool._expand_braces("*.{json,xml}") == ["*.json", "*.xml"]
+
+
+def test_expand_three_alternatives() -> None:
+    assert supertool._expand_braces("a.{x,y,z}") == ["a.x", "a.y", "a.z"]
+
+
+def test_expand_multiple_groups_cartesian() -> None:
+    result = supertool._expand_braces("{a,b}.{x,y}")
+    assert result == ["a.x", "a.y", "b.x", "b.y"]
+
+
+def test_expand_nested_groups() -> None:
+    result = supertool._expand_braces("{a,b{1,2}}")
+    assert result == ["a", "b1", "b2"]
+
+
+def test_expand_dedupes_collisions() -> None:
+    # `{a,a}` → ["a"] (not ["a", "a"])
+    assert supertool._expand_braces("{a,a}") == ["a"]
+
+
+def test_expand_unbalanced_returns_literal() -> None:
+    # Missing close — return unchanged, let downstream handle.
+    assert supertool._expand_braces("foo.{json") == ["foo.{json"]
+
+
+def test_expand_empty_alternative() -> None:
+    # `{,bak}` → ["", "bak"] — useful for `file{,.bak}` style
+    assert supertool._expand_braces("f{,.bak}") == ["f", "f.bak"]
+
+
+# ---------------------------------------------------------------------------
+# op_glob integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a small tree with mixed extensions, chdir into it."""
+    (tmp_path / "a.json").write_text("{}")
+    (tmp_path / "a.xml").write_text("<x/>")
+    (tmp_path / "a.txt").write_text("nope")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.json").write_text("{}")
+    (sub / "b.xml").write_text("<x/>")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_op_glob_brace_returns_both_extensions(tmp_files: Path) -> None:
+    out = supertool.op_glob("**/*.{json,xml}", no_auto_read=True)
+    assert "a.json" in out
+    assert "a.xml" in out
+    assert "b.json" in out
+    assert "b.xml" in out
+    assert "a.txt" not in out
+    # Count line says 4 files
+    assert "(4 files)" in out
+
+
+def test_op_glob_brace_repro_from_issue(tmp_files: Path) -> None:
+    """Exact failure mode from issue #161 — should now return matches."""
+    out = supertool.op_glob("**/*.{json,xml}:no-auto-read".split(":")[0], no_auto_read=True)
+    assert "(0 files)" not in out
+
+
+def test_op_glob_no_braces_unchanged(tmp_files: Path) -> None:
+    out = supertool.op_glob("**/*.json", no_auto_read=True)
+    assert "a.json" in out
+    assert "b.json" in out
+    assert "a.xml" not in out
+
+
+def test_op_glob_brace_dedup(tmp_files: Path) -> None:
+    # `{json,json}` shouldn't double-count
+    out = supertool.op_glob("**/*.{json,json}", no_auto_read=True)
+    assert "(2 files)" in out


### PR DESCRIPTION
## Summary

- `glob:src/**/*.{json,xml}` previously returned 0 files silently — Python's `glob.glob` doesn't expand braces, caller expected shell/fd/ripgrep semantics
- New `_expand_braces` helper supports multi-group (`{a,b}.{x,y}` → 4) and nesting (`{a,b{1,2}}` → 3); `_glob_files` fans out + dedupes at entry
- Patterns without braces unchanged

Closes #161.

## Test plan

- [x] 12 new tests in `tests/test_glob_braces.py` — helper unit + `op_glob` integration (single group, multi-group cartesian, nesting, dedupe, unbalanced passthrough, real-world repro)
- [x] Full suite: 2884 passed, 2 unrelated pre-existing phpstan adapter failures on master