### PR TITLE
git-conflicts: show author + MR for the incoming side

### DIFF
--- a/presets/git/conflicts.py
+++ b/presets/git/conflicts.py
@@ -6,6 +6,7 @@ and want to see all conflicts in one call without re-running merge.
 """
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -82,37 +83,41 @@ def _incoming_branch(ref: str) -> str:
 
 
 def _incoming_mr(branch: str) -> str:
-    """Resolve MR/PR identifier for the incoming branch, glab first then gh. Empty on failure."""
+    """Resolve MR/PR identifier for the incoming branch, glab first then gh. Empty on failure.
+
+    Advisory only — every external-tool failure (timeout, missing binary,
+    malformed JSON, non-zero exit) collapses to an empty string so the
+    caller never sees a traceback that would wipe the conflict listing.
+    """
     if not branch:
         return ""
     if shutil.which("glab"):
-        res = subprocess.run(
-            ["glab", "mr", "list", "--source-branch", branch, "--output", "json"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if res.returncode == 0 and res.stdout.strip().startswith("["):
-            import json
-            try:
+        try:
+            res = subprocess.run(
+                ["glab", "mr", "list", "--source-branch", branch, "--state", "opened", "--output", "json"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if res.returncode == 0 and res.stdout.strip().startswith("["):
                 mrs = json.loads(res.stdout)
-            except json.JSONDecodeError:
-                mrs = []
-            if mrs:
-                mr = mrs[0]
-                return f"!{mr.get('iid', '?')} {mr.get('title', '')}".strip()
+                if mrs:
+                    mr = mrs[0]
+                    return f"!{mr.get('iid', '?')} {mr.get('title', '')}".strip()
+        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+            pass
     if shutil.which("gh"):
-        res = subprocess.run(
-            ["gh", "pr", "list", "--head", branch, "--json", "number,title", "--limit", "1"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if res.returncode == 0 and res.stdout.strip().startswith("["):
-            import json
-            try:
+        try:
+            res = subprocess.run(
+                ["gh", "pr", "list", "--head", branch, "--state", "open",
+                 "--json", "number,title", "--limit", "1"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if res.returncode == 0 and res.stdout.strip().startswith("["):
                 prs = json.loads(res.stdout)
-            except json.JSONDecodeError:
-                prs = []
-            if prs:
-                pr = prs[0]
-                return f"#{pr.get('number', '?')} {pr.get('title', '')}".strip()
+                if prs:
+                    pr = prs[0]
+                    return f"#{pr.get('number', '?')} {pr.get('title', '')}".strip()
+        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+            pass
     return ""
 
 

--- a/presets/git/conflicts.py
+++ b/presets/git/conflicts.py
@@ -7,10 +7,17 @@ and want to see all conflicts in one call without re-running merge.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 
 DEFAULT_PREVIEW_LINES = 12
+
+_STATE_TO_REF = {
+    "merge": "MERGE_HEAD",
+    "cherry-pick": "CHERRY_PICK_HEAD",
+    "revert": "REVERT_HEAD",
+}
 
 
 def _git(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
@@ -57,6 +64,75 @@ def _all_conflict_blocks(path: str, max_lines_per_block: int) -> str:
     if not out:
         return "  (no <<<<<<< marker found — likely binary or stage-only conflict)"
     return "\n".join(out)
+
+
+def _incoming_branch(ref: str) -> str:
+    """Best-effort branch name for the incoming side of a merge."""
+    res = _git(["name-rev", "--name-only", "--exclude=refs/tags/*", ref])
+    if res.returncode != 0:
+        return ""
+    name = res.stdout.strip()
+    if not name or name == "undefined":
+        return ""
+    for prefix in ("remotes/origin/", "remotes/upstream/"):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    return name.split("~", 1)[0].split("^", 1)[0]
+
+
+def _incoming_mr(branch: str) -> str:
+    """Resolve MR/PR identifier for the incoming branch, glab first then gh. Empty on failure."""
+    if not branch:
+        return ""
+    if shutil.which("glab"):
+        res = subprocess.run(
+            ["glab", "mr", "list", "--source-branch", branch, "--output", "json"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if res.returncode == 0 and res.stdout.strip().startswith("["):
+            import json
+            try:
+                mrs = json.loads(res.stdout)
+            except json.JSONDecodeError:
+                mrs = []
+            if mrs:
+                mr = mrs[0]
+                return f"!{mr.get('iid', '?')} {mr.get('title', '')}".strip()
+    if shutil.which("gh"):
+        res = subprocess.run(
+            ["gh", "pr", "list", "--head", branch, "--json", "number,title", "--limit", "1"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if res.returncode == 0 and res.stdout.strip().startswith("["):
+            import json
+            try:
+                prs = json.loads(res.stdout)
+            except json.JSONDecodeError:
+                prs = []
+            if prs:
+                pr = prs[0]
+                return f"#{pr.get('number', '?')} {pr.get('title', '')}".strip()
+    return ""
+
+
+def _incoming_info(path: str, state: str) -> list[str]:
+    """Lines describing the incoming side for this file. Empty when not applicable."""
+    ref = _STATE_TO_REF.get(state)
+    if not ref:
+        return []
+    log = _git(["log", "-1", "--format=%h %an %ar :: %s", ref, "--", path])
+    if log.returncode != 0 or not log.stdout.strip():
+        return []
+    lines = [f"  Last touched (theirs): {log.stdout.strip()}"]
+    if state == "merge":
+        branch = _incoming_branch(ref)
+        if branch:
+            lines.append(f"  Incoming branch: {branch}")
+            mr = _incoming_mr(branch)
+            if mr:
+                lines.append(f"  MR: {mr}")
+    return lines
 
 
 def _detect_state() -> str:
@@ -106,6 +182,8 @@ def main() -> int:
 
     for path in conflicts:
         print(f"\n## {path}")
+        for line in _incoming_info(path, state):
+            print(line)
         print(_all_conflict_blocks(path, preview))
 
     return 0

--- a/tests/test_git_conflicts.py
+++ b/tests/test_git_conflicts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from unittest import mock
 
 
 PRESET = Path(__file__).parent.parent / "presets" / "git" / "conflicts.py"
@@ -47,3 +48,56 @@ def test_no_markers_message(tmp_path: Path) -> None:
     f.write_text("clean file\n")
     out = conflicts._all_conflict_blocks(str(f), max_lines_per_block=10)
     assert "no <<<<<<< marker" in out
+
+
+def _git_result(stdout: str = "", returncode: int = 0):
+    return mock.Mock(stdout=stdout, returncode=returncode, stderr="")
+
+
+def test_incoming_info_skipped_outside_merge_states() -> None:
+    assert conflicts._incoming_info("foo.py", "rebase") == []
+    assert conflicts._incoming_info("foo.py", "") == []
+
+
+def test_incoming_info_merge_includes_author_branch_and_mr() -> None:
+    log_line = "a1b2c3d Florian DAVID 2 hours ago :: Rename underscore properties"
+    fake_git = mock.Mock(side_effect=[
+        _git_result(stdout=log_line + "\n"),
+        _git_result(stdout="remotes/origin/feature/rename-props\n"),
+    ])
+    fake_which = mock.Mock(side_effect=lambda cmd: "/usr/bin/glab" if cmd == "glab" else None)
+    fake_run = mock.Mock(return_value=_git_result(
+        stdout='[{"iid": 21803, "title": "Rename underscore properties"}]\n'
+    ))
+    with mock.patch.object(conflicts, "_git", fake_git), \
+         mock.patch.object(conflicts.shutil, "which", fake_which), \
+         mock.patch.object(conflicts.subprocess, "run", fake_run):
+        lines = conflicts._incoming_info("foo.py", "merge")
+    assert lines == [
+        f"  Last touched (theirs): {log_line}",
+        "  Incoming branch: feature/rename-props",
+        "  MR: !21803 Rename underscore properties",
+    ]
+
+
+def test_incoming_info_cherry_pick_only_shows_log() -> None:
+    log_line = "a1b2c3d Author 1 hour ago :: pick subject"
+    fake_git = mock.Mock(return_value=_git_result(stdout=log_line + "\n"))
+    with mock.patch.object(conflicts, "_git", fake_git):
+        lines = conflicts._incoming_info("foo.py", "cherry-pick")
+    assert lines == [f"  Last touched (theirs): {log_line}"]
+
+
+def test_incoming_info_no_mr_tool_available() -> None:
+    log_line = "abc Author 5m ago :: subject"
+    fake_git = mock.Mock(side_effect=[
+        _git_result(stdout=log_line + "\n"),
+        _git_result(stdout="feature/x\n"),
+    ])
+    with mock.patch.object(conflicts, "_git", fake_git), \
+         mock.patch.object(conflicts.shutil, "which", return_value=None):
+        lines = conflicts._incoming_info("foo.py", "merge")
+    assert lines == [
+        f"  Last touched (theirs): {log_line}",
+        "  Incoming branch: feature/x",
+    ]

--- a/tests/test_git_conflicts.py
+++ b/tests/test_git_conflicts.py
@@ -101,3 +101,26 @@ def test_incoming_info_no_mr_tool_available() -> None:
         f"  Last touched (theirs): {log_line}",
         "  Incoming branch: feature/x",
     ]
+
+
+def test_incoming_info_swallows_glab_timeout() -> None:
+    """A hanging glab must not crash the whole op."""
+    import subprocess as _sub
+    log_line = "abc Author 5m ago :: subject"
+    fake_git = mock.Mock(side_effect=[
+        _git_result(stdout=log_line + "\n"),
+        _git_result(stdout="feature/x\n"),
+    ])
+    fake_which = mock.Mock(side_effect=lambda c: f"/usr/bin/{c}" if c == "glab" else None)
+
+    def boom(*a, **kw):
+        raise _sub.TimeoutExpired(cmd="glab", timeout=5)
+
+    with mock.patch.object(conflicts, "_git", fake_git), \
+         mock.patch.object(conflicts.shutil, "which", fake_which), \
+         mock.patch.object(conflicts.subprocess, "run", side_effect=boom):
+        lines = conflicts._incoming_info("foo.py", "merge")
+    assert lines == [
+        f"  Last touched (theirs): {log_line}",
+        "  Incoming branch: feature/x",
+    ]


### PR DESCRIPTION
Closes #166

## Summary
- Add `Last touched (theirs)` line per conflicting file with `git log -1 --format='%h %an %ar :: %s' <ref> -- <path>`
- Add `Incoming branch` (resolved via `git name-rev`) and `MR:` lines for merge state
- Try `glab mr list --source-branch` first, fall back to `gh pr list --head` so the op works on both GitLab and GitHub
- Cherry-pick / revert: only the log line (no branch concept); rebase: skipped

## Test plan
- [x] 7 unit tests pass (4 existing + 3 new covering merge/cherry-pick/no-tool branches)
- [ ] Manual: trigger a merge conflict, run `./supertool 'git-conflicts'`, confirm author + branch + MR appear