### PR TITLE
git-merge: point to git-conflicts in conflict footer

### DIFF
--- a/presets/git/merge.py
+++ b/presets/git/merge.py
@@ -115,6 +115,7 @@ def main() -> int:
     print(f"Status: CONFLICT ({len(conflicts)} file(s))")
     print(f"Ours: {head_before} | Theirs: {their_sha} | Base: {merge_base}")
     print("Next:")
+    print("  - See every conflict block (this output shows the first per file): ./supertool 'git-conflicts'")
     print("  - Edit files manually, then ./supertool 'git-commit:::resolve merge'")
     print("  - Or pick a side: ./supertool 'git-resolve:::ours:::PATH' (or theirs, or all)")
     print("  - Or abort: git merge --abort")


### PR DESCRIPTION
Closes #167

## Summary
- Add one line to the conflict-state \`Next:\` footer in \`presets/git/merge.py\` recommending \`./supertool 'git-conflicts'\` for users who need every conflict block (the \`git-merge\` op shows only the first per file).
- No new infra, no hook — surfaces the existing op at the right moment.

## Test plan
- [x] Existing \`tests/test_git_merge.py\` (block helpers) still passes
- [ ] Manual: trigger a merge conflict, run \`./supertool 'git-merge:REF'\`, confirm the new line appears in the Next block