### PR TITLE
git-conflicts: append git-resolve hint in footer

### DIFF
--- a/presets/git/conflicts.py
+++ b/presets/git/conflicts.py
@@ -108,6 +108,9 @@ def main() -> int:
         print(f"\n## {path}")
         print(_all_conflict_blocks(path, preview))
 
+    print("\nResolve: ./supertool 'git-resolve:::ours:::PATH' | ./supertool 'git-resolve:::theirs:::PATH'")
+    print("Or edit manually, then: git add PATH && git commit")
+
     return 0
 
 


### PR DESCRIPTION
Closes #168

## Summary
- Append two lines after the per-file conflict listing recommending \`./supertool 'git-resolve:::ours:::PATH'\` / \`:::theirs:::PATH\`, plus the manual-edit fallback. Matches the issue's exact phrasing.

## Test plan
- [x] Existing tests pass
- [ ] Manual: in a conflict state, \`./supertool 'git-conflicts'\` shows the new footer