### PR TITLE
gl-mr: cap comment section at 2000 chars

### DIFF
--- a/presets/gitlab/mr.py
+++ b/presets/gitlab/mr.py
@@ -237,7 +237,8 @@ def _budgeted_comments(notes: list, budget: int, tail: int) -> tuple[list[str], 
         head_kept.append(r)
         used += len(r)
     hidden = head_pool[len(head_kept):]
-    return head_kept + (["__GAP__"] if hidden else []) + tail_slice, len(hidden), sum(len(r) for r in hidden)
+    hidden_bytes = sum(len(r.encode("utf-8")) for r in hidden)
+    return head_kept + (["__GAP__"] if hidden else []) + tail_slice, len(hidden), hidden_bytes
 
 
 def main() -> int:

--- a/presets/gitlab/mr.py
+++ b/presets/gitlab/mr.py
@@ -13,6 +13,8 @@ import sys
 
 DESCRIPTION_MAX = 2000
 COMMENT_MAX = 500
+COMMENT_TOTAL_MAX = 2000
+TAIL_COMMENTS = 2
 
 
 def _relative_age(iso: str) -> str:
@@ -197,13 +199,56 @@ def _format_error(stderr: str, resource: str, identifier: str) -> str:
     return f"ERROR: glab failed for {resource} #{identifier}: {stderr.strip()}"
 
 
+def _render_note(note: dict) -> str:
+    """Format one MR note for printing. Body capped at COMMENT_MAX chars."""
+    author = (note.get("author") or {}).get("username", "?")
+    body = (note.get("body") or "")[:COMMENT_MAX]
+    created = (note.get("created_at") or "")[:10]
+    return f"\n**{author}** ({created}):\n{body}\n"
+
+
+def _fmt_kb(nbytes: int) -> str:
+    if nbytes < 1024:
+        return f"{nbytes}B"
+    return f"{nbytes / 1024:.1f}KB"
+
+
+def _budgeted_comments(notes: list, budget: int, tail: int) -> tuple[list[str], int, int]:
+    """Pick rendered notes fitting a total-char budget, keeping the last `tail` for recency.
+
+    Returns (rendered_lines, hidden_count, hidden_bytes). Notes are assumed
+    sorted ascending (oldest first) — same order as the GitLab API.
+    """
+    rendered_all = [_render_note(n) for n in notes]
+    if not rendered_all:
+        return [], 0, 0
+    tail_keep = min(tail, len(rendered_all))
+    if tail_keep >= len(rendered_all):
+        return rendered_all, 0, 0
+    tail_slice = rendered_all[-tail_keep:] if tail_keep else []
+    head_pool = rendered_all[:-tail_keep] if tail_keep else rendered_all
+    tail_size = sum(len(r) for r in tail_slice)
+    remaining = max(0, budget - tail_size)
+    head_kept: list[str] = []
+    used = 0
+    for r in head_pool:
+        if used + len(r) > remaining:
+            break
+        head_kept.append(r)
+        used += len(r)
+    hidden = head_pool[len(head_kept):]
+    return head_kept + (["__GAP__"] if hidden else []) + tail_slice, len(hidden), sum(len(r) for r in hidden)
+
+
 def main() -> int:
     if len(sys.argv) < 2:
-        print("ERROR: usage: mr.py NUMBER [status]")
+        print("ERROR: usage: mr.py NUMBER [status|full]")
         return 1
 
     arg = sys.argv[1]
-    slim = len(sys.argv) > 2 and sys.argv[2] == "status"
+    flags = sys.argv[2:]
+    slim = "status" in flags
+    full = "full" in flags
 
     # If not all digits, treat as branch name and resolve to MR number
     if not arg.isdigit():
@@ -544,12 +589,21 @@ def main() -> int:
         pass
 
     print(f"\n## Comments ({len(human_notes)})")
-    for note in human_notes[-10:]:
-        note_author = (note.get("author") or {}).get("username", "?")
-        body = (note.get("body") or "")[:COMMENT_MAX]
-        created = (note.get("created_at") or "")[:10]
-        print(f"\n**{note_author}** ({created}):")
-        print(body)
+    if full:
+        for r in (_render_note(n) for n in human_notes):
+            print(r, end="")
+    else:
+        rendered, hidden_count, hidden_bytes = _budgeted_comments(
+            human_notes, COMMENT_TOTAL_MAX, TAIL_COMMENTS,
+        )
+        for r in rendered:
+            if r == "__GAP__":
+                print(
+                    f"\n... {hidden_count} more comment(s) hidden ({_fmt_kb(hidden_bytes)})."
+                    f" Use gl-mr:{iid}:full for everything."
+                )
+                continue
+            print(r, end="")
 
     return 0
 

--- a/tests/test_gitlab_mr.py
+++ b/tests/test_gitlab_mr.py
@@ -363,3 +363,50 @@ def test_relative_age_formats() -> None:
     assert mr._relative_age((now - timedelta(days=3)).isoformat().replace("+00:00", "Z")).endswith("d ago")
     assert mr._relative_age("") == "?"
     assert mr._relative_age("not-a-date") == "?"
+
+
+def _note(author: str, body: str, day: str = "2026-05-24") -> dict:
+    return {"author": {"username": author}, "body": body, "created_at": f"{day}T00:00:00Z"}
+
+
+def test_budgeted_comments_no_truncation_when_under_budget() -> None:
+    notes = [_note("alice", "hi"), _note("bob", "hey")]
+    rendered, hidden_count, hidden_bytes = mr._budgeted_comments(notes, budget=10_000, tail=2)
+    assert "__GAP__" not in rendered
+    assert hidden_count == 0
+    assert hidden_bytes == 0
+    assert len(rendered) == 2
+
+
+def test_budgeted_comments_inserts_gap_and_keeps_tail() -> None:
+    big = "X" * 1500
+    notes = [_note(f"u{i}", big) for i in range(8)]
+    rendered, hidden_count, hidden_bytes = mr._budgeted_comments(notes, budget=2000, tail=2)
+    assert "__GAP__" in rendered
+    assert hidden_count >= 1
+    assert hidden_bytes > 0
+    # Tail of 2 still present at end
+    tail = [r for r in rendered if r != "__GAP__"][-2:]
+    assert any("u6" in r for r in tail)
+    assert any("u7" in r for r in tail)
+
+
+def test_budgeted_comments_empty_list() -> None:
+    rendered, hidden_count, hidden_bytes = mr._budgeted_comments([], budget=2000, tail=2)
+    assert rendered == []
+    assert hidden_count == 0
+    assert hidden_bytes == 0
+
+
+def test_budgeted_comments_tail_larger_than_list_skips_gap() -> None:
+    notes = [_note("a", "x"), _note("b", "y")]
+    rendered, hidden_count, _ = mr._budgeted_comments(notes, budget=2000, tail=5)
+    assert "__GAP__" not in rendered
+    assert hidden_count == 0
+    assert len(rendered) == 2
+
+
+def test_fmt_kb_thresholds() -> None:
+    assert mr._fmt_kb(500) == "500B"
+    assert mr._fmt_kb(2048) == "2.0KB"
+    assert mr._fmt_kb(8192) == "8.0KB"

--- a/tests/test_gitlab_mr.py
+++ b/tests/test_gitlab_mr.py
@@ -410,3 +410,13 @@ def test_fmt_kb_thresholds() -> None:
     assert mr._fmt_kb(500) == "500B"
     assert mr._fmt_kb(2048) == "2.0KB"
     assert mr._fmt_kb(8192) == "8.0KB"
+
+
+def test_budgeted_comments_hidden_bytes_counts_utf8() -> None:
+    """Hidden-bytes must reflect UTF-8 byte length, not codepoint count."""
+    big_multibyte = "é" * 1500  # 2 bytes/char in UTF-8
+    notes = [_note(f"u{i}", big_multibyte) for i in range(8)]
+    _, hidden_count, hidden_bytes = mr._budgeted_comments(notes, budget=2000, tail=2)
+    assert hidden_count > 0
+    # Char-counting would give roughly hidden_count * 1500; UTF-8 ~doubles it.
+    assert hidden_bytes >= hidden_count * 1500

--- a/tests/test_gitlab_mr.py
+++ b/tests/test_gitlab_mr.py
@@ -413,10 +413,17 @@ def test_fmt_kb_thresholds() -> None:
 
 
 def test_budgeted_comments_hidden_bytes_counts_utf8() -> None:
-    """Hidden-bytes must reflect UTF-8 byte length, not codepoint count."""
-    big_multibyte = "é" * 1500  # 2 bytes/char in UTF-8
+    """Hidden-bytes must reflect UTF-8 byte length, not codepoint count.
+
+    Body is truncated to COMMENT_MAX=500 chars before rendering; with all-multibyte
+    content the resulting render is ~1000 bytes — strictly larger than the codepoint
+    count, which proves we're counting bytes.
+    """
+    big_multibyte = "é" * 1500  # 2 bytes/char in UTF-8, gets truncated to 500 chars
     notes = [_note(f"u{i}", big_multibyte) for i in range(8)]
+    rendered_one_chars = len(mr._render_note(notes[0]))
+    rendered_one_bytes = len(mr._render_note(notes[0]).encode("utf-8"))
+    assert rendered_one_bytes > rendered_one_chars, "multibyte body must inflate byte count"
     _, hidden_count, hidden_bytes = mr._budgeted_comments(notes, budget=2000, tail=2)
     assert hidden_count > 0
-    # Char-counting would give roughly hidden_count * 1500; UTF-8 ~doubles it.
-    assert hidden_bytes >= hidden_count * 1500
+    assert hidden_bytes == hidden_count * rendered_one_bytes


### PR DESCRIPTION
Closes #170

## Summary
- Add \`COMMENT_TOTAL_MAX = 2000\` budget for the gl-mr Comments section
- Helper \`_budgeted_comments()\` keeps oldest-fit-first + last 2 for recency, signals a gap with a sentinel that becomes the summary line
- Summary: \`... N more comment(s) hidden (XKB). Use gl-mr:NUM:full for everything.\`
- New \`:full\` positional flag bypasses the cap entirely
- 5 new unit tests on the helper + KB formatter

## Out of scope (per issue's "optional" items)
- Bot-author detection / one-line collapse — happy to do as follow-up
- \`:nocomments\` flag — same

## Test plan
- [x] \`pytest tests/test_gitlab_mr.py\` — 23/23 pass
- [ ] Manual: \`./supertool 'gl-mr:21803'\` (Kevin-heavy MR) — confirm hidden count + tail comments preserved
- [ ] Manual: \`./supertool 'gl-mr:21803:full'\` — confirm cap bypassed