### PR TITLE
git-commit: detect existing MR/PR in post-commit hint

### DIFF
--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -15,7 +15,9 @@ Special MSG values:
 """
 from __future__ import annotations
 
+import json
 import os
+import shutil
 import subprocess
 import sys
 
@@ -27,6 +29,44 @@ def _git(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess[str]
         ["git"] + args,
         capture_output=True, text=True, timeout=timeout,
     )
+
+
+def _existing_mr_for_branch(branch: str) -> str:
+    """Open MR/PR identifier for `branch`, or empty when none / no tool available.
+
+    Tries glab first (GitLab), falls back to gh (GitHub). All failures swallowed —
+    this is advisory output for the post-commit hint, never blocking.
+    """
+    if not branch:
+        return ""
+    if shutil.which("glab"):
+        try:
+            res = subprocess.run(
+                ["glab", "mr", "list", "--source-branch", branch, "--state", "opened",
+                 "--output", "json"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if res.returncode == 0 and res.stdout.strip().startswith("["):
+                mrs = json.loads(res.stdout)
+                if mrs:
+                    iid = mrs[0].get("iid") or mrs[0].get("number") or "?"
+                    return f"!{iid}"
+        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+            pass
+    if shutil.which("gh"):
+        try:
+            res = subprocess.run(
+                ["gh", "pr", "list", "--head", branch, "--state", "open",
+                 "--json", "number", "--limit", "1"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if res.returncode == 0 and res.stdout.strip().startswith("["):
+                prs = json.loads(res.stdout)
+                if prs:
+                    return f"#{prs[0].get('number', '?')}"
+        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+            pass
+    return ""
 
 
 def _head_sha() -> str:
@@ -120,7 +160,12 @@ def main() -> int:
         # Next-step hint
         upstream_res = _git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
         if upstream_res.returncode == 0 and upstream_res.stdout.strip():
-            print("Next: git push (or ./supertool 'mr:.max/mr.md|TIME|LABELS' for push+MR)")
+            branch = _git(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            existing = _existing_mr_for_branch(branch)
+            if existing:
+                print(f"Next: git push (updates {existing})")
+            else:
+                print("Next: git push (or ./supertool 'mr:.max/mr.md|TIME|LABELS' for push+MR)")
         else:
             print("Next: git push -u origin HEAD (no upstream set)")
         return 0

--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -37,7 +37,7 @@ def _existing_mr_for_branch(branch: str) -> str:
     Tries glab first (GitLab), falls back to gh (GitHub). All failures swallowed —
     this is advisory output for the post-commit hint, never blocking.
     """
-    if not branch:
+    if not branch or branch == "HEAD":
         return ""
     if shutil.which("glab"):
         try:
@@ -160,7 +160,6 @@ def main() -> int:
         # Next-step hint
         upstream_res = _git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
         if upstream_res.returncode == 0 and upstream_res.stdout.strip():
-            branch = _git(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
             existing = _existing_mr_for_branch(branch)
             if existing:
                 print(f"Next: git push (updates {existing})")

--- a/tests/test_git_commit_existing_mr.py
+++ b/tests/test_git_commit_existing_mr.py
@@ -22,6 +22,11 @@ def test_empty_branch_returns_empty() -> None:
     assert commit._existing_mr_for_branch("") == ""
 
 
+def test_detached_head_returns_empty() -> None:
+    """`git rev-parse --abbrev-ref HEAD` returns 'HEAD' when detached."""
+    assert commit._existing_mr_for_branch("HEAD") == ""
+
+
 def test_glab_match_returns_bang_iid() -> None:
     fake_which = mock.Mock(side_effect=lambda c: "/usr/bin/glab" if c == "glab" else None)
     fake_run = mock.Mock(return_value=_proc('[{"iid": 21816, "title": "x"}]'))

--- a/tests/test_git_commit_existing_mr.py
+++ b/tests/test_git_commit_existing_mr.py
@@ -1,0 +1,88 @@
+"""Unit tests for presets/git/commit.py _existing_mr_for_branch helper."""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+
+PRESET = Path(__file__).parent.parent / "presets" / "git" / "commit.py"
+_spec = importlib.util.spec_from_file_location("git_commit", PRESET)
+assert _spec is not None and _spec.loader is not None
+commit = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(commit)
+
+
+def _proc(stdout: str = "", returncode: int = 0):
+    return mock.Mock(stdout=stdout, returncode=returncode, stderr="")
+
+
+def test_empty_branch_returns_empty() -> None:
+    assert commit._existing_mr_for_branch("") == ""
+
+
+def test_glab_match_returns_bang_iid() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: "/usr/bin/glab" if c == "glab" else None)
+    fake_run = mock.Mock(return_value=_proc('[{"iid": 21816, "title": "x"}]'))
+    with mock.patch.object(commit.shutil, "which", fake_which), \
+         mock.patch.object(commit.subprocess, "run", fake_run):
+        assert commit._existing_mr_for_branch("feature/x") == "!21816"
+
+
+def test_gh_fallback_when_no_glab() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: "/usr/bin/gh" if c == "gh" else None)
+    fake_run = mock.Mock(return_value=_proc('[{"number": 172}]'))
+    with mock.patch.object(commit.shutil, "which", fake_which), \
+         mock.patch.object(commit.subprocess, "run", fake_run):
+        assert commit._existing_mr_for_branch("feature/x") == "#172"
+
+
+def test_no_tool_available_returns_empty() -> None:
+    with mock.patch.object(commit.shutil, "which", return_value=None):
+        assert commit._existing_mr_for_branch("feature/x") == ""
+
+
+def test_glab_empty_list_falls_through_to_gh() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: f"/usr/bin/{c}" if c in ("glab", "gh") else None)
+    call_count = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _proc("[]")  # glab: no MR
+        return _proc('[{"number": 9}]')  # gh: PR exists
+
+    with mock.patch.object(commit.shutil, "which", fake_which), \
+         mock.patch.object(commit.subprocess, "run", side_effect=fake_run):
+        assert commit._existing_mr_for_branch("feature/x") == "#9"
+
+
+def test_glab_timeout_falls_through() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: f"/usr/bin/{c}" if c in ("glab", "gh") else None)
+    call_count = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise subprocess.TimeoutExpired(cmd="glab", timeout=5)
+        return _proc('[{"number": 42}]')
+
+    with mock.patch.object(commit.shutil, "which", fake_which), \
+         mock.patch.object(commit.subprocess, "run", side_effect=fake_run):
+        assert commit._existing_mr_for_branch("feature/x") == "#42"
+
+
+def test_glab_malformed_json_falls_through() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: f"/usr/bin/{c}" if c in ("glab", "gh") else None)
+    call_count = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _proc("[not json")
+        return _proc('[{"number": 7}]')
+
+    with mock.patch.object(commit.shutil, "which", fake_which), \
+         mock.patch.object(commit.subprocess, "run", side_effect=fake_run):
+        assert commit._existing_mr_for_branch("feature/x") == "#7"


### PR DESCRIPTION
Closes #171

## Summary
- New helper \`_existing_mr_for_branch()\` queries glab → gh for an open MR/PR on the current branch
- Post-commit hint becomes \`Next: git push (updates !21816)\` when one exists; falls back to current \`(or mr op)\` wording otherwise
- All API calls swallow errors (timeout, malformed JSON, missing CLI) — advisory only

## Out of scope
- Pipeline status (e.g. \`pipeline #139928\` in the example) — requires a second API call per commit. Happy to add as a follow-up if you want it; keeping the first iteration tight.

## Test plan
- [x] 7 new unit tests cover glab match, gh fallback, no-tool, empty-list fall-through, timeout fall-through, malformed-JSON fall-through, empty branch
- [ ] Manual: commit on a branch with an open MR — confirm the new hint wording