### PR TITLE
watch preset (Phase 1) — background pollers + reusable source contract

### DIFF
--- a/.supertool.json
+++ b/.supertool.json
@@ -7,7 +7,8 @@
     "github",
     "git",
     "xml",
-    "mcp"
+    "mcp",
+    "watch"
   ],
   "mcp": {
     "py-lsp": {

--- a/presets/watch.json
+++ b/presets/watch.json
@@ -1,0 +1,23 @@
+{
+  "description": "Watch ops — spawn background pollers for external sources (MRs, jobs, calendar) that emit events via UDS socket + status files + macOS notifications. Reusable foundation; channel consumer plugs in later.",
+  "ops": {
+    "watch": {
+      "cmd": "python3 {path}watch/dispatcher.py watch {args}",
+      "timeout": 15,
+      "description": "Spawn a background poller for SOURCE:ID. Optional :only=ev1,ev2 filters which events emit notifications. PID file: /tmp/supertool-watch-{SOURCE}__{ID}.pid",
+      "syntax": "watch:SOURCE:ID[:only=event1,event2]"
+    },
+    "unwatch": {
+      "cmd": "python3 {path}watch/dispatcher.py unwatch {args}",
+      "timeout": 10,
+      "description": "Kill the poller for SOURCE:ID and remove its PID file.",
+      "syntax": "unwatch:SOURCE:ID"
+    },
+    "watches": {
+      "cmd": "python3 {path}watch/dispatcher.py list",
+      "timeout": 5,
+      "description": "List active watch pollers as a table: source, id, started, last_event, pid.",
+      "syntax": "watches"
+    }
+  }
+}

--- a/presets/watch/README.md
+++ b/presets/watch/README.md
@@ -1,0 +1,124 @@
+# `watch` preset
+
+Background pollers for external sources (GitLab MRs, jobs, calendar, …) that
+emit events when state changes. Reusable foundation — a Phase 2 channel
+consumer will plug into the same UDS socket to push events directly into
+Claude Code.
+
+## Ops
+
+```
+watch:SOURCE:ID[:only=event1,event2]    spawn poller (fire-and-forget)
+unwatch:SOURCE:ID                       kill poller, remove PID file
+watches                                 list active pollers (table)
+```
+
+Example:
+
+```bash
+./supertool 'watch:gitlab-mr:21803'                 # all events
+./supertool 'watch:gitlab-mr:21803:only=pipeline_failed,merged'
+./supertool 'watches'
+./supertool 'unwatch:gitlab-mr:21803'
+```
+
+## Transports
+
+Pollers emit through three channels (all best-effort, none can crash the poller):
+
+| Transport            | Purpose                                                              | Path                                                 |
+| -------------------- | -------------------------------------------------------------------- | ---------------------------------------------------- |
+| UDS socket (NDJSON)  | Live event stream — Phase 2 channel consumer reads this              | `/tmp/supertool-watch.sock`                          |
+| Status file (JSON)   | Last-known state for the `watches` op + offline inspection           | `/tmp/supertool-watch-{source}__{id}.state.json`     |
+| macOS osascript      | Desktop notification on terminal status (human-facing)               | system notification center                           |
+
+## Event payload (locked — Phase 2 depends on it)
+
+```json
+{
+  "ts": "2026-05-24T19:00:00Z",
+  "source": "gitlab-mr",
+  "id": "21803",
+  "event": "pipeline_failed",
+  "payload": {
+    "pipeline_id": "139928",
+    "url": "https://gitlab.example.com/.../merge_requests/21803",
+    "title": "feat: do the thing"
+  }
+}
+```
+
+## Lifecycle
+
+Each `watch` invocation forks a detached poller process. The process IS the
+subscription — no central config to manage:
+
+- PID file per active watcher: `/tmp/supertool-watch-{source}__{id}.pid`
+- `unwatch` reads the PID file, SIGTERM (then SIGKILL after 200ms), removes the file
+- Stale PIDs swept by the `watches` op automatically
+- Pollers auto-stop when the source declares the target terminal
+  (`is_terminal(state) -> bool`)
+
+## Writing a new source
+
+Drop a folder under `presets/watch/sources/<NAME>/`:
+
+```
+sources/your-source/
+  events.json     # event vocabulary (introspection only)
+  poller.py       # the polling implementation
+```
+
+### `events.json`
+
+```json
+{
+  "source": "your-source",
+  "events": [
+    {"key": "happened",        "label": "Something happened"},
+    {"key": "happened_again",  "label": "Something happened again"}
+  ]
+}
+```
+
+### `poller.py`
+
+```python
+INTERVAL = 30  # seconds between polls
+
+def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
+    """Return (events_to_emit, new_state).
+
+    ctx = {"source": "your-source", "id": "<watcher id>", "only": [...]}.
+
+    Each event is a dict:
+      {
+        "event": "happened",
+        "payload": {...},
+        "notify_title": "Optional macOS notification title",
+        "notify_message": "Optional macOS notification body",
+      }
+
+    Diff against `state`; return only NEW events. Returning the same event
+    on every tick produces a notification storm.
+
+    The framework persists `new_state` and passes it back on the next call.
+    """
+    ...
+
+def is_terminal(state: dict) -> bool:
+    """True if the watcher should stop on its own (e.g. MR merged)."""
+    return False
+```
+
+The dispatcher handles PID files, signals, transport, the `only=` filter, and
+state persistence. Source code stays focused on "what changed?".
+
+## Phase 2 — channel consumer
+
+Lives outside this preset. It will:
+1. Bind a UDS listener at `/tmp/supertool-watch.sock`
+2. Forward each NDJSON line to Claude Code via the Channels MCP protocol
+3. Claude sees events as `<channel source="gitlab-mr" id="21803" event="pipeline_failed">...`
+
+No changes to this preset will be required.

--- a/presets/watch/dispatcher.py
+++ b/presets/watch/dispatcher.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Dispatcher for the `watch` preset — handles watch/unwatch/watches sub-ops.
+
+Each `watch:SOURCE:ID[:only=...]` invocation forks a poller child for
+SOURCE/ID. The child detaches (setsid + double-fork) and runs the source's
+`poller.poll()` function in a loop until terminal or until killed.
+
+The dispatcher does NOT contain source-specific logic. It only:
+  - Resolves the source's poller module from presets/watch/sources/
+  - Manages PID files
+  - Spawns + kills children
+  - Renders the `watches` table
+
+A source plugin lives at `presets/watch/sources/<NAME>/poller.py` and exposes:
+  - INTERVAL: int — seconds between polls
+  - poll(state: dict, ctx: dict) -> tuple[list[dict], dict]
+        returns (events_to_emit, new_state)
+  - is_terminal(state: dict) -> bool
+        True when the watcher should stop on its own (merged/closed/finished)
+
+Each event is a dict {event: str, payload: dict, notify_title?: str,
+notify_message?: str}. The dispatcher passes them to transport.emit_event.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+# Allow importing transport as a sibling module when launched via `python3 dispatcher.py`.
+sys.path.insert(0, str(Path(__file__).parent))
+import transport  # noqa: E402
+
+SOURCES_DIR = Path(__file__).parent / "sources"
+
+
+def _load_source(name: str):
+    """Import the poller module for SOURCE from sources/<name>/poller.py."""
+    poller_path = SOURCES_DIR / name / "poller.py"
+    if not poller_path.exists():
+        return None
+    spec = importlib.util.spec_from_file_location(f"watch_source_{name}", poller_path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse_args(parts: list[str]) -> tuple[str, str, list[str]]:
+    """Parse SOURCE ID [only=ev1,ev2 ...] from positional argv segments.
+
+    Supertool's {args} placeholder explodes the colon-separated op into one
+    argv element per segment, so we receive ["gitlab-mr", "21803", "only=..."]
+    rather than a single colon-joined string.
+
+    Returns (source, id, allowed_event_keys_or_empty_meaning_all).
+    """
+    if len(parts) < 1 or not parts[0]:
+        raise ValueError("missing SOURCE")
+    if len(parts) < 2 or not parts[1]:
+        raise ValueError(f"missing ID for source {parts[0]!r}")
+    source, watcher_id = parts[0], parts[1]
+    only: list[str] = []
+    for p in parts[2:]:
+        if p.startswith("only="):
+            only = [e for e in p[len("only="):].split(",") if e]
+    return source, watcher_id, only
+
+
+def cmd_watch(parts: list[str]) -> int:
+    try:
+        source, watcher_id, only = _parse_args(parts)
+    except ValueError as e:
+        print(f"ERROR: {e}")
+        return 1
+    poller = _load_source(source)
+    if poller is None:
+        avail = ", ".join(sorted(p.name for p in SOURCES_DIR.iterdir() if p.is_dir())) or "(none)"
+        print(f"ERROR: unknown source {source!r}. Available: {avail}")
+        return 1
+    pid_file = transport.pid_path(source, watcher_id)
+    if os.path.exists(pid_file):
+        try:
+            existing = int(Path(pid_file).read_text().strip())
+            if transport._pid_alive(existing):
+                print(f"Already watching {source}:{watcher_id} (PID {existing}). "
+                      f"Use ./supertool 'unwatch:{source}:{watcher_id}' to stop.")
+                return 0
+        except (OSError, ValueError):
+            pass
+        try:
+            os.unlink(pid_file)
+        except OSError:
+            pass
+
+    child_pid = _spawn_poller(source, watcher_id, only)
+    if child_pid == 0:
+        # Child never returns here; _run_poll_loop exits.
+        return 0
+    print(f"Watching {source}:{watcher_id} (PID {child_pid})")
+    if only:
+        print(f"Filter: {','.join(only)}")
+    print(f"State: {transport.state_path(source, watcher_id)}")
+    return 0
+
+
+def cmd_unwatch(parts: list[str]) -> int:
+    try:
+        source, watcher_id, _ = _parse_args(parts)
+    except ValueError as e:
+        print(f"ERROR: {e}")
+        return 1
+    pid_file = transport.pid_path(source, watcher_id)
+    if not os.path.exists(pid_file):
+        print(f"No active watcher for {source}:{watcher_id}.")
+        return 0
+    try:
+        pid = int(Path(pid_file).read_text().strip())
+    except (OSError, ValueError):
+        try:
+            os.unlink(pid_file)
+        except OSError:
+            pass
+        print(f"Stale PID file removed for {source}:{watcher_id}.")
+        return 0
+    if transport._pid_alive(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            time.sleep(0.2)
+            if transport._pid_alive(pid):
+                os.kill(pid, signal.SIGKILL)
+        except OSError as e:
+            print(f"ERROR: could not stop PID {pid}: {e}")
+            return 1
+    try:
+        os.unlink(pid_file)
+    except OSError:
+        pass
+    print(f"Stopped watcher for {source}:{watcher_id} (PID {pid}).")
+    return 0
+
+
+def cmd_list() -> int:
+    rows = transport.list_active_pids()
+    if not rows:
+        print("No active watchers.")
+        return 0
+    widths = {
+        "source": max(6, max(len(r["source"]) for r in rows)),
+        "id": max(2, max(len(r["id"]) for r in rows)),
+        "pid": max(5, max(len(str(r["pid"])) for r in rows)),
+        "started": 20,
+        "last_event": max(10, max(len(r["last_event"] or "-") for r in rows)),
+    }
+    header = (
+        f"{'SOURCE':<{widths['source']}}  "
+        f"{'ID':<{widths['id']}}  "
+        f"{'PID':<{widths['pid']}}  "
+        f"{'STARTED':<{widths['started']}}  "
+        f"{'LAST_EVENT':<{widths['last_event']}}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(
+            f"{r['source']:<{widths['source']}}  "
+            f"{r['id']:<{widths['id']}}  "
+            f"{r['pid']:<{widths['pid']}}  "
+            f"{r['started']:<{widths['started']}}  "
+            f"{(r['last_event'] or '-'):<{widths['last_event']}}"
+        )
+    return 0
+
+
+def _spawn_poller(source: str, watcher_id: str, only: list[str]) -> int:
+    """Detach a poller child (double-fork) and return its PID to the parent."""
+    r, w = os.pipe()
+    pid = os.fork()
+    if pid != 0:
+        # Parent: wait for child to report grandchild PID, then return.
+        os.close(w)
+        try:
+            grand_pid = int(os.read(r, 32).decode().strip() or "0")
+        except (OSError, ValueError):
+            grand_pid = 0
+        os.close(r)
+        os.waitpid(pid, 0)
+        return grand_pid
+    # First child: detach session, fork grandchild, report PID, exit.
+    os.close(r)
+    os.setsid()
+    pid2 = os.fork()
+    if pid2 != 0:
+        os.write(w, str(pid2).encode())
+        os.close(w)
+        os._exit(0)
+    # Grandchild: close inherited fd, run the loop.
+    os.close(w)
+    _run_poll_loop(source, watcher_id, only)
+    os._exit(0)
+    return 0  # unreachable
+
+
+def _run_poll_loop(source: str, watcher_id: str, only: list[str]) -> None:
+    """Grandchild's poll loop. Writes PID file, runs until terminal or signal."""
+    # Redirect stdio to /dev/null so the poller can't pollute the parent's terminal.
+    try:
+        devnull = os.open(os.devnull, os.O_RDWR)
+        os.dup2(devnull, 0)
+        os.dup2(devnull, 1)
+        os.dup2(devnull, 2)
+        if devnull > 2:
+            os.close(devnull)
+    except OSError:
+        pass
+
+    pid_file = transport.pid_path(source, watcher_id)
+    try:
+        Path(pid_file).write_text(f"{os.getpid()}\n")
+    except OSError:
+        return
+
+    poller = _load_source(source)
+    if poller is None:
+        try:
+            os.unlink(pid_file)
+        except OSError:
+            pass
+        return
+
+    state: dict[str, Any] = transport.read_state(source, watcher_id).get("source_state", {}) or {}
+    ctx = {"source": source, "id": watcher_id, "only": only}
+    interval = int(getattr(poller, "INTERVAL", 30))
+    stop_flag = {"stop": False}
+
+    def _handle_sigterm(*_a):
+        stop_flag["stop"] = True
+
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+    signal.signal(signal.SIGINT, _handle_sigterm)
+
+    try:
+        while not stop_flag["stop"]:
+            try:
+                events, new_state = poller.poll(state, ctx)
+            except Exception as e:  # noqa: BLE001 — never crash, log to state
+                full = transport.read_state(source, watcher_id)
+                full["last_error"] = {"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                                       "message": str(e)}
+                transport.write_state(source, watcher_id, full)
+                time.sleep(interval)
+                continue
+
+            for ev in events:
+                if only and ev.get("event") not in only:
+                    continue
+                transport.emit_event(
+                    source, watcher_id,
+                    ev.get("event", "unknown"),
+                    ev.get("payload", {}),
+                    notify_title=ev.get("notify_title"),
+                    notify_message=ev.get("notify_message"),
+                )
+
+            full = transport.read_state(source, watcher_id)
+            full["source_state"] = new_state
+            transport.write_state(source, watcher_id, full)
+            state = new_state
+
+            if hasattr(poller, "is_terminal") and poller.is_terminal(new_state):
+                break
+
+            for _ in range(interval):
+                if stop_flag["stop"]:
+                    break
+                time.sleep(1)
+    finally:
+        try:
+            os.unlink(pid_file)
+        except OSError:
+            pass
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("ERROR: usage: dispatcher.py {watch|unwatch|list} [ARG]")
+        return 1
+    sub = argv[1]
+    rest = argv[2:]
+    if sub == "watch":
+        return cmd_watch(rest)
+    if sub == "unwatch":
+        return cmd_unwatch(rest)
+    if sub == "list":
+        return cmd_list()
+    print(f"ERROR: unknown sub-op {sub!r}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/presets/watch/dispatcher.py
+++ b/presets/watch/dispatcher.py
@@ -66,6 +66,10 @@ def _parse_args(parts: list[str]) -> tuple[str, str, list[str]]:
     if len(parts) < 2 or not parts[1]:
         raise ValueError(f"missing ID for source {parts[0]!r}")
     source, watcher_id = parts[0], parts[1]
+    # PID/state filenames use `__` to separate source and id (see transport.py).
+    # Allowing it inside either field would make `list_active_pids` ambiguous.
+    if "__" in source or "__" in watcher_id:
+        raise ValueError("SOURCE and ID must not contain '__' (reserved as filename separator)")
     only: list[str] = []
     for p in parts[2:]:
         if p.startswith("only="):

--- a/presets/watch/sources/gitlab-mr/events.json
+++ b/presets/watch/sources/gitlab-mr/events.json
@@ -1,0 +1,11 @@
+{
+  "source": "gitlab-mr",
+  "events": [
+    {"key": "pipeline_failed",      "label": "Pipeline failed"},
+    {"key": "pipeline_succeeded",   "label": "Pipeline succeeded"},
+    {"key": "pipeline_running",     "label": "Pipeline started running"},
+    {"key": "merged",               "label": "MR merged"},
+    {"key": "closed",               "label": "MR closed"},
+    {"key": "conflicts_appeared",   "label": "Conflicts appeared"}
+  ]
+}

--- a/presets/watch/sources/gitlab-mr/poller.py
+++ b/presets/watch/sources/gitlab-mr/poller.py
@@ -1,0 +1,130 @@
+"""gitlab-mr watcher source.
+
+Polls a single GitLab merge request via `glab api` and emits events when
+status changes. Terminal when the MR is merged or closed.
+
+Source plugin contract:
+- INTERVAL: int seconds between polls (30s default)
+- poll(state, ctx) -> (events, new_state)
+- is_terminal(state) -> bool
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Any
+
+INTERVAL = 30
+
+TERMINAL_MR_STATES = {"merged", "closed"}
+TERMINAL_PIPELINE_STATES = {"success", "failed", "canceled", "skipped", "manual"}
+
+
+def _glab_api(endpoint: str) -> dict | list | None:
+    if not shutil.which("glab"):
+        return None
+    try:
+        r = subprocess.run(
+            ["glab", "api", endpoint],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _fetch(iid: str) -> dict[str, Any] | None:
+    data = _glab_api(f"projects/:id/merge_requests/{iid}")
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
+    iid = ctx["id"]
+    data = _fetch(iid)
+    if data is None:
+        return [], state  # transient — try again next tick
+
+    mr_state = str(data.get("state") or "")
+    has_conflicts = bool(data.get("has_conflicts"))
+    pipeline = data.get("head_pipeline") or data.get("pipeline") or {}
+    pipeline_status = str(pipeline.get("status") or "") if isinstance(pipeline, dict) else ""
+    pipeline_id = str(pipeline.get("id") or "") if isinstance(pipeline, dict) else ""
+    title = str(data.get("title") or f"MR !{iid}")
+    web_url = str(data.get("web_url") or "")
+
+    events: list[dict] = []
+    prev_pipeline = state.get("pipeline_status", "")
+    prev_state = state.get("mr_state", "")
+    prev_conflicts = bool(state.get("has_conflicts", False))
+
+    # Pipeline transitions
+    if pipeline_status and pipeline_status != prev_pipeline:
+        if pipeline_status == "failed":
+            events.append({
+                "event": "pipeline_failed",
+                "payload": {"pipeline_id": pipeline_id, "url": web_url, "title": title},
+                "notify_title": f"!{iid} pipeline failed",
+                "notify_message": title,
+            })
+        elif pipeline_status == "success":
+            events.append({
+                "event": "pipeline_succeeded",
+                "payload": {"pipeline_id": pipeline_id, "url": web_url, "title": title},
+                "notify_title": f"!{iid} pipeline ok",
+                "notify_message": title,
+            })
+        elif pipeline_status == "running" and prev_pipeline not in ("running", ""):
+            events.append({
+                "event": "pipeline_running",
+                "payload": {"pipeline_id": pipeline_id, "url": web_url, "title": title},
+            })
+
+    # MR state transitions
+    if mr_state and mr_state != prev_state:
+        if mr_state == "merged":
+            events.append({
+                "event": "merged",
+                "payload": {"url": web_url, "title": title},
+                "notify_title": f"!{iid} merged",
+                "notify_message": title,
+            })
+        elif mr_state == "closed":
+            events.append({
+                "event": "closed",
+                "payload": {"url": web_url, "title": title},
+                "notify_title": f"!{iid} closed",
+                "notify_message": title,
+            })
+
+    # Conflict transitions (rising edge only — appeared, not resolved)
+    if has_conflicts and not prev_conflicts:
+        events.append({
+            "event": "conflicts_appeared",
+            "payload": {"url": web_url, "title": title},
+            "notify_title": f"!{iid} conflicts",
+            "notify_message": title,
+        })
+
+    new_state = {
+        "mr_state": mr_state,
+        "pipeline_status": pipeline_status,
+        "pipeline_id": pipeline_id,
+        "has_conflicts": has_conflicts,
+        "title": title,
+        "web_url": web_url,
+    }
+    return events, new_state
+
+
+def is_terminal(state: dict) -> bool:
+    if state.get("mr_state") in TERMINAL_MR_STATES:
+        return True
+    return False

--- a/presets/watch/sources/gitlab-mr/poller.py
+++ b/presets/watch/sources/gitlab-mr/poller.py
@@ -18,7 +18,6 @@ from typing import Any
 INTERVAL = 30
 
 TERMINAL_MR_STATES = {"merged", "closed"}
-TERMINAL_PIPELINE_STATES = {"success", "failed", "canceled", "skipped", "manual"}
 
 
 def _glab_api(endpoint: str) -> dict | list | None:

--- a/presets/watch/transport.py
+++ b/presets/watch/transport.py
@@ -1,0 +1,183 @@
+"""Transport writers for watch pollers.
+
+Pollers emit events through three transports:
+- UDS socket (NDJSON) at /tmp/supertool-watch.sock — for consumers like the
+  Phase 2 channel server. Silent when no listener bound.
+- Status file at /tmp/supertool-watch-{source}-{id}.state.json — last-known
+  state so `watches` op can render it without scanning processes.
+- macOS osascript desktop notification — human-facing ping on terminal/error.
+  No-op on non-macOS.
+
+All writers swallow errors. A watcher must never die because a transport
+hiccupped.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SOCK_PATH = "/tmp/supertool-watch.sock"
+STATE_DIR = "/tmp"
+
+
+def state_path(source: str, watcher_id: str) -> str:
+    return f"{STATE_DIR}/supertool-watch-{source}__{watcher_id}.state.json"
+
+
+def pid_path(source: str, watcher_id: str) -> str:
+    return f"{STATE_DIR}/supertool-watch-{source}__{watcher_id}.pid"
+
+
+def emit_socket(payload: dict[str, Any]) -> None:
+    """Best-effort write of one NDJSON line to the UDS socket. Silent if no listener."""
+    if not os.path.exists(SOCK_PATH):
+        return
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(0.5)
+        s.connect(SOCK_PATH)
+        s.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+        s.close()
+    except OSError:
+        return
+
+
+def write_state(source: str, watcher_id: str, state: dict[str, Any]) -> None:
+    """Atomically replace the status file with the latest known state."""
+    path = state_path(source, watcher_id)
+    tmp = f"{path}.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def read_state(source: str, watcher_id: str) -> dict[str, Any]:
+    path = state_path(source, watcher_id)
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def desktop_notify(title: str, message: str) -> None:
+    """Fire-and-forget macOS notification. No-op elsewhere."""
+    if sys.platform != "darwin":
+        return
+    if not shutil.which("osascript"):
+        return
+    body = message.replace('"', '\\"')
+    head = title.replace('"', '\\"')
+    script = f'display notification "{body}" with title "{head}"'
+    try:
+        subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True, timeout=3, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return
+
+
+def emit_event(
+    source: str,
+    watcher_id: str,
+    event_key: str,
+    payload: dict[str, Any],
+    *,
+    notify_title: str | None = None,
+    notify_message: str | None = None,
+) -> None:
+    """All transports in one call.
+
+    Writes the event to the UDS socket (if any listener), refreshes the
+    status file with the latest event, and optionally fires a desktop
+    notification when title+message are provided.
+    """
+    record = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "source": source,
+        "id": watcher_id,
+        "event": event_key,
+        "payload": payload,
+    }
+    emit_socket(record)
+    current = read_state(source, watcher_id)
+    current["last_event"] = record
+    current.setdefault("first_seen", record["ts"])
+    write_state(source, watcher_id, current)
+    if notify_title and notify_message:
+        desktop_notify(notify_title, notify_message)
+
+
+def list_active_pids() -> list[dict[str, Any]]:
+    """Scan /tmp for live watcher PID files. Stale entries are pruned in place.
+
+    Returns rows with: source, id, pid, started (mtime ISO), state file existence
+    flag, and last event from the state file when readable.
+    """
+    rows: list[dict[str, Any]] = []
+    prefix = "supertool-watch-"
+    suffix = ".pid"
+    for name in sorted(os.listdir(STATE_DIR)):
+        if not (name.startswith(prefix) and name.endswith(suffix)):
+            continue
+        path = os.path.join(STATE_DIR, name)
+        try:
+            pid = int(Path(path).read_text().strip())
+        except (OSError, ValueError):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            continue
+        # supertool-watch-{source}__{id}.pid
+        stem = name[len(prefix):-len(suffix)]
+        if "__" not in stem:
+            continue
+        source, watcher_id = stem.split("__", 1)
+        if not _pid_alive(pid):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            continue
+        started = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ", time.gmtime(os.path.getmtime(path))
+        )
+        state = read_state(source, watcher_id)
+        rows.append({
+            "source": source,
+            "id": watcher_id,
+            "pid": pid,
+            "started": started,
+            "last_event": (state.get("last_event") or {}).get("event", ""),
+            "last_event_ts": (state.get("last_event") or {}).get("ts", ""),
+        })
+    return rows
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True

--- a/presets/watch/transport.py
+++ b/presets/watch/transport.py
@@ -39,14 +39,20 @@ def emit_socket(payload: dict[str, Any]) -> None:
     """Best-effort write of one NDJSON line to the UDS socket. Silent if no listener."""
     if not os.path.exists(SOCK_PATH):
         return
+    s: socket.socket | None = None
     try:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.settimeout(0.5)
         s.connect(SOCK_PATH)
         s.sendall((json.dumps(payload) + "\n").encode("utf-8"))
-        s.close()
     except OSError:
         return
+    finally:
+        if s is not None:
+            try:
+                s.close()
+            except OSError:
+                pass
 
 
 def write_state(source: str, watcher_id: str, state: dict[str, Any]) -> None:

--- a/tests/test_watch_dispatcher.py
+++ b/tests/test_watch_dispatcher.py
@@ -50,6 +50,16 @@ def test_parse_args_empty_errors() -> None:
         dispatcher._parse_args([])
 
 
+def test_parse_args_rejects_double_underscore_in_source() -> None:
+    with pytest.raises(ValueError, match="must not contain '__'"):
+        dispatcher._parse_args(["bad__source", "21803"])
+
+
+def test_parse_args_rejects_double_underscore_in_id() -> None:
+    with pytest.raises(ValueError, match="must not contain '__'"):
+        dispatcher._parse_args(["gitlab-mr", "bad__id"])
+
+
 def test_load_source_known() -> None:
     mod = dispatcher._load_source("gitlab-mr")
     assert mod is not None

--- a/tests/test_watch_dispatcher.py
+++ b/tests/test_watch_dispatcher.py
@@ -1,0 +1,90 @@
+"""Unit tests for presets/watch/dispatcher.py arg parsing + listing."""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+WATCH_DIR = Path(__file__).parent.parent / "presets" / "watch"
+sys.path.insert(0, str(WATCH_DIR))
+
+_d_spec = importlib.util.spec_from_file_location("watch_dispatcher", WATCH_DIR / "dispatcher.py")
+assert _d_spec is not None and _d_spec.loader is not None
+dispatcher = importlib.util.module_from_spec(_d_spec)
+_d_spec.loader.exec_module(dispatcher)
+
+_t_spec = importlib.util.spec_from_file_location("watch_transport", WATCH_DIR / "transport.py")
+assert _t_spec is not None and _t_spec.loader is not None
+transport = importlib.util.module_from_spec(_t_spec)
+_t_spec.loader.exec_module(transport)
+
+
+def test_parse_args_basic() -> None:
+    assert dispatcher._parse_args(["gitlab-mr", "21803"]) == ("gitlab-mr", "21803", [])
+
+
+def test_parse_args_with_only_filter() -> None:
+    source, watcher_id, only = dispatcher._parse_args(
+        ["gitlab-mr", "21803", "only=pipeline_failed,merged"]
+    )
+    assert source == "gitlab-mr"
+    assert watcher_id == "21803"
+    assert only == ["pipeline_failed", "merged"]
+
+
+def test_parse_args_empty_only_ignored() -> None:
+    _, _, only = dispatcher._parse_args(["gitlab-mr", "21803", "only="])
+    assert only == []
+
+
+def test_parse_args_missing_id_errors() -> None:
+    with pytest.raises(ValueError):
+        dispatcher._parse_args(["gitlab-mr"])
+
+
+def test_parse_args_empty_errors() -> None:
+    with pytest.raises(ValueError):
+        dispatcher._parse_args([])
+
+
+def test_load_source_known() -> None:
+    mod = dispatcher._load_source("gitlab-mr")
+    assert mod is not None
+    assert hasattr(mod, "poll")
+    assert hasattr(mod, "INTERVAL")
+
+
+def test_load_source_unknown() -> None:
+    assert dispatcher._load_source("does-not-exist") is None
+
+
+def test_list_empty(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    rows = transport.list_active_pids()
+    assert rows == []
+
+
+def test_list_skips_stale_pid_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    # PID 1 exists (init); a clearly stale impossible PID — pick a very high one
+    stale = tmp_path / "supertool-watch-fake__stale.pid"
+    stale.write_text("9999999\n")
+    rows = transport.list_active_pids()
+    assert rows == []
+    # Stale file should have been pruned
+    assert not stale.exists()
+
+
+def test_list_includes_live_pid(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    own_pid = os.getpid()
+    live = tmp_path / f"supertool-watch-test-source__myid.pid"
+    live.write_text(f"{own_pid}\n")
+    rows = transport.list_active_pids()
+    assert len(rows) == 1
+    assert rows[0]["source"] == "test-source"
+    assert rows[0]["id"] == "myid"
+    assert rows[0]["pid"] == own_pid

--- a/tests/test_watch_gitlab_mr_poller.py
+++ b/tests/test_watch_gitlab_mr_poller.py
@@ -1,0 +1,93 @@
+"""Unit tests for the gitlab-mr poller source — state diff logic."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+POLLER = Path(__file__).parent.parent / "presets" / "watch" / "sources" / "gitlab-mr" / "poller.py"
+_spec = importlib.util.spec_from_file_location("gitlab_mr_poller", POLLER)
+assert _spec is not None and _spec.loader is not None
+poller = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(poller)
+
+
+def _mr(state="opened", pipeline_status="running", pipeline_id="9", conflicts=False, **kw):
+    return {
+        "iid": 21803,
+        "title": kw.get("title", "feat: do the thing"),
+        "state": state,
+        "has_conflicts": conflicts,
+        "head_pipeline": {"id": pipeline_id, "status": pipeline_status},
+        "web_url": "https://example.com/mr/21803",
+    }
+
+
+def test_no_change_emits_nothing() -> None:
+    state = {"mr_state": "opened", "pipeline_status": "running", "has_conflicts": False}
+    with mock.patch.object(poller, "_fetch", return_value=_mr()):
+        events, new_state = poller.poll(state, {"id": "21803"})
+    assert events == []
+    assert new_state["mr_state"] == "opened"
+
+
+def test_pipeline_running_to_failed_emits_failed() -> None:
+    state = {"mr_state": "opened", "pipeline_status": "running"}
+    with mock.patch.object(poller, "_fetch", return_value=_mr(pipeline_status="failed")):
+        events, _ = poller.poll(state, {"id": "21803"})
+    assert len(events) == 1
+    assert events[0]["event"] == "pipeline_failed"
+    assert events[0]["payload"]["url"] == "https://example.com/mr/21803"
+    assert events[0]["notify_title"]
+
+
+def test_pipeline_running_to_success_emits_succeeded() -> None:
+    state = {"mr_state": "opened", "pipeline_status": "running"}
+    with mock.patch.object(poller, "_fetch", return_value=_mr(pipeline_status="success")):
+        events, _ = poller.poll(state, {"id": "21803"})
+    assert any(e["event"] == "pipeline_succeeded" for e in events)
+
+
+def test_pipeline_pending_to_running_emits_running() -> None:
+    state = {"mr_state": "opened", "pipeline_status": "pending"}
+    with mock.patch.object(poller, "_fetch", return_value=_mr(pipeline_status="running")):
+        events, _ = poller.poll(state, {"id": "21803"})
+    assert any(e["event"] == "pipeline_running" for e in events)
+
+
+def test_merge_emits_merged() -> None:
+    state = {"mr_state": "opened", "pipeline_status": "success"}
+    with mock.patch.object(poller, "_fetch", return_value=_mr(state="merged", pipeline_status="success")):
+        events, _ = poller.poll(state, {"id": "21803"})
+    assert any(e["event"] == "merged" for e in events)
+
+
+def test_conflict_rising_edge_emits_once() -> None:
+    state_before = {"has_conflicts": False, "mr_state": "opened", "pipeline_status": "running"}
+    with mock.patch.object(poller, "_fetch", return_value=_mr(conflicts=True)):
+        events1, new_state = poller.poll(state_before, {"id": "21803"})
+    assert any(e["event"] == "conflicts_appeared" for e in events1)
+    # Same data again — no new event
+    with mock.patch.object(poller, "_fetch", return_value=_mr(conflicts=True)):
+        events2, _ = poller.poll(new_state, {"id": "21803"})
+    assert all(e["event"] != "conflicts_appeared" for e in events2)
+
+
+def test_is_terminal_when_merged() -> None:
+    assert poller.is_terminal({"mr_state": "merged"}) is True
+
+
+def test_is_terminal_when_closed() -> None:
+    assert poller.is_terminal({"mr_state": "closed"}) is True
+
+
+def test_is_not_terminal_when_open() -> None:
+    assert poller.is_terminal({"mr_state": "opened"}) is False
+
+
+def test_fetch_failure_returns_no_events() -> None:
+    with mock.patch.object(poller, "_fetch", return_value=None):
+        events, new_state = poller.poll({"x": 1}, {"id": "21803"})
+    assert events == []
+    assert new_state == {"x": 1}  # state preserved on transient failure

--- a/tests/test_watch_transport.py
+++ b/tests/test_watch_transport.py
@@ -1,0 +1,83 @@
+"""Unit tests for presets/watch/transport.py event emission + state I/O."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+WATCH_DIR = Path(__file__).parent.parent / "presets" / "watch"
+sys.path.insert(0, str(WATCH_DIR))
+
+_spec = importlib.util.spec_from_file_location("watch_transport", WATCH_DIR / "transport.py")
+assert _spec is not None and _spec.loader is not None
+transport = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(transport)
+
+
+def test_state_path_naming() -> None:
+    assert transport.state_path("gitlab-mr", "21803").endswith("supertool-watch-gitlab-mr__21803.state.json")
+
+
+def test_pid_path_naming() -> None:
+    assert transport.pid_path("gitlab-mr", "21803").endswith("supertool-watch-gitlab-mr__21803.pid")
+
+
+def test_write_and_read_state_roundtrip(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    payload = {"mr_state": "opened", "pipeline_status": "running"}
+    transport.write_state("gitlab-mr", "21803", payload)
+    out = transport.read_state("gitlab-mr", "21803")
+    assert out == payload
+
+
+def test_read_state_missing_returns_empty(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    assert transport.read_state("gitlab-mr", "does-not-exist") == {}
+
+
+def test_read_state_corrupt_returns_empty(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    p = Path(transport.state_path("gitlab-mr", "21803"))
+    p.write_text("{not json")
+    assert transport.read_state("gitlab-mr", "21803") == {}
+
+
+def test_emit_socket_no_listener_silent(monkeypatch, tmp_path) -> None:
+    """When the socket file doesn't exist, emit_socket is a no-op (no exception)."""
+    monkeypatch.setattr(transport, "SOCK_PATH", str(tmp_path / "nonexistent.sock"))
+    transport.emit_socket({"event": "test"})
+
+
+def test_emit_event_writes_state_with_last_event(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(transport, "SOCK_PATH", str(tmp_path / "nonexistent.sock"))
+    monkeypatch.setattr(transport, "desktop_notify", lambda *a, **kw: None)
+    transport.emit_event(
+        "gitlab-mr", "21803",
+        "pipeline_failed",
+        {"pipeline_id": "139928"},
+    )
+    state = transport.read_state("gitlab-mr", "21803")
+    assert state["last_event"]["event"] == "pipeline_failed"
+    assert state["last_event"]["source"] == "gitlab-mr"
+    assert state["last_event"]["id"] == "21803"
+    assert state["last_event"]["payload"]["pipeline_id"] == "139928"
+    assert "first_seen" in state
+
+
+def test_emit_event_preserves_existing_state_keys(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(transport, "SOCK_PATH", str(tmp_path / "nonexistent.sock"))
+    transport.write_state("gitlab-mr", "21803", {"source_state": {"keep": "me"}})
+    transport.emit_event("gitlab-mr", "21803", "merged", {})
+    state = transport.read_state("gitlab-mr", "21803")
+    assert state["source_state"] == {"keep": "me"}
+    assert state["last_event"]["event"] == "merged"
+
+
+def test_desktop_notify_noop_off_macos(monkeypatch) -> None:
+    monkeypatch.setattr(transport.sys, "platform", "linux")
+    # Should not raise even though osascript wouldn't work
+    transport.desktop_notify("title", "message")


### PR DESCRIPTION
Refs #165 (Phase 1 of the design comment).

## Summary

Reusable foundation for background-event watching:

- New \`watch\` preset with ops \`watch\`, \`unwatch\`, \`watches\`
- Source-plugin contract — new source = new folder under \`presets/watch/sources/<name>/\` (poller.py + events.json). 50-line poller per source.
- Three transports per event:
  - UDS socket (NDJSON) at \`/tmp/supertool-watch.sock\` — Phase 2 channel consumer will listen here
  - Status file at \`/tmp/supertool-watch-{source}__{id}.state.json\` — last-known state for \`watches\` and offline inspection
  - macOS osascript desktop notification — human-facing
- First source: \`gitlab-mr\`. Emits \`pipeline_failed\`, \`pipeline_succeeded\`, \`pipeline_running\`, \`merged\`, \`closed\`, \`conflicts_appeared\`.
- Lifecycle: PID file per active watcher, SIGTERM-then-SIGKILL on \`unwatch\`, auto-stop on terminal state.
- Filename separator is \`__\` between source and id to handle sources with hyphens (e.g. \`gitlab-mr\`).

## What this unlocks

\`./supertool 'watch:gitlab-mr:21803' 'watch:gitlab-mr:21810' 'watches'\` — start two watchers and list them in one batched call. macOS notification fires when either pipeline finishes.

Phase 2 (channel consumer) is a separate MR. It listens on the same UDS socket and pushes events into Claude Code via the Channels MCP protocol. Zero changes to this preset will be needed.

## Out of scope

- Channel consumer (Phase 2)
- \`gitlab-job\` source (mostly copy of \`gitlab-mr\`)
- GitHub Actions / Calendar / other sources

## Test plan

- [x] 29 unit tests pass (\`tests/test_watch_dispatcher.py\`, \`test_watch_transport.py\`, \`test_watch_gitlab_mr_poller.py\`)
- [x] Smoke test: \`watch:gitlab-mr:99999\` → \`watches\` (shows the row) → \`unwatch:gitlab-mr:99999\` (cleans up). PID file lifecycle verified.
- [ ] Real-world: watch an actual MR through a pipeline cycle, confirm desktop notification fires.