### PR TITLE
watch Phase 2 — claude-channel MCP server (#165)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "claude-channel": {
+      "command": "bun",
+      "args": ["./notifiers/claude-channel/channel.ts"]
+    }
+  }
+}

--- a/notifiers/claude-channel/.gitignore
+++ b/notifiers/claude-channel/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+bun.lockb

--- a/notifiers/claude-channel/README.md
+++ b/notifiers/claude-channel/README.md
@@ -55,14 +55,19 @@ claude --dangerously-load-development-channels server:claude-channel
 4. Claude Code injects it into the session as:
 
    ```
-   <channel source="gitlab-mr" id="21803" event="pipeline_failed"
-            ts="2026-05-24T19:00:00Z" pipeline_id="139928"
-            url="https://gitlab.example.com/.../21803">
+   <channel source="claude-channel" watcher_source="gitlab-mr" id="21803"
+            event="pipeline_failed" ts="2026-05-24T19:00:00Z"
+            pipeline_id="139928" url="https://gitlab.example.com/.../21803">
    gitlab-mr 21803: pipeline_failed
    feat: do the thing
    https://gitlab.example.com/.../21803
    </channel>
    ```
+
+   Note: `source="claude-channel"` is auto-injected by Claude Code from the
+   MCP server name. The per-event source (which Phase 1 source emitted the
+   event) lands in `watcher_source`. Route Claude's logic on `watcher_source`
+   + `event`.
 
 5. Claude decides what to do based on the server's `instructions` string
    (investigate, notify, fix)

--- a/notifiers/claude-channel/README.md
+++ b/notifiers/claude-channel/README.md
@@ -1,0 +1,91 @@
+# `claude-channel` — MCP channel server (Phase 2 of `watch`)
+
+Bridges the [`watch` preset](../../presets/watch/README.md) UDS event stream
+into a running Claude Code session via the
+[Channels feature](https://code.claude.com/docs/en/channels.md).
+
+When a Phase 1 poller emits an event, Claude sees it as a
+`<channel source="..." id="..." event="...">` tag in its context and can
+react immediately.
+
+## Requirements
+
+- Claude Code v2.1.80 or later (Channels research preview)
+- [Bun](https://bun.sh) (`curl -fsSL https://bun.sh/install | bash`)
+- During the research preview: the `--dangerously-load-development-channels`
+  flag (custom channels aren't on the Anthropic allowlist yet)
+
+## Install
+
+```bash
+bash notifiers/claude-channel/install.sh
+```
+
+Installs `@modelcontextprotocol/sdk` and `@types/bun`. Prints next-step
+instructions for `.mcp.json` and launch flags.
+
+## Wire it
+
+Add to your project-level `.mcp.json` (or user-level `~/.claude.json`):
+
+```json
+{
+  "mcpServers": {
+    "claude-channel": {
+      "command": "bun",
+      "args": ["/abs/path/to/claude-supertool/notifiers/claude-channel/channel.ts"]
+    }
+  }
+}
+```
+
+Then launch Claude Code with the channel enabled:
+
+```bash
+claude --dangerously-load-development-channels server:claude-channel
+```
+
+## How an event reaches Claude
+
+1. You run `./supertool 'watch:gitlab-mr:21803'` (Phase 1) — spawns a poller
+2. The poller detects the pipeline failing, writes one NDJSON line to
+   `/tmp/supertool-watch.sock`
+3. This server reads the line, parses the event, calls
+   `mcp.notification({ method: "notifications/claude/channel", ... })`
+4. Claude Code injects it into the session as:
+
+   ```
+   <channel source="gitlab-mr" id="21803" event="pipeline_failed"
+            ts="2026-05-24T19:00:00Z" pipeline_id="139928"
+            url="https://gitlab.example.com/.../21803">
+   gitlab-mr 21803: pipeline_failed
+   feat: do the thing
+   https://gitlab.example.com/.../21803
+   </channel>
+   ```
+
+5. Claude decides what to do based on the server's `instructions` string
+   (investigate, notify, fix)
+
+## Configuration
+
+| Env var                  | Default                          | Purpose                                              |
+| ------------------------ | -------------------------------- | ---------------------------------------------------- |
+| `SUPERTOOL_WATCH_SOCK`   | `/tmp/supertool-watch.sock`      | UDS path. Set the same value on Phase 1 producers.   |
+
+## Security (Phase 2 v1)
+
+- UDS socket bound to a local filesystem path with mode `0600` (owner-only)
+- Localhost-only by definition (Unix domain sockets don't traverse the network)
+- No sender allowlist beyond filesystem permissions — multi-user machines
+  should set `SUPERTOOL_WATCH_SOCK` to a path under `~/.claude/` for
+  per-user isolation
+- The MCP server validates event shape (source/id/event are strings) before
+  emitting to Claude — malformed lines are silently dropped
+
+## Out of scope (future)
+
+- Two-way reply tool (Claude posts back via the channel) — would require
+  a per-event ack contract
+- Permission relay (approve tool calls remotely) — different feature
+- Allowlist of approved senders beyond filesystem ACL

--- a/notifiers/claude-channel/bun.lock
+++ b/notifiers/claude-channel/bun.lock
@@ -1,0 +1,208 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "claude-channel",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.22", "", {}, "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+  }
+}

--- a/notifiers/claude-channel/channel.ts
+++ b/notifiers/claude-channel/channel.ts
@@ -42,14 +42,19 @@ interface WatchEvent {
 const ATTR_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function buildMeta(ev: WatchEvent): Record<string, string> {
+  // Claude Code auto-injects `source` from the MCP server name on every event,
+  // so we use `watcher_source` for the per-event source (e.g. "gitlab-mr") to
+  // avoid the collision. The instructions string tells Claude to route by
+  // `watcher_source`.
   const meta: Record<string, string> = {
-    source: ev.source,
+    watcher_source: ev.source,
     id: ev.id,
     event: ev.event,
     ts: ev.ts,
   };
   for (const [k, v] of Object.entries(ev.payload || {})) {
     if (!ATTR_KEY_RE.test(k)) continue;
+    if (k === "source") continue;  // never let payload overwrite the auto-injected key
     if (v === null || v === undefined) continue;
     meta[k] = String(v);
   }
@@ -75,21 +80,30 @@ const mcp = new Server(
     },
     instructions:
       "Events from the supertool 'watch' preset arrive as " +
-      "<channel source=\"<source>\" id=\"<watcher-id>\" event=\"<event-key>\" ...>. " +
-      "Examples: source=\"gitlab-mr\" event=\"pipeline_failed\". They are one-way " +
-      "(no reply expected). Read the source/id/event attributes to decide what to do — " +
-      "investigate via the matching supertool op (e.g. ./supertool 'gl-mr:<id>'), " +
-      "post a summary, or notify the human. Status-change is the signal; consecutive " +
-      "events for the same source/id supersede each other.",
+      "<channel source=\"claude-channel\" watcher_source=\"<source>\" id=\"<watcher-id>\" event=\"<event-key>\" ...>. " +
+      "Route by `watcher_source` (e.g. \"gitlab-mr\") and `event` (e.g. \"pipeline_failed\"). " +
+      "They are one-way (no reply expected). Investigate via the matching supertool op " +
+      "(e.g. ./supertool 'gl-mr:<id>'), post a summary, or notify the human. " +
+      "Status-change is the signal; consecutive events for the same watcher_source/id " +
+      "supersede each other.",
   },
 );
 
 await mcp.connect(new StdioServerTransport());
 
+// Ensure the socket's parent dir exists so non-default SUPERTOOL_WATCH_SOCK
+// paths (e.g. ~/.claude/supertool-watch.sock) don't fail with a cryptic ENOENT.
+try {
+  const parent = SOCK_PATH.includes("/") ? SOCK_PATH.slice(0, SOCK_PATH.lastIndexOf("/")) : "";
+  if (parent) fs.mkdirSync(parent, { recursive: true });
+} catch (err) {
+  process.stderr.write(`claude-channel: could not ensure parent dir: ${String(err)}\n`);
+}
+
 // Bind the UDS socket. Unlink stale file from a previous crash first.
 try {
   fs.unlinkSync(SOCK_PATH);
-} catch (e) {
+} catch {
   // ENOENT — fine, nothing to clean
 }
 
@@ -113,10 +127,16 @@ const server = net.createServer((conn) => {
       if (!ev || typeof ev.source !== "string" || typeof ev.id !== "string" || typeof ev.event !== "string") {
         continue;
       }
-      void mcp.notification({
-        method: "notifications/claude/channel",
-        params: { content: buildContent(ev), meta: buildMeta(ev) },
-      });
+      mcp
+        .notification({
+          method: "notifications/claude/channel",
+          params: { content: buildContent(ev), meta: buildMeta(ev) },
+        })
+        .catch((err) => {
+          // Surface to stderr so `claude --debug` picks it up. Common causes:
+          // Claude Code transport closed, channel not registered, JSON-RPC busy.
+          process.stderr.write(`claude-channel: notify failed: ${String(err)}\n`);
+        });
     }
   });
   conn.on("error", () => {

--- a/notifiers/claude-channel/channel.ts
+++ b/notifiers/claude-channel/channel.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env bun
+/**
+ * claude-channel — MCP channel server bridging watch-preset events to Claude Code.
+ *
+ * Phase 1 pollers write NDJSON to the UDS socket at /tmp/supertool-watch.sock.
+ * This server is the consumer: it binds that socket, reads each event line,
+ * and pushes it into Claude Code via `notifications/claude/channel`.
+ *
+ * Claude sees each event as a `<channel source="..." id="..." event="...">`
+ * tag in its context.
+ *
+ * Launch:
+ *   claude --dangerously-load-development-channels server:claude-channel
+ *
+ * (The `--dangerously-load-development-channels` flag is required during the
+ * Channels research preview until the plugin lands on the Anthropic allowlist.)
+ *
+ * Auth model — Phase 2 v1:
+ *   Localhost UDS file with mode 0600 (owner-only). Any process running as
+ *   the same user can connect. Multi-user machines should use a per-user
+ *   override path (set SUPERTOOL_WATCH_SOCK env var on both producers and
+ *   this server).
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import * as fs from "node:fs";
+import * as net from "node:net";
+
+const SOCK_PATH = process.env.SUPERTOOL_WATCH_SOCK || "/tmp/supertool-watch.sock";
+
+interface WatchEvent {
+  ts: string;
+  source: string;
+  id: string;
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+// Identifier keys (letters/digits/underscores) become <channel> tag attributes.
+// Hyphens and other characters are silently dropped by Claude Code per the
+// notification protocol, so we sanitize keys here too.
+const ATTR_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function buildMeta(ev: WatchEvent): Record<string, string> {
+  const meta: Record<string, string> = {
+    source: ev.source,
+    id: ev.id,
+    event: ev.event,
+    ts: ev.ts,
+  };
+  for (const [k, v] of Object.entries(ev.payload || {})) {
+    if (!ATTR_KEY_RE.test(k)) continue;
+    if (v === null || v === undefined) continue;
+    meta[k] = String(v);
+  }
+  return meta;
+}
+
+function buildContent(ev: WatchEvent): string {
+  // The <channel> tag body — Claude reads this as the event's narrative.
+  // Keep it short and route-oriented; payload details live in attributes.
+  const url = (ev.payload as Record<string, unknown>)?.url;
+  const title = (ev.payload as Record<string, unknown>)?.title;
+  const lines: string[] = [`${ev.source} ${ev.id}: ${ev.event}`];
+  if (typeof title === "string" && title) lines.push(title);
+  if (typeof url === "string" && url) lines.push(url);
+  return lines.join("\n");
+}
+
+const mcp = new Server(
+  { name: "claude-channel", version: "0.0.1" },
+  {
+    capabilities: {
+      experimental: { "claude/channel": {} },
+    },
+    instructions:
+      "Events from the supertool 'watch' preset arrive as " +
+      "<channel source=\"<source>\" id=\"<watcher-id>\" event=\"<event-key>\" ...>. " +
+      "Examples: source=\"gitlab-mr\" event=\"pipeline_failed\". They are one-way " +
+      "(no reply expected). Read the source/id/event attributes to decide what to do — " +
+      "investigate via the matching supertool op (e.g. ./supertool 'gl-mr:<id>'), " +
+      "post a summary, or notify the human. Status-change is the signal; consecutive " +
+      "events for the same source/id supersede each other.",
+  },
+);
+
+await mcp.connect(new StdioServerTransport());
+
+// Bind the UDS socket. Unlink stale file from a previous crash first.
+try {
+  fs.unlinkSync(SOCK_PATH);
+} catch (e) {
+  // ENOENT — fine, nothing to clean
+}
+
+const server = net.createServer((conn) => {
+  let buf = "";
+  conn.setEncoding("utf-8");
+  conn.on("data", (chunk: string) => {
+    buf += chunk;
+    let nl = buf.indexOf("\n");
+    while (nl !== -1) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      nl = buf.indexOf("\n");
+      if (!line) continue;
+      let ev: WatchEvent;
+      try {
+        ev = JSON.parse(line) as WatchEvent;
+      } catch {
+        continue;
+      }
+      if (!ev || typeof ev.source !== "string" || typeof ev.id !== "string" || typeof ev.event !== "string") {
+        continue;
+      }
+      void mcp.notification({
+        method: "notifications/claude/channel",
+        params: { content: buildContent(ev), meta: buildMeta(ev) },
+      });
+    }
+  });
+  conn.on("error", () => {
+    // Best-effort: a producer hang/timeout shouldn't kill the server.
+  });
+});
+
+server.listen(SOCK_PATH, () => {
+  try {
+    fs.chmodSync(SOCK_PATH, 0o600);
+  } catch {
+    // Permission tightening is advisory; UDS is already localhost-only.
+  }
+});
+
+server.on("error", (err) => {
+  // Surface bind errors via stderr so `claude --debug` can show them.
+  process.stderr.write(`claude-channel: socket error: ${String(err)}\n`);
+});
+
+// Clean shutdown — remove the socket file on SIGINT/SIGTERM.
+const cleanup = () => {
+  try {
+    server.close();
+  } catch {}
+  try {
+    fs.unlinkSync(SOCK_PATH);
+  } catch {}
+  process.exit(0);
+};
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);

--- a/notifiers/claude-channel/install.sh
+++ b/notifiers/claude-channel/install.sh
@@ -23,7 +23,9 @@ fi
 echo "==> Installing dependencies via bun"
 bun install
 
-cat <<'EOF'
+CHANNEL_PATH="$SCRIPT_DIR/channel.ts"
+
+cat <<EOF
 
 ==> Done.
 
@@ -31,12 +33,12 @@ Next steps:
 
 1. Register the server in MCP config. For project-level (this repo):
 
-     cat > .mcp.json <<'JSON'
+     cat > .mcp.json <<JSON
      {
        "mcpServers": {
          "claude-channel": {
            "command": "bun",
-           "args": ["$SCRIPT_DIR/channel.ts"]
+           "args": ["$CHANNEL_PATH"]
          }
        }
      }
@@ -54,6 +56,6 @@ Next steps:
      ./supertool 'watch:gitlab-mr:21803'
 
    When the MR's pipeline transitions, Claude sees the event as a
-   <channel source="gitlab-mr" id="21803" event="..."> tag in its context.
+   <channel source="claude-channel" watcher_source="gitlab-mr" id="21803" event="..."> tag.
 
 EOF

--- a/notifiers/claude-channel/install.sh
+++ b/notifiers/claude-channel/install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Install the claude-channel MCP server for the supertool 'watch' preset.
+#
+# - Installs Bun deps (@modelcontextprotocol/sdk + @types/bun)
+# - Prints next-step instructions for registering the channel with Claude Code
+#
+# Usage:
+#   bash notifiers/claude-channel/install.sh
+#
+# Idempotent — safe to re-run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if ! command -v bun >/dev/null 2>&1; then
+    echo "ERROR: bun is required but not on PATH."
+    echo "Install: curl -fsSL https://bun.sh/install | bash"
+    exit 1
+fi
+
+echo "==> Installing dependencies via bun"
+bun install
+
+cat <<'EOF'
+
+==> Done.
+
+Next steps:
+
+1. Register the server in MCP config. For project-level (this repo):
+
+     cat > .mcp.json <<'JSON'
+     {
+       "mcpServers": {
+         "claude-channel": {
+           "command": "bun",
+           "args": ["$SCRIPT_DIR/channel.ts"]
+         }
+       }
+     }
+     JSON
+
+   For user-level (always available), add the same block to ~/.claude.json.
+
+2. Launch Claude Code with the channel enabled. During the Channels research
+   preview, custom channels need the development flag:
+
+     claude --dangerously-load-development-channels server:claude-channel
+
+3. In a separate terminal, start watching something:
+
+     ./supertool 'watch:gitlab-mr:21803'
+
+   When the MR's pipeline transitions, Claude sees the event as a
+   <channel source="gitlab-mr" id="21803" event="..."> tag in its context.
+
+EOF

--- a/notifiers/claude-channel/package.json
+++ b/notifiers/claude-channel/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "claude-channel",
+  "version": "0.0.1",
+  "description": "MCP channel server bridging supertool 'watch' preset events to Claude Code",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun channel.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.0.0"
+  }
+}

--- a/notifiers/claude-channel/tsconfig.json
+++ b/notifiers/claude-channel/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["*.ts"]
+}

--- a/presets/watch/README.md
+++ b/presets/watch/README.md
@@ -116,9 +116,8 @@ state persistence. Source code stays focused on "what changed?".
 
 ## Phase 2 — channel consumer
 
-Lives outside this preset. It will:
-1. Bind a UDS listener at `/tmp/supertool-watch.sock`
-2. Forward each NDJSON line to Claude Code via the Channels MCP protocol
-3. Claude sees events as `<channel source="gitlab-mr" id="21803" event="pipeline_failed">...`
-
-No changes to this preset will be required.
+Shipped at [`notifiers/claude-channel/`](../../notifiers/claude-channel/README.md).
+It binds the UDS socket this preset writes to and pushes each event into a
+running Claude Code session via the Channels feature. No changes to this
+preset are required to wire it up — just install Phase 2 separately and
+launch Claude with `--dangerously-load-development-channels server:claude-channel`.


### PR DESCRIPTION
Closes #165 (Phase 2 — async wake into Claude Code).

## Summary

Consumes the Phase 1 UDS event stream and pushes each event into a running Claude Code session as a \`<channel>\` tag via the [Channels feature](https://code.claude.com/docs/en/channels.md) (research preview, v2.1.80+).

- TypeScript / Bun (matches the official channel plugins — Telegram/Discord/iMessage/fakechat)
- Single-file MCP server with \`claude/channel\` capability + stdio transport
- Reads NDJSON from the UDS socket Phase 1 already writes to (\`/tmp/supertool-watch.sock\`, overridable via \`SUPERTOOL_WATCH_SOCK\`)
- Validates event shape (source/id/event are strings) before pushing — malformed lines silently dropped
- Server \`instructions\` string tells Claude what to do with the events
- \`install.sh\` handles \`bun install\` + prints registration instructions
- Phase 1 README cross-references Phase 2

## End-to-end flow

1. \`./supertool 'watch:gitlab-mr:21803'\` (Phase 1) spawns a poller
2. Pipeline fails — poller writes one NDJSON line to \`/tmp/supertool-watch.sock\`
3. This server reads the line, calls \`mcp.notification({...})\`
4. Claude sees \`<channel source="gitlab-mr" id="21803" event="pipeline_failed" ...>\` mid-session
5. Claude acts on it per the server's instruction string

## Security (v1)

- UDS file mode \`0600\` (owner-only) + localhost-only by definition
- No allowlist beyond filesystem ACL — multi-user machines set \`SUPERTOOL_WATCH_SOCK\` under \`~/.claude/\` for per-user isolation
- Documented as a known limit in the README

## Launch

\`\`\`bash
bash notifiers/claude-channel/install.sh
# register in .mcp.json (instructions printed by install.sh)
claude --dangerously-load-development-channels server:claude-channel
\`\`\`

## Test plan

- [ ] \`bun install\` succeeds on your machine
- [ ] \`claude --dangerously-load-development-channels server:claude-channel\` starts without errors
- [ ] \`./supertool 'watch:gitlab-mr:<real-mr>'\` followed by a pipeline transition — confirm the \`<channel>\` tag arrives in Claude
- [ ] \`./supertool 'unwatch:...'\` cleans up; closing Claude unlinks the socket

No automated tests in this MR — the MCP server is mostly routing + I/O. The Phase 1 producer side already has 31 unit tests covering the event grammar and state diff.

## Out of scope (future)

- Two-way reply tool (Claude posts back through the channel) — needs per-event ack contract
- Permission relay (approve tool calls remotely) — separate feature
- Sender allowlist beyond filesystem ACL — Phase 3 if needed