### PR TITLE
watch: github-pr source (reuses gh-pr op's _gh helper)

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -11,7 +11,8 @@
     "devto",
     "bluesky",
     "xml",
-    "mcp"
+    "mcp",
+    "watch"
   ],
   "mcp": {
     "_example-php-lsp": {

--- a/presets/watch/sources/github-pr/events.json
+++ b/presets/watch/sources/github-pr/events.json
@@ -6,6 +6,7 @@
     {"key": "checks_pending",           "label": "PR checks started running"},
     {"key": "review_approved",          "label": "PR approved"},
     {"key": "review_changes_requested", "label": "Reviewer requested changes"},
+    {"key": "comment_added",            "label": "New comment on the PR"},
     {"key": "merged",                   "label": "PR merged"},
     {"key": "closed",                   "label": "PR closed without merge"},
     {"key": "conflicts_appeared",       "label": "PR became unmergeable"}

--- a/presets/watch/sources/github-pr/events.json
+++ b/presets/watch/sources/github-pr/events.json
@@ -1,0 +1,13 @@
+{
+  "source": "github-pr",
+  "events": [
+    {"key": "checks_failed",            "label": "PR checks failed"},
+    {"key": "checks_succeeded",         "label": "PR checks succeeded"},
+    {"key": "checks_pending",           "label": "PR checks started running"},
+    {"key": "review_approved",          "label": "PR approved"},
+    {"key": "review_changes_requested", "label": "Reviewer requested changes"},
+    {"key": "merged",                   "label": "PR merged"},
+    {"key": "closed",                   "label": "PR closed without merge"},
+    {"key": "conflicts_appeared",       "label": "PR became unmergeable"}
+  ]
+}

--- a/presets/watch/sources/github-pr/poller.py
+++ b/presets/watch/sources/github-pr/poller.py
@@ -29,10 +29,11 @@ _spec.loader.exec_module(_pr_op)
 _gh = _pr_op._gh  # type: ignore[attr-defined]
 
 # Fields we ask gh for on each poll. Cheap (single API call) and covers every
-# event in events.json.
+# event in events.json. `comments` returns the issue-comments array; we just
+# need its length to detect new comments.
 _VIEW_FIELDS = (
     "state,mergeable,isDraft,title,url,reviewDecision,"
-    "statusCheckRollup,number,headRefName"
+    "statusCheckRollup,number,headRefName,comments"
 )
 
 TERMINAL_PR_STATES = {"MERGED", "CLOSED"}
@@ -95,11 +96,14 @@ def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
     url = str(data.get("url") or "")
     review_decision = str(data.get("reviewDecision") or "").upper()
     checks_state = _rollup_state(data.get("statusCheckRollup"))
+    comments_list = data.get("comments") if isinstance(data.get("comments"), list) else []
+    comments_count = len(comments_list)
 
     prev_pr = state.get("pr_state", "")
     prev_checks = state.get("checks_state", "")
     prev_review = state.get("review_decision", "")
     prev_mergeable = state.get("mergeable", "")
+    prev_comments_count = state.get("comments_count")  # None on first poll
 
     events: list[dict] = []
 
@@ -159,6 +163,25 @@ def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
                 "notify_message": title,
             })
 
+    # Comment count rising — new issue-comment(s) added since last poll.
+    # First poll (prev_comments_count is None) only records the baseline so
+    # we don't fire an event on watch-start.
+    if prev_comments_count is not None and comments_count > prev_comments_count:
+        delta = comments_count - prev_comments_count
+        latest = comments_list[-1] if comments_list else {}
+        author = ((latest.get("author") or {}).get("login") if isinstance(latest, dict) else "") or "?"
+        events.append({
+            "event": "comment_added",
+            "payload": {
+                "url": url,
+                "title": title,
+                "author": author,
+                "new_count": delta,
+            },
+            "notify_title": f"#{number} new comment{'s' if delta > 1 else ''}",
+            "notify_message": f"by {author}: {title}",
+        })
+
     # Mergeable rising edge — fires when going from MERGEABLE/UNKNOWN to CONFLICTING
     if mergeable == "CONFLICTING" and prev_mergeable != "CONFLICTING":
         events.append({
@@ -173,6 +196,7 @@ def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
         "mergeable": mergeable,
         "checks_state": checks_state,
         "review_decision": review_decision,
+        "comments_count": comments_count,
         "title": title,
         "url": url,
     }

--- a/presets/watch/sources/github-pr/poller.py
+++ b/presets/watch/sources/github-pr/poller.py
@@ -1,0 +1,183 @@
+"""github-pr watcher source.
+
+Polls a single GitHub pull request via `gh pr view --json` and emits events
+when state changes. Terminal when the PR is merged or closed.
+
+Reuses `_gh` from presets/github/pr.py — no duplicated CLI wrapping.
+
+Source plugin contract:
+- INTERVAL: int seconds between polls (30s default)
+- poll(state, ctx) -> (events, new_state)
+- is_terminal(state) -> bool
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+INTERVAL = 30
+
+# Import the existing _gh CLI wrapper from the gh-pr op so we share one source
+# of truth for gh invocation, error handling, and timeouts.
+_PR_MODULE_PATH = Path(__file__).parents[3] / "github" / "pr.py"
+_spec = importlib.util.spec_from_file_location("github_pr_op", _PR_MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+_pr_op = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pr_op)
+_gh = _pr_op._gh  # type: ignore[attr-defined]
+
+# Fields we ask gh for on each poll. Cheap (single API call) and covers every
+# event in events.json.
+_VIEW_FIELDS = (
+    "state,mergeable,isDraft,title,url,reviewDecision,"
+    "statusCheckRollup,number,headRefName"
+)
+
+TERMINAL_PR_STATES = {"MERGED", "CLOSED"}
+
+
+def _rollup_state(rollup: list | None) -> str:
+    """Aggregate gh's statusCheckRollup into a single state string.
+
+    Mirrors the heuristic the GitHub UI uses: FAILURE if any failed, PENDING
+    if any still running, SUCCESS if everything passed. Empty list / None
+    means no checks configured — we return "" so we don't fire events.
+    """
+    if not isinstance(rollup, list) or not rollup:
+        return ""
+    statuses = []
+    for c in rollup:
+        if not isinstance(c, dict):
+            continue
+        # Two flavours: check runs (status/conclusion) and statuses (state).
+        conclusion = (c.get("conclusion") or "").upper()
+        status = (c.get("status") or "").upper()
+        state = (c.get("state") or "").upper()
+        if status and status not in ("COMPLETED", ""):
+            statuses.append("PENDING")
+            continue
+        if conclusion:
+            statuses.append(conclusion)
+            continue
+        if state:
+            statuses.append(state)
+    if any(s in ("FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "ERROR") for s in statuses):
+        return "FAILURE"
+    if any(s in ("PENDING", "QUEUED", "IN_PROGRESS", "WAITING") for s in statuses):
+        return "PENDING"
+    if statuses and all(s in ("SUCCESS", "NEUTRAL", "SKIPPED") for s in statuses):
+        return "SUCCESS"
+    return ""
+
+
+def _fetch(number: str) -> dict[str, Any] | None:
+    r = _gh(["pr", "view", number, "--json", _VIEW_FIELDS])
+    if r.returncode != 0:
+        return None
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
+    number = ctx["id"]
+    data = _fetch(number)
+    if data is None:
+        return [], state  # transient — try again next tick
+
+    pr_state = str(data.get("state") or "").upper()
+    mergeable = str(data.get("mergeable") or "").upper()
+    title = str(data.get("title") or f"PR #{number}")
+    url = str(data.get("url") or "")
+    review_decision = str(data.get("reviewDecision") or "").upper()
+    checks_state = _rollup_state(data.get("statusCheckRollup"))
+
+    prev_pr = state.get("pr_state", "")
+    prev_checks = state.get("checks_state", "")
+    prev_review = state.get("review_decision", "")
+    prev_mergeable = state.get("mergeable", "")
+
+    events: list[dict] = []
+
+    # Check-suite transitions
+    if checks_state and checks_state != prev_checks:
+        if checks_state == "FAILURE":
+            events.append({
+                "event": "checks_failed",
+                "payload": {"url": url, "title": title},
+                "notify_title": f"#{number} checks failed",
+                "notify_message": title,
+            })
+        elif checks_state == "SUCCESS":
+            events.append({
+                "event": "checks_succeeded",
+                "payload": {"url": url, "title": title},
+                "notify_title": f"#{number} checks ok",
+                "notify_message": title,
+            })
+        elif checks_state == "PENDING" and prev_checks not in ("PENDING", ""):
+            events.append({
+                "event": "checks_pending",
+                "payload": {"url": url, "title": title},
+            })
+
+    # Review decision transitions (only fire on real decisions, ignore "")
+    if review_decision and review_decision != prev_review:
+        if review_decision == "APPROVED":
+            events.append({
+                "event": "review_approved",
+                "payload": {"url": url, "title": title},
+                "notify_title": f"#{number} approved",
+                "notify_message": title,
+            })
+        elif review_decision == "CHANGES_REQUESTED":
+            events.append({
+                "event": "review_changes_requested",
+                "payload": {"url": url, "title": title},
+                "notify_title": f"#{number} changes requested",
+                "notify_message": title,
+            })
+
+    # PR terminal transitions
+    if pr_state and pr_state != prev_pr:
+        if pr_state == "MERGED":
+            events.append({
+                "event": "merged",
+                "payload": {"url": url, "title": title},
+                "notify_title": f"#{number} merged",
+                "notify_message": title,
+            })
+        elif pr_state == "CLOSED":
+            events.append({
+                "event": "closed",
+                "payload": {"url": url, "title": title},
+                "notify_title": f"#{number} closed",
+                "notify_message": title,
+            })
+
+    # Mergeable rising edge — fires when going from MERGEABLE/UNKNOWN to CONFLICTING
+    if mergeable == "CONFLICTING" and prev_mergeable != "CONFLICTING":
+        events.append({
+            "event": "conflicts_appeared",
+            "payload": {"url": url, "title": title},
+            "notify_title": f"#{number} conflicts",
+            "notify_message": title,
+        })
+
+    new_state = {
+        "pr_state": pr_state,
+        "mergeable": mergeable,
+        "checks_state": checks_state,
+        "review_decision": review_decision,
+        "title": title,
+        "url": url,
+    }
+    return events, new_state
+
+
+def is_terminal(state: dict) -> bool:
+    return state.get("pr_state") in TERMINAL_PR_STATES

--- a/tests/test_watch_github_pr_poller.py
+++ b/tests/test_watch_github_pr_poller.py
@@ -1,0 +1,162 @@
+"""Unit tests for the github-pr watcher source — state diff + rollup logic."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+POLLER = Path(__file__).parent.parent / "presets" / "watch" / "sources" / "github-pr" / "poller.py"
+_spec = importlib.util.spec_from_file_location("github_pr_poller", POLLER)
+assert _spec is not None and _spec.loader is not None
+poller = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(poller)
+
+
+def _pr(
+    state="OPEN", mergeable="MERGEABLE", review="", checks=None, title="some PR",
+):
+    return {
+        "state": state,
+        "mergeable": mergeable,
+        "title": title,
+        "url": "https://github.com/org/repo/pull/42",
+        "number": 42,
+        "headRefName": "feature/x",
+        "isDraft": False,
+        "reviewDecision": review,
+        "statusCheckRollup": checks or [],
+    }
+
+
+# ---- rollup -----------------------------------------------------------------
+
+def test_rollup_empty_returns_empty() -> None:
+    assert poller._rollup_state(None) == ""
+    assert poller._rollup_state([]) == ""
+
+
+def test_rollup_all_success() -> None:
+    rollup = [
+        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+    ]
+    assert poller._rollup_state(rollup) == "SUCCESS"
+
+
+def test_rollup_one_failure_dominates() -> None:
+    rollup = [
+        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"status": "COMPLETED", "conclusion": "FAILURE"},
+    ]
+    assert poller._rollup_state(rollup) == "FAILURE"
+
+
+def test_rollup_in_progress_pending() -> None:
+    rollup = [
+        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"status": "IN_PROGRESS", "conclusion": ""},
+    ]
+    assert poller._rollup_state(rollup) == "PENDING"
+
+
+def test_rollup_handles_state_flavour() -> None:
+    """Statuses (vs check runs) use `state`, not status/conclusion."""
+    rollup = [{"state": "FAILURE"}]
+    assert poller._rollup_state(rollup) == "FAILURE"
+
+
+def test_rollup_neutral_skipped_treated_as_success() -> None:
+    rollup = [
+        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"status": "COMPLETED", "conclusion": "NEUTRAL"},
+        {"status": "COMPLETED", "conclusion": "SKIPPED"},
+    ]
+    assert poller._rollup_state(rollup) == "SUCCESS"
+
+
+# ---- poll -------------------------------------------------------------------
+
+def test_no_change_emits_nothing() -> None:
+    state = {"pr_state": "OPEN", "checks_state": "SUCCESS", "review_decision": "", "mergeable": "MERGEABLE"}
+    with mock.patch.object(poller, "_fetch", return_value=_pr(checks=[{"status": "COMPLETED", "conclusion": "SUCCESS"}])):
+        events, _ = poller.poll(state, {"id": "42"})
+    assert events == []
+
+
+def test_checks_failed_emits_failed() -> None:
+    state = {"checks_state": "PENDING"}
+    rollup = [{"status": "COMPLETED", "conclusion": "FAILURE"}]
+    with mock.patch.object(poller, "_fetch", return_value=_pr(checks=rollup)):
+        events, _ = poller.poll(state, {"id": "42"})
+    assert any(e["event"] == "checks_failed" for e in events)
+
+
+def test_checks_succeeded_emits_succeeded() -> None:
+    state = {"checks_state": "PENDING"}
+    rollup = [{"status": "COMPLETED", "conclusion": "SUCCESS"}]
+    with mock.patch.object(poller, "_fetch", return_value=_pr(checks=rollup)):
+        events, _ = poller.poll(state, {"id": "42"})
+    assert any(e["event"] == "checks_succeeded" for e in events)
+
+
+def test_merged_emits_merged_and_is_terminal() -> None:
+    state = {"pr_state": "OPEN"}
+    with mock.patch.object(poller, "_fetch", return_value=_pr(state="MERGED")):
+        events, new_state = poller.poll(state, {"id": "42"})
+    assert any(e["event"] == "merged" for e in events)
+    assert poller.is_terminal(new_state) is True
+
+
+def test_closed_emits_closed_and_is_terminal() -> None:
+    state = {"pr_state": "OPEN"}
+    with mock.patch.object(poller, "_fetch", return_value=_pr(state="CLOSED")):
+        events, new_state = poller.poll(state, {"id": "42"})
+    assert any(e["event"] == "closed" for e in events)
+    assert poller.is_terminal(new_state) is True
+
+
+def test_review_approved_emits_event() -> None:
+    state = {"review_decision": "REVIEW_REQUIRED"}
+    with mock.patch.object(poller, "_fetch", return_value=_pr(review="APPROVED")):
+        events, _ = poller.poll(state, {"id": "42"})
+    assert any(e["event"] == "review_approved" for e in events)
+
+
+def test_changes_requested_emits_event() -> None:
+    state = {"review_decision": ""}
+    with mock.patch.object(poller, "_fetch", return_value=_pr(review="CHANGES_REQUESTED")):
+        events, _ = poller.poll(state, {"id": "42"})
+    assert any(e["event"] == "review_changes_requested" for e in events)
+
+
+def test_conflict_rising_edge_emits_once() -> None:
+    state = {"mergeable": "MERGEABLE"}
+    with mock.patch.object(poller, "_fetch", return_value=_pr(mergeable="CONFLICTING")):
+        events1, new_state = poller.poll(state, {"id": "42"})
+    assert any(e["event"] == "conflicts_appeared" for e in events1)
+    # Same state again — must not re-fire
+    with mock.patch.object(poller, "_fetch", return_value=_pr(mergeable="CONFLICTING")):
+        events2, _ = poller.poll(new_state, {"id": "42"})
+    assert all(e["event"] != "conflicts_appeared" for e in events2)
+
+
+def test_fetch_failure_preserves_state() -> None:
+    state = {"checks_state": "PENDING", "marker": "keep"}
+    with mock.patch.object(poller, "_fetch", return_value=None):
+        events, new_state = poller.poll(state, {"id": "42"})
+    assert events == []
+    assert new_state == state
+
+
+def test_is_terminal_open_returns_false() -> None:
+    assert poller.is_terminal({"pr_state": "OPEN"}) is False
+
+
+def test_gh_helper_imported_from_pr_op() -> None:
+    """The poller must use the existing gh wrapper from presets/github/pr.py."""
+    import inspect
+    assert poller._gh.__module__ == "github_pr_op"
+    # _gh signature: (args, timeout=10)
+    sig = inspect.signature(poller._gh)
+    assert "args" in sig.parameters

--- a/tests/test_watch_github_pr_poller.py
+++ b/tests/test_watch_github_pr_poller.py
@@ -15,6 +15,7 @@ _spec.loader.exec_module(poller)
 
 def _pr(
     state="OPEN", mergeable="MERGEABLE", review="", checks=None, title="some PR",
+    comments=None,
 ):
     return {
         "state": state,
@@ -26,6 +27,7 @@ def _pr(
         "isDraft": False,
         "reviewDecision": review,
         "statusCheckRollup": checks or [],
+        "comments": comments or [],
     }
 
 
@@ -151,6 +153,40 @@ def test_fetch_failure_preserves_state() -> None:
 
 def test_is_terminal_open_returns_false() -> None:
     assert poller.is_terminal({"pr_state": "OPEN"}) is False
+
+
+def test_first_poll_records_comment_count_without_event() -> None:
+    """First poll on empty state must NOT fire comment_added — just baseline."""
+    comments = [{"author": {"login": "alice"}, "body": "hi"}]
+    with mock.patch.object(poller, "_fetch", return_value=_pr(comments=comments)):
+        events, new_state = poller.poll({}, {"id": "42"})
+    assert all(e["event"] != "comment_added" for e in events)
+    assert new_state["comments_count"] == 1
+
+
+def test_comment_count_increase_emits_comment_added() -> None:
+    state = {"comments_count": 1}
+    comments = [
+        {"author": {"login": "alice"}, "body": "hi"},
+        {"author": {"login": "bob"}, "body": "second"},
+    ]
+    with mock.patch.object(poller, "_fetch", return_value=_pr(comments=comments)):
+        events, _ = poller.poll(state, {"id": "42"})
+    matches = [e for e in events if e["event"] == "comment_added"]
+    assert len(matches) == 1
+    assert matches[0]["payload"]["author"] == "bob"
+    assert matches[0]["payload"]["new_count"] == 1
+
+
+def test_comment_count_unchanged_no_event() -> None:
+    state = {"comments_count": 2}
+    comments = [
+        {"author": {"login": "alice"}, "body": "hi"},
+        {"author": {"login": "bob"}, "body": "second"},
+    ]
+    with mock.patch.object(poller, "_fetch", return_value=_pr(comments=comments)):
+        events, _ = poller.poll(state, {"id": "42"})
+    assert all(e["event"] != "comment_added" for e in events)
 
 
 def test_gh_helper_imported_from_pr_op() -> None:


### PR DESCRIPTION
Adds a github-pr source for the watch preset.

## Summary

- New source under \`presets/watch/sources/github-pr/\` (events.json + poller.py)
- Polls a GitHub PR via \`gh pr view --json state,mergeable,reviewDecision,statusCheckRollup,...\` every 30s
- Emits transitions: \`checks_failed\` / \`checks_succeeded\` / \`checks_pending\` (statusCheckRollup aggregated like the GitHub UI), \`review_approved\` / \`review_changes_requested\`, \`merged\` / \`closed\`, \`conflicts_appeared\` (rising-edge)
- **Reuses \`_gh\` from \`presets/github/pr.py\` via importlib** — single source of truth for gh CLI invocation, no duplicated wrapping
- Adds \`watch\` to \`.supertool.example.json\` presets list (missed in #177)

## Real use case

\`./supertool 'watch:github-pr:178'\` — Claude reacts when checks flip, reviews land, or the PR merges/conflicts. Pairs with the Phase 2 channel for async wake.

## Test plan

- [x] 17 unit tests pass (rollup aggregator + every state-diff path)
- [x] Real smoke against PR #177 — got \`MERGED\` + \`checks=SUCCESS\` + correct title/URL
- [ ] Live end-to-end: \`watch:github-pr:179\` (this PR), watch Claude react when it merges

## Out of scope

- \`github-actions\` standalone source (workflow runs without a PR) — follow-up if useful