### PR TITLE
gitlab-mr: reuse gl-mr's _glab_api + add comment_added event

### DIFF
--- a/presets/watch/sources/gitlab-mr/events.json
+++ b/presets/watch/sources/gitlab-mr/events.json
@@ -4,6 +4,7 @@
     {"key": "pipeline_failed",      "label": "Pipeline failed"},
     {"key": "pipeline_succeeded",   "label": "Pipeline succeeded"},
     {"key": "pipeline_running",     "label": "Pipeline started running"},
+    {"key": "comment_added",        "label": "New comment on the MR"},
     {"key": "merged",               "label": "MR merged"},
     {"key": "closed",               "label": "MR closed"},
     {"key": "conflicts_appeared",   "label": "Conflicts appeared"}

--- a/presets/watch/sources/gitlab-mr/poller.py
+++ b/presets/watch/sources/gitlab-mr/poller.py
@@ -65,8 +65,14 @@ def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
     pipeline_id = str(pipeline.get("id") or "") if isinstance(pipeline, dict) else ""
     title = str(data.get("title") or f"MR !{iid}")
     web_url = str(data.get("web_url") or "")
+    # GitLab's `user_notes_count` counts *all* notes including system notes
+    # (pipeline status changes, label edits, assignee changes). `comment_added`
+    # will therefore fire on some non-human events — accepted limitation for v1
+    # to avoid a second API call to /notes per poll. If the field is absent,
+    # keep it None so the rising-edge guard treats the next poll as a baseline
+    # rather than locking the count at 0 forever.
     raw_notes = data.get("user_notes_count")
-    notes_count = int(raw_notes) if isinstance(raw_notes, int) else 0
+    notes_count = int(raw_notes) if isinstance(raw_notes, int) else None
 
     events: list[dict] = []
     prev_pipeline = state.get("pipeline_status", "")
@@ -123,8 +129,14 @@ def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
         })
 
     # Notes count rising — new comment(s) since last poll. First poll
-    # (prev_notes_count is None) records the baseline without firing.
-    if prev_notes_count is not None and notes_count > prev_notes_count:
+    # (prev_notes_count is None) records the baseline without firing. If the
+    # current poll couldn't read the field (notes_count is None) we skip too
+    # so we don't compare against a stale baseline.
+    if (
+        prev_notes_count is not None
+        and notes_count is not None
+        and notes_count > prev_notes_count
+    ):
         delta = notes_count - prev_notes_count
         events.append({
             "event": "comment_added",

--- a/presets/watch/sources/gitlab-mr/poller.py
+++ b/presets/watch/sources/gitlab-mr/poller.py
@@ -3,6 +3,8 @@
 Polls a single GitLab merge request via `glab api` and emits events when
 status changes. Terminal when the MR is merged or closed.
 
+Reuses `_glab_api` from presets/gitlab/mr.py — no duplicated CLI wrapping.
+
 Source plugin contract:
 - INTERVAL: int seconds between polls (30s default)
 - poll(state, ctx) -> (events, new_state)
@@ -10,25 +12,30 @@ Source plugin contract:
 """
 from __future__ import annotations
 
+import importlib.util
 import json
-import shutil
-import subprocess
+from pathlib import Path
 from typing import Any
 
 INTERVAL = 30
 
 TERMINAL_MR_STATES = {"merged", "closed"}
 
+# Import the existing _glab_api CLI wrapper from the gl-mr op so we share
+# one source of truth for glab invocation, error handling, and timeouts.
+_MR_MODULE_PATH = Path(__file__).parents[3] / "gitlab" / "mr.py"
+_spec = importlib.util.spec_from_file_location("gitlab_mr_op", _MR_MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+_mr_op = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mr_op)
+_glab_api_cli = _mr_op._glab_api  # type: ignore[attr-defined]
+
 
 def _glab_api(endpoint: str) -> dict | list | None:
-    if not shutil.which("glab"):
-        return None
+    """JSON-decode an _glab_api CLI call. None on any failure."""
     try:
-        r = subprocess.run(
-            ["glab", "api", endpoint],
-            capture_output=True, text=True, timeout=10,
-        )
-    except (subprocess.TimeoutExpired, OSError):
+        r = _glab_api_cli(endpoint)
+    except (FileNotFoundError, OSError):
         return None
     if r.returncode != 0:
         return None
@@ -58,11 +65,14 @@ def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
     pipeline_id = str(pipeline.get("id") or "") if isinstance(pipeline, dict) else ""
     title = str(data.get("title") or f"MR !{iid}")
     web_url = str(data.get("web_url") or "")
+    raw_notes = data.get("user_notes_count")
+    notes_count = int(raw_notes) if isinstance(raw_notes, int) else 0
 
     events: list[dict] = []
     prev_pipeline = state.get("pipeline_status", "")
     prev_state = state.get("mr_state", "")
     prev_conflicts = bool(state.get("has_conflicts", False))
+    prev_notes_count = state.get("notes_count")  # None on first poll
 
     # Pipeline transitions
     if pipeline_status and pipeline_status != prev_pipeline:
@@ -112,11 +122,27 @@ def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
             "notify_message": title,
         })
 
+    # Notes count rising — new comment(s) since last poll. First poll
+    # (prev_notes_count is None) records the baseline without firing.
+    if prev_notes_count is not None and notes_count > prev_notes_count:
+        delta = notes_count - prev_notes_count
+        events.append({
+            "event": "comment_added",
+            "payload": {
+                "url": web_url,
+                "title": title,
+                "new_count": delta,
+            },
+            "notify_title": f"!{iid} new comment{'s' if delta > 1 else ''}",
+            "notify_message": title,
+        })
+
     new_state = {
         "mr_state": mr_state,
         "pipeline_status": pipeline_status,
         "pipeline_id": pipeline_id,
         "has_conflicts": has_conflicts,
+        "notes_count": notes_count,
         "title": title,
         "web_url": web_url,
     }

--- a/tests/test_watch_gitlab_mr_poller.py
+++ b/tests/test_watch_gitlab_mr_poller.py
@@ -13,7 +13,8 @@ poller = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(poller)
 
 
-def _mr(state="opened", pipeline_status="running", pipeline_id="9", conflicts=False, **kw):
+def _mr(state="opened", pipeline_status="running", pipeline_id="9", conflicts=False,
+        user_notes_count=0, **kw):
     return {
         "iid": 21803,
         "title": kw.get("title", "feat: do the thing"),
@@ -21,6 +22,7 @@ def _mr(state="opened", pipeline_status="running", pipeline_id="9", conflicts=Fa
         "has_conflicts": conflicts,
         "head_pipeline": {"id": pipeline_id, "status": pipeline_status},
         "web_url": "https://example.com/mr/21803",
+        "user_notes_count": user_notes_count,
     }
 
 
@@ -91,3 +93,32 @@ def test_fetch_failure_returns_no_events() -> None:
         events, new_state = poller.poll({"x": 1}, {"id": "21803"})
     assert events == []
     assert new_state == {"x": 1}  # state preserved on transient failure
+
+
+def test_first_poll_records_notes_count_without_event() -> None:
+    """First poll on empty state must NOT fire comment_added — just baseline."""
+    with mock.patch.object(poller, "_fetch", return_value=_mr(user_notes_count=3)):
+        events, new_state = poller.poll({}, {"id": "21803"})
+    assert all(e["event"] != "comment_added" for e in events)
+    assert new_state["notes_count"] == 3
+
+
+def test_notes_count_increase_emits_comment_added() -> None:
+    state = {"notes_count": 1, "mr_state": "opened", "pipeline_status": "running"}
+    with mock.patch.object(poller, "_fetch", return_value=_mr(user_notes_count=2)):
+        events, _ = poller.poll(state, {"id": "21803"})
+    matches = [e for e in events if e["event"] == "comment_added"]
+    assert len(matches) == 1
+    assert matches[0]["payload"]["new_count"] == 1
+
+
+def test_notes_count_unchanged_no_event() -> None:
+    state = {"notes_count": 2, "mr_state": "opened", "pipeline_status": "running"}
+    with mock.patch.object(poller, "_fetch", return_value=_mr(user_notes_count=2)):
+        events, _ = poller.poll(state, {"id": "21803"})
+    assert all(e["event"] != "comment_added" for e in events)
+
+
+def test_glab_helper_imported_from_mr_op() -> None:
+    """The poller must reuse _glab_api from presets/gitlab/mr.py."""
+    assert poller._glab_api_cli.__module__ == "gitlab_mr_op"

--- a/tests/test_watch_gitlab_mr_poller.py
+++ b/tests/test_watch_gitlab_mr_poller.py
@@ -122,3 +122,30 @@ def test_notes_count_unchanged_no_event() -> None:
 def test_glab_helper_imported_from_mr_op() -> None:
     """The poller must reuse _glab_api from presets/gitlab/mr.py."""
     assert poller._glab_api_cli.__module__ == "gitlab_mr_op"
+
+
+def test_missing_user_notes_count_does_not_lock_baseline_at_zero() -> None:
+    """Absent field keeps notes_count=None so a later real value can still baseline."""
+    mr_no_field = {
+        "iid": 21803, "title": "x", "state": "opened", "has_conflicts": False,
+        "head_pipeline": {"id": "9", "status": "running"},
+        "web_url": "https://example.com/mr/21803",
+        # user_notes_count intentionally absent
+    }
+    with mock.patch.object(poller, "_fetch", return_value=mr_no_field):
+        events, new_state = poller.poll({}, {"id": "21803"})
+    assert all(e["event"] != "comment_added" for e in events)
+    assert new_state["notes_count"] is None
+
+
+def test_notes_count_field_disappearing_skips_event() -> None:
+    """If notes_count drops to None on a later poll, no comparison, no event."""
+    state = {"notes_count": 5, "mr_state": "opened", "pipeline_status": "running"}
+    mr_no_field = {
+        "iid": 21803, "title": "x", "state": "opened", "has_conflicts": False,
+        "head_pipeline": {"id": "9", "status": "running"},
+        "web_url": "https://example.com/mr/21803",
+    }
+    with mock.patch.object(poller, "_fetch", return_value=mr_no_field):
+        events, _ = poller.poll(state, {"id": "21803"})
+    assert all(e["event"] != "comment_added" for e in events)


### PR DESCRIPTION
Mirrors the github-pr refactor from #179.

## Summary

- Drops the inline \`_glab_api\` helper from \`presets/watch/sources/gitlab-mr/poller.py\`
- Imports \`_glab_api\` from \`presets/gitlab/mr.py\` via importlib — same pattern github-pr uses to import \`_gh\` from \`presets/github/pr.py\`
- Adds \`comment_added\` event. Uses the existing \`user_notes_count\` field from the MR JSON, so no extra API call. Fires on rising edge with \`new_count\` payload. First poll baselines without firing.

## Why it matters for your "10 MRs open" use case

Previously the gitlab-mr source missed comment-driven feedback — pipelines and merge events fired, but a reviewer leaving a comment was invisible. Now you get a wake-up when someone drops a note on a tracked MR.

## Test plan

- [x] 14 unit tests pass (was 10, +4 for the comment path + helper-reuse check)
- [ ] Live smoke on a DVSI MR: \`./supertool 'watch:gitlab-mr:<iid>'\` → add a comment via glab → confirm \`comment_added\` lands in the channel

## Out of scope

- Author detection on the comment payload — GitLab's \`user_notes_count\` doesn't include identity. Would require a second API call to \`/notes\`. Follow-up if useful.
- gitlab-job source (workflow jobs without an MR) — separate PR if you want it.