### PR TITLE
docs: watch preset + claude-channel + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`watch` preset — background event pollers with async wake into Claude Code.** New ops `watch:SOURCE:ID[:only=...]`, `unwatch:SOURCE:ID`, `watches`. Each invocation forks a detached poller that emits state-change events to a UDS socket, a status file, and macOS Notification Center. Source-plugin contract makes new sources ~50 lines. Bundled sources: `github-pr` (PR state, checks, reviews, comments, merge/close, conflicts) and `gitlab-mr` (MR state, pipeline, merge/close, conflicts). Closes [#165](https://github.com/Digital-Process-Tools/claude-supertool/issues/165). See [docs/presets/watch.md](docs/presets/watch.md).
+- **`notifiers/claude-channel/` — MCP channel server for async wake.** TypeScript / Bun server that binds the watch UDS socket and pushes events into a running Claude Code session via the Channels feature (research preview, requires Claude Code v2.1.80+). Events arrive as `<channel source="claude-channel" watcher_source="<source>" id="<id>" event="<event>" ...>` tags. UDS file mode 0600 + localhost-only auth model. Launch with `claude --dangerously-load-development-channels server:claude-channel`. See [notifiers/claude-channel/README.md](notifiers/claude-channel/README.md).
 - **`glob` brace expansion.** `glob:src/**/*.{json,xml}` now fans out into `*.json` + `*.xml` (shell/fd/ripgrep semantics) and dedupes results, instead of silently returning 0 files. Supports multiple groups (`{a,b}.{x,y}` → 4) and nesting (`{a,b{1,2}}` → 3). Patterns without braces are unchanged. Closes [#161](https://github.com/Digital-Process-Tools/claude-supertool/issues/161).
 
 ## [0.14.0] — 2026-05-23

--- a/README.md
+++ b/README.md
@@ -284,6 +284,39 @@ Or set `"notifier_debug": true` in your `.supertool.json` for persistent traces.
 
 ---
 
+## Watch — react to external events while you're away
+
+The `watch` preset spawns background pollers that emit events when external state changes — a PR's checks flip red, a GitLab pipeline finishes, an MR gets a new comment. Pair it with the [claude-channel](notifiers/claude-channel/README.md) MCP server and Claude Code wakes up mid-session to handle the event without you typing anything.
+
+### Two layers
+
+1. **`watch` preset** — `watch:SOURCE:ID` spawns a detached poller. Events emit to a UDS socket, a status file, and macOS Notification Center. Bundled sources: `github-pr`, `gitlab-mr`. Write your own source in ~50 lines.
+2. **`claude-channel` MCP server** — TypeScript / Bun. Binds the UDS socket and pushes events into a running Claude Code session via the [Channels feature](https://code.claude.com/docs/en/channels.md) (research preview, v2.1.80+). Optional — the watch preset is useful even without it.
+
+### Quickstart
+
+```bash
+./supertool 'watch:github-pr:179'                 # start watching
+./supertool 'watch:github-pr:179:only=merged'     # filter event types
+./supertool 'watches'                             # list active pollers
+./supertool 'unwatch:github-pr:179'               # stop one
+```
+
+Run `bash notifiers/claude-channel/install.sh` to install the MCP server, register it in `.mcp.json`, and launch Claude with:
+
+```bash
+claude --dangerously-load-development-channels server:claude-channel
+```
+
+Each event lands in Claude as `<channel source="claude-channel" watcher_source="github-pr" id="179" event="merged" ...>`.
+
+### Reference
+
+- Preset deep-dive (ops, sources, lifecycle, plugin contract): [docs/presets/watch.md](docs/presets/watch.md)
+- MCP server (install, security, event format): [notifiers/claude-channel/README.md](notifiers/claude-channel/README.md)
+
+---
+
 ## RTK integration
 
 When [rtk](https://github.com/reachingforthejack/rtk) is installed, supertool automatically delegates `read`, `grep`, and `wc` to RTK for compressed output. No configuration needed — detected via `which rtk` at first use.

--- a/docs/presets/index.md
+++ b/docs/presets/index.md
@@ -20,6 +20,7 @@ Supertool merges preset ops at startup — project-level ops always override on 
 | `devto` | Publish, read, and engage on Dev.to | [devto.md](devto.md) | `python3`, `DEVTO_API_KEY` |
 | `bluesky` | Post, read, and engage on Bluesky | [bluesky.md](bluesky.md) | `python3`, `BLUESKY_HANDLE` + `BLUESKY_APP_PASSWORD` |
 | `xml` | Read-only XPath queries over XML files | [xml.md](xml.md) | `python3` |
+| `watch` | Background pollers + async wake on external events (PRs, MRs, pipelines) | [watch.md](watch.md) | `gh` and/or `glab` per source |
 
 ## Writing your own preset
 

--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -1,0 +1,156 @@
+# `watch` preset
+
+Background pollers for external sources that emit events on state-change. The framework writes events to a UDS socket; consumers (macOS Notification Center, or the [claude-channel](../../notifiers/claude-channel/README.md) MCP server) pick them up and push them where you need them.
+
+## Ops
+
+```
+watch:SOURCE:ID[:only=event1,event2]   spawn poller (fire-and-forget)
+unwatch:SOURCE:ID                      kill the poller, remove PID file
+watches                                list active pollers
+```
+
+Example:
+
+```bash
+./supertool 'watch:github-pr:179'                        # all events
+./supertool 'watch:github-pr:179:only=checks_failed'     # filter
+./supertool 'watch:gitlab-mr:21803:only=pipeline_failed,merged'
+./supertool 'watches'
+./supertool 'unwatch:github-pr:179'
+```
+
+Composable in one batched call:
+
+```bash
+./supertool 'watch:github-pr:179' 'watch:github-pr:180' 'watches'
+```
+
+## Bundled sources
+
+| Source | Polls | Events |
+|---|---|---|
+| `github-pr` | `gh pr view <N> --json state,mergeable,reviewDecision,statusCheckRollup,comments,...` | `checks_failed`, `checks_succeeded`, `checks_pending`, `review_approved`, `review_changes_requested`, `comment_added`, `merged`, `closed`, `conflicts_appeared` |
+| `gitlab-mr` | `glab api projects/:id/merge_requests/<iid>` | `pipeline_failed`, `pipeline_succeeded`, `pipeline_running`, `merged`, `closed`, `conflicts_appeared` |
+
+Each source declares its event vocabulary in `presets/watch/sources/<NAME>/events.json` for introspection.
+
+## Transports
+
+Pollers emit through three channels (all best-effort, none can crash the poller):
+
+| Transport | Path | Purpose |
+|---|---|---|
+| UDS socket (NDJSON) | `/tmp/supertool-watch.sock` | Live event stream — consumers read this |
+| Status file (JSON) | `/tmp/supertool-watch-{source}__{id}.state.json` | Last-known state for `watches` op + offline inspection |
+| macOS osascript | system notification center | Desktop ping on terminal status / error |
+
+Override the socket path with `SUPERTOOL_WATCH_SOCK` env var (must be set on both pollers and the consumer).
+
+## Event payload (locked contract)
+
+```json
+{
+  "ts": "2026-05-24T19:00:00Z",
+  "source": "github-pr",
+  "id": "179",
+  "event": "checks_failed",
+  "payload": {
+    "url": "https://github.com/.../pull/179",
+    "title": "feat: do the thing"
+  }
+}
+```
+
+Consumers can rely on `ts/source/id/event/payload` always being present. Extra fields inside `payload` vary by source — see each source's `events.json` and `poller.py`.
+
+## Lifecycle
+
+Each `watch` invocation forks a detached poller process. The process IS the subscription — no central config:
+
+- PID file per active watcher: `/tmp/supertool-watch-{source}__{id}.pid`
+- `unwatch` reads the PID file, SIGTERM (then SIGKILL after 200ms), removes the file
+- Stale PIDs swept by the `watches` op automatically
+- Pollers auto-stop when the source declares the target terminal (`is_terminal(state) -> bool`)
+
+`SOURCE` and `ID` must not contain `__` (reserved as the filename separator).
+
+## Writing a new source
+
+Drop a folder under `presets/watch/sources/<NAME>/`:
+
+```
+sources/your-source/
+  events.json   # event vocabulary (introspection)
+  poller.py     # the polling implementation
+```
+
+### `events.json`
+
+```json
+{
+  "source": "your-source",
+  "events": [
+    {"key": "happened",       "label": "Something happened"},
+    {"key": "happened_again", "label": "Something happened again"}
+  ]
+}
+```
+
+### `poller.py`
+
+```python
+INTERVAL = 30  # seconds between polls
+
+def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
+    """Return (events_to_emit, new_state).
+
+    ctx = {"source": "...", "id": "...", "only": [...]}.
+
+    Diff against `state`; return only NEW events. Returning the same event
+    every tick produces a notification storm. The framework persists
+    `new_state` and passes it back next call.
+
+    Each event is a dict:
+      {
+        "event": "happened",
+        "payload": {...},
+        "notify_title": "Optional macOS notification title",
+        "notify_message": "Optional macOS notification body",
+      }
+    """
+    ...
+
+def is_terminal(state: dict) -> bool:
+    """True if the watcher should stop on its own (e.g. PR merged)."""
+    return False
+```
+
+### Reuse an existing op's CLI helper
+
+Most sources wrap a CLI tool (`gh`, `glab`, …) that an existing supertool op already wraps cleanly. Don't duplicate the wrapping — import the helper directly:
+
+```python
+import importlib.util
+from pathlib import Path
+
+_PR_MODULE_PATH = Path(__file__).parents[3] / "github" / "pr.py"
+_spec = importlib.util.spec_from_file_location("github_pr_op", _PR_MODULE_PATH)
+_pr_op = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pr_op)
+_gh = _pr_op._gh  # single source of truth for gh invocation
+```
+
+`gitlab-mr` does the same with `_glab_api` from `presets/gitlab/mr.py`.
+
+The framework handles PID files, signals, transport, the `only=` filter, and state persistence. Source code stays focused on *what changed*.
+
+## Async wake into Claude Code
+
+The `watch` preset alone gives you desktop notifications + queryable status. To make Claude *react* to events in real time, install the companion [claude-channel](../../notifiers/claude-channel/README.md) MCP server. It binds the UDS socket and pushes each event into a running Claude Code session via the [Channels feature](https://code.claude.com/docs/en/channels.md).
+
+End-to-end (see [claude-channel/README.md](../../notifiers/claude-channel/README.md) for the install steps):
+
+```
+poller → /tmp/supertool-watch.sock → claude-channel MCP server → <channel> tag in Claude
+```


### PR DESCRIPTION
Documentation pass for the watch feature shipped across #177, #178, #179.

## Summary

- New \`docs/presets/watch.md\` — full deep-dive: ops, bundled sources, transports, event payload contract, lifecycle (PID files / unwatch / stale cleanup), source-plugin contract, the \"reuse an existing op's CLI helper\" pattern, and the path to async wake via claude-channel.
- \`docs/presets/index.md\` — added \`watch\` row to the shipped-presets table.
- Top-level \`README.md\` — new \"Watch — react to external events while you're away\" section between the cursor-witness docs and the RTK integration block, parallel to the cursor-witness section. Quickstart commands + pointers to the two deep-dive docs.
- \`CHANGELOG.md\` — entries under [Unreleased] for the watch preset and the claude-channel MCP server. Phrased around what users get, not implementation detail.

## Out of scope

- Stand-alone \`docs/channels.md\` — the claude-channel MCP server already has \`notifiers/claude-channel/README.md\` which docs/presets/watch.md links to. Not duplicating.
- Bumping the version in CHANGELOG — keeping under [Unreleased] until you cut a release.

## Test plan

- [x] All links in the new content resolve (relative paths verified by hand)
- [ ] Skim the rendered docs on GitHub once merged to confirm formatting

(Doc-only, no code touched. No tests added.)