### PR TITLE
fix(gh): reclassify "no GitHub host" stderr (closes #183)

### DIFF
--- a/presets/github/issue.py
+++ b/presets/github/issue.py
@@ -25,10 +25,12 @@ def _gh(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
 def _format_error(stderr: str, resource: str, identifier: str) -> str:
     """Classify gh errors into actionable messages for LLMs."""
     s = stderr.lower()
+    if "github host" in s or "not a git repository" in s or "git remotes" in s:
+        return f"ERROR: cwd is not a GitHub repo. cd into a GitHub-cloned repo, or run gh directly with --repo OWNER/REPO."
     if "could not resolve" in s or "404" in s or "not found" in s:
         return f"ERROR: {resource} #{identifier} not found in this repo. Check the number or verify you're in the right repo (gh repo view)."
-    if "auth" in s or "login" in s or "token" in s:
-        return f"ERROR: gh CLI not authenticated. Run: gh auth login"
+    if "401" in s or "unauthorized" in s or "not logged in" in s or "token" in s:
+        return f"ERROR: gh CLI not authenticated. Run: gh auth login (verify with: gh auth status)"
     if "rate limit" in s or "429" in s:
         return "ERROR: GitHub API rate limit exceeded. Wait a few minutes and retry."
     if "403" in s or "forbidden" in s:

--- a/presets/github/job.py
+++ b/presets/github/job.py
@@ -46,10 +46,12 @@ def _local_branch_check(source: str) -> str:
 def _format_error(stderr: str, resource: str, identifier: str) -> str:
     """Classify gh errors into actionable messages for LLMs."""
     s = stderr.lower()
+    if "github host" in s or "not a git repository" in s or "git remotes" in s:
+        return f"ERROR: cwd is not a GitHub repo. cd into a GitHub-cloned repo, or run gh directly with --repo OWNER/REPO."
     if "could not resolve" in s or "404" in s or "not found" in s:
         return f"ERROR: {resource} #{identifier} not found. Check the ID. Use gh-run to list jobs first, then gh-job with the job ID."
-    if "auth" in s or "login" in s or "token" in s:
-        return f"ERROR: gh CLI not authenticated. Run: gh auth login"
+    if "401" in s or "unauthorized" in s or "not logged in" in s or "token" in s:
+        return f"ERROR: gh CLI not authenticated. Run: gh auth login (verify with: gh auth status)"
     if "rate limit" in s or "429" in s:
         return "ERROR: GitHub API rate limit exceeded. Wait a few minutes and retry."
     if "403" in s or "forbidden" in s:

--- a/presets/github/pr.py
+++ b/presets/github/pr.py
@@ -67,10 +67,12 @@ def _local_branch_check(source: str) -> str:
 def _format_error(stderr: str, resource: str, identifier: str) -> str:
     """Classify gh errors into actionable messages for LLMs."""
     s = stderr.lower()
+    if "github host" in s or "not a git repository" in s or "git remotes" in s:
+        return f"ERROR: cwd is not a GitHub repo. cd into a GitHub-cloned repo, or run gh directly with --repo OWNER/REPO."
     if "could not resolve" in s or "404" in s or "not found" in s:
         return f"ERROR: {resource} #{identifier} not found in this repo. Check the number or verify you're in the right repo (gh repo view)."
-    if "auth" in s or "login" in s or "token" in s:
-        return f"ERROR: gh CLI not authenticated. Run: gh auth login"
+    if "401" in s or "unauthorized" in s or "not logged in" in s or "token" in s:
+        return f"ERROR: gh CLI not authenticated. Run: gh auth login (verify with: gh auth status)"
     if "rate limit" in s or "429" in s:
         return "ERROR: GitHub API rate limit exceeded. Wait a few minutes and retry."
     if "403" in s or "forbidden" in s:

--- a/presets/github/run.py
+++ b/presets/github/run.py
@@ -34,10 +34,12 @@ def _local_branch_check(source: str) -> str:
 def _format_error(stderr: str, resource: str, identifier: str) -> str:
     """Classify gh errors into actionable messages for LLMs."""
     s = stderr.lower()
+    if "github host" in s or "not a git repository" in s or "git remotes" in s:
+        return f"ERROR: cwd is not a GitHub repo. cd into a GitHub-cloned repo, or run gh directly with --repo OWNER/REPO."
     if "could not resolve" in s or "404" in s or "not found" in s:
         return f"ERROR: {resource} #{identifier} not found. Check the ID or verify you're in the right repo (gh repo view)."
-    if "auth" in s or "login" in s or "token" in s:
-        return f"ERROR: gh CLI not authenticated. Run: gh auth login"
+    if "401" in s or "unauthorized" in s or "not logged in" in s or "token" in s:
+        return f"ERROR: gh CLI not authenticated. Run: gh auth login (verify with: gh auth status)"
     if "rate limit" in s or "429" in s:
         return "ERROR: GitHub API rate limit exceeded. Wait a few minutes and retry."
     if "403" in s or "forbidden" in s:

--- a/tests/test_error_format.py
+++ b/tests/test_error_format.py
@@ -112,6 +112,30 @@ class TestFallback:
         assert "42" in result
 
 
+class TestGitHubNotARepo:
+    """gh in a non-GitHub cwd must not be misclassified as auth failure (issue #183)."""
+
+    NO_HOST_STDERR = (
+        "none of the git remotes configured for this repository point to a "
+        "known GitHub host. To tell gh about a new GitHub host, please use "
+        "`gh auth login`\n"
+    )
+
+    @pytest.mark.parametrize("script", ["issue.py", "pr.py", "run.py", "job.py"])
+    def test_no_github_host_not_misclassified_as_auth(self, script):
+        fn = _load_format_error("github", script)
+        result = fn(self.NO_HOST_STDERR, "Issue", "78")
+        assert "not authenticated" not in result.lower()
+        assert "github repo" in result.lower() or "--repo" in result
+
+    @pytest.mark.parametrize("script", ["issue.py", "pr.py", "run.py", "job.py"])
+    def test_not_a_git_repository(self, script):
+        fn = _load_format_error("github", script)
+        result = fn("fatal: not a git repository", "PR", "1")
+        assert "not authenticated" not in result.lower()
+        assert "--repo" in result or "GitHub-cloned" in result
+
+
 class TestJobSpecificHints:
     """Job error messages include hints about which op to use first."""
 


### PR DESCRIPTION
## Summary

`gh` emits `…point to a known GitHub host. To tell gh about a new GitHub host, please use 'gh auth login'` when cwd has no GitHub remote. `_format_error` matched on the bare substrings `auth` / `login` / `token` and surfaced this as **"gh CLI not authenticated"** — even though `gh` itself was perfectly authenticated via keyring (issue #183).

## Fix

In all 4 `gh-*` presets (`pr.py`, `issue.py`, `run.py`, `job.py`):

- Detect **"github host" / "not a git repository" / "git remotes"** first → surface as *"cwd is not a GitHub repo, use --repo OWNER/REPO"*.
- Tighten auth detection to `401` / `unauthorized` / `not logged in` / `token` (drop bare `auth` and `login` which trip on gh's own help text).

Did not adopt the issue's suggestion of running `gh auth status` as a pre-flight — that's a second subprocess per call. The repro is purely a classification bug; fixing classification is sufficient.

## Test plan

- [x] `tests/test_error_format.py` — 75 pass (8 new regression cases in `TestGitHubNotARepo` covering the keyring-auth repro stderr + bare `not a git repository`)
- [x] Existing `TestAuth::test_unauthorized` and `test_token_error` still pass
- [x] Full suite: 2968 pass, 2 fail (pre-existing `test_validators_phpstan` failures on master, unrelated)