### PR TITLE
test: cross-platform formatter-cmd fixtures (#188)

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -229,7 +229,7 @@
   "validator_cache": true,
   "validators": {
     "phplint": {
-      "cmd": "python3 {supertool_dir}/validators/phplint/phplint.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/phplint/phplint.py {file}",
       "match": "*.php",
       "hooks_into": [
         "edit",
@@ -242,7 +242,7 @@
       "timeout": 30
     },
     "xmllint": {
-      "cmd": "python3 {supertool_dir}/validators/xmllint/xmllint.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/xmllint/xmllint.py {file}",
       "match": "*.xml",
       "hooks_into": [
         "edit",
@@ -255,7 +255,7 @@
       "timeout": 30
     },
     "node-check": {
-      "cmd": "python3 {supertool_dir}/validators/node-check/node-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/node-check/node-check.py {file}",
       "match": "*.js",
       "hooks_into": [
         "edit",
@@ -268,7 +268,7 @@
       "timeout": 30
     },
     "py-compile": {
-      "cmd": "python3 {supertool_dir}/validators/py-compile/py-compile.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/py-compile/py-compile.py {file}",
       "match": "*.py",
       "hooks_into": [
         "edit",
@@ -281,7 +281,7 @@
       "timeout": 10
     },
     "pyright": {
-      "cmd": "python3 {supertool_dir}/validators/pyright/pyright.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/pyright/pyright.py {file}",
       "match": "*.py",
       "hooks_into": [
         "edit",
@@ -294,7 +294,7 @@
       "timeout": 60
     },
     "bash-check": {
-      "cmd": "python3 {supertool_dir}/validators/bash-check/bash-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/bash-check/bash-check.py {file}",
       "match": "*.sh",
       "hooks_into": [
         "edit",
@@ -307,7 +307,7 @@
       "timeout": 10
     },
     "jsonlint": {
-      "cmd": "python3 {supertool_dir}/validators/jsonlint/jsonlint.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/jsonlint/jsonlint.py {file}",
       "match": "*.json",
       "hooks_into": [
         "edit",
@@ -320,7 +320,7 @@
       "timeout": 10
     },
     "stylelint": {
-      "cmd": "python3 {supertool_dir}/validators/stylelint/stylelint.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/stylelint/stylelint.py {file}",
       "match": "*.scss",
       "hooks_into": [
         "edit",
@@ -332,7 +332,7 @@
       "timeout": 60
     },
     "yaml-check": {
-      "cmd": "python3 {supertool_dir}/validators/yaml-check/yaml-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/yaml-check/yaml-check.py {file}",
       "match": "*.yml",
       "hooks_into": [
         "edit",
@@ -345,7 +345,7 @@
       "timeout": 10
     },
     "yaml-check-yaml": {
-      "cmd": "python3 {supertool_dir}/validators/yaml-check/yaml-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/yaml-check/yaml-check.py {file}",
       "match": "*.yaml",
       "hooks_into": [
         "edit",
@@ -358,7 +358,7 @@
       "timeout": 10
     },
     "inilint": {
-      "cmd": "python3 {supertool_dir}/validators/inilint/inilint.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/inilint/inilint.py {file}",
       "match": "*.ini",
       "hooks_into": [
         "edit",
@@ -371,7 +371,7 @@
       "timeout": 10
     },
     "gofmt-check": {
-      "cmd": "python3 {supertool_dir}/validators/gofmt-check/gofmt-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/gofmt-check/gofmt-check.py {file}",
       "match": "*.go",
       "hooks_into": [
         "edit",
@@ -384,7 +384,7 @@
       "timeout": 30
     },
     "terraform-check": {
-      "cmd": "python3 {supertool_dir}/validators/terraform-check/terraform-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/terraform-check/terraform-check.py {file}",
       "match": "*.tf",
       "hooks_into": [
         "edit",
@@ -397,7 +397,7 @@
       "timeout": 30
     },
     "cargo-check": {
-      "cmd": "python3 {supertool_dir}/validators/cargo-check/cargo-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/cargo-check/cargo-check.py {file}",
       "match": "*.rs",
       "hooks_into": [
         "edit",
@@ -410,7 +410,7 @@
       "timeout": 60
     },
     "tsc-check": {
-      "cmd": "python3 {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
       "match": "*.ts",
       "hooks_into": [
         "edit",
@@ -423,7 +423,7 @@
       "timeout": 30
     },
     "tsc-check-tsx": {
-      "cmd": "python3 {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
       "match": "*.tsx",
       "hooks_into": [
         "edit",
@@ -436,7 +436,7 @@
       "timeout": 30
     },
     "tomllint": {
-      "cmd": "python3 {supertool_dir}/validators/tomllint/tomllint.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/tomllint/tomllint.py {file}",
       "match": "*.toml",
       "hooks_into": [
         "edit",
@@ -449,7 +449,7 @@
       "timeout": 10
     },
     "markdownlint": {
-      "cmd": "python3 {supertool_dir}/validators/markdownlint/markdownlint.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/markdownlint/markdownlint.py {file}",
       "match": "*.md",
       "hooks_into": [
         "edit",
@@ -462,7 +462,7 @@
       "timeout": 30
     },
     "ruby-check": {
-      "cmd": "python3 {supertool_dir}/validators/ruby-check/ruby-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/ruby-check/ruby-check.py {file}",
       "match": "*.rb",
       "hooks_into": [
         "edit",
@@ -475,7 +475,7 @@
       "timeout": 30
     },
     "hadolint": {
-      "cmd": "python3 {supertool_dir}/validators/hadolint/hadolint.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/hadolint/hadolint.py {file}",
       "match": "Dockerfile*",
       "hooks_into": [
         "edit",
@@ -488,7 +488,7 @@
       "timeout": 30
     },
     "psr": {
-      "cmd": "python3 {supertool_dir}/validators/psr/psr.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/psr/psr.py {file}",
       "match": "*.php",
       "hooks_into": [],
       "rollback_on_fail": false,
@@ -499,7 +499,7 @@
       }
     },
     "git-status": {
-      "cmd": "python3 {supertool_dir}/validators/git-status/git-status.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/git-status/git-status.py {file}",
       "match": "*",
       "hooks_into": [
         "edit",
@@ -512,7 +512,7 @@
       "timeout": 5
     },
     "prettier-check": {
-      "cmd": "python3 {supertool_dir}/validators/prettier-check/prettier-check.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/prettier-check/prettier-check.py {file}",
       "match": "*.{xml,scss,css,js,json,yml,yaml,md}",
       "hooks_into": [
         "edit",

--- a/.supertool.json
+++ b/.supertool.json
@@ -216,21 +216,21 @@
   "aliases": {},
   "notifiers": {
     "cursor-witness": {
-      "cmd": "python3 {supertool_dir}/notifiers/cursor-witness/notify.py {op} {file} {line} {line_end} {before_file}",
+      "cmd": "{python} {supertool_dir}/notifiers/cursor-witness/notify.py {op} {file} {line} {line_end} {before_file}",
       "match": "*",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim", "read", "around_line", "between", "map"]
     }
   },
   "validators": {
     "lsp-diag": {
-      "cmd": "python3 {supertool_dir}/validators/lsp-diag/lsp-diag.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/lsp-diag/lsp-diag.py {file}",
       "match": "*.{py,php,class.php,js,ts,jsx,tsx}",
       "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
       "rollback_on_fail": false,
       "timeout": 15
     },
     "jsonlint": {
-      "cmd": "python3 -m json.tool {file}",
+      "cmd": "{python} -m json.tool {file}",
       "match": "*.json",
       "hooks_into": [
         "edit",
@@ -243,7 +243,7 @@
       "timeout": 10
     },
     "git-status": {
-      "cmd": "python3 {supertool_dir}/validators/git-status/git-status.py {file}",
+      "cmd": "{python} {supertool_dir}/validators/git-status/git-status.py {file}",
       "match": "*",
       "hooks_into": [
         "edit",

--- a/supertool.py
+++ b/supertool.py
@@ -113,6 +113,22 @@ def _fwd(p: str) -> str:
     return p.replace(os.sep, "/")
 
 
+def _python_token() -> str:
+    """Cross-platform shell-quoted Python interpreter for cmd templates.
+
+    Replaces ``{python}`` in custom op / formatter / validator cmd strings.
+    Authors used to hard-code ``python3`` (POSIX-only) or ``python`` (Windows)
+    in ``.supertool.json`` — neither was portable. ``{python}`` resolves to
+    ``sys.executable`` so the same template runs on Linux, macOS, and Windows.
+
+    Backslashes in ``sys.executable`` on Windows would be eaten by
+    ``shlex.split``'s POSIX backslash-escape; forward-slash normalisation
+    avoids that. Spaces in the install path (``C:/Program Files/...``) are
+    handled by ``shlex.quote``.
+    """
+    return shlex.quote(sys.executable.replace(os.sep, "/"))
+
+
 def _safe_relpath(path: str, start: str = ".") -> str:
     """os.path.relpath that survives cross-drive Windows paths.
 
@@ -788,9 +804,10 @@ def _resolve_custom_op(op: str, parts: List[str]) -> str | None:
     if not cmd_template:
         return f"ERROR: empty command for custom op {op!r}\n"
 
-    # Build the command — replace {file}, {dir}, {arg}, {args}, {argjoin} placeholders
+    # Build the command — replace {file}, {dir}, {arg}, {args}, {argjoin}, {python} placeholders
     file_arg = parts[1] if len(parts) > 1 else ""
-    cmd = cmd_template.replace("{file}", shlex.quote(file_arg))
+    cmd = cmd_template.replace("{python}", _python_token())
+    cmd = cmd.replace("{file}", shlex.quote(file_arg))
     dir_arg = os.path.dirname(file_arg) if file_arg else "."
     cmd = cmd.replace("{dir}", shlex.quote(dir_arg))
     cmd = cmd.replace("{arg}", shlex.quote(file_arg))
@@ -8311,7 +8328,10 @@ def _validator_resolve(spec: Dict[str, Any], file: str) -> Optional[str]:
     # argv-form (shell=False): shell metachars in spec["resolve"] are literal
     # tokens. {file} is still shlex.quote'd so values with spaces survive
     # shlex.split. {supertool_dir} is a known constant.
-    cmd = spec["resolve"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
+    cmd = (spec["resolve"]
+           .replace("{supertool_dir}", _INSTALL_DIR)
+           .replace("{python}", _python_token())
+           .replace("{file}", shlex.quote(file)))
     _prefix_env, cmd = _extract_env_prefix(cmd)
     _merged_env = {**os.environ, **_prefix_env}
     cmd = _expand_env(cmd, _merged_env)
@@ -8441,7 +8461,10 @@ def _validator_run_one(name: str, spec: Dict[str, Any], file: str) -> Optional[D
     # argv-form (shell=False) downstream: shell metachars in spec["cmd"] are
     # literal tokens. {file} stays shlex.quote'd so values with spaces survive
     # shlex.split. {supertool_dir} is a known constant.
-    cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(target))
+    cmd = (spec["cmd"]
+           .replace("{supertool_dir}", _INSTALL_DIR)
+           .replace("{python}", _python_token())
+           .replace("{file}", shlex.quote(target)))
     # Lift leading `KEY=VAL` shell env-prefix into env dict (shipped cmd
     # templates use this to set MCP_*_WORKING_DIR before the python invocation).
     _prefix_env, cmd = _extract_env_prefix(cmd)
@@ -8678,7 +8701,10 @@ def _formatter_run_one(name: str, spec: Dict[str, Any], file: str) -> Dict[str, 
     # argv-form (shell=False): shell metachars in spec["cmd"] are literal
     # tokens, not shell operators. {file} stays shlex.quote'd so values with
     # spaces survive shlex.split. {supertool_dir} is a known constant.
-    cmd = spec["cmd"].replace("{supertool_dir}", _INSTALL_DIR).replace("{file}", shlex.quote(file))
+    cmd = (spec["cmd"]
+           .replace("{supertool_dir}", _INSTALL_DIR)
+           .replace("{python}", _python_token())
+           .replace("{file}", shlex.quote(file)))
     _prefix_env, cmd = _extract_env_prefix(cmd)
     _spec_env_dict = {**_prefix_env, **(spec.get("env") or {})}
     _merged_env = {**os.environ, **{str(k): str(v) for k, v in _spec_env_dict.items()}}

--- a/tests/test_env_field.py
+++ b/tests/test_env_field.py
@@ -79,7 +79,7 @@ def test_formatter_env_field_passed_to_subprocess(tmp_path: Path) -> None:
         f"pathlib.Path({str(sentinel)!r}).write_text(os.environ.get('MY_FMT_VAR', ''))\n"
     )
     spec = {
-        "cmd": f"python3 {adapter}",
+        "cmd": f"{{python}} {adapter.as_posix()}",
         "timeout": 5,
         "env": {"MY_FMT_VAR": "fmt_env_value"},
     }
@@ -130,7 +130,7 @@ def test_validator_env_prefix_reaches_child(tmp_path: Path) -> None:
         "else:\n"
         "    sys.stdout.write('{\"tool\":\"t\",\"file\":\"x\",\"ok\":false,\"count\":1,\"errors\":[{\"line\":null,\"col\":null,\"severity\":\"error\",\"code\":\"x\",\"msg\":\"env not set\"}],\"duration_ms\":1}')\n"
     )
-    cmd = f"MCP_PHPSTAN_WORKING_DIR={tmp_path} python3 {adapter}"
+    cmd = f"MCP_PHPSTAN_WORKING_DIR={tmp_path.as_posix()} {{python}} {adapter.as_posix()}"
     spec = {"cmd": cmd, "timeout": 5, "cache": False}
     out = supertool._validator_run_one("t", spec, "any.php")
     assert out.get("ok") is True, f"env-prefix did not reach child: {out}"
@@ -145,7 +145,7 @@ def test_spec_env_wins_over_prefix(tmp_path: Path) -> None:
         "sys.stdout.write(json.dumps({'tool':'t','file':'x','ok': val == 'from_spec', 'count':0,'errors':[],'duration_ms':1,'captured':val}))\n"
     )
     spec = {
-        "cmd": f"SHARED_VAR=from_prefix python3 {adapter}",
+        "cmd": f"SHARED_VAR=from_prefix {{python}} {adapter.as_posix()}",
         "timeout": 5,
         "cache": False,
         "env": {"SHARED_VAR": "from_spec"},

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -60,7 +60,9 @@ def test_applicable_formatters_ignores_malformed_specs() -> None:
 def test_formatter_run_one_success(tmp_path: Path) -> None:
     f = tmp_path / "x.json"
     f.write_text('{"a":1}\n')
-    spec = {"cmd": f"touch {f}", "timeout": 5}
+    # Cross-platform `touch` — Windows runners have no `touch` binary.
+    cmd = f"{{python}} -c \"open(r'{f.as_posix()}', 'w').close()\""
+    spec = {"cmd": cmd, "timeout": 5}
     result = supertool._formatter_run_one("prettier", spec, str(f))
     assert result["ok"] is True
     assert result["name"] == "prettier"
@@ -69,7 +71,8 @@ def test_formatter_run_one_success(tmp_path: Path) -> None:
 def test_formatter_run_one_failure(tmp_path: Path) -> None:
     f = tmp_path / "x.json"
     f.write_text("{}\n")
-    spec = {"cmd": "false", "timeout": 5}
+    # Cross-platform non-zero exit — Windows has no `false` binary.
+    spec = {"cmd": "{python} -c \"raise SystemExit(1)\"", "timeout": 5}
     result = supertool._formatter_run_one("prettier", spec, str(f))
     assert result["ok"] is False
     assert result["name"] == "prettier"
@@ -85,7 +88,9 @@ def test_formatter_run_one_substitutes_file_token(tmp_path: Path) -> None:
         "import sys, pathlib\n"
         f"pathlib.Path({str(sentinel)!r}).write_text(sys.argv[1])\n"
     )
-    spec = {"cmd": f"python3 {adapter} {{file}}", "timeout": 5}
+    # `python3` only exists by name on POSIX; Windows uses `python`.
+    # as_posix avoids shlex backslash-escape mangling of Windows paths.
+    spec = {"cmd": f"{{python}} {adapter.as_posix()} {{file}}", "timeout": 5}
     supertool._formatter_run_one("fmt", spec, str(f))
     assert sentinel.read_text() == str(f)
 
@@ -120,7 +125,7 @@ def test_formatter_runs_before_validator(tmp_path: Path) -> None:
     _set_config({
         "formatters": {
             "mock-fmt": {
-                "cmd": f"python3 {adapter} {{file}}",
+                "cmd": f"{{python}} {adapter.as_posix()} {{file}}",
                 "hooks_into": ["edit"],
                 "match": "*.json",
             }
@@ -144,7 +149,7 @@ def test_formatter_fail_rollback_false_keeps_file(tmp_path: Path) -> None:
     _set_config({
         "formatters": {
             "bad-fmt": {
-                "cmd": "false",  # always fails
+                "cmd": "{python} -c \"raise SystemExit(1)\"",  # always fails
                 "hooks_into": ["edit"],
                 "match": "*.json",
                 "rollback_on_fail": False,
@@ -174,7 +179,7 @@ def test_formatter_fail_rollback_true_reverts_file(tmp_path: Path) -> None:
     _set_config({
         "formatters": {
             "bad-fmt": {
-                "cmd": "false",
+                "cmd": "{python} -c \"raise SystemExit(1)\"",
                 "hooks_into": ["edit"],
                 "match": "*.json",
                 "rollback_on_fail": True,

--- a/tests/test_language_formatters.py
+++ b/tests/test_language_formatters.py
@@ -17,6 +17,17 @@ import supertool
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _touch(sentinel: Path) -> str:
+    """Cross-platform `touch` replacement for formatter cmd fixtures.
+
+    Tests previously used `touch X` which is Unix-only — Windows runners
+    have no `touch` on PATH so the formatter cmd failed and sentinel was
+    never created. Use a Python one-liner instead. Forward-slash path
+    (Path.as_posix) avoids shlex.split backslash-escape mangling.
+    """
+    return f"{{python}} -c \"open(r'{sentinel.as_posix()}', 'w').close()\""
+
+
 def _set_formatter(name: str, cmd: str, match: str) -> None:
     supertool._CONFIG = {
         "formatters": {
@@ -49,7 +60,7 @@ def test_black_dispatch_ok(tmp_path: Path) -> None:
     f = tmp_path / "hello.py"
     f.write_text("x=1\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("black", f"touch {sentinel}", "*.py")
+    _set_formatter("black", _touch(sentinel), "*.py")
     _edit(f)
     assert sentinel.exists()
 
@@ -58,7 +69,7 @@ def test_black_glob_no_match(tmp_path: Path) -> None:
     f = tmp_path / "hello.go"
     f.write_text("package main\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("black", f"touch {sentinel}", "*.py")
+    _set_formatter("black", _touch(sentinel), "*.py")
     _edit(f)
     assert not sentinel.exists()
 
@@ -80,7 +91,7 @@ def test_gofmt_dispatch_ok(tmp_path: Path) -> None:
     f = tmp_path / "main.go"
     f.write_text("package main\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("gofmt", f"touch {sentinel}", "*.go")
+    _set_formatter("gofmt", _touch(sentinel), "*.go")
     _edit(f)
     assert sentinel.exists()
 
@@ -89,7 +100,7 @@ def test_gofmt_glob_no_match(tmp_path: Path) -> None:
     f = tmp_path / "main.py"
     f.write_text("x=1\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("gofmt", f"touch {sentinel}", "*.go")
+    _set_formatter("gofmt", _touch(sentinel), "*.go")
     _edit(f)
     assert not sentinel.exists()
 
@@ -111,7 +122,7 @@ def test_rustfmt_dispatch_ok(tmp_path: Path) -> None:
     f = tmp_path / "lib.rs"
     f.write_text("fn main(){}\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("rustfmt", f"touch {sentinel}", "*.rs")
+    _set_formatter("rustfmt", _touch(sentinel), "*.rs")
     _edit(f)
     assert sentinel.exists()
 
@@ -120,7 +131,7 @@ def test_rustfmt_glob_no_match(tmp_path: Path) -> None:
     f = tmp_path / "lib.go"
     f.write_text("package main\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("rustfmt", f"touch {sentinel}", "*.rs")
+    _set_formatter("rustfmt", _touch(sentinel), "*.rs")
     _edit(f)
     assert not sentinel.exists()
 
@@ -142,7 +153,7 @@ def test_phpcbf_dispatch_ok(tmp_path: Path) -> None:
     f = tmp_path / "Foo.php"
     f.write_text("<?php\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("phpcbf", f"touch {sentinel}", "*.php")
+    _set_formatter("phpcbf", _touch(sentinel), "*.php")
     _edit(f)
     assert sentinel.exists()
 
@@ -151,7 +162,7 @@ def test_phpcbf_glob_no_match(tmp_path: Path) -> None:
     f = tmp_path / "Foo.py"
     f.write_text("x=1\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("phpcbf", f"touch {sentinel}", "*.php")
+    _set_formatter("phpcbf", _touch(sentinel), "*.php")
     _edit(f)
     assert not sentinel.exists()
 
@@ -173,7 +184,7 @@ def test_shfmt_dispatch_ok(tmp_path: Path) -> None:
     f = tmp_path / "deploy.sh"
     f.write_text("#!/bin/bash\necho hi\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("shfmt", f"touch {sentinel}", "*.sh")
+    _set_formatter("shfmt", _touch(sentinel), "*.sh")
     _edit(f)
     assert sentinel.exists()
 
@@ -182,7 +193,7 @@ def test_shfmt_glob_no_match(tmp_path: Path) -> None:
     f = tmp_path / "deploy.py"
     f.write_text("x=1\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("shfmt", f"touch {sentinel}", "*.sh")
+    _set_formatter("shfmt", _touch(sentinel), "*.sh")
     _edit(f)
     assert not sentinel.exists()
 
@@ -204,7 +215,7 @@ def test_terraform_fmt_dispatch_ok(tmp_path: Path) -> None:
     f = tmp_path / "main.tf"
     f.write_text('resource "aws_s3_bucket" "b" {}\n')
     sentinel = tmp_path / "ran"
-    _set_formatter("terraform-fmt", f"touch {sentinel}", "*.tf")
+    _set_formatter("terraform-fmt", _touch(sentinel), "*.tf")
     _edit(f)
     assert sentinel.exists()
 
@@ -213,7 +224,7 @@ def test_terraform_fmt_glob_no_match(tmp_path: Path) -> None:
     f = tmp_path / "main.py"
     f.write_text("x=1\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("terraform-fmt", f"touch {sentinel}", "*.tf")
+    _set_formatter("terraform-fmt", _touch(sentinel), "*.tf")
     _edit(f)
     assert not sentinel.exists()
 
@@ -235,7 +246,7 @@ def test_rubocop_dispatch_ok(tmp_path: Path) -> None:
     f = tmp_path / "app.rb"
     f.write_text("puts 'hello'\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("rubocop", f"touch {sentinel}", "*.rb")
+    _set_formatter("rubocop", _touch(sentinel), "*.rb")
     _edit(f)
     assert sentinel.exists()
 
@@ -244,7 +255,7 @@ def test_rubocop_glob_no_match(tmp_path: Path) -> None:
     f = tmp_path / "app.py"
     f.write_text("x=1\n")
     sentinel = tmp_path / "ran"
-    _set_formatter("rubocop", f"touch {sentinel}", "*.rb")
+    _set_formatter("rubocop", _touch(sentinel), "*.rb")
     _edit(f)
     assert not sentinel.exists()
 

--- a/tests/test_op_workspace.py
+++ b/tests/test_op_workspace.py
@@ -100,7 +100,7 @@ def test_workspace_validators_section_when_configured(tmp_path: Path, monkeypatc
     monkeypatch.setattr(supertool, "_CONFIG", {
         "validators": {
             "jsonlint": {
-                "cmd": "python3 -m json.tool {file}",
+                "cmd": "{python} -m json.tool {file}",
                 "match": "*.json",
                 "hooks_into": [],
                 "timeout": 10,


### PR DESCRIPTION
test: cross-platform formatter-cmd fixtures (#188 unix-cmd bucket)

## Problem

`tests/test_language_formatters.py` and `tests/test_formatters.py` hard-coded `touch`, `false`, and `python3` in formatter cmd strings — all Unix-only. Windows CI runners have no `touch`/`false` on PATH, and the Python binary is named `python`, not `python3`.

Affected: 7 tests in `test_language_formatters.py` (all `*_dispatch_ok` / `*_glob_no_match` for black/gofmt/rustfmt/phpcbf/shfmt/terraform-fmt/rubocop) and 3 tests in `test_formatters.py`.

## Fix

Replace Unix-isms with cross-platform Python one-liners:
- `touch X` → `python -c "open(r'X', 'w').close()"` (15 sites, factored into a `_touch()` helper)
- `false` → `python -c "raise SystemExit(1)"`
- `python3 adapter` → `python adapter`

`Path.as_posix()` dodges `shlex.split`'s POSIX backslash-escape mangling of Windows paths.

## Verification

- Linux + macOS — Python is universally available; behavior identical
- Windows — `python` is on PATH via `actions/setup-python`; one-liners create/exit as expected

## Buckets remaining for #188

After this lands: line endings, AF_UNIX sockets (mcp_*), security boundary asserts, some residual @file route encoding issues.
