### PR TITLE
fix: @file route accepts Windows drive-letter paths (#188)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,5 @@ jobs:
           python -c "import shutil; shutil.copyfile('supertool.py', 'supertool')"
           python -c "import os, stat; os.chmod('supertool', os.stat('supertool').st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)"
       - name: Run tests (full suite — slow tests included)
-        # Override pyproject addopts default of `-m 'not slow'` so CI exercises
-        # the slow MCP-fallback and batch-stress paths the dev inner loop skips.
-        run: pytest -m ''
+        # DIAG #188: target buckets for traceback triage. Revert before merge.
+        run: pytest tests/test_at_file_route.py tests/test_batch_op.py -m '' --tb=short --no-cov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,5 +38,6 @@ jobs:
           python -c "import shutil; shutil.copyfile('supertool.py', 'supertool')"
           python -c "import os, stat; os.chmod('supertool', os.stat('supertool').st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)"
       - name: Run tests (full suite — slow tests included)
-        # DIAG #188: target buckets for traceback triage. Revert before merge.
-        run: pytest tests/test_at_file_route.py tests/test_batch_op.py -m '' --tb=short --no-cov
+        # Override pyproject addopts default of `-m 'not slow'` so CI exercises
+        # the slow MCP-fallback and batch-stress paths the dev inner loop skips.
+        run: pytest -m ''

--- a/supertool.py
+++ b/supertool.py
@@ -2499,7 +2499,7 @@ def _glob_files(
 # Dispatch
 # ---------------------------------------------------------------------------
 
-_DRIVE_LETTER = re.compile(r"^[A-Za-z]$")
+_DRIVE_LETTER = re.compile(r"^@?[A-Za-z]$")
 _URL_SCHEMES = ("http", "https", "ftp", "ftps", "ssh", "git", "file", "ws", "wss")
 # Numeric port, optionally followed by '/path' or '?query' or end — used to
 # absorb 'https://host' + ':8080/path' fragments that arose from `:`-splitting.


### PR DESCRIPTION
fix: @file route accepts Windows drive-letter paths (#188 dispatch bucket)

## Problem

`_split_arg` recognised bare Windows drive letters (`C:\path`) but missed the `@`-prefixed form used by the @file route (`@C:\path`). On Windows CI runners:

```
edit:@C:\Users\runneradmin\AppData\Local\Temp\pytest-.../e.json
```

was split into:
```
["edit", "@C", "\\Users\\runneradmin\\...", ...]
```

`len(parts) > 2` triggered the "fields on the colon CLI" rejection. Symptom: `ERROR: @file not found: C`.

## Fix

One-character regex change:

```py
- _DRIVE_LETTER = re.compile(r"^[A-Za-z]$")
+ _DRIVE_LETTER = re.compile(r"^@?[A-Za-z]$")
```

So drive-letter absorption now also fires after the `@` marker. No behavior change for POSIX paths or non-@ ops — bare `C:\path` continued to work, `@C:\path` now joins.

## Impact

Recovers ~25+ Windows tests across:
- `test_at_file_route` (all 22 failures)
- `test_batch_op` (8 failures)
- `test_chaos_multi_op_chains` (likely similar)
- `test_dispatch::test_dispatch_replace_no_path_defaults_to_cwd`

## Buckets remaining for #188

AF_UNIX sockets (test_mcp_*), security boundary asserts, residual line endings.
