### PR TITLE
fix: publish allowlist os.pathsep + tempfile.gettempdir (#188)

### DIFF
--- a/presets/_publish_safety.py
+++ b/presets/_publish_safety.py
@@ -66,13 +66,16 @@ def _body_allowlist() -> tuple[Path, ...]:
 
     Additive sources:
       1. `_DEFAULT_BODY_ALLOWLIST`
-      2. `$SUPERTOOL_PUBLISH_BODY_ALLOWLIST` env (colon-separated)
+      2. `$SUPERTOOL_PUBLISH_BODY_ALLOWLIST` env (os.pathsep-separated:
+         `:` on POSIX, `;` on Windows)
       3. `"publish_body_allowlist": [...]` in `.supertool.json`
     """
     paths = list(_DEFAULT_BODY_ALLOWLIST)
     extra = os.environ.get("SUPERTOOL_PUBLISH_BODY_ALLOWLIST", "")
     if extra:
-        paths.extend(p for p in extra.split(":") if p)
+        # os.pathsep — `:` on POSIX, `;` on Windows. A literal `:` would
+        # mangle Windows paths like `C:\Temp\drafts` at the drive letter.
+        paths.extend(p for p in extra.split(os.pathsep) if p)
     cfg_extra = _supertool_config().get("publish_body_allowlist")
     if isinstance(cfg_extra, list):
         paths.extend(str(p) for p in cfg_extra if isinstance(p, str))
@@ -109,7 +112,7 @@ def safe_resolve_body_path(arg: str) -> Path:
         f"ERROR: publish body path escapes the safety allowlist: {raw_path!r}\n"
         f"  resolved to: {resolved}\n"
         f"  allowed dirs (relative to cwd): {rel}\n"
-        f"  Extend (additive): SUPERTOOL_PUBLISH_BODY_ALLOWLIST=path1:path2\n"
+        f"  Extend (additive): SUPERTOOL_PUBLISH_BODY_ALLOWLIST=path1{os.pathsep}path2\n"
         f"    or `\"publish_body_allowlist\": [\"path1\"]` in .supertool.json\n"
     )
     sys.exit(2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,12 +27,15 @@ def pytest_configure(config):  # noqa: ARG001
     # `tmp_path` for body files (outside the production .max/ / drafts/ /
     # posts/ / blog/ allowlist) and don't `|force`, so opt the suite in.
     # Security regression tests in test_security_publish.py unset these.
-    pytest_root = os.environ.get("PYTEST_CURRENT_TEST") or "/tmp/pytest-of-"
-    # tmp_path lives under /private/var/folders (macOS) or /tmp (Linux).
-    # Add the broadest sensible roots to the allowlist for tests.
+    # tmp_path lives under tempfile.gettempdir() — /tmp (Linux), /var/folders
+    # (macOS), C:\Users\...\AppData\Local\Temp (Windows). Joining with the
+    # platform's path separator (os.pathsep) keeps the Windows drive-letter
+    # colon from being interpreted as a list separator.
+    import tempfile
+    _tmp_roots = [tempfile.gettempdir(), "/tmp", "/var/folders", "/private/var/folders"]
     os.environ.setdefault(
         "SUPERTOOL_PUBLISH_BODY_ALLOWLIST",
-        "/private/var/folders:/tmp:/var/folders",
+        os.pathsep.join(_tmp_roots),
     )
     os.environ.setdefault("SUPERTOOL_NO_PUBLISH_CONFIRM", "1")
 


### PR DESCRIPTION
fix: publish allowlist uses os.pathsep + tempfile.gettempdir on Windows (#188)

## Problem

The #149 publish-safety guard rejected every `tmp_path` body on Windows runners:

```
ERROR: publish body path escapes the safety allowlist: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-...\\p.md'
```

Two root causes:

1. **`_publish_safety.py:75`** — `extra.split(":")` for `SUPERTOOL_PUBLISH_BODY_ALLOWLIST`. The drive-letter colon in `C:\Temp\drafts` is mistaken for a list separator. Use `os.pathsep` (`:` on POSIX, `;` on Windows).

2. **`tests/conftest.py:35`** — hard-coded `"/private/var/folders:/tmp:/var/folders"`. All Unix paths; Windows pytest `tmp_path` lives under `C:\Users\runneradmin\AppData\Local\Temp\`. Build the allowlist from `tempfile.gettempdir()` (real platform tmp) + the historical Unix roots, joined with `os.pathsep`.

## Impact

Recovers ~20 Windows test failures across:
- `test_devto` (7 SystemExit:2 + 2 assertion)
- `test_comment_file` (4)
- `test_security_devto` (4)
- `test_security_hashnode` (1)

## Buckets remaining for #188

AF_UNIX sockets (test_mcp_*), formatter binaries (skipif), test_security_hardening_150 (encoding/permission), residual edge-cases.
