### PR TITLE
test: CRLF write_bytes + skipif Windows chmod/symlink/exec (#188)

### DIFF
--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
+import pytest
 import supertool
 
 
@@ -235,6 +237,10 @@ def test_grep_recursive_invalid_regex(tmp_path: Path) -> None:
     assert isinstance(results, list)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows filesystem ignores chmod 0o000 — file stays readable.",
+)
 def test_grep_recursive_unreadable_file(tmp_path: Path) -> None:
     """_grep_recursive skips unreadable files."""
     f = tmp_path / "secret.php"
@@ -301,6 +307,10 @@ def test_grep_recursive_context_invalid_regex(tmp_path: Path) -> None:
     assert isinstance(groups, list)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows filesystem ignores chmod 0o000 — file stays readable.",
+)
 def test_grep_recursive_context_unreadable_file(tmp_path: Path) -> None:
     """_grep_recursive_context skips unreadable files."""
     f = tmp_path / "secret.php"

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -442,6 +443,10 @@ def test_map_directory_no_supported_files(tmp_path: Path) -> None:
     assert "no supported files" in out
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows filesystem ignores chmod 0o000 — file stays readable.",
+)
 def test_regex_extract_oserror(tmp_path: Path) -> None:
     """_regex_extract returns [] when file can't be read."""
     f = tmp_path / "broken.py"

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
+import pytest
 import supertool
 
 
 def test_read_returns_line_numbered_content(tmp_path: Path) -> None:
     f = tmp_path / "hello.py"
-    f.write_text("line1\nline2\nline3\n")
+    # write_bytes preserves LF — write_text on Windows translates \n → \r\n,
+    # bumping byte count and adding a "crlf" meta tag.
+    f.write_bytes(b"line1\nline2\nline3\n")
     out = supertool.op_read(str(f))
     assert "(3 lines, 18 bytes)" in out
     assert "     1→line1" in out
@@ -199,6 +203,11 @@ def test_dispatch_read_full_keyword(tmp_path: Path, monkeypatch) -> None:
 # Meta suffix (symlink / git / encoding / mtime / exec / crlf / conflict)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows symlinks resolve through the \\\\?\\ UNC prefix; the test "
+    "assertion expects a POSIX-style relative or absolute target.",
+)
 def test_read_meta_symlink(tmp_path: Path) -> None:
     target = tmp_path / "real.txt"
     target.write_text("hi")
@@ -231,7 +240,9 @@ def test_read_meta_conflict_markers(tmp_path: Path) -> None:
 
 def test_read_meta_clean_tracked_is_silent(tmp_path: Path) -> None:
     f = tmp_path / "plain.txt"
-    f.write_text("hello\n")
+    # write_bytes preserves LF — write_text on Windows would emit \r\n and
+    # trigger the "crlf" meta tag this test asserts is absent.
+    f.write_bytes(b"hello\n")
     out = supertool.op_read(str(f))
     first = out.splitlines()[0]
     for tok in ("bin", "non-utf8", "crlf", "cf!", "->"):
@@ -248,6 +259,10 @@ import subprocess as _sp
 import time as _time
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows filesystem doesn't expose Unix executable bit — chmod 0o755 is a no-op.",
+)
 def test_path_meta_suffix_executable_bit(tmp_path: Path) -> None:
     f = tmp_path / "run.sh"
     f.write_text("#!/bin/sh\necho hi\n")


### PR DESCRIPTION
test: CRLF write_bytes + skipif Windows-incompatible chmod/symlink/exec (#188)

## Problems

Six remaining Windows-only failures, all small POSIX assumptions in tests:

1. `test_read_returns_line_numbered_content`, `test_read_meta_clean_tracked_is_silent` — `Path.write_text("...\n")` translates `\n` to `\r\n` on Windows. Byte count expected `18` actual `21`; second test asserts `"crlf"` not in output but the meta tag fires.
2. `test_read_meta_symlink` — Windows resolves symlinks through `\\?\` UNC prefix; the assertion expects a POSIX-style target.
3. `test_path_meta_suffix_executable_bit` — Windows has no Unix exec bit; `chmod 0o755` is a no-op.
4. `test_grep_recursive_unreadable_file`, `test_grep_recursive_context_unreadable_file`, `test_regex_extract_oserror` — all rely on `chmod(0o000)` to trigger `OSError` so the function skips the file. Windows ignores Unix mode bits; the file stays readable.

## Fixes

- `write_bytes(b"...")` instead of `write_text("...")` on the two CRLF-sensitive tests.
- `@pytest.mark.skipif(sys.platform == "win32", ...)` on the symlink, exec-bit, and three chmod tests.

POSIX behaviour unchanged.

## Buckets remaining for #188

Formatter binary tests (skipif when missing), test_op_format/test_notifiers (formatter routing), test_at_file_route TOML, test_chaos Windows file-lock concurrency, test_huge_batch slow tests (10min on Windows runners — separate `@slow` mark).
