### PR TITLE
fix: {python} in notifier cmds + cross-platform fixtures (#188)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -8275,8 +8275,9 @@ def _run_notifiers(op: str, path: str, line: Optional[int] = None,
     if pre_content is not None:
         try:
             ext = os.path.splitext(path)[1] or ".txt"
+            # tempfile.gettempdir() — `/tmp` is POSIX-only.
             fd, before_file = tempfile.mkstemp(
-                prefix="supertool-before-", suffix=ext, dir="/tmp")
+                prefix="supertool-before-", suffix=ext, dir=tempfile.gettempdir())
             with os.fdopen(fd, "wb") as f:
                 f.write(pre_content)
         except OSError:
@@ -8293,6 +8294,7 @@ def _run_notifiers(op: str, path: str, line: Optional[int] = None,
             s = str(val) if val is not None and val != "" else ""
             return shlex.quote(s)
         cmd = (cmd
+               .replace("{python}", _python_token())
                .replace("{op}", _sub(op))
                .replace("{file}", _sub(path))
                .replace("{line}", _sub(line))

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -27,7 +27,7 @@ def test_applicable_notifiers_filters_by_op_and_match(tmp_path: Path) -> None:
     _set_config({
         "notifiers": {
             "watch-php": {
-                "cmd": "true",
+                "cmd": "{python} -c \"pass\"",
                 "match": "*.php",
                 "hooks_into": ["edit", "read"],
             }
@@ -44,10 +44,15 @@ def test_applicable_notifiers_filters_by_op_and_match(tmp_path: Path) -> None:
 def test_notifier_fires_on_edit(tmp_path: Path) -> None:
     """Mutating an edit-hooked notifier writes its side effect."""
     marker = tmp_path / "fired.txt"
+    # sh -c is POSIX-only; use python so the cmd works on Windows too.
     _set_config({
         "notifiers": {
             "marker": {
-                "cmd": f"sh -c 'echo {{op}} {{file}} > {marker}'",
+                "cmd": (
+                    f"{{python}} -c \"import sys, pathlib; "
+                    f"pathlib.Path(r'{marker.as_posix()}').write_text(sys.argv[1] + ' ' + sys.argv[2])\" "
+                    f"{{op}} {{file}}"
+                ),
                 "match": "*",
                 "hooks_into": ["edit"],
             }
@@ -70,7 +75,11 @@ def test_notifier_fires_on_read(tmp_path: Path) -> None:
     _set_config({
         "notifiers": {
             "read-watch": {
-                "cmd": f"sh -c 'echo {{op}} {{file}} > {marker}'",
+                "cmd": (
+                    f"{{python}} -c \"import sys, pathlib; "
+                    f"pathlib.Path(r'{marker.as_posix()}').write_text(sys.argv[1] + ' ' + sys.argv[2])\" "
+                    f"{{op}} {{file}}"
+                ),
                 "match": "*",
                 "hooks_into": ["read"],
             }
@@ -131,7 +140,7 @@ def test_notifier_debug_log_off_by_default(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("SUPERTOOL_NOTIFIER_DEBUG", raising=False)
     _set_config({
         "notifiers": {
-            "n": {"cmd": "true", "match": "*", "hooks_into": ["edit"]}
+            "n": {"cmd": "{python} -c \"pass\"", "match": "*", "hooks_into": ["edit"]}
         }
     })
     supertool._run_notifiers("edit", "x.php")
@@ -146,7 +155,7 @@ def test_notifier_debug_log_via_env(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("SUPERTOOL_NOTIFIER_DEBUG_LOG", str(log))
     _set_config({
         "notifiers": {
-            "n": {"cmd": "true", "match": "*.php", "hooks_into": ["edit"]}
+            "n": {"cmd": "{python} -c \"pass\"", "match": "*.php", "hooks_into": ["edit"]}
         }
     })
     supertool._run_notifiers("edit", "x.php")
@@ -165,7 +174,7 @@ def test_notifier_debug_log_via_config(tmp_path: Path, monkeypatch) -> None:
     _set_config({
         "notifier_debug": True,
         "notifiers": {
-            "n": {"cmd": "true", "match": "*", "hooks_into": ["edit"]}
+            "n": {"cmd": "{python} -c \"pass\"", "match": "*", "hooks_into": ["edit"]}
         }
     })
     supertool._run_notifiers("edit", "y.php")
@@ -189,8 +198,9 @@ def test_empty_placeholders_preserve_positional_argv(tmp_path: Path) -> None:
     _set_config({
         "notifiers": {
             "echo-argv": {
-                # 5 positional slots after the script — same shape as notify.py
-                "cmd": f'python3 -c "import sys, json; open(\'{marker}\', \'w\').write(json.dumps(sys.argv[1:]))" '
+                # 5 positional slots after the script — same shape as notify.py.
+                # Use {python} token + as_posix so the cmd works on Windows too.
+                "cmd": f'{{python}} -c "import sys, json; open(r\'{marker.as_posix()}\', \'w\').write(json.dumps(sys.argv[1:]))" '
                        f'{{op}} {{file}} {{line}} {{line_end}} {{before_file}}',
                 "match": "*",
                 "hooks_into": ["edit"],

--- a/tests/test_notifiers_cursor_witness.py
+++ b/tests/test_notifiers_cursor_witness.py
@@ -18,6 +18,12 @@ from pathlib import Path
 import pytest
 
 
+pytestmark = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="cursor-witness notifier uses AF_UNIX sockets — not available on this platform",
+)
+
+
 NOTIFY_SCRIPT = str(Path(__file__).parent.parent / "notifiers" / "cursor-witness" / "notify.py")
 
 

--- a/tests/test_op_format.py
+++ b/tests/test_op_format.py
@@ -26,7 +26,7 @@ def test_op_format_no_formatters_configured() -> None:
 
 
 def test_op_format_no_path_returns_error() -> None:
-    _set_formatters({"fmt": {"cmd": "true", "match": "*.json"}})
+    _set_formatters({"fmt": {"cmd": "{python} -c \"pass\"", "match": "*.json"}})
     result = supertool.op_format("")
     assert result.startswith("ERROR")
 
@@ -37,7 +37,7 @@ def test_op_format_runs_matching_formatter(tmp_path: Path) -> None:
     sentinel = tmp_path / "ran"
     _set_formatters({
         "prettier": {
-            "cmd": f"touch {sentinel}",
+            "cmd": f"{{python}} -c \"open(r\'{sentinel.as_posix()}\', \'w\').close()\"",
             "match": "*.json",
         }
     })
@@ -53,8 +53,8 @@ def test_op_format_with_tool_filter(tmp_path: Path) -> None:
     sentinel_a = tmp_path / "ran_a"
     sentinel_b = tmp_path / "ran_b"
     _set_formatters({
-        "fmt-a": {"cmd": f"touch {sentinel_a}", "match": "*.json"},
-        "fmt-b": {"cmd": f"touch {sentinel_b}", "match": "*.json"},
+        "fmt-a": {"cmd": f"{{python}} -c \"open(r\'{sentinel_a.as_posix()}\', \'w\').close()\"", "match": "*.json"},
+        "fmt-b": {"cmd": f"{{python}} -c \"open(r\'{sentinel_b.as_posix()}\', \'w\').close()\"", "match": "*.json"},
     })
     result = supertool.op_format(str(f), tool_filter=["fmt-a"])
     assert sentinel_a.exists()
@@ -64,7 +64,7 @@ def test_op_format_with_tool_filter(tmp_path: Path) -> None:
 
 
 def test_op_format_tool_filter_no_match() -> None:
-    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    _set_formatters({"prettier": {"cmd": "{python} -c \"pass\"", "match": "*.json"}})
     result = supertool.op_format("x.json", tool_filter=["nonexistent"])
     assert "no formatters matched filter" in result
 
@@ -72,7 +72,7 @@ def test_op_format_tool_filter_no_match() -> None:
 def test_op_format_no_glob_match(tmp_path: Path) -> None:
     f = tmp_path / "x.php"
     f.write_text("<?php\n")
-    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    _set_formatters({"prettier": {"cmd": "{python} -c \"pass\"", "match": "*.json"}})
     result = supertool.op_format(str(f))
     assert "no formatters matched this file" in result
 
@@ -80,7 +80,7 @@ def test_op_format_no_glob_match(tmp_path: Path) -> None:
 def test_op_format_formatter_failure_shown(tmp_path: Path) -> None:
     f = tmp_path / "x.json"
     f.write_text("{}\n")
-    _set_formatters({"bad-fmt": {"cmd": "false", "match": "*.json"}})
+    _set_formatters({"bad-fmt": {"cmd": "{python} -c \"raise SystemExit(1)\"", "match": "*.json"}})
     result = supertool.op_format(str(f))
     assert "fail" in result
     assert "bad-fmt" in result
@@ -93,7 +93,7 @@ def test_op_format_formatter_failure_shown(tmp_path: Path) -> None:
 def test_op_format_verbose_shows_marker(tmp_path: Path) -> None:
     f = tmp_path / "x.json"
     f.write_text("{}\n")
-    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    _set_formatters({"prettier": {"cmd": "{python} -c \"pass\"", "match": "*.json"}})
     result = supertool.op_format(str(f), verbose=True)
     assert "[verbose]" in result
 
@@ -101,7 +101,7 @@ def test_op_format_verbose_shows_marker(tmp_path: Path) -> None:
 def test_op_format_non_verbose_no_marker(tmp_path: Path) -> None:
     f = tmp_path / "x.json"
     f.write_text("{}\n")
-    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    _set_formatters({"prettier": {"cmd": "{python} -c \"pass\"", "match": "*.json"}})
     result = supertool.op_format(str(f), verbose=False)
     assert "[verbose]" not in result
 
@@ -113,7 +113,7 @@ def test_op_format_non_verbose_no_marker(tmp_path: Path) -> None:
 def test_dispatch_format_verbose_flag(tmp_path: Path) -> None:
     f = tmp_path / "x.json"
     f.write_text("{}\n")
-    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    _set_formatters({"prettier": {"cmd": "{python} -c \"pass\"", "match": "*.json"}})
     result = supertool.dispatch(f"format:{f}:verbose")
     assert "[verbose]" in result
 
@@ -124,8 +124,8 @@ def test_dispatch_format_tools_and_verbose(tmp_path: Path) -> None:
     sentinel_a = tmp_path / "ran_a"
     sentinel_b = tmp_path / "ran_b"
     _set_formatters({
-        "fmt-a": {"cmd": f"touch {sentinel_a}", "match": "*.json"},
-        "fmt-b": {"cmd": f"touch {sentinel_b}", "match": "*.json"},
+        "fmt-a": {"cmd": f"{{python}} -c \"open(r\'{sentinel_a.as_posix()}\', \'w\').close()\"", "match": "*.json"},
+        "fmt-b": {"cmd": f"{{python}} -c \"open(r\'{sentinel_b.as_posix()}\', \'w\').close()\"", "match": "*.json"},
     })
     result = supertool.dispatch(f"format:{f}:fmt-a:verbose")
     assert sentinel_a.exists()

--- a/tests/test_op_staged.py
+++ b/tests/test_op_staged.py
@@ -57,7 +57,8 @@ def test_validate_staged_single_file(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     _set_validators({
         "jsoncheck": {
-            "cmd": "printf '%s' '{\"tool\":\"jsoncheck\",\"ok\":true,\"count\":0,\"errors\":[],\"duration_ms\":1}'",
+            # printf is POSIX-only; use python so the cmd works on Windows too.
+            "cmd": "{python} -c \"import sys; sys.stdout.write('{\\\"tool\\\":\\\"jsoncheck\\\",\\\"ok\\\":true,\\\"count\\\":0,\\\"errors\\\":[],\\\"duration_ms\\\":1}')\"",
             "match": "*.json",
             "hooks_into": ["edit"],
         }
@@ -98,7 +99,7 @@ def test_format_staged_single_file(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     sentinel = tmp_path / "fmt_ran"
     _set_formatters({
         "prettier": {
-            "cmd": f"touch {sentinel}",
+            "cmd": f"{{python}} -c \"open(r\'{sentinel.as_posix()}\', \'w\').close()\"",
             "match": "*.json",
         }
     })
@@ -155,7 +156,7 @@ def test_format_staged_verbose_passes_through(tmp_path: Path, monkeypatch: pytes
     _git(["add", "style.json"], repo)
 
     _set_formatters({
-        "prettier": {"cmd": "true", "match": "*.json"},
+        "prettier": {"cmd": "{python} -c \"pass\"", "match": "*.json"},
     })
     result = supertool.op_format_staged(verbose=True)
     assert "[verbose]" in result
@@ -198,6 +199,6 @@ def test_dispatch_format_staged_verbose(tmp_path: Path, monkeypatch: pytest.Monk
     f.write_text("{}\n")
     _git(["add", "style.json"], repo)
 
-    _set_formatters({"prettier": {"cmd": "true", "match": "*.json"}})
+    _set_formatters({"prettier": {"cmd": "{python} -c \"pass\"", "match": "*.json"}})
     result = supertool.dispatch("format_staged:verbose")
     assert "[verbose]" in result


### PR DESCRIPTION
fix: {python} token in notifier cmds + cross-platform fixtures (#188)

## Problem

Seven Windows failures across test_op_format, test_op_staged, test_notifiers — all formatter / notifier cmd fixtures hard-coded POSIX-only binaries:

- `touch X` (no `touch.exe` on Windows runners)
- `cmd: "true"` / `cmd: "false"` (no `true.exe` / `false.exe`)
- `cmd: "printf '%s' '<json>'"` (no `printf.exe`)

Notifier dispatch (`_run_notifiers`) also lacked `{python}` substitution, so a portable test fixture couldn't be expressed even after #192 introduced the token for formatters / validators / custom ops.

## Fix

1. **supertool.py `_run_notifiers`** — add `{python}` to the substitution list (mirrors the 4 chokepoints #192 already updated). Switch tempfile dir from hard-coded `/tmp` to `tempfile.gettempdir()`.

2. **Test fixtures** — replace each Unix-only literal:
   - `f"touch {X}"` → `f"{{python}} -c \"open(r'{X.as_posix()}', 'w').close()\""`
   - `"cmd": "true"` → `"cmd": "{python} -c \\"pass\\""`
   - `"cmd": "false"` → `"cmd": "{python} -c \\"raise SystemExit(1)\\""`
   - `"cmd": "printf '%s' '<json>'"` → `"cmd": "{python} -c \\"import sys; sys.stdout.write('...')\\""`

POSIX behaviour unchanged (Python is always on PATH).

## Buckets remaining for #188

Formatter binary tests requiring real php-cs-fixer/phpcbf/prettier (skipif when binary missing), test_at_file_route TOML, test_chaos Windows file-lock concurrency, test_security_* (5F), test_dispatch (2F), test_bluesky (1F), test_huge_batch slow tests.
