### PR TITLE
test: skipif Windows on bash-shebang formatter suites (#188)

### DIFF
--- a/tests/test_formatters_php_cs_fixer.py
+++ b/tests/test_formatters_php_cs_fixer.py
@@ -9,6 +9,13 @@ from pathlib import Path
 
 import pytest
 
+import sys
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Adapter tests use bash shebang stubs (#!/usr/bin/env bash) — not available on Windows runners",
+)
+
 ADAPTER = Path(__file__).parent.parent / "formatters" / "php-cs-fixer" / "php-cs-fixer.py"
 
 

--- a/tests/test_formatters_phpcbf.py
+++ b/tests/test_formatters_phpcbf.py
@@ -9,6 +9,13 @@ from pathlib import Path
 
 import pytest
 
+import sys
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Adapter tests use bash shebang stubs (#!/usr/bin/env bash) — not available on Windows runners",
+)
+
 ADAPTER = Path(__file__).parent.parent / "formatters" / "phpcbf" / "phpcbf.py"
 
 

--- a/tests/test_formatters_prettier_write.py
+++ b/tests/test_formatters_prettier_write.py
@@ -9,6 +9,13 @@ from pathlib import Path
 
 import pytest
 
+import sys
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Adapter tests use bash shebang stubs (#!/usr/bin/env bash) — not available on Windows runners",
+)
+
 ADAPTER = Path(__file__).parent.parent / "formatters" / "prettier-write" / "prettier-write.py"
 
 


### PR DESCRIPTION
test: skipif Windows on bash-shebang formatter adapter suites (#188)

## Problem

`test_formatters_phpcbf.py`, `test_formatters_php_cs_fixer.py`, `test_formatters_prettier_write.py` all create shell stubs via `#!/usr/bin/env bash` and rely on POSIX exec semantics to drive the adapter's exit-code paths:

```python
stub.write_text("#!/usr/bin/env bash\nexit 0\n")
stub.chmod(0o755)
env = {**os.environ, "PHPCBF_BIN": str(stub)}
subprocess.run([sys.executable, str(ADAPTER), str(f)], env=env)
```

9 such stubs across the 3 files. Windows runners have no `bash` on PATH (the shebang is ignored) and `chmod 0o755` is a no-op — the adapter then fails to spawn the binary, breaking 8 Windows tests.

## Fix

Module-level `pytestmark = pytest.mark.skipif(sys.platform == "win32", ...)` on each of the 3 suites. The adapters themselves are still exercised by `test_language_formatters` (which uses cross-platform `{python}` stubs from #192).

POSIX behaviour unchanged.

## Buckets remaining for #188

test_at_file_route TOML (4F), test_chaos Windows file-lock concurrency (2F), test_security_* path/encoding edge cases (~5F), test_dispatch (2F), test_bluesky (1F), test_huge_batch slow tests.
