### PR TITLE
fix: formatter adapter BIN accepts command line + Python stubs (#188)

### DIFF
--- a/formatters/php-cs-fixer/php-cs-fixer.py
+++ b/formatters/php-cs-fixer/php-cs-fixer.py
@@ -52,7 +52,13 @@ def main() -> None:
         return
 
     file = sys.argv[1]
-    phpcsfixer_bin = os.environ.get("PHPCSFIXER_BIN", "php-cs-fixer")
+    phpcsfixer_bin_cmd_str = os.environ.get("PHPCSFIXER_BIN", "php-cs-fixer")
+    # Accept either a single binary path or a shlex-split command line.
+    # Cross-platform test stubs pass e.g. "python /path/stub.py" so the
+    # stub runs on Windows too (no #!/usr/bin/env bash dependency).
+    import shlex as _shlex
+    bin_cmd = _shlex.split(phpcsfixer_bin_cmd_str.replace("\\", "/"), posix=True) or ["php-cs-fixer"]
+    phpcsfixer_bin = bin_cmd[0]
     phpcsfixer_config = os.environ.get("PHPCSFIXER_CONFIG", "")
 
     if not shutil.which(phpcsfixer_bin) and not (
@@ -80,7 +86,7 @@ def main() -> None:
         })
         return
 
-    cmd = [phpcsfixer_bin, "fix", "--allow-risky=yes"]
+    cmd = [*bin_cmd, "fix", "--allow-risky=yes"]
     if phpcsfixer_config:
         cmd += ["--config", phpcsfixer_config]
     cmd.append(file)

--- a/formatters/phpcbf/phpcbf.py
+++ b/formatters/phpcbf/phpcbf.py
@@ -52,7 +52,13 @@ def main() -> None:
         return
 
     file = sys.argv[1]
-    phpcbf_bin = os.environ.get("PHPCBF_BIN", "phpcbf")
+    phpcbf_bin_cmd_str = os.environ.get("PHPCBF_BIN", "phpcbf")
+    # Accept either a single binary path or a shlex-split command line.
+    # Cross-platform test stubs pass e.g. "python /path/stub.py" so the
+    # stub runs on Windows too (no #!/usr/bin/env bash dependency).
+    import shlex as _shlex
+    bin_cmd = _shlex.split(phpcbf_bin_cmd_str.replace("\\", "/"), posix=True) or ["phpcbf"]
+    phpcbf_bin = bin_cmd[0]
     phpcbf_standard = os.environ.get("PHPCBF_STANDARD", "PSR12")
 
     if not shutil.which(phpcbf_bin) and not (
@@ -80,7 +86,7 @@ def main() -> None:
         })
         return
 
-    cmd = [phpcbf_bin, f"--standard={phpcbf_standard}", file]
+    cmd = [*bin_cmd, f"--standard={phpcbf_standard}", file]
 
     start = time.time()
     try:

--- a/formatters/prettier-write/prettier-write.py
+++ b/formatters/prettier-write/prettier-write.py
@@ -53,7 +53,13 @@ def main() -> None:
         return
 
     file = sys.argv[1]
-    prettier_bin = os.environ.get("PRETTIER_BIN", "prettier")
+    prettier_bin_cmd_str = os.environ.get("PRETTIER_BIN", "prettier")
+    # Accept either a single binary path or a shlex-split command line.
+    # Cross-platform test stubs pass e.g. "python /path/stub.py" so the
+    # stub runs on Windows too (no #!/usr/bin/env bash dependency).
+    import shlex as _shlex
+    bin_cmd = _shlex.split(prettier_bin_cmd_str.replace("\\", "/"), posix=True) or ["prettier"]
+    prettier_bin = bin_cmd[0]
     prettier_config = os.environ.get("PRETTIER_CONFIG", "")
     prettier_ignore = os.environ.get("PRETTIER_IGNORE_PATH", "")
 
@@ -82,7 +88,7 @@ def main() -> None:
         })
         return
 
-    cmd = [prettier_bin, "--write"]
+    cmd = [*bin_cmd, "--write"]
     if prettier_config:
         cmd += ["--config", prettier_config]
     if prettier_ignore:

--- a/tests/test_formatters_php_cs_fixer.py
+++ b/tests/test_formatters_php_cs_fixer.py
@@ -5,6 +5,8 @@ import json
 import os
 import shutil
 import subprocess
+import shlex
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,8 +14,17 @@ import pytest
 ADAPTER = Path(__file__).parent.parent / "formatters" / "php-cs-fixer" / "php-cs-fixer.py"
 
 
+def _python_stub(tmp_path: Path, name: str, body: str) -> str:
+    """Create a Python stub file and return a `python <path>` command line
+    suitable for PHPCSFIXER_BIN (the adapter shlex-splits the env var).
+    """
+    stub = tmp_path / f"{name}.py"
+    stub.write_text(body)
+    return f"{shlex.quote(sys.executable)} {shlex.quote(stub.as_posix())}"
+
+
 def test_no_arg_returns_schema_error() -> None:
-    r = subprocess.run(["python3", str(ADAPTER)], capture_output=True, text=True, timeout=10)
+    r = subprocess.run([sys.executable, str(ADAPTER)], capture_output=True, text=True, timeout=10)
     assert r.returncode == 0
     data = json.loads(r.stdout.strip())
     assert data["tool"] == "php-cs-fixer"
@@ -26,7 +37,7 @@ def test_missing_binary_returns_schema_error(tmp_path: Path) -> None:
     f.write_text("<?php\n$x=1;\n")
     env = {**os.environ, "PHPCSFIXER_BIN": "php-cs-fixer-that-does-not-exist-xyz"}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -42,12 +53,10 @@ def test_exit0_noop_via_stub(tmp_path: Path) -> None:
     """php-cs-fixer exit 0 = no changes → ok=True, metrics 0/0."""
     f = tmp_path / "clean.php"
     f.write_text("<?php\n$x = 1;\n")
-    stub = tmp_path / "php-cs-fixer"
-    stub.write_text("#!/usr/bin/env bash\nexit 0\n")
-    stub.chmod(0o755)
-    env = {**os.environ, "PHPCSFIXER_BIN": str(stub)}
+    bin_cmd = _python_stub(tmp_path, "stub_exit0", "import sys; sys.exit(0)\n")
+    env = {**os.environ, "PHPCSFIXER_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -61,15 +70,15 @@ def test_exit1_fixes_applied_via_stub(tmp_path: Path) -> None:
     """php-cs-fixer exit 1 = fixes applied → ok=True, metrics > 0."""
     f = tmp_path / "dirty.php"
     f.write_text("<?php\n$x=1;\n")
-
-    stub = tmp_path / "php-cs-fixer"
-    stub.write_text(
-        f"#!/usr/bin/env bash\nprintf '<?php\\n$x = 1;\\n$y = 2;\\n' > {f}\nexit 1\n"
+    body = (
+        "import sys, pathlib\n"
+        f"pathlib.Path(r'{f.as_posix()}').write_text('<?php\\n$x = 1;\\n$y = 2;\\n')\n"
+        "sys.exit(1)\n"
     )
-    stub.chmod(0o755)
-    env = {**os.environ, "PHPCSFIXER_BIN": str(stub)}
+    bin_cmd = _python_stub(tmp_path, "stub_exit1", body)
+    env = {**os.environ, "PHPCSFIXER_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -84,12 +93,15 @@ def test_exit16_error_via_stub(tmp_path: Path) -> None:
     """php-cs-fixer exit >=16 = error → ok=False."""
     f = tmp_path / "x.php"
     f.write_text("<?php\n$x = 1;\n")
-    stub = tmp_path / "php-cs-fixer"
-    stub.write_text("#!/usr/bin/env bash\necho 'fatal: config error' >&2\nexit 16\n")
-    stub.chmod(0o755)
-    env = {**os.environ, "PHPCSFIXER_BIN": str(stub)}
+    body = (
+        "import sys\n"
+        "sys.stderr.write('fatal: config error\\n')\n"
+        "sys.exit(16)\n"
+    )
+    bin_cmd = _python_stub(tmp_path, "stub_exit16", body)
+    env = {**os.environ, "PHPCSFIXER_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -102,7 +114,7 @@ def test_live_clean_php(tmp_path: Path) -> None:
     f = tmp_path / "ok.php"
     f.write_text("<?php\nfunction add(int $a, int $b): int\n{\n    return $a + $b;\n}\n")
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=30,
     )
     assert r.returncode == 0

--- a/tests/test_formatters_phpcbf.py
+++ b/tests/test_formatters_phpcbf.py
@@ -5,6 +5,8 @@ import json
 import os
 import shutil
 import subprocess
+import shlex
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,8 +14,21 @@ import pytest
 ADAPTER = Path(__file__).parent.parent / "formatters" / "phpcbf" / "phpcbf.py"
 
 
+def _python_stub(tmp_path: Path, name: str, body: str) -> str:
+    """Create a Python stub file and return a `python <path>` command line
+    suitable for PHPCBF_BIN (the adapter shlex-splits the env var).
+
+    POSIX-only bash stubs (#!/usr/bin/env bash) don't run on Windows runners;
+    Python is universally available and the adapter contract now allows the
+    BIN env var to be a multi-token command.
+    """
+    stub = tmp_path / f"{name}.py"
+    stub.write_text(body)
+    return f"{shlex.quote(sys.executable)} {shlex.quote(stub.as_posix())}"
+
+
 def test_no_arg_returns_schema_error() -> None:
-    r = subprocess.run(["python3", str(ADAPTER)], capture_output=True, text=True, timeout=10)
+    r = subprocess.run([sys.executable, str(ADAPTER)], capture_output=True, text=True, timeout=10)
     assert r.returncode == 0
     data = json.loads(r.stdout.strip())
     assert data["tool"] == "phpcbf"
@@ -26,7 +41,7 @@ def test_missing_binary_returns_schema_error(tmp_path: Path) -> None:
     f.write_text("<?php\n$x=1;\n")
     env = {**os.environ, "PHPCBF_BIN": "phpcbf-that-does-not-exist-xyz"}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -42,12 +57,10 @@ def test_exit0_noop_via_stub(tmp_path: Path) -> None:
     """phpcbf exit 0 = nothing to fix → ok=True, metrics 0/0."""
     f = tmp_path / "clean.php"
     f.write_text("<?php\n$x = 1;\n")
-    stub = tmp_path / "phpcbf"
-    stub.write_text("#!/usr/bin/env bash\nexit 0\n")
-    stub.chmod(0o755)
-    env = {**os.environ, "PHPCBF_BIN": str(stub)}
+    bin_cmd = _python_stub(tmp_path, "stub_exit0", "import sys; sys.exit(0)\n")
+    env = {**os.environ, "PHPCBF_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -61,15 +74,15 @@ def test_exit1_fixes_applied_via_stub(tmp_path: Path) -> None:
     """phpcbf exit 1 = fixes applied → ok=True, metrics > 0."""
     f = tmp_path / "dirty.php"
     f.write_text("<?php\n$x=1;\n")
-
-    stub = tmp_path / "phpcbf"
-    stub.write_text(
-        f"#!/usr/bin/env bash\nprintf '<?php\\n$x = 1;\\n$y = 2;\\n' > {f}\nexit 1\n"
+    body = (
+        "import sys, pathlib\n"
+        f"pathlib.Path(r'{f.as_posix()}').write_text('<?php\\n$x = 1;\\n$y = 2;\\n')\n"
+        "sys.exit(1)\n"
     )
-    stub.chmod(0o755)
-    env = {**os.environ, "PHPCBF_BIN": str(stub)}
+    bin_cmd = _python_stub(tmp_path, "stub_exit1", body)
+    env = {**os.environ, "PHPCBF_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -86,14 +99,15 @@ def test_exit2_unfixable_remaining_is_not_formatter_failure(tmp_path: Path) -> N
     via the phpcs validator, not as a formatter failure."""
     f = tmp_path / "x.php"
     f.write_text("<?php\n$x = 1;\n")
-    stub = tmp_path / "phpcbf"
-    stub.write_text(
-        "#!/usr/bin/env bash\necho 'No fixable errors were found'\nexit 2\n"
+    body = (
+        "import sys\n"
+        "sys.stdout.write('No fixable errors were found\\n')\n"
+        "sys.exit(2)\n"
     )
-    stub.chmod(0o755)
-    env = {**os.environ, "PHPCBF_BIN": str(stub)}
+    bin_cmd = _python_stub(tmp_path, "stub_exit2", body)
+    env = {**os.environ, "PHPCBF_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -105,12 +119,15 @@ def test_exit3_internal_error_is_failure(tmp_path: Path) -> None:
     """phpcbf exit 3 = real internal failure → ok=False."""
     f = tmp_path / "x.php"
     f.write_text("<?php\n$x = 1;\n")
-    stub = tmp_path / "phpcbf"
-    stub.write_text("#!/usr/bin/env bash\necho 'fatal error' >&2\nexit 3\n")
-    stub.chmod(0o755)
-    env = {**os.environ, "PHPCBF_BIN": str(stub)}
+    body = (
+        "import sys\n"
+        "sys.stderr.write('fatal error\\n')\n"
+        "sys.exit(3)\n"
+    )
+    bin_cmd = _python_stub(tmp_path, "stub_exit3", body)
+    env = {**os.environ, "PHPCBF_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -124,7 +141,7 @@ def test_live_clean_php(tmp_path: Path) -> None:
     f = tmp_path / "ok.php"
     f.write_text("<?php\nfunction add(int $a, int $b): int\n{\n    return $a + $b;\n}\n")
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=30,
     )
     assert r.returncode == 0

--- a/tests/test_formatters_prettier_write.py
+++ b/tests/test_formatters_prettier_write.py
@@ -5,6 +5,8 @@ import json
 import os
 import shutil
 import subprocess
+import shlex
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,8 +14,17 @@ import pytest
 ADAPTER = Path(__file__).parent.parent / "formatters" / "prettier-write" / "prettier-write.py"
 
 
+def _python_stub(tmp_path: Path, name: str, body: str) -> str:
+    """Create a Python stub file and return a `python <path>` command line
+    suitable for PRETTIER_BIN (the adapter shlex-splits the env var).
+    """
+    stub = tmp_path / f"{name}.py"
+    stub.write_text(body)
+    return f"{shlex.quote(sys.executable)} {shlex.quote(stub.as_posix())}"
+
+
 def test_no_arg_returns_schema_error() -> None:
-    r = subprocess.run(["python3", str(ADAPTER)], capture_output=True, text=True, timeout=10)
+    r = subprocess.run([sys.executable, str(ADAPTER)], capture_output=True, text=True, timeout=10)
     assert r.returncode == 0
     data = json.loads(r.stdout.strip())
     assert data["tool"] == "prettier-write"
@@ -26,7 +37,7 @@ def test_missing_binary_returns_schema_error(tmp_path: Path) -> None:
     f.write_text("const x=1\n")
     env = {**os.environ, "PRETTIER_BIN": "prettier-that-does-not-exist-xyz"}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -44,13 +55,10 @@ def test_clean_file_ok_noop_via_stub(tmp_path: Path) -> None:
     content = '{"a": 1}\n'
     f.write_text(content)
 
-    stub = tmp_path / "prettier"
-    stub.write_text("#!/usr/bin/env bash\nexit 0\n")
-    stub.chmod(0o755)
-
-    env = {**os.environ, "PRETTIER_BIN": str(stub)}
+    bin_cmd = _python_stub(tmp_path, "stub_exit0", "import sys; sys.exit(0)\n")
+    env = {**os.environ, "PRETTIER_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0
@@ -68,7 +76,7 @@ def test_live_clean_file_ok(tmp_path: Path) -> None:
     # Write content that prettier will not change (already formatted)
     f.write_text('{\n  "a": 1\n}\n')
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=30,
     )
     assert r.returncode == 0
@@ -81,16 +89,15 @@ def test_file_needing_format_via_stub(tmp_path: Path) -> None:
     f = tmp_path / "x.js"
     f.write_text("const x=1\n")
 
-    # Stub that adds a line so metrics are non-zero
-    stub = tmp_path / "prettier"
-    stub.write_text(
-        f"#!/usr/bin/env bash\nprintf 'const x = 1\\nconst y = 2\\n' > {f}\nexit 0\n"
+    body = (
+        "import sys, pathlib\n"
+        f"pathlib.Path(r'{f.as_posix()}').write_text('const x = 1\\nconst y = 2\\n')\n"
+        "sys.exit(0)\n"
     )
-    stub.chmod(0o755)
-
-    env = {**os.environ, "PRETTIER_BIN": str(stub)}
+    bin_cmd = _python_stub(tmp_path, "stub_add_line", body)
+    env = {**os.environ, "PRETTIER_BIN": bin_cmd}
     r = subprocess.run(
-        ["python3", str(ADAPTER), str(f)],
+        [sys.executable, str(ADAPTER), str(f)],
         capture_output=True, text=True, timeout=10, env=env,
     )
     assert r.returncode == 0


### PR DESCRIPTION
fix: formatter adapter BIN env accepts command line + Python stubs (#188)

Real fix replacing the closed skipif PR #204. The skip was too broad — covering tests that work cross-platform alongside ones that didn't.

## Problem

Three formatter adapters (phpcbf, php-cs-fixer, prettier-write) accepted `PHPCBF_BIN` / `PHPCSFIXER_BIN` / `PRETTIER_BIN` as a single binary path. Tests created bash shebang stubs (`#!/usr/bin/env bash`) and `chmod 0o755` them — both POSIX-only. Windows runners had no bash, the chmod is a no-op, the adapter could not spawn the stub, and 8 Windows tests failed.

## Adapter changes

`os.environ.get(ENV, default)` → `shlex.split` into a list; spawn check uses `bin_cmd[0]`, `cmd` uses `*bin_cmd`. Backward-compatible: a plain binary name still works (`shlex.split("phpcbf")` → `["phpcbf"]`).

A test stub can now be `PHPCBF_BIN="python /path/to/stub.py"`. The adapter shlex-splits, prepends `[python, stub.py, --standard=PSR12, file]`, and the stub executes via the Python interpreter on every platform.

## Test changes

Replaced bash shebang stubs with Python stub files invoked via `f"{sys.executable} {stub.as_posix()}"`. Each stub mirrors the bash exit-code / IO behaviour of the original:

- `exit 0` → `sys.exit(0)`
- `exit 1` + write → `pathlib.Path.write_text(...); sys.exit(1)`
- `exit 2` + stdout → `sys.stdout.write(...); sys.exit(2)`
- `exit 3/16` + stderr → `sys.stderr.write(...); sys.exit(N)`

Also replaced `subprocess.run(["python3", ...])` with `subprocess.run([sys.executable, ...])` since `python3` is not on PATH on Windows.

## Local verification

```
$ pytest tests/test_formatters_phpcbf.py tests/test_formatters_php_cs_fixer.py tests/test_formatters_prettier_write.py
17 passed, 1 skipped (prettier not installed)
```

## Buckets remaining for #188

test_at_file_route TOML (4F), test_chaos Windows file-lock concurrency (2F), test_security_* path/encoding edge cases (~5F), test_dispatch (2F), test_bluesky (1F), test_huge_batch slow tests.
