### PR TITLE
test: cross-platform fixes for at_file/dispatch/security suites (#188)

### DIFF
--- a/tests/test_at_file_route.py
+++ b/tests/test_at_file_route.py
@@ -305,8 +305,9 @@ class TestTomlPayload:
     def test_paste_with_triple_literal_preserves_backslash(self, tmp_path: Path) -> None:
         target = tmp_path / "out.sh"
         spec = tmp_path / "p.toml"
+        # as_posix avoids Windows backslashes being interpreted as TOML escapes.
         spec.write_text(
-            f'path = "{target}"\n'
+            f'path = "{target.as_posix()}"\n'
             "content = '''\n"
             "claude -p \"...\" --permission-mode bypass \\\n"
             "  --disallowedTools \"Grep,Glob\"\n"
@@ -327,7 +328,7 @@ class TestTomlPayload:
         spec.write_text(
             'old = "DEBUG = False"\n'
             'new = "DEBUG = True"\n'
-            f'path = "{target}"\n'
+            f'path = "{target.as_posix()}"\n'
         )
         out = supertool.dispatch(f"edit:@{spec}")
         assert "ERROR" not in out
@@ -338,7 +339,7 @@ class TestTomlPayload:
         target.write_text("a\nb\nc\nd\n")
         spec = tmp_path / "rl.toml"
         spec.write_text(
-            f'path = "{target}"\n'
+            f'path = "{target.as_posix()}"\n'
             "start = 2\n"
             "end = 3\n"
             "content = '''X\nY'''\n"
@@ -351,7 +352,7 @@ class TestTomlPayload:
         target = tmp_path / "out.txt"
         import io
         payload = (
-            f'path = "{target}"\n'
+            f'path = "{target.as_posix()}"\n'
             "content = '''line1\nline2 with \\ backslash\nline3'''\n"
         )
         monkeypatch.setattr("sys.stdin", io.StringIO(payload))

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -34,7 +34,9 @@ def test_dispatch_grep(tmp_path: Path) -> None:
     f.write_text("foo\nbar\n")
     out = supertool.dispatch(f"grep:foo:{f}")
     assert "--- grep:" in out
-    assert str(f) + "\n" in out
+    # op output normalises paths to forward slashes (#189) — assert against the
+    # posix form so the test passes on both POSIX and Windows runners.
+    assert f.as_posix() + "\n" in out
     assert "  1:foo" in out
 
 
@@ -95,7 +97,8 @@ def test_dispatch_grep_with_context(tmp_path: Path) -> None:
     f = tmp_path / "src.py"
     f.write_text("before\nMATCH\nafter\n")
     out = supertool.dispatch(f"grep:MATCH:{f}:10:1")
-    assert str(f) + "\n" in out
+    # Forward-slash normalised output (#189).
+    assert f.as_posix() + "\n" in out
     assert "  2:MATCH" in out
     assert "  1-before" in out
     assert "  3-after" in out

--- a/tests/test_security_devto.py
+++ b/tests/test_security_devto.py
@@ -705,7 +705,8 @@ class TestOutboundLedgerPath:
 
     def test_track_file_is_fixed_path(self) -> None:
         """TRACK_FILE must be under ~/.config/devto/, not overridable via env or args."""
-        track_path = str(outbound_mod.TRACK_FILE)
+        # Normalise separators — Windows uses backslashes in Path.__str__.
+        track_path = str(outbound_mod.TRACK_FILE).replace("\\", "/")
         assert ".config/devto/my_outbound_comments" in track_path, (
             f"TRACK_FILE is not the expected fixed path: {track_path!r}"
         )

--- a/tests/test_security_edge_cases.py
+++ b/tests/test_security_edge_cases.py
@@ -7,6 +7,7 @@ or pins a fix.
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -155,6 +156,10 @@ def test_op_edit_unreadable_file_returns_error(tmp_path: Path) -> None:
         os.chmod(f, 0o644)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows filesystem ignores chmod 0o000 — file stays readable.",
+)
 def test_op_replace_skips_unreadable_binary_peek(tmp_path: Path) -> None:
     """Replace must continue when binary peek hits OSError on a single file."""
     f1 = tmp_path / "good.txt"
@@ -171,6 +176,11 @@ def test_op_replace_skips_unreadable_binary_peek(tmp_path: Path) -> None:
         os.chmod(f2, 0o644)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Mocked fdopen returns a stub that never closes the fd; Windows can't "
+    "unlink an open file, so the cleanup-leftover assertion fails on Windows only.",
+)
 def test_atomic_write_recovers_from_write_failure(tmp_path: Path, monkeypatch) -> None:
     """If write fails mid-flight, tmp file is cleaned up + original preserved."""
     f = tmp_path / "target.txt"

--- a/tests/test_security_hashnode.py
+++ b/tests/test_security_hashnode.py
@@ -216,6 +216,9 @@ def test_token_resolution_only_reads_fixed_paths(monkeypatch, tmp_path) -> None:
     only HASHNODE_TOKEN (the value itself) is honored, not a path."""
     monkeypatch.delenv("HASHNODE_TOKEN", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
+    # os.path.expanduser uses USERPROFILE on Windows, HOME on POSIX. Set both
+    # so the test repoints `~` to tmp_path on every platform.
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     # Plant an "evil" file at a non-allowed location
     evil = tmp_path / "evil.txt"
     evil.write_text("STOLEN_FROM_EVIL_LOCATION\n")


### PR DESCRIPTION
test: cross-platform fixes for at_file/dispatch/security suites (#188)

Six distinct Windows-only failures across 5 files:

1. **`test_dispatch_grep` + `test_dispatch_grep_with_context`** — op output normalises paths to forward slashes (#189). Tests asserted `str(f) + "\n" in out` (backslash on Windows) → use `f.as_posix()`.

2. **`test_at_file_route::TestTomlPayload`** (4 tests) — wrote TOML basic-strings like `path = "C:\Users\runneradmin\..."`. TOML treats `\U` as a Unicode escape so `tomllib` fails at column 13 (the `\U` after `C:`). Use `target.as_posix()` in the payload — forward slashes pass through unchanged.

3. **`test_security_devto::test_track_file_is_fixed_path`** — assertion compared a forward-slash substring against `Path.__str__` which is backslash on Windows. Normalise both.

4. **`test_security_hashnode::test_token_resolution_only_reads_fixed_paths`** — `os.path.expanduser` uses `USERPROFILE` on Windows, `HOME` on POSIX. The test set `HOME` only. Set both.

5. **`test_security_edge_cases::test_op_replace_skips_unreadable_binary_peek`** — `chmod 0o000` is a no-op on Windows. Skipif `win32`.

6. **`test_security_edge_cases::test_atomic_write_recovers_from_write_failure`** — test mocks `fdopen` to return a stub that never closes the fd. Windows can't unlink a file with an open handle, so cleanup leaves the tmp file behind. Skipif `win32` — the assertion is correct on POSIX where unlink-while-open works.

POSIX behaviour unchanged.

## Buckets remaining for #188

test_chaos batch_edit_chain (regex/repr nit), test_huge_batch (slow), test_security_publish_149 path tests, plus a few one-offs.
