### PR TITLE
fix: last 6 Windows CI failures (#188)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -722,7 +722,10 @@ def _safe_path(p: str, *, allow_outside_cwd: Optional[bool] = None) -> str:
     try:
         abs_p = os.path.realpath(expanded)
     except (ValueError, OSError) as e:
-        raise SecurityError(f"path cannot be resolved: {p!r} ({e})")
+        # Truncate path in the error message — matches existing SecurityError
+        # style of not echoing arbitrarily-large user input back verbatim.
+        shown = p if len(p) <= 120 else p[:120] + "…"
+        raise SecurityError(f"path cannot be resolved: {shown!r} ({e})")
     if allow_outside_cwd:
         return abs_p
     # Windows: NTFS is case-insensitive (`C:\Users` == `c:\users`) and uses

--- a/supertool.py
+++ b/supertool.py
@@ -595,12 +595,20 @@ _RTK_CHECKED = False
 
 
 def _has_rtk() -> str | None:
-    """Return rtk binary path if available, None otherwise. Cached."""
+    """Return rtk binary path if available, None otherwise. Cached.
+
+    Honours ``SUPERTOOL_NO_RTK=1`` — used by tests that spawn supertool in a
+    subprocess and need the unwrapped output format regardless of whether the
+    user has rtk on their PATH.
+    """
     global _RTK_PATH, _RTK_CHECKED
     if not _RTK_CHECKED:
         _RTK_CHECKED = True
-        from shutil import which
-        _RTK_PATH = which("rtk")
+        if os.environ.get("SUPERTOOL_NO_RTK") == "1":
+            _RTK_PATH = None
+        else:
+            from shutil import which
+            _RTK_PATH = which("rtk")
     return _RTK_PATH
 
 
@@ -654,6 +662,13 @@ class SecurityError(Exception):
     pass
 
 
+# Hard cap on path length passed to _safe_path. Sized well above MAX_PATH (260)
+# and the extended-length namespace (32767) is too permissive for an op arg —
+# 4096 catches obvious abuse (1MB args from fuzz tests) while leaving every
+# legitimate path well under the limit.
+_MAX_SAFE_PATH_LEN = 4096
+
+
 def _safe_path(p: str, *, allow_outside_cwd: Optional[bool] = None) -> str:
     """Resolve `p` and enforce repo-root containment (closes #146).
 
@@ -693,8 +708,21 @@ def _safe_path(p: str, *, allow_outside_cwd: Optional[bool] = None) -> str:
     # would leak as an uncaught traceback. Reject early with a clean message.
     if "\x00" in p:
         raise SecurityError(f"path contains NUL byte: {p!r}")
+    # Windows: paths longer than MAX_PATH (260) make _getfinalpathname raise
+    # ValueError("path too long for Windows") from inside os.path.realpath.
+    # Reject oversized paths up front with a clean SecurityError so dispatch
+    # returns a clean "ERROR: ..." instead of an uncaught traceback. 4096 is
+    # well above MAX_PATH (260) and extended-length (32767) workable values
+    # — any real op path stays well under it.
+    if len(p) > _MAX_SAFE_PATH_LEN:
+        raise SecurityError(
+            f"path too long ({len(p)} chars, max {_MAX_SAFE_PATH_LEN})"
+        )
     expanded = os.path.expanduser(os.path.expandvars(p))
-    abs_p = os.path.realpath(expanded)
+    try:
+        abs_p = os.path.realpath(expanded)
+    except (ValueError, OSError) as e:
+        raise SecurityError(f"path cannot be resolved: {p!r} ({e})")
     if allow_outside_cwd:
         return abs_p
     # Windows: NTFS is case-insensitive (`C:\Users` == `c:\users`) and uses

--- a/tests/_winenv.py
+++ b/tests/_winenv.py
@@ -24,7 +24,7 @@ from typing import Dict
 # ``python.exe`` launch — only SYSTEMROOT + WINDIR for DLL resolution.
 # PATHEXT is kept so ``shutil.which`` behaves the same way for the validator
 # adapter (still returns None for missing tools).
-_KEEP = ("SYSTEMROOT", "WINDIR", "TEMP", "TMP", "PATHEXT", "COMSPEC")
+_KEEP = frozenset({"SYSTEMROOT", "WINDIR", "TEMP", "TMP", "PATHEXT", "COMSPEC"})
 
 
 def empty_path_env() -> Dict[str, str]:

--- a/tests/_winenv.py
+++ b/tests/_winenv.py
@@ -1,0 +1,33 @@
+"""Shared helper for tests that strip PATH but still need to run a subprocess.
+
+On Windows, passing ``env={"PATH": ""}`` wipes SYSTEMROOT/WINDIR/PATHEXT too,
+which prevents the Python interpreter from starting (cannot locate system
+DLLs). The subprocess then produces empty stdout and the test crashes with a
+``JSONDecodeError`` instead of validating the adapter's graceful-degrade path.
+
+``empty_path_env()`` returns an env dict with PATH stripped but Windows
+essentials preserved, so ``shutil.which(tool)`` still returns ``None`` (tool
+not findable) while ``python.exe`` itself can still launch.
+
+POSIX note: the ``KEEP`` names are Windows-specific. On Linux/macOS none of
+them exist in ``os.environ`` (case-sensitive), so the comprehension yields an
+empty dict and the returned env is just ``{"PATH": ""}`` — same behaviour as
+the original tests. Single code path, no platform branch needed.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+# Windows env vars the Python interpreter (and core CRT) need to start at all.
+# APPDATA / LOCALAPPDATA / USERPROFILE are NOT required for a bare
+# ``python.exe`` launch — only SYSTEMROOT + WINDIR for DLL resolution.
+# PATHEXT is kept so ``shutil.which`` behaves the same way for the validator
+# adapter (still returns None for missing tools).
+_KEEP = ("SYSTEMROOT", "WINDIR", "TEMP", "TMP", "PATHEXT", "COMSPEC")
+
+
+def empty_path_env() -> Dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k.upper() in _KEEP}
+    env["PATH"] = ""
+    return env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,11 @@ def pytest_configure(config):  # noqa: ARG001
     import os
     os.environ.setdefault("SUPERTOOL_ALLOW_OUTSIDE_CWD", "1")
     os.environ.setdefault("SUPERTOOL_ALLOW_VIM_SHELL", "1")
+    # Tests that spawn supertool as a subprocess must not delegate `read` to
+    # rtk (different output format breaks byte-identical assertions). The
+    # in-process _disable_rtk_and_config fixture covers same-process tests;
+    # SUPERTOOL_NO_RTK covers subprocess-spawned tests like test_parallel.
+    os.environ.setdefault("SUPERTOOL_NO_RTK", "1")
     # #149: publish-body allowlist + confirm gate. Existing publish tests use
     # `tmp_path` for body files (outside the production .max/ / drafts/ /
     # posts/ / blog/ allowlist) and don't `|force`, so opt the suite in.

--- a/tests/test_hadolint.py
+++ b/tests/test_hadolint.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from _winenv import empty_path_env
+
 ADAPTER = Path(__file__).parent.parent / "validators" / "hadolint" / "hadolint.py"
 
 
@@ -33,7 +35,7 @@ def test_missing_tool_graceful(tmp_path: Path) -> None:
         [sys.executable, str(ADAPTER), str(f)],
         capture_output=True,
         text=True,
-        env={"PATH": ""},
+        env=empty_path_env(),
     )
     out = json.loads(result.stdout)
     assert out["ok"] is True

--- a/tests/test_markdownlint.py
+++ b/tests/test_markdownlint.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from _winenv import empty_path_env
+
 ADAPTER = Path(__file__).parent.parent / "validators" / "markdownlint" / "markdownlint.py"
 
 
@@ -33,7 +35,7 @@ def test_missing_tool_graceful(tmp_path: Path) -> None:
         [sys.executable, str(ADAPTER), str(f)],
         capture_output=True,
         text=True,
-        env={"PATH": ""},
+        env=empty_path_env(),
     )
     out = json.loads(result.stdout)
     assert out["ok"] is True

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -20,6 +20,10 @@ def _subprocess_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     """
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "utf-8"
+    # Force unwrapped output — without this, supertool delegates `read` to rtk
+    # when rtk is on the user's PATH, which uses different rendering (`1 │ hi`
+    # vs `     1→hi`) and breaks the byte-identical assertions below.
+    env["SUPERTOOL_NO_RTK"] = "1"
     env.pop("SUPERTOOL_PARALLEL", None)
     if extra:
         env.update(extra)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -20,11 +20,11 @@ def _subprocess_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     """
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "utf-8"
-    # Force unwrapped output — without this, supertool delegates `read` to rtk
-    # when rtk is on the user's PATH, which uses different rendering (`1 │ hi`
-    # vs `     1→hi`) and breaks the byte-identical assertions below.
-    env["SUPERTOOL_NO_RTK"] = "1"
     env.pop("SUPERTOOL_PARALLEL", None)
+    # SUPERTOOL_NO_RTK=1 is set in conftest.pytest_configure (covers all
+    # subprocess-spawning tests) — env.copy() picks it up here. Without it,
+    # supertool delegates `read` to rtk and rtk's output format (`1 │ hi`)
+    # breaks the byte-identical assertions below.
     if extra:
         env.update(extra)
     return env

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from _winenv import empty_path_env
+
 ADAPTER = Path(__file__).parent.parent / "validators" / "pyright" / "pyright.py"
 
 
@@ -33,7 +35,7 @@ def test_missing_tool_graceful(tmp_path: Path) -> None:
         [sys.executable, str(ADAPTER), str(f)],
         capture_output=True,
         text=True,
-        env={"PATH": ""},
+        env=empty_path_env(),
     )
     out = json.loads(result.stdout)
     assert out["ok"] is True

--- a/tests/test_ruby_check.py
+++ b/tests/test_ruby_check.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from _winenv import empty_path_env
+
 ADAPTER = Path(__file__).parent.parent / "validators" / "ruby-check" / "ruby-check.py"
 
 
@@ -33,7 +35,7 @@ def test_missing_tool_graceful(tmp_path: Path) -> None:
         [sys.executable, str(ADAPTER), str(f)],
         capture_output=True,
         text=True,
-        env={"PATH": ""},
+        env=empty_path_env(),
     )
     out = json.loads(result.stdout)
     assert out["ok"] is True

--- a/tests/test_tsc_check.py
+++ b/tests/test_tsc_check.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from _winenv import empty_path_env
+
 ADAPTER = Path(__file__).parent.parent / "validators" / "tsc-check" / "tsc-check.py"
 
 
@@ -34,7 +36,7 @@ def test_missing_tool_graceful(tmp_path: Path, monkeypatch) -> None:
         [sys.executable, str(ADAPTER), str(f)],
         capture_output=True,
         text=True,
-        env={"PATH": ""},
+        env=empty_path_env(),
     )
     out = json.loads(result.stdout)
     assert out["ok"] is True


### PR DESCRIPTION
fix: last 6 Windows CI failures + 1 macOS rtk delegation (#188)

Stacks on top of PR #212. After #212 lands, Windows 3.11/3.12 are green and
3.9/3.10 are down to 6 distinct failures, plus a long-standing macOS local
failure when rtk is on PATH.

## Source fixes

- `_safe_path` (`supertool.py`): cap path arg at 4096 chars + wrap
  `os.path.realpath` in `try/except` for `ValueError`/`OSError`. Windows
  `_getfinalpathname` raises `ValueError("path too long for Windows")` on
  paths past `MAX_PATH`; was leaking as an uncaught traceback in the 1MB
  fuzz test (`test_security_dispatch_parser::TestVeryLongArg::test_1mb_single_arg`).
  Named the threshold as `_MAX_SAFE_PATH_LEN`.

- `_has_rtk()` (`supertool.py`): honour `SUPERTOOL_NO_RTK=1` env var so tests
  that spawn supertool as a subprocess can force the unwrapped output format
  regardless of whether the user has rtk on PATH.

## Test fixes

- `tests/_winenv.py` (new): `empty_path_env()` returns an env dict with PATH
  stripped but Windows essentials preserved (`SYSTEMROOT`, `WINDIR`, `TEMP`,
  `TMP`, `PATHEXT`, `COMSPEC`). Without those, the bare `python.exe`
  subprocess can't locate system DLLs → empty stdout → `JSONDecodeError`
  instead of the validator's graceful-degrade path firing. On POSIX none of
  the kept vars exist in `os.environ`, so the helper degrades to
  `{"PATH": ""}` — no behaviour change for Linux/macOS.

- `tests/test_{hadolint,markdownlint,ruby_check,pyright,tsc_check}.py`:
  swap `env={"PATH": ""}` for `env=empty_path_env()`. POSIX behaviour
  unchanged.

- `tests/test_parallel.py::test_parallel_disabled_by_default`: set
  `SUPERTOOL_NO_RTK=1` in `_subprocess_env`. Fixes the failure on dev
  machines that have rtk installed (rtk-rendered `1 │ hi` vs supertool's
  `     1→hi` — broke the byte-identical assertion).

## Out of scope

Local py3.14 vim/hex tests fail on macOS regardless of this branch; CI
matrix tops out at 3.12 so they're not gating. Tracked separately.

Closes the Windows residuals on #188.
