### PR TITLE
ci: lock Windows in as required + OS badge (#188)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,6 @@ on:
 jobs:
   pytest:
     runs-on: ${{ matrix.os }}
-    # Windows currently surfaces ~100+ real path-sep / line-ending / Unix-tool
-    # failures (tracked separately). Treat windows-latest as informational
-    # until #182 follow-ups land, so PRs gate on linux+macos.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 [![Tests](https://github.com/Digital-Process-Tools/claude-supertool/actions/workflows/tests.yml/badge.svg)](https://github.com/Digital-Process-Tools/claude-supertool/actions/workflows/tests.yml)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)
+[![OS](https://img.shields.io/badge/tested%20on-Linux%20%7C%20macOS%20%7C%20Windows-blue)](https://github.com/Digital-Process-Tools/claude-supertool/actions/workflows/tests.yml)
 [![License](https://img.shields.io/badge/license-Community-brightgreen)](LICENSE)
 [![Version](https://img.shields.io/badge/version-0.11.0-orange)](.claude-plugin/plugin.json)
 


### PR DESCRIPTION
After #214, Windows 3.9-3.12 are green on master. Lock the gain in:

- Drop `continue-on-error: \${{ matrix.os == 'windows-latest' }}` from .github/workflows/tests.yml — Windows regressions now block merge instead of slipping by silently.
- Add `tested on: Linux | macOS | Windows` badge to README (same shape as claude-remember).

Closes the original #182 ask.