### PR TITLE
fix(gh-pr): fetch reviewThreads via GraphQL

### DIFF
--- a/presets/github/pr.py
+++ b/presets/github/pr.py
@@ -64,6 +64,36 @@ def _local_branch_check(source: str) -> str:
         return ""
 
 
+def _fetch_review_threads(url: str, number: int | str) -> list[dict]:
+    """Fetch reviewThreads via GraphQL — gh pr view --json doesn't expose them.
+
+    Parses owner/repo from PR URL. Returns [] on any failure (silent fallback).
+    """
+    if not url:
+        return []
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/\d+", url)
+    if not m:
+        return []
+    owner, repo = m.group(1), m.group(2)
+    query = (
+        "query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r)"
+        "{pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved}}}}}"
+    )
+    try:
+        r = _gh([
+            "api", "graphql",
+            "-f", f"query={query}",
+            "-F", f"o={owner}", "-F", f"r={repo}", "-F", f"n={number}",
+        ])
+        if r.returncode != 0:
+            return []
+        data = json.loads(r.stdout)
+        return (((data.get("data") or {}).get("repository") or {})
+                .get("pullRequest", {}).get("reviewThreads", {}).get("nodes") or [])
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        return []
+
+
 def _format_error(stderr: str, resource: str, identifier: str) -> str:
     """Classify gh errors into actionable messages for LLMs."""
     s = stderr.lower()
@@ -123,7 +153,7 @@ def main() -> int:
             "number,title,state,author,headRefName,baseRefName,labels,"
             "milestone,reviewDecision,reviews,mergeCommit,mergeable,"
             "isDraft,url,body,comments,additions,deletions,changedFiles,"
-            "statusCheckRollup,assignees,createdAt,updatedAt,reviewThreads"
+            "statusCheckRollup,assignees,createdAt,updatedAt"
         ])
     except FileNotFoundError:
         print("ERROR: gh not found — install from https://cli.github.com")
@@ -205,8 +235,8 @@ def main() -> int:
             age_str += f" | Updated: {_relative_age(updated_at)}"
         print(age_str)
 
-    # Unresolved review threads — distinct blocker from comments
-    review_threads = d.get("reviewThreads") or []
+    # Unresolved review threads — fetched via GraphQL (not exposed by gh pr view --json)
+    review_threads = _fetch_review_threads(d.get("url", ""), iid)
     if review_threads:
         unresolved = sum(1 for t in review_threads if not t.get("isResolved"))
         print(f"Unresolved threads: {unresolved} / {len(review_threads)}")

--- a/presets/github/pr.py
+++ b/presets/github/pr.py
@@ -88,9 +88,11 @@ def _fetch_review_threads(url: str, number: int | str) -> list[dict]:
         if r.returncode != 0:
             return []
         data = json.loads(r.stdout)
-        return (((data.get("data") or {}).get("repository") or {})
-                .get("pullRequest", {}).get("reviewThreads", {}).get("nodes") or [])
-    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        repo_node = (data.get("data") or {}).get("repository") or {}
+        pr_node = repo_node.get("pullRequest") or {}
+        threads = pr_node.get("reviewThreads") or {}
+        return threads.get("nodes") or []
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, AttributeError, TypeError):
         return []
 
 

--- a/tests/test_github_pr.py
+++ b/tests/test_github_pr.py
@@ -166,16 +166,22 @@ def test_main_full_mode_with_assignees_age_threads(monkeypatch, capsys) -> None:
         assignees=[{"login": "alice"}, {"login": "bob"}],
         createdAt="2026-05-01T10:00:00Z",
         updatedAt="2026-05-08T10:00:00Z",
-        reviewThreads=[
+    )
+    graphql_payload = json.dumps({
+        "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [
             {"isResolved": True},
             {"isResolved": False},
             {"isResolved": False},
-        ],
-    )
-    monkeypatch.setattr(
-        pr.subprocess, "run",
-        lambda *a, **kw: _fake_run(payload, returncode=0),
-    )
+        ]}}}}
+    })
+
+    def dispatch(*a, **kw):
+        argv = a[0] if a else kw.get("args", [])
+        if "graphql" in argv:
+            return _fake_run(graphql_payload, returncode=0)
+        return _fake_run(payload, returncode=0)
+
+    monkeypatch.setattr(pr.subprocess, "run", dispatch)
     monkeypatch.setattr(sys, "argv", ["pr.py", "12"])
     rc = pr.main()
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary

- `gh pr view --json` does not expose `reviewThreads` — caused every `gh-pr:N` call to fail with `Unknown JSON field: "reviewThreads"`.
- Drops the field from the `pr view` call; fetches threads via a follow-up `gh api graphql` query, parsed from PR URL.
- Silent fallback to empty list on graphql failure — preserves the "Unresolved threads" line when available, never blocks the dashboard.

Closes #187

## Test plan

- [x] `python3 presets/github/pr.py 186` — full dashboard renders
- [x] `python3 presets/github/pr.py 186 status` — slim mode renders
- [x] `pytest tests/test_github_pr.py tests/test_security_github.py` — 48/48 pass
- [ ] CI green