### PR TITLE
fix(batch): defer formatters to end of multi-op invocation

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -8832,6 +8832,40 @@ def _formatter_render_row(result: Dict[str, Any]) -> Optional[str]:
     return line
 
 
+# Deferred-formatter state for multi-op invocations.
+# When _DEFER_FORMATTERS is True, _run_with_validators queues formatter
+# (path → {name: spec}) instead of running them inline. main() drains the
+# queue once after all ops complete, ensuring tidy rules (e.g.
+# no_unused_imports) don't strip code that a later op in the same call
+# was about to use. See issue #164.
+_DEFER_FORMATTERS: bool = False
+_FORMAT_QUEUE: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
+
+def _drain_format_queue() -> str:
+    """Run queued formatters on each path once. Returns rendered output block."""
+    global _FORMAT_QUEUE
+    if not _FORMAT_QUEUE:
+        return ""
+    rows: list = []
+    for path, applicable in _FORMAT_QUEUE.items():
+        if not applicable:
+            continue
+        results = _formatters_run_batch(applicable, path)
+        path_rows: list = []
+        for result in results:
+            row = _formatter_render_row(result)
+            if row:
+                path_rows.append(row)
+        if path_rows:
+            rows.append(f"  {path}")
+            rows.extend(f"    {r}" for r in path_rows)
+    _FORMAT_QUEUE = {}
+    if not rows:
+        return ""
+    return "\n--- formatters (deferred) ---\n" + "\n".join(rows) + "\n"
+
+
 def _formatters_run_batch(
     applicable: Dict[str, Dict[str, Any]], path: str
 ) -> list:
@@ -8866,6 +8900,15 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
     applicable_fmt = _applicable_formatters(op, path)
     applicable = _applicable_validators(op, path)
     applicable_notif = _applicable_notifiers(op, path)
+
+    # Multi-op invocation: queue formatters for end-of-batch instead of
+    # running inline. Tidy rules (no_unused_imports) would otherwise strip
+    # symbols a later op in the same call is about to consume. Issue #164.
+    if _DEFER_FORMATTERS and applicable_fmt:
+        abs_path = os.path.abspath(path)
+        bucket = _FORMAT_QUEUE.setdefault(abs_path, {})
+        bucket.update(applicable_fmt)
+        applicable_fmt = {}
     if not applicable_fmt and not applicable:
         # No validators/formatters — still need pre_content for notifier diff view
         pre_for_notif = None
@@ -11243,28 +11286,49 @@ def main(argv: List[str]) -> int:
     # sequential to keep reasoning simple. Output order = input order.
     bodies: List[str]
     workers = _parallel_workers()
-    if (
+    parallel_path = (
         workers >= 2
         and len(argv) > 1
         and all(_is_parallel_safe(a) for a in argv)
-    ):
-        # Warm caches before threads so module-global init races are avoided
-        _load_config()
-        _has_rtk()
-        _has_tree_sitter()
-        _has_ctags()
-        from concurrent.futures import ThreadPoolExecutor
-        max_workers = min(workers, len(argv))
-        with ThreadPoolExecutor(max_workers=max_workers) as ex:
-            bodies = list(ex.map(dispatch, argv))
-    else:
-        bodies = [dispatch(a) for a in argv]
+    )
+    # Defer formatters for multi-op sequential invocations (mutating ops).
+    # Parallel path is read-only — no formatters fire there anyway.
+    global _DEFER_FORMATTERS, _FORMAT_QUEUE
+    defer = len(argv) > 1 and not parallel_path
+    if defer:
+        _DEFER_FORMATTERS = True
+        _FORMAT_QUEUE = {}
+
+    try:
+        if parallel_path:
+            # Warm caches before threads so module-global init races are avoided
+            _load_config()
+            _has_rtk()
+            _has_tree_sitter()
+            _has_ctags()
+            from concurrent.futures import ThreadPoolExecutor
+            max_workers = min(workers, len(argv))
+            with ThreadPoolExecutor(max_workers=max_workers) as ex:
+                bodies = list(ex.map(dispatch, argv))
+        else:
+            bodies = [dispatch(a) for a in argv]
+    finally:
+        if defer:
+            _DEFER_FORMATTERS = False
 
     for body in bodies:
         sys.stdout.write(body)
         total_out_bytes += len(body.encode("utf-8"))
         if _body_indicates_failure(body):
             any_failure = True
+
+    # Drain deferred formatters now that every op has landed.
+    if defer:
+        drain_out = _drain_format_queue()
+        if drain_out:
+            sys.stdout.write(drain_out)
+            total_out_bytes += len(drain_out.encode("utf-8"))
+
     log_call(argv, total_out_bytes)
     return 1 if any_failure else 0
 

--- a/tests/test_formatters_deferred.py
+++ b/tests/test_formatters_deferred.py
@@ -82,6 +82,53 @@ def test_defer_handles_different_files_independently(tmp_path, monkeypatch) -> N
     assert counter.read_text().count("run\n") == 2
 
 
+def test_defer_runs_formatter_on_survivor_when_later_op_rolls_back(tmp_path, monkeypatch) -> None:
+    """Op 1 succeeds, op 2's validator rolls back — formatter still runs on op 1's file."""
+    a = tmp_path / "a.py"
+    b = tmp_path / "b.py"
+    a.write_text("x = 1\n")
+    b.write_text("y = 1\n")
+
+    cmd, counter = _make_counting_cmd(tmp_path)
+    # Validator: fails when file contains "BAD". rollback_on_fail restores pre-content.
+    val_script = tmp_path / "val.sh"
+    val_script.write_text(
+        "#!/bin/sh\n"
+        'if grep -q BAD "$1"; then\n'
+        '  printf \'{"ok":false,"tool":"fakeval","errors":[{"msg":"bad token"}]}\'\n'
+        "  exit 1\n"
+        "fi\n"
+        'printf \'{"ok":true,"tool":"fakeval"}\'\n'
+    )
+    val_script.chmod(0o755)
+
+    supertool._CONFIG = {
+        "formatters": {
+            "fakefmt": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.py"},
+        },
+        "validators": {
+            "fakeval": {
+                "cmd": f"{val_script} {{file}}",
+                "hooks_into": ["edit"],
+                "match": "*.py",
+                "rollback_on_fail": True,
+            },
+        },
+    }
+    supertool._CONFIG_CHECKED = True
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([
+        f"edit:::x = 1:::x = 2:::{a}",        # clean — survives
+        f"edit:::y = 1:::y = BAD:::{b}",      # validator fails → rollback
+    ])
+    # Survivor edited; rolled-back file restored.
+    assert a.read_text() == "x = 2\n"
+    assert b.read_text() == "y = 1\n"
+    # Formatter ran (deferred) at least once — survivor a.py must be in the queue.
+    assert counter.read_text().count("run\n") >= 1
+
+
 def test_defer_state_reset_between_invocations(tmp_path, monkeypatch) -> None:
     """Module-level queue must not leak across main() calls."""
     target = tmp_path / "c.py"

--- a/tests/test_formatters_deferred.py
+++ b/tests/test_formatters_deferred.py
@@ -1,0 +1,95 @@
+"""Tests for deferred-formatter behavior in multi-op invocations.
+
+Issue #164: when several ops in one ./supertool call mutate the same file,
+formatters running between ops (e.g. php-cs-fixer's no_unused_imports) can
+strip symbols that a later op was about to consume. Defer formatters to
+end-of-batch to keep "1 invocation = 1 round-trip" honest.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def _set_formatters(fmt: dict) -> None:
+    supertool._CONFIG = {"formatters": fmt}
+    supertool._CONFIG_CHECKED = True
+
+
+def _make_counting_cmd(tmp_path: Path) -> tuple[str, Path]:
+    """Build a formatter cmd that appends a line to a counter file each call."""
+    counter = tmp_path / "fmt_runs.log"
+    counter.write_text("")
+    script = tmp_path / "fmt.sh"
+    script.write_text(
+        "#!/bin/sh\n"
+        f"echo run >> {counter}\n"
+        # Emit SCHEMA noop so renderer stays silent.
+        'printf \'{"ok":true,"changes":{"lines_added":0,"lines_removed":0,"bytes_delta":0}}\'\n'
+    )
+    script.chmod(0o755)
+    return f"{script} {{file}}", counter
+
+
+def test_defer_runs_formatter_once_per_file_across_multi_op(tmp_path, monkeypatch, capsys) -> None:
+    target = tmp_path / "a.py"
+    target.write_text("x = 1\n")
+    cmd, counter = _make_counting_cmd(tmp_path)
+    _set_formatters({"fakefmt": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.py"}})
+
+    # Two edit ops on the same file — without deferral, formatter runs twice.
+    monkeypatch.chdir(tmp_path)
+    argv = [
+        f"edit:::x = 1:::x = 2:::{target}",
+        f"edit:::x = 2:::x = 3:::{target}",
+    ]
+    rc = supertool.main(argv)
+    assert rc == 0
+    assert target.read_text() == "x = 3\n"
+    # Formatter ran exactly once for the file (deferred to end of batch).
+    runs = counter.read_text().count("run\n")
+    assert runs == 1, f"expected 1 deferred run, got {runs}"
+
+
+def test_single_op_still_runs_formatter_inline(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "b.py"
+    target.write_text("x = 1\n")
+    cmd, counter = _make_counting_cmd(tmp_path)
+    _set_formatters({"fakefmt": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.py"}})
+
+    monkeypatch.chdir(tmp_path)
+    rc = supertool.main([f"edit:::x = 1:::x = 2:::{target}"])
+    assert rc == 0
+    assert counter.read_text().count("run\n") == 1
+
+
+def test_defer_handles_different_files_independently(tmp_path, monkeypatch) -> None:
+    a = tmp_path / "a.py"
+    b = tmp_path / "b.py"
+    a.write_text("x = 1\n")
+    b.write_text("y = 1\n")
+    cmd, counter = _make_counting_cmd(tmp_path)
+    _set_formatters({"fakefmt": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.py"}})
+
+    monkeypatch.chdir(tmp_path)
+    rc = supertool.main([
+        f"edit:::x = 1:::x = 2:::{a}",
+        f"edit:::y = 1:::y = 2:::{b}",
+    ])
+    assert rc == 0
+    # Two distinct files → formatter runs once per file.
+    assert counter.read_text().count("run\n") == 2
+
+
+def test_defer_state_reset_between_invocations(tmp_path, monkeypatch) -> None:
+    """Module-level queue must not leak across main() calls."""
+    target = tmp_path / "c.py"
+    target.write_text("x = 1\n")
+    cmd, counter = _make_counting_cmd(tmp_path)
+    _set_formatters({"fakefmt": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.py"}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([f"edit:::x = 1:::x = 2:::{target}", f"edit:::x = 2:::x = 3:::{target}"])
+    assert supertool._DEFER_FORMATTERS is False
+    assert supertool._FORMAT_QUEUE == {}


### PR DESCRIPTION
## Summary

- Closes #164. Multi-op `./supertool 'op1' 'op2' ...` invocations now queue formatters per-file and drain them once after every op has landed.
- Fixes the case where `php-cs-fixer`'s `no_unused_imports` strips a `use X;` line between op 1 and op 2, breaking op 2's call site.
- Validators still run inline per-op — rollback semantics preserved.
- Single-op calls: unchanged. Parallel batches: read-only, unaffected.

## Mechanics

- Module-level state: `_DEFER_FORMATTERS` + `_FORMAT_QUEUE` (abs_path → {name: spec}).
- `_run_with_validators`: when defer mode, merge applicable formatters into the queue and skip the inline run.
- `main()`: enables defer when `len(argv) > 1` and sequential; drains via `_drain_format_queue()` after the dispatch loop; resets state in `finally`.

## Test plan

- [x] `tests/test_formatters_deferred.py` — 4 new tests: 1 run per file across multi-op, single-op still inline, distinct files independent, state reset between invocations.
- [x] Full formatter/batch/validator sweep: 392 passed (2 phpstan failures pre-exist on master, unrelated).
- [ ] CI green