### PR TITLE
feat: defer slow validators to end-of-call with opt-in tier field (#219)

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -18,22 +18,28 @@
     "_example-php-lsp": {
       "cmd": "cclsp",
       "match": "*.{php,class.php}",
-      "env": { "CCLSP_CONFIG_PATH": ".claude/cclsp.json" },
+      "env": {
+        "CCLSP_CONFIG_PATH": ".claude/cclsp.json"
+      },
       "tools": {
         "resolve": "find_workspace_symbols",
-        "refs":    "find_references",
-        "diag":    "get_diagnostics",
-        "hover":   "get_hover",
-        "rename":  "rename_symbol"
+        "refs": "find_references",
+        "diag": "get_diagnostics",
+        "hover": "get_hover",
+        "rename": "rename_symbol"
       },
       "timeout": 60
     },
     "_example-rector-warm": {
-      "cmd": ["mcp-rector-warm", "--working-dir=/abs/path/to/project", "--config=/abs/path/to/project/rector.php"],
+      "cmd": [
+        "mcp-rector-warm",
+        "--working-dir=/abs/path/to/project",
+        "--config=/abs/path/to/project/rector.php"
+      ],
       "match": "*.php",
       "timeout": 120,
       "idle_timeout": 1800,
-      "_install": "composer global require dpt/mcp-rector-warm — then this server is on $PATH. Pair with validators/rector-mcp/ adapter for warm-process Rector validation. See validators/rector-mcp/README.md."
+      "_install": "composer global require dpt/mcp-rector-warm \u2014 then this server is on $PATH. Pair with validators/rector-mcp/ adapter for warm-process Rector validation. See validators/rector-mcp/README.md."
     }
   },
   "introduction": "supertool batches multiple file operations into one Bash call.\n\nInvoke via Bash:\n./supertool \\\n    'read:src/app/Module.py' \\\n    'read:src/app/Config.py' \\\n    'grep:class:src/app/:20' \\\n    'glob:src/app/**/*.py'\n\nRules:\n- One call, many ops. 6-7 per call is normal. Each separate call wastes money.\n- Paths are relative to project root.\n- Single quotes around each op.\n- Use Read tool ONLY for the file you're about to Edit \u2014 supertool for everything else.\n\n@file payload route (mutating ops only \u2014 edit, replace, replace_lines, paste, vim):\n- Inline:  ./supertool 'edit:::OLD:::NEW:::PATH'\n- Payload: ./supertool 'edit:@-' <<'EOF' ... EOF   (or 'edit:@path.toml')\n- Format auto-detected: starts with { or [ \u2192 JSON; else TOML.\n- TOML '''triple-single-quote''' preserves backslashes/quotes/newlines byte-for-byte \u2014 use for code blocks. Single-quoted 'literal' for one-liners with \\e etc.\n- Field names match the syntax tokens lowercased (edit:::OLD:::NEW:::PATH \u2192 old, new, path).\n\nTo avoid escape problems, use chr(10)/chr(27) instead of \\n/\\x1b in payload content.",
@@ -291,7 +297,8 @@
         "vim"
       ],
       "rollback_on_fail": true,
-      "timeout": 60
+      "timeout": 60,
+      "tier": "slow"
     },
     "bash-check": {
       "cmd": "{python} {supertool_dir}/validators/bash-check/bash-check.py {file}",
@@ -407,7 +414,8 @@
         "vim"
       ],
       "rollback_on_fail": false,
-      "timeout": 60
+      "timeout": 60,
+      "tier": "slow"
     },
     "tsc-check": {
       "cmd": "{python} {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
@@ -420,7 +428,8 @@
         "vim"
       ],
       "rollback_on_fail": false,
-      "timeout": 30
+      "timeout": 30,
+      "tier": "slow"
     },
     "tsc-check-tsx": {
       "cmd": "{python} {supertool_dir}/validators/tsc-check/tsc-check.py {file}",
@@ -496,7 +505,8 @@
       "env": {
         "PSR_STANDARD": "PSR12",
         "PSR_SEVERITY": "9"
-      }
+      },
+      "tier": "slow"
     },
     "git-status": {
       "cmd": "{python} {supertool_dir}/validators/git-status/git-status.py {file}",

--- a/supertool.py
+++ b/supertool.py
@@ -8850,6 +8850,13 @@ def _formatter_render_row(result: Dict[str, Any]) -> Optional[str]:
 _DEFER_FORMATTERS: bool = False
 _FORMAT_QUEUE: Dict[str, Dict[str, Dict[str, Any]]] = {}
 
+# Deferred-validator state for multi-op invocations (issue #219).
+# Validators with tier="slow" are queued here as (name, path) pairs instead of
+# running per-op. main() drains once after all ops complete, deduping by
+# (name, path) and preserving insertion order.
+_VALIDATOR_DEFER_QUEUE: "list[tuple[str, Dict[str, Any], str]]" = []
+_VALIDATOR_DEFER_SEEN: "set[tuple[str, str]]" = set()
+
 
 def _drain_format_queue() -> str:
     """Run queued formatters on each path once. Returns rendered output block."""
@@ -8873,6 +8880,23 @@ def _drain_format_queue() -> str:
     if not rows:
         return ""
     return "\n--- formatters (deferred) ---\n" + "\n".join(rows) + "\n"
+
+
+def _drain_validator_queue() -> str:
+    """Run queued slow validators once per unique (name, path) pair. Returns rendered output block."""
+    global _VALIDATOR_DEFER_QUEUE, _VALIDATOR_DEFER_SEEN
+    if not _VALIDATOR_DEFER_QUEUE:
+        return ""
+    rows: list = []
+    for name, spec, path in _VALIDATOR_DEFER_QUEUE:
+        data = _validator_run_one(name, spec, path)
+        if data is not None:
+            rows.extend(_validator_render_diff(None, data))
+    _VALIDATOR_DEFER_QUEUE = []
+    _VALIDATOR_DEFER_SEEN = set()
+    if not rows:
+        return ""
+    return "\n[validators-deferred]\n" + "\n".join(rows) + "\n"
 
 
 def _formatters_run_batch(
@@ -8907,8 +8931,25 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
     if not path:
         return do_op()
     applicable_fmt = _applicable_formatters(op, path)
-    applicable = _applicable_validators(op, path)
+    applicable_all = _applicable_validators(op, path)
     applicable_notif = _applicable_notifiers(op, path)
+
+    # Split validators into fast (run per-op) and slow (deferred to end-of-call).
+    # tier="slow" validators are queued in _VALIDATOR_DEFER_QUEUE and drained by
+    # main() after all ops complete. Dedup by (name, path) preserves insertion order.
+    # When not in defer mode (single-op call), all validators run inline regardless of tier.
+    applicable: Dict[str, Dict[str, Any]] = {}
+    if _DEFER_FORMATTERS:
+        for name, spec in applicable_all.items():
+            if spec.get("tier", "fast") == "slow":
+                key = (name, os.path.abspath(path))
+                if key not in _VALIDATOR_DEFER_SEEN:
+                    _VALIDATOR_DEFER_SEEN.add(key)
+                    _VALIDATOR_DEFER_QUEUE.append((name, spec, os.path.abspath(path)))
+            else:
+                applicable[name] = spec
+    else:
+        applicable = applicable_all
 
     # Multi-op invocation: queue formatters for end-of-batch instead of
     # running inline. Tidy rules (no_unused_imports) would otherwise strip
@@ -11302,11 +11343,13 @@ def main(argv: List[str]) -> int:
     )
     # Defer formatters for multi-op sequential invocations (mutating ops).
     # Parallel path is read-only — no formatters fire there anyway.
-    global _DEFER_FORMATTERS, _FORMAT_QUEUE
+    global _DEFER_FORMATTERS, _FORMAT_QUEUE, _VALIDATOR_DEFER_QUEUE, _VALIDATOR_DEFER_SEEN
     defer = len(argv) > 1 and not parallel_path
     if defer:
         _DEFER_FORMATTERS = True
         _FORMAT_QUEUE = {}
+        _VALIDATOR_DEFER_QUEUE = []
+        _VALIDATOR_DEFER_SEEN = set()
 
     try:
         if parallel_path:
@@ -11337,6 +11380,10 @@ def main(argv: List[str]) -> int:
         if drain_out:
             sys.stdout.write(drain_out)
             total_out_bytes += len(drain_out.encode("utf-8"))
+        validator_drain_out = _drain_validator_queue()
+        if validator_drain_out:
+            sys.stdout.write(validator_drain_out)
+            total_out_bytes += len(validator_drain_out.encode("utf-8"))
 
     log_call(argv, total_out_bytes)
     return 1 if any_failure else 0

--- a/tests/test_validators_deferred.py
+++ b/tests/test_validators_deferred.py
@@ -1,0 +1,243 @@
+"""Tests for deferred-validator behavior — issue #219.
+
+Validators with tier="slow" queue as (name, path) pairs instead of running
+per-op. main() drains once after all ops, deduped by (name, path).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import supertool
+
+
+def _make_counting_validator(tmp_path: Path, *, ok: bool = True) -> tuple[str, Path]:
+    """Build a validator cmd that appends a line to a counter file each call.
+
+    Emits minimal SCHEMA.md JSON on stdout. Uses sys.executable -c style (via
+    helper file) to avoid quoting/escaping issues cross-platform.
+    """
+    counter = tmp_path / "val_runs.log"
+    counter.write_text("")
+    helper = tmp_path / "_val_helper.py"
+    if ok:
+        result_json = '{"tool": "fakeval", "file": "x", "ok": true, "count": 0, "errors": [], "duration_ms": 1}'
+    else:
+        result_json = '{"tool": "fakeval", "file": "x", "ok": false, "count": 1, "errors": [{"line": null, "col": null, "severity": "error", "code": "e", "msg": "fail"}], "duration_ms": 1}'
+    helper.write_text(
+        "import sys\n"
+        f"open({str(counter)!r}, 'a').write('run\\n')\n"
+        f"print({result_json!r})\n"
+    )
+    exe = sys.executable.replace("\\", "/")
+    helper_fwd = str(helper).replace("\\", "/")
+    return f"{exe} {helper_fwd} {{file}}", counter
+
+
+def _cfg(tmp_path: Path, validators: dict) -> None:
+    supertool._CONFIG = {"validators": validators}
+    supertool._CONFIG_CHECKED = True
+
+
+def test_slow_validator_does_not_run_per_op_runs_once_at_end(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "a.php"
+    target.write_text("<?php $x = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "tier": "slow", "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    rc = supertool.main([
+        f"edit:::$x = 1:::$x = 2:::{target}",
+        f"edit:::$x = 2:::$x = 3:::{target}",
+    ])
+    assert rc == 0
+    runs = counter.read_text().count("run\n")
+    assert runs == 1, f"expected 1 deferred run, got {runs}"
+
+
+def test_fast_validator_runs_per_op(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "a.php"
+    target.write_text("<?php $x = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "tier": "fast", "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([
+        f"edit:::$x = 1:::$x = 2:::{target}",
+        f"edit:::$x = 2:::$x = 3:::{target}",
+    ])
+    runs = counter.read_text().count("run\n")
+    # before + after per op = 4 total for 2 ops (before-op1, after-op1, before-op2, after-op2)
+    assert runs == 4, f"fast validator runs before+after per op (4 for 2 ops), got {runs}"
+
+
+def test_default_tier_behaves_as_fast(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "a.php"
+    target.write_text("<?php $x = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([
+        f"edit:::$x = 1:::$x = 2:::{target}",
+        f"edit:::$x = 2:::$x = 3:::{target}",
+    ])
+    runs = counter.read_text().count("run\n")
+    assert runs == 4, f"default tier must match fast behavior (4 runs for 2 ops), got {runs}"
+
+
+def test_dedup_three_edits_same_file_runs_slow_once(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "a.php"
+    target.write_text("<?php $x = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "tier": "slow", "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([
+        f"edit:::$x = 1:::$x = 2:::{target}",
+        f"edit:::$x = 2:::$x = 3:::{target}",
+        f"edit:::$x = 3:::$x = 4:::{target}",
+    ])
+    runs = counter.read_text().count("run\n")
+    assert runs == 1, f"3 edits on same file → 1 slow run (dedup), got {runs}"
+
+
+def test_multi_file_slow_validator_runs_per_file(tmp_path, monkeypatch) -> None:
+    a = tmp_path / "a.php"
+    b = tmp_path / "b.php"
+    a.write_text("<?php $x = 1;\n")
+    b.write_text("<?php $y = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "tier": "slow", "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([
+        f"edit:::$x = 1:::$x = 2:::{a}",
+        f"edit:::$y = 1:::$y = 2:::{b}",
+        f"edit:::$x = 2:::$x = 3:::{a}",
+    ])
+    runs = counter.read_text().count("run\n")
+    assert runs == 2, f"two distinct files → 2 slow runs (one per file), got {runs}"
+
+
+def test_mixed_fast_and_slow_on_same_op(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "a.php"
+    target.write_text("<?php $x = 1;\n")
+
+    fast_counter = tmp_path / "fast_runs.log"
+    fast_counter.write_text("")
+    slow_counter = tmp_path / "slow_runs.log"
+    slow_counter.write_text("")
+
+    exe = sys.executable.replace("\\", "/")
+    fast_result = '{"tool": "fastval", "file": "x", "ok": true, "count": 0, "errors": [], "duration_ms": 1}'
+    slow_result = '{"tool": "slowval", "file": "x", "ok": true, "count": 0, "errors": [], "duration_ms": 1}'
+
+    fast_helper = tmp_path / "_fast.py"
+    fast_helper.write_text(
+        "import sys\n"
+        f"open({str(fast_counter)!r}, 'a').write('run\\n')\n"
+        f"print({fast_result!r})\n"
+    )
+
+    slow_helper = tmp_path / "_slow.py"
+    slow_helper.write_text(
+        "import sys\n"
+        f"open({str(slow_counter)!r}, 'a').write('run\\n')\n"
+        f"print({slow_result!r})\n"
+    )
+
+    fast_fwd = str(fast_helper).replace("\\", "/")
+    slow_fwd = str(slow_helper).replace("\\", "/")
+
+    supertool._CONFIG = {"validators": {
+        "fastval": {"cmd": f"{exe} {fast_fwd} {{file}}", "hooks_into": ["edit"],
+                    "match": "*.php", "tier": "fast", "cache": False},
+        "slowval": {"cmd": f"{exe} {slow_fwd} {{file}}", "hooks_into": ["edit"],
+                    "match": "*.php", "tier": "slow", "cache": False},
+    }}
+    supertool._CONFIG_CHECKED = True
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([
+        f"edit:::$x = 1:::$x = 2:::{target}",
+        f"edit:::$x = 2:::$x = 3:::{target}",
+    ])
+
+    fast_runs = fast_counter.read_text().count("run\n")
+    slow_runs = slow_counter.read_text().count("run\n")
+    # fast: before+after per op = 4 for 2 ops
+    assert fast_runs == 4, f"fast validator runs before+after per op (4), got {fast_runs}"
+    assert slow_runs == 1, f"slow validator deferred+deduped = 1 run, got {slow_runs}"
+
+
+def test_deferred_failure_does_not_rollback_prior_fast_passed_ops(tmp_path, monkeypatch, capsys) -> None:
+    """Slow validator fails at end-of-call → output contains failure, file not rolled back."""
+    target = tmp_path / "a.php"
+    target.write_text("<?php $x = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path, ok=False)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "tier": "slow", "rollback_on_fail": False, "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([
+        f"edit:::$x = 1:::$x = 2:::{target}",
+        f"edit:::$x = 2:::$x = 3:::{target}",
+    ])
+    # Edits landed — no rollback
+    assert target.read_text() == "<?php $x = 3;\n"
+    # Deferred validator ran once
+    assert counter.read_text().count("run\n") == 1
+    # Output contains the deferred block
+    captured = capsys.readouterr()
+    assert "[validators-deferred]" in captured.out
+
+
+def test_deferred_output_appears_under_validators_deferred_header(tmp_path, monkeypatch, capsys) -> None:
+    target = tmp_path / "a.php"
+    target.write_text("<?php $x = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "tier": "slow", "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([
+        f"edit:::$x = 1:::$x = 2:::{target}",
+        f"edit:::$x = 2:::$x = 3:::{target}",
+    ])
+    captured = capsys.readouterr()
+    assert "[validators-deferred]" in captured.out
+
+
+def test_defer_state_reset_between_invocations(tmp_path, monkeypatch) -> None:
+    """Module-level queue must not leak across main() calls."""
+    target = tmp_path / "c.php"
+    target.write_text("<?php $x = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "tier": "slow", "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([f"edit:::$x = 1:::$x = 2:::{target}", f"edit:::$x = 2:::$x = 3:::{target}"])
+    assert supertool._VALIDATOR_DEFER_QUEUE == []
+    assert supertool._VALIDATOR_DEFER_SEEN == set()
+
+
+def test_single_op_slow_validator_runs_inline(tmp_path, monkeypatch) -> None:
+    """Single-op call: no defer mode — slow validator runs inline like fast (before + after)."""
+    target = tmp_path / "a.php"
+    target.write_text("<?php $x = 1;\n")
+    cmd, counter = _make_counting_validator(tmp_path)
+    _cfg(tmp_path, {"fakeval": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.php",
+                                "tier": "slow", "cache": False}})
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([f"edit:::$x = 1:::$x = 2:::{target}"])
+    runs = counter.read_text().count("run\n")
+    # Single op = no defer mode, slow treated as fast: before + after = 2 runs
+    assert runs == 2, f"single-op: slow runs inline (before+after = 2), got {runs}"

--- a/validators/SCHEMA.md
+++ b/validators/SCHEMA.md
@@ -59,6 +59,7 @@ Universal JSON. Every adapter emits this shape. Validator core never parses tool
 | `opt_in`          | bool             | no       | When true, validator only runs when explicitly requested (not on every hook).             |
 | `resolve`         | string           | no       | Shell command that maps the edited file to the file the adapter should receive.           |
 | `env`             | object           | no       | Extra environment variables merged into the subprocess env (`os.environ \| spec.env`). Values are coerced to strings. Example: `{"PHPSTAN_LEVEL": "8", "PHPSTAN_CONFIG": "phpstan.neon"}`. |
+| `tier`            | string           | no       | `"fast"` (default) or `"slow"`. `fast` runs inline per-op with per-op rollback semantics. `slow` defers to end-of-call, deduped by `(validator, path)` — runs once per unique pair regardless of how many ops touched the file. Failures reported under `[validators-deferred]` header; no auto-rollback. Use `slow` for heavy validators (phpstan, phpunit, rector) to avoid re-running on every edit in a multi-op batch. |
 
 ## Adding a validator
 


### PR DESCRIPTION
## Summary

Closes #219 — adds opt-in `tier: "slow"` field on validator configs so heavy validators (phpstan, phpunit, rector) run **once per unique `(validator, file)` pair** at end of call instead of after every mutating op.

Before:
```bash
./supertool 'edit:@e1.json' 'edit:@e2.json' 'edit:@e3.json'   # all same file
# phpstan runs 3x. Same semantic analysis. Pure waste.
```

After (with `phpstan.tier = "slow"`):
```bash
./supertool 'edit:@e1.json' 'edit:@e2.json' 'edit:@e3.json'
# phpstan runs ONCE on that file at end of call.
```

## Design

- `tier: "fast"` (default if missing) — current behavior, per-op rollback semantics preserved
- `tier: "slow"` — queued in dedup set, drained once at end-of-call, rendered under `[validators-deferred]` header reusing existing format
- Single-op calls always run inline regardless of tier (defer needs multi-op batch)
- Slow-tier failures appear in output but do NOT roll back prior ops (matches deferred-formatter model that already shipped)
- Zero behavior change for users without the field

## Changes

- `supertool.py` — +51 lines: 2 module-level globals (`_VALIDATOR_DEFER_QUEUE`, `_VALIDATOR_DEFER_SEEN`), tier-split in `_run_with_validators`, `_drain_validator_queue()` called from `main()` after `_drain_format_queue()`
- `.supertool.example.json` — `"tier": "slow"` on `pyright`, `cargo-check`, `tsc-check`, `psr` (the heavy validators present in the example file)
- `validators/SCHEMA.md` — documents `tier` field, two valid values, default
- `tests/test_validators_deferred.py` — 10 new tests, all pass

## Test plan

- [x] `pytest tests/test_validators.py tests/test_validators_deferred.py` — 61/61 pass
- [x] Defer scenarios covered: same-file dedup, multi-file, mixed fast+slow on same op, deferred-failure-no-rollback, fast-tier-default-omitted, queue reset between invocations
- [ ] CI — pending this PR's run
