### PR TITLE
fix: group [validators-deferred] output by file path (#234)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -8885,19 +8885,30 @@ def _drain_format_queue() -> str:
 
 
 def _drain_validator_queue() -> str:
-    """Run queued slow validators once per unique (name, path) pair. Returns rendered output block."""
+    """Run queued slow validators once per unique (name, path) pair. Returns rendered output block.
+
+    Output groups results by path with a file header per group, so the
+    reader knows which file each validator row belongs to (issue #234).
+    """
     global _VALIDATOR_DEFER_QUEUE, _VALIDATOR_DEFER_SEEN
     if not _VALIDATOR_DEFER_QUEUE:
         return ""
-    rows: list = []
+    by_path: "dict[str, list[str]]" = {}
     for name, spec, path in _VALIDATOR_DEFER_QUEUE:
         data = _validator_run_one(name, spec, path)
-        if data is not None:
-            rows.extend(_validator_render_diff(None, data))
+        if data is None:
+            continue
+        path_rows = _validator_render_diff(None, data)
+        if path_rows:
+            by_path.setdefault(path, []).extend(path_rows)
     _VALIDATOR_DEFER_QUEUE = []
     _VALIDATOR_DEFER_SEEN = set()
-    if not rows:
+    if not by_path:
         return ""
+    rows: list = []
+    for path, path_rows in by_path.items():
+        rows.append(f"  {path}")
+        rows.extend(f"    {r}" for r in path_rows)
     return "\n[validators-deferred]\n" + "\n".join(rows) + "\n"
 
 

--- a/tests/test_validators_deferred_file_header.py
+++ b/tests/test_validators_deferred_file_header.py
@@ -1,0 +1,90 @@
+"""Issue #234 — `[validators-deferred]` output must show which file each
+validator row belongs to. Mirrors the formatter-deferred grouping."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import supertool
+
+
+def _stub_runner(monkeypatch) -> None:
+    """Stub _validator_run_one so we don't shell out to a real validator."""
+    def fake(name: str, spec: Dict[str, Any], path: str) -> Dict[str, Any]:
+        return {
+            "tool": name,
+            "file": path,
+            "ok": False,
+            "count": 1,
+            "errors": [{"line": 1, "col": 1, "severity": "error",
+                        "code": "E1", "msg": f"err in {path}"}],
+            "duration_ms": 1,
+            "elapsed_s": 0.01,
+        }
+    monkeypatch.setattr(supertool, "_validator_run_one", fake)
+
+
+def _reset_queue() -> None:
+    supertool._VALIDATOR_DEFER_QUEUE.clear()
+    supertool._VALIDATOR_DEFER_SEEN.clear()
+
+
+def test_deferred_output_groups_by_path_with_header(monkeypatch) -> None:
+    """Two files, same slow validator — output must include both paths as headers."""
+    _reset_queue()
+    _stub_runner(monkeypatch)
+    spec = {"cmd": "irrelevant", "match": "*.php", "tier": "slow"}
+    supertool._VALIDATOR_DEFER_QUEUE.extend([
+        ("phpstan", spec, "src/A.php"),
+        ("phpstan", spec, "src/B.php"),
+    ])
+
+    out = supertool._drain_validator_queue()
+
+    assert "[validators-deferred]" in out
+    assert "src/A.php" in out, f"path header for src/A.php missing:\n{out}"
+    assert "src/B.php" in out, f"path header for src/B.php missing:\n{out}"
+    # path headers must appear BEFORE the validator row for that file
+    a_idx = out.index("src/A.php")
+    b_idx = out.index("src/B.php")
+    a_err = out.index("err in src/A.php")
+    b_err = out.index("err in src/B.php")
+    assert a_idx < a_err
+    assert b_idx < b_err
+
+
+def test_deferred_output_single_file_still_has_header(monkeypatch) -> None:
+    """One file should still emit its path header for consistency."""
+    _reset_queue()
+    _stub_runner(monkeypatch)
+    spec = {"cmd": "irrelevant", "match": "*.php", "tier": "slow"}
+    supertool._VALIDATOR_DEFER_QUEUE.append(("phpstan", spec, "src/Only.php"))
+
+    out = supertool._drain_validator_queue()
+
+    assert "[validators-deferred]" in out
+    assert "src/Only.php" in out
+
+
+def test_deferred_output_empty_queue_returns_empty(monkeypatch) -> None:
+    """No queued validators → empty string (no spurious header)."""
+    _reset_queue()
+    out = supertool._drain_validator_queue()
+    assert out == ""
+
+
+def test_deferred_output_multiple_validators_same_file_grouped(monkeypatch) -> None:
+    """Two slow validators on one path — both rows under one path header."""
+    _reset_queue()
+    _stub_runner(monkeypatch)
+    spec_a = {"cmd": "a", "match": "*.php", "tier": "slow"}
+    spec_b = {"cmd": "b", "match": "*.php", "tier": "slow"}
+    supertool._VALIDATOR_DEFER_QUEUE.extend([
+        ("phpstan", spec_a, "src/X.php"),
+        ("phpmd", spec_b, "src/X.php"),
+    ])
+
+    out = supertool._drain_validator_queue()
+
+    # path header (2-space indent + path) appears once, both validator rows underneath
+    assert out.count("  src/X.php\n") == 1, f"path header should appear once:\n{out}"
+    assert "phpstan" in out and "phpmd" in out


### PR DESCRIPTION
## Summary

Slow-tier validator results stacked together with no file header in multi-file batches — readers had to grep error messages to figure out which row went with which file. Mirrors the path-grouping pattern already in \`_drain_format_queue\`.

### Before
\`\`\`
[validators-deferred]
phpstan : 0 → 2  (+2) ✗   1.2s
  + L42 ...
phpstan : 0 → 1  (+1) ✗   1.0s
  + L88 ...
\`\`\`

### After
\`\`\`
[validators-deferred]
  src/A.php
    phpstan : 0 → 2  (+2) ✗   1.2s
      + L42 ...
  src/B.php
    phpstan : 0 → 1  (+1) ✗   1.0s
      + L88 ...
\`\`\`

Closes #234

## TDD

- 4 unit tests in \`test_validators_deferred_file_header.py\` — RED first against unpatched code (2/4 fail), GREEN after fix (14/14 pass with existing deferred suite)
- Stubs \`_validator_run_one\` to avoid shelling out
- Asserts: path header present per file, single header per file when multiple validators hit it, empty queue → empty output

## Test plan
- [x] \`pytest tests/test_validators_deferred_file_header.py tests/test_validators_deferred.py\` — 14 passed
- [ ] CI green