### PR TITLE
fix: cursor-witness scrolls diff view to edited line (#236)

### DIFF
--- a/notifiers/cursor-witness/extension/src/extension.ts
+++ b/notifiers/cursor-witness/extension/src/extension.ts
@@ -89,6 +89,24 @@ async function openFile(event: WitnessEvent): Promise<void> {
       const beforeUri = vscode.Uri.file(event.before_file);
       const label = `${event.op} ${path.basename(event.file)} (Max)`;
       await vscode.commands.executeCommand("vscode.diff", beforeUri, fileUri, label, { preview: false });
+      // Scroll the diff to the edited line (issue #236). vscode.diff focuses
+      // the right-hand (after) editor by default, so activeTextEditor is the
+      // after-file — check fsPath to confirm before revealing.
+      if (event.line && event.line > 0) {
+        const editor = vscode.window.activeTextEditor;
+        if (editor && editor.document.uri.fsPath === event.file) {
+          const startLine = Math.max(0, event.line - 1);
+          const endLine = event.line_end && event.line_end >= event.line
+            ? Math.min(event.line_end - 1, editor.document.lineCount - 1)
+            : startLine;
+          const lastLine = Math.min(endLine, editor.document.lineCount - 1);
+          const range = new vscode.Range(
+            new vscode.Position(startLine, 0),
+            new vscode.Position(lastLine, editor.document.lineAt(lastLine).text.length),
+          );
+          editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+        }
+      }
       // Best-effort cleanup of the temp before-file once VSCode has read it.
       // Delay so the diff editor finishes loading.
       setTimeout(() => {

--- a/supertool.py
+++ b/supertool.py
@@ -8299,6 +8299,28 @@ _sweep_old_notifier_temp_files()
 atexit.register(_sweep_old_notifier_temp_files)
 
 
+def _first_changed_line(pre: bytes, post_path: str) -> Optional[int]:
+    """Return the 1-indexed line of the first difference between pre bytes
+    and the current contents of post_path. None if the file is unreadable
+    or unchanged. Used by mutating-op notifiers so observers (cursor-witness)
+    can scroll the diff view to the edit (issue #236)."""
+    try:
+        with open(post_path, "rb") as f:
+            post = f.read()
+    except OSError:
+        return None
+    if pre == post:
+        return None
+    pre_lines = pre.splitlines(keepends=True)
+    post_lines = post.splitlines(keepends=True)
+    n = min(len(pre_lines), len(post_lines))
+    for i in range(n):
+        if pre_lines[i] != post_lines[i]:
+            return i + 1
+    # All shared lines match — the divergence is at the tail (insert/delete).
+    return n + 1 if (len(pre_lines) != len(post_lines)) else None
+
+
 def _run_notifiers(op: str, path: str, line: Optional[int] = None,
                    pre_content: Optional[bytes] = None,
                    line_end: Optional[int] = None) -> None:
@@ -8316,6 +8338,10 @@ def _run_notifiers(op: str, path: str, line: Optional[int] = None,
     if not specs:
         _notifier_log(f"no notifier applicable for op={op} path={path}")
         return
+    # Mutating ops carry no caller-supplied line but the diff against pre_content
+    # gives us the first changed line — let observers (cursor-witness) scroll to it.
+    if line is None and pre_content is not None and path and os.path.isfile(path):
+        line = _first_changed_line(pre_content, path)
     _notifier_log(f"dispatch op={op} path={path} line={line} line_end={line_end} pre_content={len(pre_content) if pre_content else 0}B notifiers={list(specs.keys())}")
 
     before_file = ""

--- a/tests/test_notifier_first_changed_line.py
+++ b/tests/test_notifier_first_changed_line.py
@@ -1,0 +1,49 @@
+"""Issue #236 — mutating-op notifier must compute the first changed line
+from pre_content vs the post-edit file, so observers (cursor-witness) can
+scroll the diff view to the edit instead of parking at line 1."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def test_first_changed_line_middle_edit(tmp_path: Path) -> None:
+    pre = b"a\nb\nc\nd\ne\n"
+    f = tmp_path / "f.txt"
+    f.write_bytes(b"a\nb\nCHANGED\nd\ne\n")
+    assert supertool._first_changed_line(pre, str(f)) == 3
+
+
+def test_first_changed_line_first_line_edit(tmp_path: Path) -> None:
+    pre = b"a\nb\nc\n"
+    f = tmp_path / "f.txt"
+    f.write_bytes(b"X\nb\nc\n")
+    assert supertool._first_changed_line(pre, str(f)) == 1
+
+
+def test_first_changed_line_tail_insert(tmp_path: Path) -> None:
+    pre = b"a\nb\nc\n"
+    f = tmp_path / "f.txt"
+    f.write_bytes(b"a\nb\nc\nd\ne\n")
+    # Shared prefix is 3 lines; divergence at line 4.
+    assert supertool._first_changed_line(pre, str(f)) == 4
+
+
+def test_first_changed_line_tail_delete(tmp_path: Path) -> None:
+    pre = b"a\nb\nc\nd\n"
+    f = tmp_path / "f.txt"
+    f.write_bytes(b"a\nb\n")
+    # Shared prefix is 2 lines; divergence is the missing line 3.
+    assert supertool._first_changed_line(pre, str(f)) == 3
+
+
+def test_first_changed_line_no_change(tmp_path: Path) -> None:
+    pre = b"a\nb\nc\n"
+    f = tmp_path / "f.txt"
+    f.write_bytes(pre)
+    assert supertool._first_changed_line(pre, str(f)) is None
+
+
+def test_first_changed_line_missing_file_returns_none(tmp_path: Path) -> None:
+    assert supertool._first_changed_line(b"x\n", str(tmp_path / "nope.txt")) is None


### PR DESCRIPTION
## Summary

Diff view opened by cursor-witness on mutating ops always parked at line 1 because (a) supertool never sent a line number with edit events, and (b) the extension early-returned after \`vscode.diff\` without calling \`revealRange\`. Fixed both sides.

## Changes

**supertool.py**
- \`_first_changed_line(pre_bytes, post_path)\` — 1-indexed first divergence. Handles 5 cases: middle edit, first-line edit, tail insert, tail delete, unchanged.
- \`_run_notifiers\` auto-derives \`line\` from \`pre_content\` when none provided. Mutating ops now ship a real line through to notifiers without each call site computing it.

**notifiers/cursor-witness/extension/src/extension.ts**
- After \`vscode.diff\` opens the side-by-side view, reveal \`event.line\` on the active editor. Uri-fspath check guards against vscode focusing the wrong side.

## TDD

\`test_notifier_first_changed_line.py\` — 6 unit tests pinning the diff-line computation. RED on unpatched code, GREEN after.

## Test plan
- [x] \`pytest tests/test_notifier_first_changed_line.py\` — 6 passed
- [x] \`npx tsc --noEmit\` on extension — clean (after \`npm install\`)
- [ ] CI green
- [ ] Manual smoke in Cursor: edit a file at line ~50, diff view scrolls to the edit (need to rebuild + reinstall .vsix to verify)

Closes #236