### PR TITLE
chore(cursor-witness): bump to 0.1.1

### DIFF
--- a/notifiers/cursor-witness/extension/package-lock.json
+++ b/notifiers/cursor-witness/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-witness",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-witness",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.80.0",

--- a/notifiers/cursor-witness/extension/package.json
+++ b/notifiers/cursor-witness/extension/package.json
@@ -2,7 +2,7 @@
   "name": "cursor-witness",
   "displayName": "Cursor Witness",
   "description": "Watch your supertool agent work in Cursor — opens files the agent edits, jumps to changed lines.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "digital-process-tools",
   "engines": {
     "vscode": "^1.80.0"

--- a/notifiers/cursor-witness/install.sh
+++ b/notifiers/cursor-witness/install.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXT_DIR="$SCRIPT_DIR/extension"
-TARGET_NAME="digital-process-tools.cursor-witness-0.1.0"
+TARGET_NAME="digital-process-tools.cursor-witness-0.1.1"
 
 INSTALL_CURSOR=1
 INSTALL_VSCODE=0


### PR DESCRIPTION
## Summary

Version bump for the reveal-edited-line fix shipped in #237.

- \`package.json\`: 0.1.0 → 0.1.1
- \`install.sh\` TARGET_NAME bumped so the new .vsix doesn't get masked by the old install
- \`package-lock.json\` updated by \`npm install\`

Built locally with \`bash notifiers/cursor-witness/install.sh\` — installed into Cursor 0.1.1 cleanly.

Refs #236