### PR TITLE
feat: advise 'write a test' on paste of new class without one (#242)

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -2,6 +2,7 @@
   "compact": false,
   "rtk": false,
   "parallel": 0,
+  "adviseForNewTest": false,
   "presets": [
     "git",
     "github",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,6 +174,14 @@ Set `"compact": true` in `.supertool.json` to enable compact reads. When enabled
 
 Compact is disabled when using `grep=` filter or `offset` (editing needs exact lines).
 
+## Advise on new class without test
+
+```json
+{ "adviseForNewTest": true }
+```
+
+Opt-in (default false). When set, a `paste` that creates a new `*.php` file with no resolvable sibling test gets a non-blocking `[advice]` line appended to the op output. It reuses a validator's `resolve` cmd to find the would-be test path. Full contract in [validators.md → resolve](validators.md#resolve--map-a-source-file-to-its-real-target).
+
 ## Parallel execution
 
 Read-only ops in a batch can run concurrently. Output order is preserved (matches input order, not completion order).

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -209,6 +209,52 @@ Custom validators must conform to the adapter contract in `validators/SCHEMA.md`
 
 Two optional output fields worth knowing: `source_context` (array of source lines centered on the error, rendered indented under each error in verbose mode) and `diff` (unified diff string, rendered as a fenced block — useful for tools like Rector that produce a suggested patch). Full spec in [SCHEMA.md](../validators/SCHEMA.md).
 
+## resolve — map a source file to its real target
+
+By default a validator runs against the file the op touched. The optional `resolve` key lets it run against a *different* file derived from that one — the canonical case is "edited a source file, run its test." `resolve` is a shell cmd that takes the edited file (`{file}`) and prints the path to run instead:
+
+```json
+"phpunit": {
+  "cmd": "... {file}",
+  "match": "*.php",
+  "hooks_into": ["edit", "replace", "replace_lines", "paste", "vim"],
+  "resolve": "bash .claude/scripts/resolve_test.sh {file}",
+  "tier": "slow"
+}
+```
+
+**Contract — supertool reads stdout only:**
+
+- Non-empty stdout → that path becomes the validator's target.
+- Empty stdout → the validator is **skipped** for this op (nothing sensible to run).
+
+The exit code is **ignored** by the validator path. That is deliberate, and it's what makes the advisory below possible.
+
+### adviseForNewTest — nag on a new class with no test
+
+Autonomous flows that write only through supertool bypass the editor/git-hook reminders to write a test. With the top-level flag enabled:
+
+```json
+// .supertool.json — opt-in, default false
+{ "adviseForNewTest": true }
+```
+
+a `paste` that **creates a new `*.php` file** (it did not exist before) with no resolvable sibling test gets a non-blocking line appended to the op output:
+
+```
+[advice]
+ℹ new class without test — consider tests/unit/SiX/FooTest.php
+```
+
+It reuses the same `resolve` cmd declared on a validator, so the source→test path logic lives in exactly one place. Because the advisory needs the *would-be* target (which doesn't exist yet) while the validator path needs stdout to stay empty on a miss, the resolver signals the two cases on different channels:
+
+| case | stdout | stderr | exit |
+|------|--------|--------|------|
+| test exists | test path | — | 0 |
+| no test | *(empty)* | would-be target | 3 |
+
+stdout stays empty on a miss → the validator still skips, unchanged. The miss target rides on **stderr**, flagged by **exit 3** → only the advisory reads it. Advisory only: it never blocks the write, and never fires on a rewrite of an existing file.
+
 ## Format-on-save
 
 See [formatters.md](formatters.md) — formatters run after every edit, before validators, normalizing whitespace and style before the safety check runs.

--- a/supertool.py
+++ b/supertool.py
@@ -8953,6 +8953,55 @@ def _formatters_run_batch(
     return [_formatter_run_one(name, spec, path) for name, spec in applicable.items()]
 
 
+def _advise_new_test(op: str, path: str, pre_existed: bool) -> str:
+    """Advisory (never blocks): nag when a `paste` creates a new source file
+    that has no sibling test.
+
+    Opt-in via top-level config ``adviseForNewTest: true``. Reuses a validator's
+    ``resolve`` cmd (the source→test resolver) to find the would-be test target:
+    the resolver exits 3 and prints the target on stderr when no test exists
+    (stdout stays empty so the phpunit validator still skips). Returns an
+    ``[advice]`` block, or "" when not applicable.
+    """
+    if pre_existed or op != "paste":
+        return ""
+    cfg = _load_config()
+    if not cfg.get("adviseForNewTest"):
+        return ""
+    if not path.endswith(".php"):
+        return ""
+    # Reuse the source→test resolver declared on a validator (e.g. phpunit).
+    resolve_cmd = None
+    for spec in (cfg.get("validators") or {}).values():
+        if isinstance(spec, dict) and spec.get("resolve"):
+            resolve_cmd = spec["resolve"]
+            break
+    if not resolve_cmd:
+        return ""
+    cmd = (resolve_cmd
+           .replace("{supertool_dir}", _INSTALL_DIR)
+           .replace("{python}", _python_token())
+           .replace("{file}", shlex.quote(path)))
+    _prefix_env, cmd = _extract_env_prefix(cmd)
+    _merged_env = {**os.environ, **_prefix_env}
+    cmd = _expand_env(cmd, _merged_env)
+    try:
+        r = subprocess.run(shlex.split(cmd), shell=False, capture_output=True,
+                           text=True, timeout=30,
+                           env=(_merged_env if _prefix_env else None))
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    if r.returncode != 3:
+        return ""
+    target = ""
+    if r.stderr.strip():
+        target = r.stderr.strip().splitlines()[-1]
+    msg = "ℹ new class without test"
+    if target:
+        msg += f" — consider {target}"
+    return "\n[advice]\n" + msg + "\n"
+
+
 def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
     """Wrap edit op with format+snapshot+run+diff using configured formatters/validators.
 
@@ -8969,6 +9018,7 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
         return do_op()
     if not path:
         return do_op()
+    _pre_existed = os.path.isfile(path)
     applicable_fmt = _applicable_formatters(op, path)
     applicable_all = _applicable_validators(op, path)
     applicable_notif = _applicable_notifiers(op, path)
@@ -9009,7 +9059,9 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
                 pass
         body = do_op()
         _run_notifiers(op, path, pre_content=pre_for_notif)
-        return body
+        if isinstance(body, str) and body.startswith("ERROR"):
+            return body
+        return body + _advise_new_test(op, path, _pre_existed)
 
     needs_rollback = any(v.get("rollback_on_fail") for v in applicable.values())
     needs_fmt_rollback = any(v.get("rollback_on_fail") for v in applicable_fmt.values())
@@ -9090,7 +9142,7 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
     if applicable:
         suffix += "\n[validators]\n" + diff_out
 
-    return body + suffix
+    return body + suffix + _advise_new_test(op, path, _pre_existed)
 
 
 def op_validate(path: str, tool_filter: Optional[list] = None, verbose: bool = False) -> str:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -635,3 +635,62 @@ def test_phplint_adapter_no_arg_returns_schema_error() -> None:
     assert data["tool"] == "phplint"
     assert data["ok"] is False
     assert "no file arg" in data["errors"][0]["msg"]
+
+
+# ---------------------------------------------------------------------------
+# _advise_new_test — paste-time "write a test" advisory
+# ---------------------------------------------------------------------------
+
+# resolve cmd that signals a miss: exit 3 + would-be target on stderr.
+_RESOLVE_MISS = (
+    '{python} -c "import sys; '
+    "sys.stderr.write('tests/unit/SiX/FooTest.php'); sys.exit(3)\""
+)
+# resolve cmd that signals a hit: exit 0 + test path on stdout.
+_RESOLVE_HIT = '{python} -c "import sys; sys.stdout.write(\'tests/unit/SiX/FooTest.php\')"'
+
+
+def _set_advice_config(enabled: bool, resolve: str | None = _RESOLVE_MISS) -> None:
+    validators: dict = {}
+    if resolve is not None:
+        validators["phpunit"] = {"cmd": "noop", "resolve": resolve}
+    supertool._CONFIG = {"adviseForNewTest": enabled, "validators": validators}
+    supertool._CONFIG_CHECKED = True
+
+
+def test_advise_emitted_for_new_class_without_test() -> None:
+    _set_advice_config(True)
+    out = supertool._advise_new_test("paste", "Dvsi/.../Foo.class.php", pre_existed=False)
+    assert "[advice]" in out
+    assert "new class without test" in out
+    assert "tests/unit/SiX/FooTest.php" in out
+
+
+def test_advise_silent_when_flag_disabled() -> None:
+    _set_advice_config(False)
+    assert supertool._advise_new_test("paste", "Foo.class.php", pre_existed=False) == ""
+
+
+def test_advise_silent_when_file_already_existed() -> None:
+    _set_advice_config(True)
+    assert supertool._advise_new_test("paste", "Foo.class.php", pre_existed=True) == ""
+
+
+def test_advise_silent_for_non_paste_op() -> None:
+    _set_advice_config(True)
+    assert supertool._advise_new_test("edit", "Foo.class.php", pre_existed=False) == ""
+
+
+def test_advise_silent_for_non_php_file() -> None:
+    _set_advice_config(True)
+    assert supertool._advise_new_test("paste", "styles.scss", pre_existed=False) == ""
+
+
+def test_advise_silent_when_test_exists() -> None:
+    _set_advice_config(True, resolve=_RESOLVE_HIT)
+    assert supertool._advise_new_test("paste", "Foo.class.php", pre_existed=False) == ""
+
+
+def test_advise_silent_when_no_resolve_cmd() -> None:
+    _set_advice_config(True, resolve=None)
+    assert supertool._advise_new_test("paste", "Foo.class.php", pre_existed=False) == ""


### PR DESCRIPTION
## Summary

Advisory (never blocks) that nags when a `paste` creates a new `*.php` file with no resolvable sibling test — opt-in via top-level `adviseForNewTest` (default false). Closes the gap where autonomous flows writing only through supertool bypass the editor/git-hook test reminders.

## How it works

- Reuses a validator's existing `resolve` cmd as the single source→test path resolver — no duplicated path logic.
- The resolver signals a miss via **exit 3 + would-be target on stderr**, keeping **stdout empty** so the `phpunit` validator still skips unchanged (it keys on stdout, ignores exit code).
- On a new-file `paste` with exit 3, supertool appends:
  ```
  [advice]
  ℹ new class without test — consider tests/unit/SiX/FooTest.php
  ```

## Changes

- `supertool.py` — `_advise_new_test()` + wiring into `_run_with_validators` (captures pre-existing state, fires only for `paste` creating a new `.php`).
- `.supertool.example.json` — `adviseForNewTest: false`.
- `docs/validators.md` — new `resolve` section (was undocumented) + `adviseForNewTest` contract table.
- `docs/configuration.md` — short cross-linked entry.
- `tests/test_validators.py` — 7 tests (emit / flag-off / pre-existed / non-paste / non-php / test-exists / no-resolve-cmd).

The dvsi-side `resolve_test.sh` exit-3 change ships separately in the dvsi repo.

## Test plan

- [x] `pytest tests/test_validators.py` — 58 pass (7 new)
- [x] e2e: paste new class → `[advice]` with mirror path; re-paste existing → none
- [ ] CI green (2 local `test_validators_phpstan.py` failures are a local phpstan-env issue, unrelated)

Closes #242
