### PR TITLE
test: integration coverage for adviseForNewTest via a real resolver script

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -694,3 +694,71 @@ def test_advise_silent_when_test_exists() -> None:
 def test_advise_silent_when_no_resolve_cmd() -> None:
     _set_advice_config(True, resolve=None)
     assert supertool._advise_new_test("paste", "Foo.class.php", pre_existed=False) == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration: advisory driven by a real external resolver script
+# (a resolve_test.sh equivalent) — proves the subprocess + exit-3 + stderr
+# contract end-to-end, not just inline {python} -c stand-ins.
+# ---------------------------------------------------------------------------
+
+def _write_resolver_script(tmp_path: Path) -> Path:
+    """A cross-platform resolve_test.sh equivalent.
+
+    Mirrors the real script's contract against the actual filesystem:
+      already a test (*Test.php)  -> echo it on stdout, exit 0
+      mirror test exists on disk  -> echo it on stdout, exit 0
+      no test                     -> mirror target on stderr, exit 3
+    Mirror rule: /src/ -> /tests/, Foo.php -> FooTest.php.
+    """
+    script = tmp_path / "resolve_test_equiv.py"
+    script.write_text(
+        "import os, sys\n"
+        "src = sys.argv[1]\n"
+        "if src.endswith('Test.php'):\n"
+        "    sys.stdout.write(src); sys.exit(0)\n"
+        "mirror = src.replace('/src/', '/tests/')\n"
+        "if mirror.endswith('.php'):\n"
+        "    mirror = mirror[:-4] + 'Test.php'\n"
+        "if os.path.isfile(mirror):\n"
+        "    sys.stdout.write(mirror); sys.exit(0)\n"
+        "sys.stderr.write(mirror); sys.exit(3)\n"
+    )
+    return script
+
+
+def _set_advice_config_with_script(script: Path) -> None:
+    resolve = f'{{python}} {script.as_posix()} {{file}}'
+    supertool._CONFIG = {
+        "adviseForNewTest": True,
+        "validators": {"phpunit": {"cmd": "noop", "resolve": resolve}},
+    }
+    supertool._CONFIG_CHECKED = True
+
+
+def test_advise_real_script_emits_when_no_test_on_disk(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src" / "Mod"
+    src_dir.mkdir(parents=True)
+    src = src_dir / "Foo.php"
+    src.write_text("<?php\nclass Foo {}\n")
+    _set_advice_config_with_script(_write_resolver_script(tmp_path))
+
+    out = supertool._advise_new_test("paste", str(src), pre_existed=False)
+    assert "[advice]" in out
+    # The would-be target the real script wrote to stderr (exit 3).
+    expected = str(src).replace("/src/", "/tests/")[:-4] + "Test.php"
+    assert expected in out
+
+
+def test_advise_real_script_silent_when_test_on_disk(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src" / "Mod"
+    src_dir.mkdir(parents=True)
+    src = src_dir / "Foo.php"
+    src.write_text("<?php\nclass Foo {}\n")
+    # Create the mirror test so the script takes the hit branch (exit 0 + stdout).
+    test_dir = tmp_path / "tests" / "Mod"
+    test_dir.mkdir(parents=True)
+    (test_dir / "FooTest.php").write_text("<?php\nclass FooTest {}\n")
+    _set_advice_config_with_script(_write_resolver_script(tmp_path))
+
+    assert supertool._advise_new_test("paste", str(src), pre_existed=False) == ""

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -710,11 +710,14 @@ def _write_resolver_script(tmp_path: Path) -> Path:
       mirror test exists on disk  -> echo it on stdout, exit 0
       no test                     -> mirror target on stderr, exit 3
     Mirror rule: /src/ -> /tests/, Foo.php -> FooTest.php.
+
+    argv path is normalized to forward slashes so the /src/ -> /tests/
+    mirror rule works on Windows, where the path arrives with backslashes.
     """
     script = tmp_path / "resolve_test_equiv.py"
     script.write_text(
         "import os, sys\n"
-        "src = sys.argv[1]\n"
+        "src = sys.argv[1].replace(os.sep, '/')\n"
         "if src.endswith('Test.php'):\n"
         "    sys.stdout.write(src); sys.exit(0)\n"
         "mirror = src.replace('/src/', '/tests/')\n"
@@ -746,7 +749,7 @@ def test_advise_real_script_emits_when_no_test_on_disk(tmp_path: Path) -> None:
     out = supertool._advise_new_test("paste", str(src), pre_existed=False)
     assert "[advice]" in out
     # The would-be target the real script wrote to stderr (exit 3).
-    expected = str(src).replace("/src/", "/tests/")[:-4] + "Test.php"
+    expected = src.as_posix().replace("/src/", "/tests/")[:-4] + "Test.php"
     assert expected in out
 
 


### PR DESCRIPTION
## Summary

Integration coverage for `adviseForNewTest` (#243) using a **real external resolver script** — a `resolve_test.sh` equivalent — instead of inline `{python} -c` fakes.

Two tests run a standalone resolver that resolves against the actual filesystem and exercise the full subprocess + exit-code + stderr contract:

- **miss** (no test on disk) → resolver exits 3, writes the would-be target to stderr → supertool appends `[advice]` with that target.
- **hit** (mirror `FooTest.php` present) → resolver exits 0 + stdout → advisory stays silent.

This addresses the gap noted on #243: the original 7 tests proved the logic with python one-liners, but nothing exercised a real script playing the resolver role the way dvsi's `resolve_test.sh` does in production.

## Test plan

- [x] `pytest -k advise` → 9 pass (2 new)
