### PR TITLE
fix: gl/gh-issue-create @file/@- route + gitlab --description (#246)

### DIFF
--- a/presets/github/issue_create.py
+++ b/presets/github/issue_create.py
@@ -27,6 +27,8 @@ def _gh(args: list[str], timeout: int = 20) -> subprocess.CompletedProcess[str]:
 
 
 def _load_payload(path: str) -> dict:
+    if path.startswith("@"):
+        path = path[1:]
     if path == "-":
         raw = sys.stdin.read()
     else:

--- a/presets/gitlab/issue_create.py
+++ b/presets/gitlab/issue_create.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 try:
@@ -34,6 +32,8 @@ def _glab_api(method: str, endpoint: str, *extra: str, timeout: int = 15) -> sub
 
 
 def _load_payload(path: str) -> dict:
+    if path.startswith("@"):
+        path = path[1:]
     if path == "-":
         raw = sys.stdin.read()
     else:
@@ -88,90 +88,80 @@ def main() -> int:
     estimate: str = payload.get("estimate", "")
     links: list[dict] = payload.get("links") or []
 
-    tmp_desc: str | None = None
+    if description_file:
+        body = Path(description_file).read_text()
+    else:
+        body = description
+
+    if estimate:
+        if not re.match(r"^\d+(\.\d+)?[mhdw]$", estimate):
+            print(f"ERROR: invalid estimate format: {estimate!r} (expected e.g. '4h', '30m', '2d')")
+            return 1
+        body = body.rstrip() + f"\n\n/estimate {estimate}"
+
+    cmd = [
+        "issue", "create",
+        "--repo", project,
+        "--title", title,
+        "--description", body,
+    ]
+    for label in labels:
+        cmd += ["--label", label]
+    if milestone_id is not None:
+        cmd += ["--milestone", str(milestone_id)]
+    if assignee_ids:
+        cmd += ["--assignee", ",".join(str(i) for i in assignee_ids)]
+
     try:
-        if description_file:
-            body = Path(description_file).read_text()
-        else:
-            body = description
+        result = _glab(cmd, timeout=30)
+    except FileNotFoundError:
+        print("ERROR: glab not found — install from https://gitlab.com/gitlab-org/cli")
+        return 1
+    except subprocess.TimeoutExpired:
+        print("ERROR: glab timed out")
+        return 1
 
-        if estimate:
-            if not re.match(r"^\d+(\.\d+)?[mhdw]$", estimate):
-                print(f"ERROR: invalid estimate format: {estimate!r} (expected e.g. '4h', '30m', '2d')")
-                return 1
-            body = body.rstrip() + f"\n\n/estimate {estimate}"
+    if result.returncode != 0:
+        print(f"ERROR: glab issue create failed (exit {result.returncode})")
+        print(result.stderr.strip() or result.stdout.strip())
+        return 1
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-            f.write(body)
-            tmp_desc = f.name
+    output = result.stdout.strip()
+    url = ""
+    iid = ""
+    for line in output.splitlines():
+        line = line.strip()
+        if "/-/issues/" in line or "/issues/" in line:
+            url = line
+            parts = line.rstrip("/").split("/")
+            if parts:
+                iid = parts[-1]
+            break
 
-        cmd = [
-            "issue", "create",
-            "--repo", project,
-            "--title", title,
-            "--description-file", tmp_desc,
-        ]
-        for label in labels:
-            cmd += ["--label", label]
-        if milestone_id is not None:
-            cmd += ["--milestone", str(milestone_id)]
-        if assignee_ids:
-            cmd += ["--assignee", ",".join(str(i) for i in assignee_ids)]
+    if not url:
+        url = output.splitlines()[-1] if output else "?"
+        parts = url.rstrip("/").split("/")
+        iid = parts[-1] if parts else "?"
 
-        try:
-            result = _glab(cmd, timeout=30)
-        except FileNotFoundError:
-            print("ERROR: glab not found — install from https://gitlab.com/gitlab-org/cli")
-            return 1
-        except subprocess.TimeoutExpired:
-            print("ERROR: glab timed out")
-            return 1
+    if links and iid and iid != "?" and not iid.isdigit():
+        print(f"gl-issue-create OK iid={iid} url={url}  (links skipped — could not extract numeric iid)", file=sys.stderr)
+    elif links and iid and iid != "?":
+        encoded_project = project.replace("/", "%2F")
+        for link in links:
+            target_iid = link.get("target_iid")
+            link_type = link.get("type", "relates_to")
+            if target_iid is None:
+                continue
+            _glab_api(
+                "POST",
+                f"projects/{encoded_project}/issues/{iid}/links",
+                f"--field=target_project_id={encoded_project}",
+                f"--field=target_issue_iid={target_iid}",
+                f"--field=link_type={link_type}",
+            )
 
-        if result.returncode != 0:
-            print(f"ERROR: glab issue create failed (exit {result.returncode})")
-            print(result.stderr.strip() or result.stdout.strip())
-            return 1
-
-        output = result.stdout.strip()
-        url = ""
-        iid = ""
-        for line in output.splitlines():
-            line = line.strip()
-            if "/-/issues/" in line or "/issues/" in line:
-                url = line
-                parts = line.rstrip("/").split("/")
-                if parts:
-                    iid = parts[-1]
-                break
-
-        if not url:
-            url = output.splitlines()[-1] if output else "?"
-            parts = url.rstrip("/").split("/")
-            iid = parts[-1] if parts else "?"
-
-        if links and iid and iid != "?" and not iid.isdigit():
-            print(f"gl-issue-create OK iid={iid} url={url}  (links skipped — could not extract numeric iid)", file=sys.stderr)
-        elif links and iid and iid != "?":
-            encoded_project = project.replace("/", "%2F")
-            for link in links:
-                target_iid = link.get("target_iid")
-                link_type = link.get("type", "relates_to")
-                if target_iid is None:
-                    continue
-                _glab_api(
-                    "POST",
-                    f"projects/{encoded_project}/issues/{iid}/links",
-                    f"--field=target_project_id={encoded_project}",
-                    f"--field=target_issue_iid={target_iid}",
-                    f"--field=link_type={link_type}",
-                )
-
-        print(f"gl-issue-create OK iid={iid} url={url}")
-        return 0
-
-    finally:
-        if tmp_desc and os.path.exists(tmp_desc):
-            os.unlink(tmp_desc)
+    print(f"gl-issue-create OK iid={iid} url={url}")
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_create.py
+++ b/tests/test_issue_create.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import subprocess
 import sys
@@ -49,6 +50,13 @@ def _write_body_file(tmp_path: Path, content: str) -> str:
     p = tmp_path / "body.md"
     p.write_text(content)
     return str(p)
+
+
+def _flag_value(args: list[str], flag: str) -> str | None:
+    for i, a in enumerate(args):
+        if a == flag and i + 1 < len(args):
+            return args[i + 1]
+    return None
 
 
 # ===========================================================================
@@ -144,12 +152,10 @@ class TestGitlabIssueCreate:
         payload_file = _write_payload(tmp_path, payload)
         monkeypatch.setattr(sys, "argv", ["issue_create.py", payload_file])
 
-        written_bodies: list[str] = []
+        captured: list[list[str]] = []
 
         def fake_glab(args, timeout=20):
-            for i, a in enumerate(args):
-                if a == "--description-file" and i + 1 < len(args):
-                    written_bodies.append(Path(args[i + 1]).read_text())
+            captured.append(args)
             return _ok(GL_URL)
 
         monkeypatch.setattr(gl, "_glab", fake_glab)
@@ -157,8 +163,11 @@ class TestGitlabIssueCreate:
 
         rc = gl.main()
         assert rc == 0
-        assert written_bodies, "description-file arg not passed"
-        assert "From file" in written_bodies[0]
+        assert captured, "glab not called"
+        assert "--description-file" not in captured[0], "should use --description, not --description-file"
+        desc = _flag_value(captured[0], "--description")
+        assert desc is not None, "--description arg not passed"
+        assert "From file" in desc
 
     def test_estimate_appended_to_description(self, monkeypatch, capsys, tmp_path):
         payload = {
@@ -170,12 +179,10 @@ class TestGitlabIssueCreate:
         payload_file = _write_payload(tmp_path, payload)
         monkeypatch.setattr(sys, "argv", ["issue_create.py", payload_file])
 
-        written_bodies: list[str] = []
+        captured: list[list[str]] = []
 
         def fake_glab(args, timeout=20):
-            for i, a in enumerate(args):
-                if a == "--description-file" and i + 1 < len(args):
-                    written_bodies.append(Path(args[i + 1]).read_text())
+            captured.append(args)
             return _ok(GL_URL)
 
         monkeypatch.setattr(gl, "_glab", fake_glab)
@@ -183,8 +190,45 @@ class TestGitlabIssueCreate:
 
         rc = gl.main()
         assert rc == 0
-        assert written_bodies
-        assert "/estimate 4h" in written_bodies[0]
+        assert captured
+        desc = _flag_value(captured[0], "--description")
+        assert desc is not None
+        assert "/estimate 4h" in desc
+
+    def test_uses_description_flag_not_file(self, monkeypatch, capsys, tmp_path):
+        payload_file = _write_payload(tmp_path, GL_MINIMAL)
+        monkeypatch.setattr(sys, "argv", ["issue_create.py", payload_file])
+
+        captured: list[list[str]] = []
+        monkeypatch.setattr(gl, "_glab", lambda args, timeout=20: captured.append(args) or _ok(GL_URL))
+        monkeypatch.setattr(gl, "_glab_api", lambda *a, **kw: _ok("{}"))
+
+        rc = gl.main()
+        assert rc == 0
+        assert "--description-file" not in captured[0]
+        assert _flag_value(captured[0], "--description") == "Hello world"
+
+    def test_at_prefix_stripped(self, monkeypatch, capsys, tmp_path):
+        payload_file = _write_payload(tmp_path, GL_MINIMAL)
+        monkeypatch.setattr(sys, "argv", ["issue_create.py", "@" + payload_file])
+        monkeypatch.setattr(gl, "_glab", lambda args, timeout=20: _ok(GL_URL))
+        monkeypatch.setattr(gl, "_glab_api", lambda *a, **kw: _ok("{}"))
+
+        rc = gl.main()
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert "gl-issue-create OK" in out
+
+    def test_stdin_via_at_dash(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["issue_create.py", "@-"])
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(GL_MINIMAL)))
+        monkeypatch.setattr(gl, "_glab", lambda args, timeout=20: _ok(GL_URL))
+        monkeypatch.setattr(gl, "_glab_api", lambda *a, **kw: _ok("{}"))
+
+        rc = gl.main()
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert "gl-issue-create OK" in out
 
     def test_error_path_propagates(self, monkeypatch, capsys, tmp_path):
         payload_file = _write_payload(tmp_path, GL_MINIMAL)
@@ -483,3 +527,23 @@ class TestGithubIssueCreate:
             out = capsys.readouterr().out
             assert rc == 0
             assert f"number={expected_number}" in out
+
+    def test_at_prefix_stripped(self, monkeypatch, capsys, tmp_path):
+        payload_file = _write_payload(tmp_path, GH_MINIMAL)
+        monkeypatch.setattr(sys, "argv", ["issue_create.py", "@" + payload_file])
+        monkeypatch.setattr(gh, "_gh", lambda args, timeout=20: _ok(GH_URL))
+
+        rc = gh.main()
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert "gh-issue-create OK" in out
+
+    def test_stdin_via_at_dash(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["issue_create.py", "@-"])
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(GH_MINIMAL)))
+        monkeypatch.setattr(gh, "_gh", lambda args, timeout=20: _ok(GH_URL))
+
+        rc = gh.main()
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert "gh-issue-create OK" in out


### PR DESCRIPTION
Fixes both bugs reported in #246.

## Bugs

1. **gitlab `--description-file` rejected** — the installed glab build doesn't support `--description-file` ("Unknown flag"). `gitlab/issue_create.py` now passes `--description` with the body string it already holds in memory. Drops the temp file, the `try/finally` cleanup, and the now-unused `os`/`tempfile` imports. `github/issue_create.py` keeps `--body-file` (gh supports it).
2. **`@-` / `@file` route not handled** — the single-arg `*-issue-create` ops have no `:::` syntax, so they get no @file-registry route; the raw `@-` / `@file` reached the script as a literal path (`payload file not found: @-`). Both scripts now strip a leading `@` in `_load_payload`, so heredoc/stdin payloads work like the mutating ops.

## Tests

- New cases (both scripts): `@`-prefix strip, `@-` stdin routing.
- gitlab: assert `--description` is used and `--description-file` is **not**.
- Rewrote the 2 tests that read `--description-file`.
- 25/25 issue_create pass; full suite 3046 pass / 87.5% cov.

## Smoke (live)

- gh: `gh-issue-create:@-` via dispatch → created + closed a throwaway issue.
- gl: edited script via `@-` stdin + real glab on gitlab.dp.tools → created with `--description` + closed. Confirms both bugs gone.

Note: pre-existing `test_validators_phpstan` local failures (global phpstan non-JSON) are unrelated — green in CI.

Closes #246