### PR TITLE
fix(php-cs-fixer): drop deprecated PHP_CS_FIXER_IGNORE_ENV (#250)

### DIFF
--- a/formatters/php-cs-fixer/php-cs-fixer.py
+++ b/formatters/php-cs-fixer/php-cs-fixer.py
@@ -92,7 +92,6 @@ def main() -> None:
     cmd.append(file)
 
     env = os.environ.copy()
-    env.setdefault("PHP_CS_FIXER_IGNORE_ENV", "1")
 
     start = time.time()
     try:


### PR DESCRIPTION
## Problem

`formatters/php-cs-fixer/php-cs-fixer.py:95` set `PHP_CS_FIXER_IGNORE_ENV=1`. php-cs-fixer 3.95 deprecated this env var (removed in 4.0), so every run printed a stderr deprecation. In the `[formatters]` output that surfaced as `php-cs-fixer: fail` even though php-cs-fixer exited 0 — a false failure caused by the wrapper's own env var.

## Fix

Drop the `env.setdefault(...)` line. The project's `.php-cs-fixer.php` now owns the version-bypass via `->setUnsupportedPhpVersionAllowed(true)` (dvsi MR !22047).

Verified: with the env var unset and the config option set, php-cs-fixer 3.95.2 exits 0 and the deprecation warning disappears. Formatter tests pass (5 passed, 1 skipped).

Closes #250