### PR TITLE
feat: char-window for head/tail on minified single-line files (#240)

### DIFF
--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -24,9 +24,9 @@
 | `grep` (count) | `grep:PATTERN:PATH:LIMIT:CONTEXT:count` | Return match counts per file instead of content. Output: `filepath:COUNT` per line. |
 | `glob` | `glob:PATTERN` | `**` supported. **Auto-reads** if PATTERN is a concrete file path (no wildcards). |
 | `ls` | `ls:PATH` | Trailing `/` on subdirs |
-| `tail` | `tail:PATH:N` | Last N lines (default 20) |
-| `head` | `head:PATH:N` | First N lines (default 20) |
-| `wc` | `wc:PATH` | Line/word/char count (like unix `wc`). Output: `LINES WORDS CHARS PATH`. |
+| `tail` | `tail:PATH:N` | Last N lines (default 20). Minified single-line files return a char-window peek; size via `builtin-ops.tail.char_window` (default 1000). |
+| `head` | `head:PATH:N` | First N lines (default 20). Minified single-line files return a char-window peek; size via `builtin-ops.head.char_window` (default 1000). |
+| `wc` | `wc:PATH` | Line/word/char count (like unix `wc`). Output: `LINES WORDS CHARS PATH`. Flags single-line/minified files. |
 | `around` | `around:PATTERN:PATH` or `around:PATTERN:PATH:N` | Show N lines (default 10) before and after the **first** match of PATTERN in a single file. Uses line-numbered output like `read`. |
 | `grep_around` | `grep_around:PATTERN:PATH` or `grep_around:PATTERN:PATH:N:LIMIT` | Every match across files with N lines context (default N=3, LIMIT=10). Alias for `grep:PATTERN:PATH:LIMIT:CONTEXT` with sane defaults — useful for "show me how everyone uses this". |
 | `map` | `map:PATH` | Symbol map of a file or directory. Shows classes, functions, methods, constants as an indented tree with line numbers. Three-tier: tree-sitter → ctags → regex. Supports PHP, Python, JS, TS, Go, Rust, Java, Ruby. |

--- a/docs/operations/reads.md
+++ b/docs/operations/reads.md
@@ -8,9 +8,9 @@ File reading and directory listing ops. Reach for these when you know the path a
 |----|--------|--------------|
 | `read` | `read:PATH` or `read:PATH:OFFSET:LIMIT` | 300 lines / 20KB cap |
 | `read` (filter) | `read:PATH:OFFSET:LIMIT:grep=PATTERN` | Only show lines matching PATTERN (original line numbers preserved). Use `read:PATH:::grep=PATTERN` for defaults. |
-| `head` | `head:PATH:N` | First N lines (default 20) |
-| `tail` | `tail:PATH:N` | Last N lines (default 20) |
-| `wc` | `wc:PATH` | Line/word/char count (like unix `wc`). Output: `LINES WORDS CHARS PATH`. |
+| `head` | `head:PATH:N` | First N lines (default 20). Minified single-line files return a char-window peek instead of the whole giant line; window size via `builtin-ops.head.char_window` (default 1000, or env `SUPERTOOL_HEAD_CHAR_WINDOW`). |
+| `tail` | `tail:PATH:N` | Last N lines (default 20). Minified single-line files return a char-window peek; window size via `builtin-ops.tail.char_window` (default 1000, or env `SUPERTOOL_TAIL_CHAR_WINDOW`). |
+| `wc` | `wc:PATH` | Line/word/char count (like unix `wc`). Output: `LINES WORDS CHARS PATH`. Flags single-line/minified files where the line count is degenerate. |
 | `stat` | `stat:PATH` | File/directory metadata: size (bytes), last modified (ISO datetime), type (file/dir). |
 | `ls` | `ls:PATH` | Directory listing. Trailing `/` on subdirs. |
 | `glob` | `glob:PATTERN` | `**` supported. **Auto-reads** if PATTERN is a concrete file path (no wildcards). |

--- a/supertool.py
+++ b/supertool.py
@@ -150,6 +150,7 @@ MAX_READ_LINES = 300
 # Override via ops.batch.max_ops in .supertool.json for one-off bulk runs.
 MAX_BATCH_OPS = 1000
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"
+CHAR_WINDOW_CHARS = 1000  # head/tail peek window for minified single-line files
 MAX_GREP_RESULTS = 10
 MAX_GLOB_RESULTS = 50
 LOG_FILE = os.path.join(tempfile.gettempdir(), "supertool-calls.log")
@@ -1487,9 +1488,45 @@ def op_ls(path: str = ".") -> str:
     return "".join(out)
 
 
+def _looks_minified(path: str) -> bool:
+    """True when the first line overflows the byte cap with no newline — the
+    degenerate case (minified JSON/JS/CSS) where line-based head/tail/wc return
+    one giant useless line. Probes only the first MAX_READ_BYTES, so it's cheap.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            probe = f.read(MAX_READ_BYTES + 1)
+    except OSError:
+        return False
+    return len(probe) > MAX_READ_BYTES and "\n" not in probe
+
+
+def _char_window(path: str, n_chars: int, from_end: bool = False) -> str:
+    """First/last n_chars of a file as a character window, with a marker
+    reporting total size. For minified single-line files where line slicing
+    is meaningless (#240).
+    """
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        data = f.read()
+    total = len(data)
+    if from_end:
+        window = data[-n_chars:]
+        clipped = total - len(window)
+        return (f"({total} chars, single line — minified; showing last "
+                f"{len(window)}, {clipped} clipped)\n{window}\n")
+    window = data[:n_chars]
+    clipped = total - len(window)
+    return (f"({total} chars, single line — minified; showing first "
+            f"{len(window)})\n{window}\n… ({clipped} more chars truncated)\n")
+
+
 def op_tail(path: str, n: int = 20) -> str:
     if not path or not os.path.isfile(path):
         return f"ERROR: file not found: {path}\n"
+    if _looks_minified(path):
+        return _char_window(
+            path, _get_op_int("tail", "char_window", CHAR_WINDOW_CHARS),
+            from_end=True)
     with open(path, "rb") as f:
         raw_lines = f.read().splitlines(keepends=True)
     total = len(raw_lines)
@@ -1508,6 +1545,10 @@ def op_tail(path: str, n: int = 20) -> str:
 def op_head(path: str, n: int = 20) -> str:
     if not path or not os.path.isfile(path):
         return f"ERROR: file not found: {path}\n"
+    if _looks_minified(path):
+        return _char_window(
+            path, _get_op_int("head", "char_window", CHAR_WINDOW_CHARS),
+            from_end=False)
     with open(path, "rb") as f:
         raw_lines = f.read().splitlines(keepends=True)
     total = len(raw_lines)
@@ -1542,7 +1583,10 @@ def op_wc(path: str) -> str:
     lines = text.count("\n")
     words = len(text.split())
     chars = len(text)
-    return f"{lines} {words} {chars} {path}\n"
+    result = f"{lines} {words} {chars} {path}"
+    if lines <= 1 and chars > MAX_READ_BYTES:
+        result += f"  [single-line / minified — {chars} chars, {len(data)} bytes]"
+    return result + "\n"
 
 
 def op_check(preset: str, path: str) -> str:

--- a/supertool.py
+++ b/supertool.py
@@ -151,6 +151,7 @@ MAX_READ_LINES = 300
 MAX_BATCH_OPS = 1000
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"
 CHAR_WINDOW_CHARS = 1000  # head/tail peek window for minified single-line files
+MINIFIED_LINE_CHARS = 5000  # a single line this long means line-based view is useless
 MAX_GREP_RESULTS = 10
 MAX_GLOB_RESULTS = 50
 LOG_FILE = os.path.join(tempfile.gettempdir(), "supertool-calls.log")
@@ -1488,23 +1489,33 @@ def op_ls(path: str = ".") -> str:
     return "".join(out)
 
 
-def _looks_minified(path: str) -> bool:
-    """True when the first line overflows the byte cap with no newline — the
-    degenerate case (minified JSON/JS/CSS) where line-based head/tail/wc return
-    one giant useless line. Probes only the first MAX_READ_BYTES, so it's cheap.
+def _probe_minified(probe: str) -> bool:
+    """True when text overflows the byte cap AND holds a line long enough that
+    line-based head/tail/wc return one giant useless line. Catches both pure
+    single-line blobs and minified bodies behind a short leading comment
+    (e.g. `/* license */\\n` + 300KB of minified JS), which a plain
+    "no newline in the first chunk" test misses (#240).
     """
+    if len(probe) <= MAX_READ_BYTES:
+        return False
+    longest = max((len(seg) for seg in probe.split("\n")), default=0)
+    return longest >= MINIFIED_LINE_CHARS
+
+
+def _looks_minified(path: str) -> bool:
+    """Cheap minified-file detector: probes only the first MAX_READ_BYTES."""
     try:
         with open(path, "r", encoding="utf-8", errors="replace") as f:
             probe = f.read(MAX_READ_BYTES + 1)
     except OSError:
         return False
-    return len(probe) > MAX_READ_BYTES and "\n" not in probe
+    return _probe_minified(probe)
 
 
 def _char_window(path: str, n_chars: int, from_end: bool = False) -> str:
     """First/last n_chars of a file as a character window, with a marker
-    reporting total size. For minified single-line files where line slicing
-    is meaningless (#240).
+    reporting total size. For minified files where line slicing is
+    meaningless (#240).
     """
     with open(path, "r", encoding="utf-8", errors="replace") as f:
         data = f.read()
@@ -1512,12 +1523,12 @@ def _char_window(path: str, n_chars: int, from_end: bool = False) -> str:
     if from_end:
         window = data[-n_chars:]
         clipped = total - len(window)
-        return (f"({total} chars, single line — minified; showing last "
-                f"{len(window)}, {clipped} clipped)\n{window}\n")
+        return (f"({total} chars, minified; showing last {len(window)}, "
+                f"{clipped} clipped)\n… ({clipped} earlier chars)\n{window}\n")
     window = data[:n_chars]
     clipped = total - len(window)
-    return (f"({total} chars, single line — minified; showing first "
-            f"{len(window)})\n{window}\n… ({clipped} more chars truncated)\n")
+    return (f"({total} chars, minified; showing first {len(window)})\n"
+            f"{window}\n… ({clipped} more chars truncated)\n")
 
 
 def op_tail(path: str, n: int = 20) -> str:
@@ -1584,8 +1595,8 @@ def op_wc(path: str) -> str:
     words = len(text.split())
     chars = len(text)
     result = f"{lines} {words} {chars} {path}"
-    if lines <= 1 and chars > MAX_READ_BYTES:
-        result += f"  [single-line / minified — {chars} chars, {len(data)} bytes]"
+    if _probe_minified(text):
+        result += f"  [minified — {chars} chars, {len(data)} bytes]"
     return result + "\n"
 
 

--- a/tests/test_tail_head.py
+++ b/tests/test_tail_head.py
@@ -52,3 +52,61 @@ def test_head_file_shorter_than_n(tmp_path: Path) -> None:
     f.write_text("only\none\n")
     out = supertool.op_head(str(f), 100)
     assert "showing first 2" in out
+
+
+# ---------------------------------------------------------------------------
+# minified single-line files — char window instead of one giant line (#240)
+# ---------------------------------------------------------------------------
+
+def test_head_minified_single_line(tmp_path: Path) -> None:
+    f = tmp_path / "bundle.min.js"
+    f.write_text("x" * 25000)  # overflows MAX_READ_BYTES (20000)
+    out = supertool.op_head(str(f), 20)
+    assert "minified" in out
+    assert "25000 chars" in out
+    assert "showing first 1000" in out  # default CHAR_WINDOW_CHARS
+    assert "24000 more chars truncated" in out
+    assert len(out) < 5000  # the giant line is NOT dumped in full
+
+
+def test_tail_minified_single_line(tmp_path: Path) -> None:
+    f = tmp_path / "bundle.min.js"
+    f.write_text("x" * 25000)
+    out = supertool.op_tail(str(f), 20)
+    assert "minified" in out
+    assert "showing last 1000" in out
+    assert "24000 clipped" in out
+    assert "24000 earlier chars" in out  # symmetric leading marker
+    assert len(out) < 5000
+
+
+def test_head_minified_behind_leading_comment(tmp_path: Path) -> None:
+    # The #240 regression the old detector missed: a short comment line, then
+    # a giant minified line. "no newline in first chunk" returned False here,
+    # so head dumped the whole 25KB line.
+    f = tmp_path / "lib.min.js"
+    f.write_text("/* license */\n" + "y" * 25000)
+    out = supertool.op_head(str(f), 20)
+    assert "minified" in out
+    assert len(out) < 5000
+
+
+def test_head_large_normal_file_not_minified(tmp_path: Path) -> None:
+    # Overflows the cap but is genuinely line-based — must NOT char-window.
+    f = tmp_path / "big.log"
+    f.write_text("\n".join(f"line{i}" for i in range(5000)))
+    out = supertool.op_head(str(f), 3)
+    assert "minified" not in out
+    assert "     1→line0" in out
+    assert "     3→line2" in out
+
+
+def test_head_minified_respects_char_window_env(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SUPERTOOL_HEAD_CHAR_WINDOW", "50")
+    f = tmp_path / "bundle.min.js"
+    f.write_text("z" * 25000)
+    out = supertool.op_head(str(f), 20)
+    assert "showing first 50" in out
+    assert "24950 more chars truncated" in out

--- a/tests/test_wc.py
+++ b/tests/test_wc.py
@@ -31,3 +31,26 @@ def test_wc_empty_path() -> None:
 def test_wc_directory(tmp_path: Path) -> None:
     out = supertool.op_wc(str(tmp_path))
     assert "ERROR" in out
+
+
+def test_wc_flags_minified_single_line(tmp_path: Path) -> None:
+    f = tmp_path / "bundle.min.js"
+    f.write_text("a" * 25000)  # overflows MAX_READ_BYTES (20000)
+    out = supertool.op_wc(str(f))
+    assert "[minified" in out
+    assert "25000 chars" in out
+
+
+def test_wc_flags_minified_behind_leading_comment(tmp_path: Path) -> None:
+    # Same #240 shape head/tail must agree on: short comment + giant line.
+    f = tmp_path / "lib.min.js"
+    f.write_text("/* c */\n" + "b" * 25000)
+    out = supertool.op_wc(str(f))
+    assert "[minified" in out
+
+
+def test_wc_normal_large_file_not_flagged(tmp_path: Path) -> None:
+    f = tmp_path / "big.log"
+    f.write_text("\n".join(f"line{i}" for i in range(5000)))
+    out = supertool.op_wc(str(f))
+    assert "minified" not in out


### PR DESCRIPTION
Closes #240.

head/tail on a minified single-line file (e.g. 347KB uxml.json) returned the whole giant line — useless. Now they detect the degenerate case (first line overflows the byte cap with no newline) and return a character-window peek instead.

- Window size configurable via `builtin-ops.head/tail.char_window` (default 1000) or env `SUPERTOOL_HEAD_CHAR_WINDOW` / `SUPERTOOL_TAIL_CHAR_WINDOW`
- `wc` now flags single-line/minified files where the line count is degenerate
- Docs (reads.md, index.md, configuration.md), .supertool.json + .example updated
- 6 new tests

Co-Authored-By: Max <noreply>