### PR TITLE
feat(git-status): surface unpushed work on other local branches

### DIFF
--- a/presets/git/status.py
+++ b/presets/git/status.py
@@ -91,6 +91,27 @@ def main() -> int:
     if origin_head.returncode == 0 and origin_head.stdout.strip():
         print(f"Origin HEAD: {origin_head.stdout.strip()}")
 
+    # Other local branches with unpushed/unpulled work — so a commit made on a
+    # branch you're NOT standing on stays visible (classic: committed to master,
+    # then checked out a feature branch — the work looks lost from `feature`).
+    others = _git(["for-each-ref",
+                   "--format=%(refname:short)\t%(upstream:track)", "refs/heads"])
+    if others.returncode == 0:
+        rows = []
+        for line in others.stdout.splitlines():
+            name, _, track = line.partition("\t")
+            track = track.strip()
+            # Only actionable divergence — skip the current branch (covered
+            # above) and stale [gone] branches (merged, upstream pruned).
+            if name and name != branch_name and ("ahead" in track or "behind" in track):
+                rows.append((name, track))
+        if rows:
+            print(f"\n## Other branches with unpushed/unpulled work")
+            for name, track in rows[:10]:
+                print(f"  {name}  {track}")
+            if len(rows) > 10:
+                print(f"  ... ({len(rows) - 10} more)")
+
     # 2. Last 5 commits
     log_result = _git(["log", "-5", "--format=%h %ad %an | %s", "--date=short"])
     if log_result.returncode == 0 and log_result.stdout.strip():

--- a/presets/git/status.py
+++ b/presets/git/status.py
@@ -104,9 +104,11 @@ def main() -> int:
             # Only actionable divergence — skip the current branch (covered
             # above) and stale [gone] branches (merged, upstream pruned).
             if name and name != branch_name and ("ahead" in track or "behind" in track):
-                rows.append((name, track))
+                # Drop git's surrounding brackets so it reads like the rest of
+                # the file: `ahead 1, behind 3`, not `[ahead 1, behind 3]`.
+                rows.append((name, track.strip("[]")))
         if rows:
-            print(f"\n## Other branches with unpushed/unpulled work")
+            print("\n## Other branches with unpushed/unpulled work")
             for name, track in rows[:10]:
                 print(f"  {name}  {track}")
             if len(rows) > 10:

--- a/tests/test_git_status.py
+++ b/tests/test_git_status.py
@@ -171,8 +171,56 @@ def test_other_branch_unpushed_commit_surfaced(tmp_path: Path, monkeypatch) -> N
     _stub_no_mr(monkeypatch)
     out = _run_main(repo, monkeypatch)
     assert "Other branches with unpushed/unpulled work" in out
+    # The master line must be present and bracket-free, matching the clean
+    # `ahead N, behind N` style the rest of the file prints.
+    master_line = next(l for l in out.splitlines()
+                       if l.strip().startswith("master"))
+    assert master_line.strip() == "master  ahead 1"
+    assert "[ahead" not in out
+
+
+def test_gone_branch_filtered_from_section(tmp_path: Path, monkeypatch) -> None:
+    """A branch whose upstream was deleted ([gone]) is stale, not work — skipped."""
+    upstream = tmp_path / "upstream_gone.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "master")
+
+    repo = _init_repo(tmp_path)
+    _git(repo, "remote", "add", "origin", str(upstream))
+    _git(repo, "push", "-u", "origin", "master")
+
+    # A branch that tracks an upstream which then disappears → [gone].
+    _git(repo, "checkout", "-b", "doomed")
+    _git(repo, "push", "-u", "origin", "doomed")
+    _git(repo, "push", "origin", "--delete", "doomed")
+    _git(repo, "fetch", "--prune")
+    _git(repo, "checkout", "master")
+    _git(repo, "checkout", "-b", "feature")
+
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "doomed" not in out
+
+
+def test_detached_head_still_lists_diverging_branches(tmp_path: Path, monkeypatch) -> None:
+    """Detached HEAD has no current branch — all diverging branches are 'other'
+    and must still be surfaced (no orienting branch = need the overview most)."""
+    upstream = tmp_path / "upstream_det.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "master")
+
+    repo = _init_repo(tmp_path)
+    _git(repo, "remote", "add", "origin", str(upstream))
+    _git(repo, "push", "-u", "origin", "master")
+    (repo / "g").write_text("y\n")
+    _git(repo, "add", "g")
+    _git(repo, "commit", "-m", "ahead on master")
+    _git(repo, "checkout", "--detach", "HEAD")
+
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "Other branches with unpushed/unpulled work" in out
     assert "master" in out
-    assert "ahead 1" in out
 
 
 def test_no_other_branches_section_when_all_in_sync(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_git_status.py
+++ b/tests/test_git_status.py
@@ -146,3 +146,46 @@ def test_origin_head_skipped_when_no_upstream(tmp_path: Path, monkeypatch) -> No
     _stub_no_mr(monkeypatch)
     out = _run_main(repo, monkeypatch)
     assert "Origin HEAD:" not in out
+
+
+def test_other_branch_unpushed_commit_surfaced(tmp_path: Path, monkeypatch) -> None:
+    """Commit on a branch you're NOT standing on is surfaced, not hidden.
+
+    The exact failure that motivated this: work committed to master, then a
+    feature branch checked out — from `feature` the work looked lost.
+    """
+    upstream = tmp_path / "upstream.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "master")
+
+    repo = _init_repo(tmp_path)
+    _git(repo, "remote", "add", "origin", str(upstream))
+    _git(repo, "push", "-u", "origin", "master")
+
+    # Commit on master (now ahead of origin/master), then leave it behind.
+    (repo / "g").write_text("y\n")
+    _git(repo, "add", "g")
+    _git(repo, "commit", "-m", "work that lands on master")
+    _git(repo, "checkout", "-b", "feature")
+
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "Other branches with unpushed/unpulled work" in out
+    assert "master" in out
+    assert "ahead 1" in out
+
+
+def test_no_other_branches_section_when_all_in_sync(tmp_path: Path, monkeypatch) -> None:
+    """Section is omitted entirely when no other branch has divergent work."""
+    upstream = tmp_path / "upstream2.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "master")
+
+    repo = _init_repo(tmp_path)
+    _git(repo, "remote", "add", "origin", str(upstream))
+    _git(repo, "push", "-u", "origin", "master")
+    _git(repo, "checkout", "-b", "feature")
+
+    _stub_no_mr(monkeypatch)
+    out = _run_main(repo, monkeypatch)
+    assert "Other branches with unpushed/unpulled work" not in out


### PR DESCRIPTION
## Why

`git-status` only showed divergence for the branch you're standing on. Work committed to a branch you're **not** on stayed invisible.

The failure that motivated this (hit live today): #240 work was committed onto local `master`, then a feature branch was checked out. From that branch `git-status` said `clean` — the work looked lost. ~10 round-trips of reflog/rev-list spelunking to find it. One line in git-status would've shown it instantly.

## What

Adds an **'Other branches with unpushed/unpulled work'** section:

```
## Other branches with unpushed/unpulled work
  master  [ahead 1]
```

- Skips current branch (covered above)
- Skips stale `[gone]` branches (merged, upstream pruned) — noise, not work
- Caps at 10 with `... (N more)`

## Tests

2 new, 9/9 pass.

Co-Authored-By: Max <noreply>