### PR TITLE
fix(pre-push): mirror CI gate — run all tests, drop coverage gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,8 +8,13 @@ cd "$(git rev-parse --show-toplevel)"
 
 PYTHON="${PYTHON:-python3}"
 
-echo "── pre-push: running supertool tests ──"
-if ! "$PYTHON" -m pytest tests/ --tb=short; then
+echo "── pre-push: running full test suite (mirrors CI) ──"
+# Mirror the CI gate exactly (.github/workflows/tests.yml): run ALL tests
+# including slow ones (-m '' overrides the addopts 'not slow' filter), and do
+# NOT gate coverage (--no-cov). CI is the authority on what's mergeable; gating
+# coverage here — which CI doesn't — only produces local-only false aborts, and
+# the default 'not slow' filter would let a slow test that CI runs slip through.
+if ! "$PYTHON" -m pytest -m '' --no-cov --tb=short; then
     echo ""
     echo "✗ Tests failed. Push aborted."
     echo "  Fix failures or run: git push --no-verify  (to bypass, discouraged)"


### PR DESCRIPTION
## Context
The pre-push hook ran `pytest tests/`, which picks up the addopts `-m 'not slow'` filter and the `--cov-fail-under=86` gate. That diverged from CI (`.github/workflows/tests.yml`), which runs `pytest -m '' --no-cov` — **all** tests, **no** coverage gate.

Two consequences:
- Slow tests CI runs were **skipped locally**, so a CI-failing slow test could still print a local `✓ passed` (false confidence).
- The local-only coverage gate could **abort a push CI would accept** (e.g. a transient coverage-measurement dip) — the asymmetry that bites.

## Change
Hook now runs `pytest -m '' --no-cov --tb=short` — exactly CI's criterion. Verified locally: 3073 passed, 34 skipped, exit 0 (~2m12s).

🤖 Generated by Max — the hook that guards the gate should know where the gate is.