### PR TITLE
fix: preserve file mode on atomic write (#259)

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -91,6 +91,7 @@ import json
 import difflib
 import hashlib
 import os
+import stat
 import re
 import shlex
 import shutil
@@ -2901,6 +2902,15 @@ def _atomic_write(path: str, content: str) -> None:
     _safe_path(path)
     real_path = os.path.realpath(path) if os.path.islink(path) else path
     target_dir = os.path.dirname(os.path.abspath(real_path)) or "."
+    # Preserve the original file's mode (#259). mkstemp creates the temp file
+    # with 0600; os.replace would then clobber the target's mode, silently
+    # dropping the executable bit on scripts/git hooks. Capture the existing
+    # mode and re-apply it to the temp file before the rename. A brand-new
+    # file keeps mkstemp's default — no spurious +x.
+    try:
+        orig_mode = stat.S_IMODE(os.stat(real_path).st_mode)
+    except OSError:
+        orig_mode = None
     fd, tmp_path = tempfile.mkstemp(
         prefix=".supertool-", suffix=".tmp", dir=target_dir
     )
@@ -2911,6 +2921,8 @@ def _atomic_write(path: str, content: str) -> None:
         # `read(errors='surrogateescape')`).
         with os.fdopen(fd, "wb") as f:
             f.write(content.encode("utf-8", errors="surrogateescape"))
+        if orig_mode is not None:
+            os.chmod(tmp_path, orig_mode)
         os.replace(tmp_path, real_path)
     except Exception:
         try:

--- a/tests/test_atomic_write_mode_259.py
+++ b/tests/test_atomic_write_mode_259.py
@@ -13,9 +13,19 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
 
+import pytest
+
 import supertool
+
+# POSIX file modes only — Windows has no executable bit and os.chmod there
+# honors just the read-only flag, so st_mode reads back 0o666 regardless.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX file modes; Windows has no executable bit",
+)
 
 
 def _mode(p: Path) -> int:

--- a/tests/test_atomic_write_mode_259.py
+++ b/tests/test_atomic_write_mode_259.py
@@ -1,0 +1,76 @@
+"""Regression tests for #259 — atomic write must preserve the file's mode.
+
+The atomic-write path (`_atomic_write`) creates a temp file via mkstemp
+(mode 0600) and renames it over the target. Before the fix, the original
+file's mode was never copied onto the temp file, so an executable script
+(0755) silently became 0600/0644 after any mutating op — breaking `cb.sh`,
+git hooks, and any `*.sh` edited through supertool.
+
+These tests pin: every mutating op preserves the original mode; a brand-new
+file created by paste keeps the default mode (no spurious +x).
+"""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import supertool
+
+
+def _mode(p: Path) -> int:
+    return stat.S_IMODE(os.stat(p).st_mode)
+
+
+def test_edit_preserves_executable_bit(tmp_path: Path) -> None:
+    f = tmp_path / "cb.sh"
+    f.write_text("echo X\n")
+    os.chmod(f, 0o755)
+    out = supertool.op_edit("echo X", "echo Y", str(f))
+    assert "ERROR" not in out, out
+    assert _mode(f) == 0o755, f"mode lost: {oct(_mode(f))}"
+
+
+def test_paste_rewrite_preserves_executable_bit(tmp_path: Path) -> None:
+    f = tmp_path / "hook.sh"
+    f.write_text("old\n")
+    os.chmod(f, 0o755)
+    out = supertool.op_paste(str(f), "new content\n")
+    assert "ERROR" not in out, out
+    assert _mode(f) == 0o755, f"mode lost: {oct(_mode(f))}"
+
+
+def test_replace_lines_preserves_executable_bit(tmp_path: Path) -> None:
+    f = tmp_path / "run.sh"
+    f.write_text("a\nb\nc\n")
+    os.chmod(f, 0o755)
+    out = supertool.op_replace_lines(str(f), 2, 2, "B\n")
+    assert "ERROR" not in out, out
+    assert _mode(f) == 0o755, f"mode lost: {oct(_mode(f))}"
+
+
+def test_replace_preserves_executable_bit(tmp_path: Path) -> None:
+    f = tmp_path / "deploy.sh"
+    f.write_text("foo bar\n")
+    os.chmod(f, 0o755)
+    out = supertool.op_replace("foo", "baz", str(f))
+    assert "ERROR" not in out, out
+    assert _mode(f) == 0o755, f"mode lost: {oct(_mode(f))}"
+
+
+def test_edit_preserves_nondefault_readonly_group(tmp_path: Path) -> None:
+    """Any non-default mode survives — not just the executable bit."""
+    f = tmp_path / "data.txt"
+    f.write_text("X\n")
+    os.chmod(f, 0o640)
+    out = supertool.op_edit("X", "Y", str(f))
+    assert "ERROR" not in out, out
+    assert _mode(f) == 0o640, f"mode lost: {oct(_mode(f))}"
+
+
+def test_paste_new_file_keeps_default_mode(tmp_path: Path) -> None:
+    """A brand-new file must NOT inherit a spurious executable bit."""
+    f = tmp_path / "fresh.txt"
+    out = supertool.op_paste(str(f), "hello\n")
+    assert "ERROR" not in out, out
+    assert not (_mode(f) & 0o111), f"new file unexpectedly executable: {oct(_mode(f))}"

--- a/tests/test_atomic_write_mode_259.py
+++ b/tests/test_atomic_write_mode_259.py
@@ -58,6 +58,17 @@ def test_replace_preserves_executable_bit(tmp_path: Path) -> None:
     assert _mode(f) == 0o755, f"mode lost: {oct(_mode(f))}"
 
 
+def test_vim_preserves_executable_bit(tmp_path: Path) -> None:
+    """vim is named in the issue and routes through _atomic_write too."""
+    f = tmp_path / "macro.sh"
+    f.write_text("echo X\n")
+    os.chmod(f, 0o755)
+    out = supertool.op_vim(str(f), ":s/X/Y/")
+    assert "ERROR" not in out, out
+    assert f.read_text() == "echo Y\n", "substitution must apply"
+    assert _mode(f) == 0o755, f"mode lost: {oct(_mode(f))}"
+
+
 def test_edit_preserves_nondefault_readonly_group(tmp_path: Path) -> None:
     """Any non-default mode survives — not just the executable bit."""
     f = tmp_path / "data.txt"


### PR DESCRIPTION
Closes #259.

## Problem
Mutating ops (`edit`/`paste`/`replace`/`replace_lines`/`vim`) share `_atomic_write`, which creates a `0600` temp file via `mkstemp` and renames it over the target. The original file's mode was never copied, so executable scripts (`0755`) silently became `0600`/`0644` — breaking `cb.sh`, git hooks, any `*.sh`. Validators pass (`bash -n` OK); only the mode is lost, so it's easy to miss until the script is run.

## Fix
Capture the target's mode (`os.stat(real_path)`) before writing and re-apply it (`os.chmod`) to the temp file before `os.replace`. Brand-new files keep `mkstemp`'s default — no spurious `+x`. Follows symlinks via the existing `real_path`. Added `import stat`.

## Tests
6 TDD regression tests (`tests/test_atomic_write_mode_259.py`), red->green:
- edit / paste / replace / replace_lines preserve `0755`
- non-default mode (`0640`) preserved
- new-file paste keeps default mode (no `+x`)

Full suite: **3076 passed**, 34 skipped — no regression. End-to-end repro verified.