### PR TITLE
feat: per-op byte cap for around:/grep_around: (#241)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ supertool
 .claude/worktrees/
 
 .max/
+.max-ci.log

--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -78,13 +78,15 @@
     },
     "around": {
       "syntax": "around:PATTERN:PATH[:N]",
-      "description": "First match + N lines ctx (def 10). 1-shot grep+read",
-      "example": "around:def main:src/app/Module.py:15"
+      "description": "First match + N lines ctx (def 10). 1-shot grep+read. Output capped ~16KB (max_bytes) — truncates at line boundary",
+      "example": "around:def main:src/app/Module.py:15",
+      "max_bytes": 16000
     },
     "grep_around": {
       "syntax": "grep_around:PATTERN:PATH[:N[:LIMIT]]",
-      "description": "Every match + N ctx lines (def 3, limit 10). Bulk usage scan",
-      "example": "grep_around:CommandDriveCreateFile:src/:5"
+      "description": "Every match + N ctx lines (def 3, limit 10). Bulk usage scan. Output capped ~16KB (max_bytes) — truncates at line boundary",
+      "example": "grep_around:CommandDriveCreateFile:src/:5",
+      "max_bytes": 16000
     },
     "glob": {
       "syntax": "glob:PATTERN",

--- a/.supertool.json
+++ b/.supertool.json
@@ -52,13 +52,13 @@
     },
     "around": {
       "syntax": "around:PATTERN:PATH[:N]",
-      "description": "First match + N lines ctx (def 10). 1-shot grep+read",
+      "description": "First match + N lines ctx (def 10). 1-shot grep+read. Output capped ~16KB (max_bytes)",
       "example": "around:def dispatch:supertool.py:15",
       "hint": true
     },
     "grep_around": {
       "syntax": "grep_around:PATTERN:PATH[:N[:LIMIT]]",
-      "description": "Every match + N ctx lines (def 3, limit 10). Bulk usage scan",
+      "description": "Every match + N ctx lines (def 3, limit 10). Bulk usage scan. Output capped ~16KB (max_bytes)",
       "example": "grep_around:def dispatch:supertool.py:5",
       "hint": true
     },

--- a/.supertool.json
+++ b/.supertool.json
@@ -52,13 +52,13 @@
     },
     "around": {
       "syntax": "around:PATTERN:PATH[:N]",
-      "description": "First match + N lines ctx (def 10). 1-shot grep+read. Output capped ~16KB (max_bytes)",
+      "description": "First match + N lines ctx (def 10). 1-shot grep+read. Output capped ~16KB (max_bytes) — truncates at line boundary",
       "example": "around:def dispatch:supertool.py:15",
       "hint": true
     },
     "grep_around": {
       "syntax": "grep_around:PATTERN:PATH[:N[:LIMIT]]",
-      "description": "Every match + N ctx lines (def 3, limit 10). Bulk usage scan. Output capped ~16KB (max_bytes)",
+      "description": "Every match + N ctx lines (def 3, limit 10). Bulk usage scan. Output capped ~16KB (max_bytes) — truncates at line boundary",
       "example": "grep_around:def dispatch:supertool.py:5",
       "hint": true
     },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,8 @@ Entries document built-in operations (`syntax`, `description`, `example`). Set `
 | `read` | `max_bytes`   | 20000            | Max bytes per read (truncates at cap)                                                    |
 | `grep` | `max_results` | 10               | Default result limit when not specified in the op                                        |
 | `grep` | `extensions`  | `[]` (all files) | Restrict grep to these file patterns (e.g. `["*.py", "*.js"]`). Empty = search all files |
+| `around` | `max_bytes` | 16000            | Max bytes for an `around:` context window (truncates at a line boundary)                 |
+| `grep_around` | `max_bytes` | 16000       | Max bytes for a `grep_around:` (and `grep:`-with-context) window                          |
 | `glob` | `max_results` | 50               | Max files returned                                                                       |
 
 Example — increase read cap and restrict grep to PHP/XML:

--- a/docs/operations/search.md
+++ b/docs/operations/search.md
@@ -18,6 +18,8 @@ Pattern-based ops for finding content across files or zooming into a known locat
 
 A large `:N` context on a file of long (e.g. minified) lines can over-fetch — one op can dump hundreds of KB and blow your context budget. `around:` and `grep_around:` cap their output at **~16KB**, truncating at a line boundary with a footer that points at the narrower tools (smaller `:N`, or `between:` for a whole symbol). Tune via `builtin-ops.around.max_bytes` / `builtin-ops.grep_around.max_bytes` in `.supertool.json` (or `SUPERTOOL_AROUND_MAX_BYTES` / `SUPERTOOL_GREP_AROUND_MAX_BYTES`). See [configuration.md](../configuration.md#builtin-ops).
 
+`grep:` with an explicit `CONTEXT` argument (`grep:PATTERN:PATH:LIMIT:CONTEXT`) shares the `grep_around:` code path, so it is capped under the same `grep_around.max_bytes` budget. Plain `grep:` (no context) is unaffected — it has its own `LIMIT`/`max_results` bound.
+
 ## Common patterns
 
 Find all usages of a function across a codebase, with 2 lines of context:

--- a/docs/operations/search.md
+++ b/docs/operations/search.md
@@ -9,10 +9,14 @@ Pattern-based ops for finding content across files or zooming into a known locat
 | `grep` | `grep:PATTERN:PATH` or `grep:PATTERN:PATH:LIMIT` | 10 results default, code + doc extensions only. **Auto-reads** full file if PATH is a concrete file < 20KB with a match. |
 | `grep` (context) | `grep:PATTERN:PATH:LIMIT:CONTEXT` | Show CONTEXT lines before/after each match (like `grep -C`). Match lines: `path:lineno:content`. Context lines: `path-lineno-content`. Non-adjacent groups separated by `--`. |
 | `grep` (count) | `grep:PATTERN:PATH:LIMIT:CONTEXT:count` | Return match counts per file instead of content. Output: `filepath:COUNT` per line. |
-| `grep_around` | `grep_around:PATTERN:PATH` or `grep_around:PATTERN:PATH:N:LIMIT` | Every match across files with N lines context (default N=3, LIMIT=10). Alias for `grep:PATTERN:PATH:LIMIT:CONTEXT` with sane defaults — useful for "show me how everyone uses this". |
-| `around` | `around:PATTERN:PATH` or `around:PATTERN:PATH:N` | Show N lines (default 10) before and after the **first** match of PATTERN in a single file. Uses line-numbered output like `read`. |
+| `grep_around` | `grep_around:PATTERN:PATH` or `grep_around:PATTERN:PATH:N:LIMIT` | Every match across files with N lines context (default N=3, LIMIT=10). Alias for `grep:PATTERN:PATH:LIMIT:CONTEXT` with sane defaults — useful for "show me how everyone uses this". Output capped at ~16KB (see below). |
+| `around` | `around:PATTERN:PATH` or `around:PATTERN:PATH:N` | Show N lines (default 10) before and after the **first** match of PATTERN in a single file. Uses line-numbered output like `read`. Output capped at ~16KB (see below). |
 | `around_line` | `around_line:PATH:LINE` or `around_line:PATH:LINE:N` | Show N lines (default 10) of context around a specific line number. Target line marked with `→`. |
 | `between` | `between:SYMBOL:PATH` or `between:re:START:END:PATH` | Return a chunk of a file. **Symbol mode (default):** full body of a named function/method/class via tree-sitter (PHP, Python, JS, TS, Go, Rust, Java, Ruby — symbols with `::` like PHP `Foo::bar` work). **Pattern mode (`re:` prefix):** inclusive line slice from first line matching START regex to first line after matching END regex (language-agnostic). |
+
+## Output cap
+
+A large `:N` context on a file of long (e.g. minified) lines can over-fetch — one op can dump hundreds of KB and blow your context budget. `around:` and `grep_around:` cap their output at **~16KB**, truncating at a line boundary with a footer that points at the narrower tools (smaller `:N`, or `between:` for a whole symbol). Tune via `builtin-ops.around.max_bytes` / `builtin-ops.grep_around.max_bytes` in `.supertool.json` (or `SUPERTOOL_AROUND_MAX_BYTES` / `SUPERTOOL_GREP_AROUND_MAX_BYTES`). See [configuration.md](../configuration.md#builtin-ops).
 
 ## Common patterns
 

--- a/supertool.py
+++ b/supertool.py
@@ -1225,10 +1225,13 @@ def _cap_context_window(text: str, op_name: str) -> str:
     if len(encoded) <= cap:
         return text
     clipped = encoded[:cap].decode("utf-8", errors="ignore")
+    # Truncate at the last line boundary so we never cut mid-line. nl == -1
+    # means a single line longer than the cap — nothing to trim to, pass the
+    # partial through (the footer still flags it).
     nl = clipped.rfind("\n")
-    if nl > 0:
+    if nl >= 0:
         clipped = clipped[:nl + 1]
-    dropped = len(encoded) - len(clipped.encode("utf-8", errors="surrogateescape"))
+    dropped = len(encoded) - len(clipped.encode("utf-8", errors="ignore"))
     return (clipped +
             f"… truncated (~{dropped} more bytes) — narrow context (:N) "
             f"or use between: for the whole symbol\n")
@@ -1272,7 +1275,7 @@ def _around_one_file(regex: "re.Pattern[str]", path: str, n: int) -> str:
         marker = "→" if i == match_lineno else " "
         out.append(f"{i + 1:>6}{marker}{lines[i]}")
     out.append("\n")
-    return _cap_context_window("".join(out), "around")
+    return "".join(out)
 
 
 def op_around(pattern: str, path: str, n: int = 10) -> str:
@@ -1331,7 +1334,7 @@ def op_around(pattern: str, path: str, n: int = 10) -> str:
     rendered = _around_one_file(regex, path, n)
     if not rendered:
         return f"(no match for {pattern!r} in {path})\n\n"
-    return rendered
+    return _cap_context_window(rendered, "around")
 
 
 def op_between_symbol(symbol: str, path: str) -> str:

--- a/supertool.py
+++ b/supertool.py
@@ -150,6 +150,7 @@ MAX_READ_LINES = 300
 # Override via ops.batch.max_ops in .supertool.json for one-off bulk runs.
 MAX_BATCH_OPS = 1000
 MAX_READ_BYTES = 20000  # ~20KB cap — prevents Claude Code "Output too large"
+MAX_AROUND_BYTES = 16000  # per-op cap for around:/grep_around: context windows (#241)
 CHAR_WINDOW_CHARS = 1000  # head/tail peek window for minified single-line files
 MINIFIED_LINE_CHARS = 5000  # a single line this long means line-based view is useless
 MAX_GREP_RESULTS = 10
@@ -1180,7 +1181,7 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
                 else:
                     out.append(f"  {lineno}-{content}\n")
         out.append("\n")
-        return "".join(out)
+        return _cap_context_window("".join(out), "grep_around")
 
     hits = _grep_recursive(pattern, path, limit, excl)
     count = len(hits)
@@ -1208,6 +1209,29 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
 
 _AROUND_DIR_SKIP = {".git", "node_modules", "__pycache__", ".venv", "venv", ".tox", "vendor"}
 _AROUND_DIR_MAX_FILES = 20
+
+
+def _cap_context_window(text: str, op_name: str) -> str:
+    """Cap a context-window op's output at a byte budget (#241).
+
+    around:/grep_around: with a large :N on a file of long (e.g. minified)
+    lines can emit hundreds of KB in one op, blowing the caller's context.
+    Truncate at the last line boundary within the cap and append a footer
+    that points at the narrower tools. Configurable via
+    builtin-ops.<op>.max_bytes or SUPERTOOL_<OP>_MAX_BYTES.
+    """
+    cap = _get_op_int(op_name, "max_bytes", MAX_AROUND_BYTES)
+    encoded = text.encode("utf-8", errors="surrogateescape")
+    if len(encoded) <= cap:
+        return text
+    clipped = encoded[:cap].decode("utf-8", errors="ignore")
+    nl = clipped.rfind("\n")
+    if nl > 0:
+        clipped = clipped[:nl + 1]
+    dropped = len(encoded) - len(clipped.encode("utf-8", errors="surrogateescape"))
+    return (clipped +
+            f"… truncated (~{dropped} more bytes) — narrow context (:N) "
+            f"or use between: for the whole symbol\n")
 
 
 def _around_one_file(regex: "re.Pattern[str]", path: str, n: int) -> str:
@@ -1248,7 +1272,7 @@ def _around_one_file(regex: "re.Pattern[str]", path: str, n: int) -> str:
         marker = "→" if i == match_lineno else " "
         out.append(f"{i + 1:>6}{marker}{lines[i]}")
     out.append("\n")
-    return "".join(out)
+    return _cap_context_window("".join(out), "around")
 
 
 def op_around(pattern: str, path: str, n: int = 10) -> str:
@@ -1299,7 +1323,7 @@ def op_around(pattern: str, path: str, n: int = 10) -> str:
         if len(hits) >= _AROUND_DIR_MAX_FILES:
             header += f", capped at {_AROUND_DIR_MAX_FILES}"
         header += f", scanned {scanned})\n"
-        return header + "".join(hits)
+        return _cap_context_window(header + "".join(hits), "around")
 
     if not os.path.isfile(path):
         return f"ERROR: file not found: {path}\n"

--- a/tests/test_around_byte_cap_241.py
+++ b/tests/test_around_byte_cap_241.py
@@ -71,3 +71,27 @@ def test_around_env_override(tmp_path: Path, monkeypatch) -> None:
     out = supertool.op_around("TARGET20", str(f), 40)
     assert len(out.encode()) <= 4000 + 200, f"env cap ignored: {len(out)} bytes"
     assert "truncated" in out
+
+
+def test_around_dir_aggregate_capped(tmp_path: Path) -> None:
+    """Dir fan-out caps the TOTAL op output, not just each file (#241 review)."""
+    d = tmp_path / "pkg"
+    d.mkdir()
+    for i in range(10):
+        (d / f"f{i}.js").write_text(f"head{i}\n{LONG} TARGET\n{LONG}\n")
+    out = supertool.op_around("TARGET", str(d), 20)
+    assert len(out.encode()) <= 16000 + 200, f"dir aggregate not capped: {len(out)}"
+    assert "truncated" in out
+    # Exactly one truncation footer — the per-file cap was removed, so footers
+    # don't appear interleaved between files.
+    assert out.count("… truncated") == 1
+
+
+def test_around_single_giant_line_no_newline(tmp_path: Path) -> None:
+    """A single line longer than the cap: pass the partial through + footer,
+    never crash (nl == -1 branch)."""
+    f = tmp_path / "min.js"
+    f.write_text("TARGET " + "y" * 40000)  # one line, no trailing context lines
+    out = supertool.op_around("TARGET", str(f), 0)
+    assert len(out.encode()) <= 16000 + 200, f"giant line not capped: {len(out)}"
+    assert "truncated" in out

--- a/tests/test_around_byte_cap_241.py
+++ b/tests/test_around_byte_cap_241.py
@@ -1,0 +1,73 @@
+"""Regression tests for #241 — around:/grep_around: per-op byte cap.
+
+A large context (:N) on a file of long (minified) lines could dump hundreds
+of KB in a single op, blowing the caller's context budget. The ops now cap
+their output at a byte budget, truncating at a line boundary and appending a
+footer that points at the narrower tools (smaller :N, between:).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+# A long single line so a few of them blow past the 16KB cap fast.
+LONG = "x" * 4000
+
+
+def _make_long_file(tmp_path: Path, n_lines: int = 40) -> Path:
+    f = tmp_path / "big.js"
+    body = "\n".join(f"line{i} {LONG} TARGET{i}" for i in range(n_lines)) + "\n"
+    f.write_text(body)
+    return f
+
+
+def test_around_caps_large_window(tmp_path: Path) -> None:
+    f = _make_long_file(tmp_path)
+    out = supertool.op_around("TARGET20", str(f), 40)
+    assert len(out.encode()) <= 16000 + 200, f"not capped: {len(out)} bytes"
+    assert "truncated" in out
+    assert "between:" in out
+
+
+def test_around_truncates_at_line_boundary(tmp_path: Path) -> None:
+    f = _make_long_file(tmp_path)
+    out = supertool.op_around("TARGET20", str(f), 40)
+    # Everything before the footer must end on a complete line (newline).
+    footer_idx = out.index("… truncated")
+    body = out[:footer_idx]
+    assert body.endswith("\n"), "truncation cut mid-line"
+
+
+def test_around_small_file_not_capped(tmp_path: Path) -> None:
+    f = tmp_path / "small.py"
+    f.write_text("a\nb\nTARGET\nd\ne\n")
+    out = supertool.op_around("TARGET", str(f), 2)
+    assert "truncated" not in out
+    assert "TARGET" in out
+
+
+def test_grep_around_caps_large_window(tmp_path: Path) -> None:
+    f = _make_long_file(tmp_path)
+    # grep_around routes through op_grep with context > 0.
+    out = supertool.op_grep("TARGET", str(f), limit=50, context=40)
+    assert len(out.encode()) <= 16000 + 200, f"not capped: {len(out)} bytes"
+    assert "truncated" in out
+
+
+def test_grep_no_context_not_capped_by_window(tmp_path: Path) -> None:
+    """Plain grep (context=0) takes a different branch — no window footer."""
+    f = tmp_path / "small.py"
+    f.write_text("alpha\nTARGET here\nbeta\n")
+    out = supertool.op_grep("TARGET", str(f), limit=10, context=0)
+    assert "truncated (~" not in out
+    assert "TARGET" in out
+
+
+def test_around_env_override(tmp_path: Path, monkeypatch) -> None:
+    f = _make_long_file(tmp_path)
+    monkeypatch.setenv("SUPERTOOL_AROUND_MAX_BYTES", "4000")
+    out = supertool.op_around("TARGET20", str(f), 40)
+    assert len(out.encode()) <= 4000 + 200, f"env cap ignored: {len(out)} bytes"
+    assert "truncated" in out


### PR DESCRIPTION
Closes #241.

## Problem
`around:` / `grep_around:` with a large `:N` context on a file of long (e.g. minified) lines can over-fetch — a single op produced ~340KB, blowing the caller's context budget.

## Fix
New `_cap_context_window` helper caps output at **16KB**, truncating at a line boundary and appending a footer that points at the narrower tools:
`… truncated (~N more bytes) — narrow context (:N) or use between: for the whole symbol`

Applied at three render points: `around:` single-file, `around:` dir-aggregate, and the `op_grep` context branch (serves `grep_around:` and `grep:`-with-context).

Configurable: `builtin-ops.around.max_bytes` / `builtin-ops.grep_around.max_bytes` in `.supertool.json` (env: `SUPERTOOL_AROUND_MAX_BYTES` / `SUPERTOOL_GREP_AROUND_MAX_BYTES`), default 16000.

## Tests
6 TDD tests (`tests/test_around_byte_cap_241.py`) — caps, line-boundary truncation, small-file pass-through, grep_around path, plain-grep untouched, env override. RED proven by neutralizing the cap. Full suite green.

## Docs
`docs/configuration.md` (builtin-ops table), `docs/operations/search.md` (Output cap section), `.supertool.json` + `.supertool.example.json` (descriptions + max_bytes keys).