### PR TITLE
fix(git-checkout): recover in narrowed-refspec (single-branch) workspaces

### DIFF
--- a/presets/git/checkout.py
+++ b/presets/git/checkout.py
@@ -85,6 +85,19 @@ def main() -> int:
                 print(f"ERROR: ref {ref!r} matches multiple remotes: {joined}. "
                       f"Disambiguate, e.g. git checkout -b {ref} --track <remote>/{ref}")
                 return 1
+        # #267: single-branch / narrowed-refspec workspaces never create a
+        # refs/remotes/origin/<branch> tracking ref, so the #277 path above
+        # finds no match and `git fetch --all` only moved FETCH_HEAD. Fall
+        # back to an explicit single-ref fetch + checkout of FETCH_HEAD.
+        if result.returncode != 0 and ("did not match any" in s or "pathspec" in s):
+            single = _git(["fetch", "origin", ref], timeout=30)
+            if single.returncode == 0:
+                cob = _git(["checkout", "-B", ref, "FETCH_HEAD"])
+                if cob.returncode == 0:
+                    print(f"# (fetched origin {ref}, reset local branch to FETCH_HEAD)")
+                    result = cob
+                    stderr = ""
+                    s = ""
     if result.returncode != 0:
         if "not a git repository" in s:
             print("ERROR: not inside a git repository.")

--- a/tests/test_git_checkout.py
+++ b/tests/test_git_checkout.py
@@ -85,6 +85,41 @@ def test_unknown_ref_recovers_after_auto_fetch(monkeypatch, capsys) -> None:
     assert "→ feature" in out
 
 
+def test_narrowed_refspec_recovers_via_single_ref_fetch(monkeypatch, capsys) -> None:
+    """#267: single-branch refspec → `fetch --all` never creates origin/<branch>,
+    so the plain-checkout retry still fails. Falls back to an explicit
+    `fetch origin <branch>` + `checkout -B <branch> FETCH_HEAD`."""
+    calls: list[list[str]] = []
+    on_feature = {"yet": False}
+
+    def fake(args, timeout=10):
+        calls.append(args)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "--symbolic-full-name" not in args:
+            return _fake_run("feature\n" if on_feature["yet"] else "master\n")
+        if args[:2] == ["rev-parse", "--short"]:
+            return _fake_run("abc1234\n")
+        if args[:3] == ["rev-parse", "--abbrev-ref", "--symbolic-full-name"]:
+            return _fake_run("", "", 1)
+        if args[0] == "checkout" and args[1] == "-B":
+            on_feature["yet"] = True
+            return _fake_run("Reset branch 'feature'\n")
+        if args[0] == "checkout":
+            return _fake_run("", "error: pathspec 'feature' did not match any file(s)", 1)
+        if args[0] == "fetch":
+            return _fake_run()
+        return _fake_run()
+
+    monkeypatch.setattr(checkout, "_git", fake)
+    monkeypatch.setattr(checkout.sys, "argv", ["checkout.py", "feature"])
+    rc = checkout.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert ["fetch", "origin", "feature"] in calls, "should fall back to single-ref fetch"
+    assert ["checkout", "-B", "feature", "FETCH_HEAD"] in calls
+    assert "FETCH_HEAD" in out
+    assert "→ feature" in out
+
+
 def test_checkout_worktree_locked_suggests_path(monkeypatch, capsys) -> None:
     """When ref is checked out in another worktree, suggest cd <path>."""
     err = (


### PR DESCRIPTION
## Problem

`git-checkout:<branch>` fails with `ref '<branch>' not found even after fetch` in workspaces whose `remote.origin.fetch` is narrowed to a single branch (e.g. `+refs/heads/master:refs/remotes/origin/master`). The auto-fetch fallback runs `git fetch --all --prune`, which only updates `FETCH_HEAD` — it never creates `refs/remotes/origin/<branch>` — so the retry `git checkout <branch>` still fails.

Hit in DVSI Kevin-style single-branch automation worktrees.

## Fix

When the retry still hits a pathspec error, fall back to the manual workaround:

```
git fetch origin <ref>
git checkout -B <ref> FETCH_HEAD
```

`-B` is safe here: this block only runs after the first plain `git checkout <ref>` already failed, so a pre-existing local branch (which would have made that succeed) is impossible — `-B` only ever creates the branch.

## Audit

`git-diverge` and `git-merge` do **not** share the bug — neither auto-fetches nor assumes `origin/*` tracking refs; both verify a local ref and tell the user to fetch.

## Tests

Added `test_narrowed_refspec_recovers_via_single_ref_fetch`. 5/5 pass.

Closes #267