### PR TITLE
chore: bump 0.15.0 — gl-job/gh-job :grep + per-job failure patterns

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-22
+
 ### Added
 
 - **`gl-job` / `gh-job` `:grep:PATTERN` + per-job failure patterns with resolution ops.** `gl-job:ID:grep:PATTERN` (and the `gh-job` twin) runs an ad-hoc regex over the job trace — context window, gap markers, regex with literal fallback on `re.error`, and never silent-empty (no match names the pattern and shows a tail). Complements the existing `:raw` slice when you don't yet know the line numbers. Plus an optional per-job-name table in `.supertool.json`: `ops.gl-job.job_patterns` maps a job-name regex to tighter `patterns` and a `resolution` op — a failed `rector` job ends with `Resolve: ./supertool 'rector_ci_apply:<id>'` (`{id}` interpolated). No match falls back to the flat `error_patterns`. Two enablers: non-scalar custom-op config values are now JSON-encoded into their `SUPERTOOL_*` env var (so presets can `json.loads` structured config), and project-level `ops` overrides **deep-merge** into preset op-defs key-by-key (add `job_patterns` without restating the preset `cmd`). Closes [#289](https://github.com/Digital-Process-Tools/claude-supertool/issues/289). See [docs/presets/gitlab.md](docs/presets/gitlab.md).

--- a/supertool.py
+++ b/supertool.py
@@ -106,7 +106,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.14.1"
+VERSION = "0.15.0"
 
 
 def _fwd(p: str) -> str:

--- a/tests/test_mcp_config_279.py
+++ b/tests/test_mcp_config_279.py
@@ -47,4 +47,4 @@ def test_plugin_manifest_version_matches_code() -> None:
 
 
 def test_version_is_bumped_for_279() -> None:
-    assert supertool.VERSION == "0.14.1"
+    assert supertool.VERSION == "0.15.0"


### PR DESCRIPTION
Release bump for #292 (closes #289).

- `supertool.py` VERSION + `.claude-plugin/plugin.json` → 0.15.0
- CHANGELOG `[Unreleased]` → `[0.15.0] - 2026-06-22`
- version-pin test updated

Minor bump: adds `gl-job`/`gh-job` `:grep:PATTERN`, per-job failure patterns + resolution ops, JSON-encoded non-scalar config, deep-merge of project ops into preset op-defs.

🤖 Generated by Max