### PR TITLE
fix(batch): defer formatters inside batch:@file so imports survive (#291)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/supertool.py
+++ b/supertool.py
@@ -106,7 +106,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.15.0"
+VERSION = "0.15.1"
 
 
 def _fwd(p: str) -> str:
@@ -10999,53 +10999,74 @@ def _dispatch_impl(arg: str) -> str:
                                     body = f"ERROR: {_snap_err}\n"
                                     batch_ops = []
                             results: List[str] = []
-                            for _item in batch_ops:
-                                if not isinstance(_item, dict):
-                                    err = f"ERROR: each batch op must be a JSON object, got {type(_item).__name__}\n"
-                                    results.append(err)
-                                    if not continue_on_error:
-                                        break
-                                    continue
-                                _sub_op = _item.get("op", "")
-                                if not _sub_op:
-                                    err = "ERROR: batch op missing 'op' field\n"
-                                    results.append(err)
-                                    if not continue_on_error:
-                                        break
-                                    continue
-                                # Build the arg string from the op + its fields,
-                                # using the @file→parts machinery for mutating ops
-                                # (preserves validators) and plain dispatch for others.
-                                if _at_file_fields(_sub_op):
-                                    try:
-                                        _sub_parts, _sub_replace_all = _at_file_to_parts(_sub_op, _item)
-                                    except ValueError as _ve:
-                                        err = f"ERROR: {_ve}\n"
+                            # A batch is one logical change: defer per-op formatters
+                            # (no_unused_imports etc.) so an import added by op N survives
+                            # until op N+1's usage lands. main()'s len(argv)>1 guard never
+                            # fires for a lone batch:@file arg, so own the defer locally —
+                            # unless already inside a deferred multi-arg call, where main()
+                            # owns the queue. Issue #291.
+                            global _DEFER_FORMATTERS, _FORMAT_QUEUE
+                            global _VALIDATOR_DEFER_QUEUE, _VALIDATOR_DEFER_SEEN
+                            _batch_owns_defer = not _DEFER_FORMATTERS
+                            if _batch_owns_defer:
+                                _DEFER_FORMATTERS = True
+                                _FORMAT_QUEUE = {}
+                                _VALIDATOR_DEFER_QUEUE = []
+                                _VALIDATOR_DEFER_SEEN = set()
+                            try:
+                                for _item in batch_ops:
+                                    if not isinstance(_item, dict):
+                                        err = f"ERROR: each batch op must be a JSON object, got {type(_item).__name__}\n"
                                         results.append(err)
                                         if not continue_on_error:
                                             break
                                         continue
-                                    # replace_all: true on an edit op → promote to replace
-                                    if _sub_replace_all and _sub_op == "edit":
-                                        _sub_parts[0] = "replace"
-                                    # Reconstruct a triple-colon arg string so dispatch
-                                    # parses it correctly (handles colons in content).
-                                    _sub_arg = ":::".join(_sub_parts)
-                                else:
-                                    # Read-only op: build plain colon arg from known fields.
-                                    # For unknown ops, pass what we have and let dispatch error.
-                                    _fields = [str(_item[k]) for k in sorted(_item) if k != "op"]
-                                    _sub_arg = ":".join([_sub_op] + _fields) if _fields else _sub_op
-                                _sub_result = dispatch(_sub_arg)
-                                results.append(_sub_result)
-                                if not continue_on_error and _sub_result.split("\n")[1:2] and (
-                                    _sub_result.split("\n")[1].startswith("ERROR")
-                                ):
-                                    break
+                                    _sub_op = _item.get("op", "")
+                                    if not _sub_op:
+                                        err = "ERROR: batch op missing 'op' field\n"
+                                        results.append(err)
+                                        if not continue_on_error:
+                                            break
+                                        continue
+                                    # Build the arg string from the op + its fields,
+                                    # using the @file→parts machinery for mutating ops
+                                    # (preserves validators) and plain dispatch for others.
+                                    if _at_file_fields(_sub_op):
+                                        try:
+                                            _sub_parts, _sub_replace_all = _at_file_to_parts(_sub_op, _item)
+                                        except ValueError as _ve:
+                                            err = f"ERROR: {_ve}\n"
+                                            results.append(err)
+                                            if not continue_on_error:
+                                                break
+                                            continue
+                                        # replace_all: true on an edit op → promote to replace
+                                        if _sub_replace_all and _sub_op == "edit":
+                                            _sub_parts[0] = "replace"
+                                        # Reconstruct a triple-colon arg string so dispatch
+                                        # parses it correctly (handles colons in content).
+                                        _sub_arg = ":::".join(_sub_parts)
+                                    else:
+                                        # Read-only op: build plain colon arg from known fields.
+                                        # For unknown ops, pass what we have and let dispatch error.
+                                        _fields = [str(_item[k]) for k in sorted(_item) if k != "op"]
+                                        _sub_arg = ":".join([_sub_op] + _fields) if _fields else _sub_op
+                                    _sub_result = dispatch(_sub_arg)
+                                    results.append(_sub_result)
+                                    if not continue_on_error and _sub_result.split("\n")[1:2] and (
+                                        _sub_result.split("\n")[1].startswith("ERROR")
+                                    ):
+                                        break
+                            finally:
+                                if _batch_owns_defer:
+                                    _DEFER_FORMATTERS = False
                             # Only override `body` with joined results when no
                             # upstream error fired (cap rejection, snapshot reorder).
                             if not _snap_err and not _cap_exceeded:
                                 body = "".join(results)
+                                if _batch_owns_defer:
+                                    body += _drain_format_queue()
+                                    body += _drain_validator_queue()
         elif op == "validate":
             # verbose flag: literal "verbose" token anywhere after op name.
             # Forms: validate:PATH:verbose  or  validate:PATH:tool1,tool2:verbose

--- a/tests/test_formatters_deferred.py
+++ b/tests/test_formatters_deferred.py
@@ -150,3 +150,52 @@ def test_defer_state_reset_between_invocations(tmp_path, monkeypatch) -> None:
     supertool.main([f"edit:::x = 1:::x = 2:::{target}", f"edit:::x = 2:::x = 3:::{target}"])
     assert supertool._DEFER_FORMATTERS is False
     assert supertool._FORMAT_QUEUE == {}
+
+
+def test_batch_defers_formatter_once_per_file(tmp_path, monkeypatch) -> None:
+    """Issue #291: ops inside a single batch:@file call must also defer formatters.
+
+    A batch is one logical change but runs through a single argv element, so the
+    len(argv)>1 guard in main() never fired — formatters ran inline per-op and
+    no_unused_imports stripped an import a later op was about to use.
+    """
+    import json
+
+    target = tmp_path / "a.py"
+    target.write_text("x = 1\n")
+    cmd, counter = _make_counting_cmd(tmp_path)
+    _set_formatters({"fakefmt": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.py"}})
+
+    ops_file = tmp_path / "ops.json"
+    ops_file.write_text(json.dumps([
+        {"op": "edit", "path": str(target), "old": "x = 1", "new": "x = 2"},
+        {"op": "edit", "path": str(target), "old": "x = 2", "new": "x = 3"},
+    ]))
+
+    monkeypatch.chdir(tmp_path)
+    rc = supertool.main([f"batch:@{ops_file}"])
+    assert rc == 0
+    assert target.read_text() == "x = 3\n"
+    runs = counter.read_text().count("run\n")
+    assert runs == 1, f"expected 1 deferred run inside batch, got {runs}"
+
+
+def test_batch_defer_resets_state(tmp_path, monkeypatch) -> None:
+    """Batch's own defer setup must not leak the module-level queue."""
+    import json
+
+    target = tmp_path / "b.py"
+    target.write_text("x = 1\n")
+    cmd, _counter = _make_counting_cmd(tmp_path)
+    _set_formatters({"fakefmt": {"cmd": cmd, "hooks_into": ["edit"], "match": "*.py"}})
+
+    ops_file = tmp_path / "ops.json"
+    ops_file.write_text(json.dumps([
+        {"op": "edit", "path": str(target), "old": "x = 1", "new": "x = 2"},
+        {"op": "edit", "path": str(target), "old": "x = 2", "new": "x = 3"},
+    ]))
+
+    monkeypatch.chdir(tmp_path)
+    supertool.main([f"batch:@{ops_file}"])
+    assert supertool._DEFER_FORMATTERS is False
+    assert supertool._FORMAT_QUEUE == {}

--- a/tests/test_mcp_config_279.py
+++ b/tests/test_mcp_config_279.py
@@ -47,4 +47,4 @@ def test_plugin_manifest_version_matches_code() -> None:
 
 
 def test_version_is_bumped_for_279() -> None:
-    assert supertool.VERSION == "0.15.0"
+    assert supertool.VERSION == "0.15.1"


### PR DESCRIPTION
## Context

`batch:@file.json` ran its internal ops with formatters firing inline per-op, even though multi-arg invocations (`./supertool 'edit' 'edit'`) defer them via #164. Root cause: the defer guard in `main()` keys on `len(argv) > 1`, but a batch is a *single* argv element — its `for _item in batch_ops` loop never entered defer mode. So when op N added `use X;` and op N+1 added the code using X, `no_unused_imports` stripped the import after op N (silent `+0 -1`), and op N+1 referenced a gone symbol → PHPStan `class.notFound`. #291 is the batch-route duplicate of #164.

## Fix

The batch loop now owns the defer locally: `_batch_owns_defer = not _DEFER_FORMATTERS` enables defer + inits the format/validator queues before the loop, wrapped in `try/finally` to guarantee state reset, and drains the queues after all ops land. If a multi-arg invocation already owns the defer, the batch leaves the queue to `main()` — no double-drain, no premature reset.

Formatters now run once at end-of-batch, after every op applied, so an import added by one op survives until a later op's usage lands.

## Tests

`tests/test_formatters_deferred.py` +2:
- `test_batch_defers_formatter_once_per_file` — two edits in one `batch:@file`, formatter runs once (the failing repro).
- `test_batch_defer_resets_state` — defer state clean after the batch.

Full suite: 3260 passed, 34 skipped. Version → 0.15.1 (supertool.py + plugin.json + #279 pin test).

Closes #291.

🤖 Generated by Max
A batch is one change — now the formatters finally agree.
