### PR TITLE
feat(git): add git-push op for updating an existing MR (#288)

### DIFF
--- a/presets/git.json
+++ b/presets/git.json
@@ -61,6 +61,12 @@
       "timeout": 60,
       "description": "Commit MSG (stages PATHS) — HEAD before/after, hook errors surfaced. MSG=--no-edit reuses MERGE_MSG/CHERRY_PICK msg (merge or cherry-pick must be in progress)",
       "syntax": "git-commit:::MSG[:::PATH...]"
+    },
+    "git-push": {
+      "cmd": "{python} {path}git/push.py",
+      "timeout": 120,
+      "description": "Push current branch (sets upstream if missing) — remote before/after, ahead/behind, open MR/PR + pipeline. For updating an existing MR; use mr op for push+create",
+      "syntax": "git-push"
     }
   }
 }

--- a/presets/git/_git_common.py
+++ b/presets/git/_git_common.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Shared helpers for the git/* preset scripts.
+
+Holds the bits that were drifting across commit.py / push.py:
+  - _git            : thin subprocess wrapper
+  - _first_error_line: pick the salient line out of git/hook output
+  - query_open_mr   : open MR/PR for a branch, as structured fields
+
+Each script formats query_open_mr's output its own way — the lookup
+(glab → gh fallback, all failures swallowed) lives here once.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Optional
+
+
+def _git(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git"] + args,
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def _first_error_line(text: str) -> str:
+    """First line mentioning an error/rejection, else last non-empty line."""
+    for line in text.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        low = s.lower()
+        if ("error" in low or "fatal" in low or "rejected" in low
+                or "aborted" in low or "failed" in low
+                or "! [" in s or "❌" in s):
+            return s
+    for line in reversed(text.splitlines()):
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def query_open_mr(branch: str) -> Optional[dict]:
+    """Open MR/PR for `branch`, or None when none / no tool available.
+
+    Returns {source, iid, target, pipeline}. `pipeline` is the GitLab
+    pipeline status when known, else None (gh list carries no cheap check
+    state). Tries glab (GitLab) first, falls back to gh (GitHub). All
+    failures swallowed — this is advisory output, never blocking.
+    """
+    if not branch or branch == "HEAD":
+        return None
+    if shutil.which("glab"):
+        try:
+            res = subprocess.run(
+                ["glab", "mr", "list", "--source-branch", branch, "--state",
+                 "opened", "--output", "json"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if res.returncode == 0 and res.stdout.strip().startswith("["):
+                mrs = json.loads(res.stdout)
+                if mrs:
+                    mr = mrs[0]
+                    pipeline = mr.get("pipeline") or mr.get("head_pipeline") or {}
+                    return {
+                        "source": "gitlab",
+                        "iid": mr.get("iid") or mr.get("number") or "?",
+                        "target": mr.get("target_branch", "?"),
+                        "pipeline": pipeline.get("status"),
+                    }
+        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+            pass
+    if shutil.which("gh"):
+        try:
+            res = subprocess.run(
+                ["gh", "pr", "list", "--head", branch, "--state", "open",
+                 "--json", "number,baseRefName", "--limit", "1"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if res.returncode == 0 and res.stdout.strip().startswith("["):
+                prs = json.loads(res.stdout)
+                if prs:
+                    pr = prs[0]
+                    return {
+                        "source": "github",
+                        "iid": pr.get("number", "?"),
+                        "target": pr.get("baseRefName", "?"),
+                        "pipeline": None,
+                    }
+        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+            pass
+    return None

--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -15,78 +15,33 @@ Special MSG values:
 """
 from __future__ import annotations
 
-import json
 import os
-import shutil
-import subprocess
 import sys
+
+# Sibling import: runtime puts this dir on sys.path[0]; the test harness
+# loads scripts via importlib (no dir on path), so add it explicitly.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _git_common import _first_error_line, _git, query_open_mr  # noqa: E402
 
 # triple-colon separator handled by supertool; we receive plain argv here.
 
 
-def _git(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git"] + args,
-        capture_output=True, text=True, timeout=timeout,
-    )
-
-
 def _existing_mr_for_branch(branch: str) -> str:
-    """Open MR/PR identifier for `branch`, or empty when none / no tool available.
+    """Open MR/PR identifier for `branch` (e.g. !42 / #7), or empty when none.
 
-    Tries glab first (GitLab), falls back to gh (GitHub). All failures swallowed —
-    this is advisory output for the post-commit hint, never blocking.
+    Thin formatter over the shared lookup — kept for the post-commit hint.
     """
-    if not branch or branch == "HEAD":
+    mr = query_open_mr(branch)
+    if not mr:
         return ""
-    if shutil.which("glab"):
-        try:
-            res = subprocess.run(
-                ["glab", "mr", "list", "--source-branch", branch, "--state", "opened",
-                 "--output", "json"],
-                capture_output=True, text=True, timeout=5,
-            )
-            if res.returncode == 0 and res.stdout.strip().startswith("["):
-                mrs = json.loads(res.stdout)
-                if mrs:
-                    iid = mrs[0].get("iid") or mrs[0].get("number") or "?"
-                    return f"!{iid}"
-        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
-            pass
-    if shutil.which("gh"):
-        try:
-            res = subprocess.run(
-                ["gh", "pr", "list", "--head", branch, "--state", "open",
-                 "--json", "number", "--limit", "1"],
-                capture_output=True, text=True, timeout=5,
-            )
-            if res.returncode == 0 and res.stdout.strip().startswith("["):
-                prs = json.loads(res.stdout)
-                if prs:
-                    return f"#{prs[0].get('number', '?')}"
-        except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
-            pass
-    return ""
+    prefix = "!" if mr["source"] == "gitlab" else "#"
+    return f"{prefix}{mr['iid']}"
 
 
 def _head_sha() -> str:
     r = _git(["rev-parse", "--short", "HEAD"])
     return r.stdout.strip() if r.returncode == 0 else ""
-
-
-def _first_error_line(text: str) -> str:
-    for line in text.splitlines():
-        s = line.strip()
-        if not s:
-            continue
-        low = s.lower()
-        if "error" in low or "fatal" in low or "aborted" in low or "failed" in low or "❌" in s:
-            return s
-    # Fallback to last non-empty line
-    for line in reversed(text.splitlines()):
-        if line.strip():
-            return line.strip()
-    return ""
 
 
 def main() -> int:

--- a/presets/git/push.py
+++ b/presets/git/push.py
@@ -81,10 +81,15 @@ def main() -> int:
         err = _first_error_line(combined)
         if err:
             print(f"First error: {err}")
-        if "non-fast-forward" in combined or "rejected" in combined.lower():
+        low = combined.lower()
+        if "non-fast-forward" in low:
             print("Hint: remote has commits you lack — `git pull --rebase` then "
                   "retry, or force only if intentional: "
                   "`git push --force-with-lease`")
+        elif "rejected" in low or "declined" in low:
+            print("Hint: rejected by a server-side rule (protected branch / hook), "
+                  "not a divergence — check branch protection or the hook output "
+                  "above. A rebase will not help.")
         print("\n--- git output ---")
         print(combined.strip() or "(no output)")
         return result.returncode
@@ -100,8 +105,12 @@ def main() -> int:
         print(f"Remote {remote_before} → {remote_after} ({n} commit(s))")
     elif not remote_before and remote_after:
         print(f"Remote now at {remote_after} (branch created)")
-    else:
+    elif remote_before and remote_after and remote_before == remote_after:
         print("Already up to date — nothing to push")
+    else:
+        # Push succeeded but the remote-tracking SHA isn't locally resolvable
+        # (shallow clone, odd remote layout). Don't claim up-to-date.
+        print("Pushed — remote ref not locally resolvable for a before/after diff")
 
     # Ahead/behind vs upstream after the push (should be in sync on success)
     ab = _git(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"])

--- a/presets/git/push.py
+++ b/presets/git/push.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Git push — update the current branch's remote + verifiable receipt.
+
+Closes the loop for the common case the `mr` op doesn't cover: pushing a
+fix to an MR that already exists. `mr` creates; this updates.
+
+Receipt always shows:
+  - branch + upstream (sets upstream on first push)
+  - commits pushed (remote SHA before/after) or "already up to date"
+  - ahead/behind vs the remote afterwards
+  - open MR/PR for the branch + pipeline status (push triggers a run)
+
+Non-fast-forward rejections are surfaced loudly with a hint, never
+auto-forced — mirrors git-commit's no-silent-bypass philosophy.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+# Sibling import: runtime puts this dir on sys.path[0]; the test harness
+# loads scripts via importlib (no dir on path), so add it explicitly.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _git_common import _first_error_line, _git, query_open_mr  # noqa: E402
+
+
+def _upstream_ref() -> str:
+    """Configured upstream of HEAD (e.g. origin/foo), or empty if none."""
+    r = _git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
+def _remote_sha(ref: str) -> str:
+    if not ref:
+        return ""
+    r = _git(["rev-parse", "--short", ref])
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
+def _open_mr_line(branch: str) -> str:
+    """One-line MR/PR summary for the post-push receipt, or empty."""
+    mr = query_open_mr(branch)
+    if not mr:
+        return ""
+    if mr["source"] == "gitlab":
+        return (f"MR !{mr['iid']} → {mr['target']} | "
+                f"pipeline: {mr['pipeline'] or 'triggered'}")
+    return f"PR #{mr['iid']} → {mr['target']} | checks triggered"
+
+
+def main() -> int:
+    if _git(["rev-parse", "--git-dir"]).returncode != 0:
+        print("ERROR: not inside a git repository.")
+        return 1
+
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+    if not branch or branch == "HEAD":
+        print("ERROR: detached HEAD — checkout a branch before pushing.")
+        return 1
+
+    upstream = _upstream_ref()
+    has_upstream = bool(upstream)
+    remote_before = _remote_sha(upstream) if has_upstream else ""
+
+    print(f"# git-push on {branch}")
+    if has_upstream:
+        print(f"Upstream: {upstream}" + (f" @ {remote_before}" if remote_before else ""))
+    else:
+        print("Upstream: none — setting on first push (origin)")
+
+    if has_upstream:
+        result = _git(["push"], timeout=120)
+    else:
+        result = _git(["push", "-u", "origin", "HEAD"], timeout=120)
+
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+
+    if result.returncode != 0:
+        print("Status: PUSH REJECTED ✗")
+        err = _first_error_line(combined)
+        if err:
+            print(f"First error: {err}")
+        if "non-fast-forward" in combined or "rejected" in combined.lower():
+            print("Hint: remote has commits you lack — `git pull --rebase` then "
+                  "retry, or force only if intentional: "
+                  "`git push --force-with-lease`")
+        print("\n--- git output ---")
+        print(combined.strip() or "(no output)")
+        return result.returncode
+
+    # Success — recompute upstream (now set if it was the first push)
+    upstream = upstream or _upstream_ref()
+    remote_after = _remote_sha(upstream)
+
+    print("Status: pushed ✓")
+    if remote_before and remote_after and remote_before != remote_after:
+        rng = _git(["rev-list", "--count", f"{remote_before}..{remote_after}"])
+        n = rng.stdout.strip() if rng.returncode == 0 else "?"
+        print(f"Remote {remote_before} → {remote_after} ({n} commit(s))")
+    elif not remote_before and remote_after:
+        print(f"Remote now at {remote_after} (branch created)")
+    else:
+        print("Already up to date — nothing to push")
+
+    # Ahead/behind vs upstream after the push (should be in sync on success)
+    ab = _git(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"])
+    if ab.returncode == 0:
+        parts = ab.stdout.strip().split()
+        if len(parts) == 2:
+            ahead, behind = int(parts[0]), int(parts[1])
+            if ahead or behind:
+                print(f"vs upstream: ahead {ahead}, behind {behind}")
+            else:
+                print("vs upstream: in sync")
+
+    mr_line = _open_mr_line(branch)
+    if mr_line:
+        print(mr_line)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_git_commit_existing_mr.py
+++ b/tests/test_git_commit_existing_mr.py
@@ -1,4 +1,6 @@
-"""Unit tests for presets/git/commit.py _existing_mr_for_branch helper."""
+"""Unit tests for commit.py _existing_mr_for_branch — a thin formatter over
+presets/git/_common.query_open_mr. Patches happen on _common (where the
+glab→gh lookup lives) and assert through commit's !iid/#iid formatting."""
 from __future__ import annotations
 
 import importlib.util
@@ -11,7 +13,11 @@ PRESET = Path(__file__).parent.parent / "presets" / "git" / "commit.py"
 _spec = importlib.util.spec_from_file_location("git_commit", PRESET)
 assert _spec is not None and _spec.loader is not None
 commit = importlib.util.module_from_spec(_spec)
+# exec_module runs commit.py's `sys.path.insert(...)`, making `_common`
+# importable below and registering it in sys.modules.
 _spec.loader.exec_module(commit)
+
+import _git_common as _common  # noqa: E402  — resolvable after commit.py inserted its dir
 
 
 def _proc(stdout: str = "", returncode: int = 0):
@@ -30,21 +36,21 @@ def test_detached_head_returns_empty() -> None:
 def test_glab_match_returns_bang_iid() -> None:
     fake_which = mock.Mock(side_effect=lambda c: "/usr/bin/glab" if c == "glab" else None)
     fake_run = mock.Mock(return_value=_proc('[{"iid": 21816, "title": "x"}]'))
-    with mock.patch.object(commit.shutil, "which", fake_which), \
-         mock.patch.object(commit.subprocess, "run", fake_run):
+    with mock.patch.object(_common.shutil, "which", fake_which), \
+         mock.patch.object(_common.subprocess, "run", fake_run):
         assert commit._existing_mr_for_branch("feature/x") == "!21816"
 
 
 def test_gh_fallback_when_no_glab() -> None:
     fake_which = mock.Mock(side_effect=lambda c: "/usr/bin/gh" if c == "gh" else None)
     fake_run = mock.Mock(return_value=_proc('[{"number": 172}]'))
-    with mock.patch.object(commit.shutil, "which", fake_which), \
-         mock.patch.object(commit.subprocess, "run", fake_run):
+    with mock.patch.object(_common.shutil, "which", fake_which), \
+         mock.patch.object(_common.subprocess, "run", fake_run):
         assert commit._existing_mr_for_branch("feature/x") == "#172"
 
 
 def test_no_tool_available_returns_empty() -> None:
-    with mock.patch.object(commit.shutil, "which", return_value=None):
+    with mock.patch.object(_common.shutil, "which", return_value=None):
         assert commit._existing_mr_for_branch("feature/x") == ""
 
 
@@ -58,8 +64,8 @@ def test_glab_empty_list_falls_through_to_gh() -> None:
             return _proc("[]")  # glab: no MR
         return _proc('[{"number": 9}]')  # gh: PR exists
 
-    with mock.patch.object(commit.shutil, "which", fake_which), \
-         mock.patch.object(commit.subprocess, "run", side_effect=fake_run):
+    with mock.patch.object(_common.shutil, "which", fake_which), \
+         mock.patch.object(_common.subprocess, "run", side_effect=fake_run):
         assert commit._existing_mr_for_branch("feature/x") == "#9"
 
 
@@ -73,8 +79,8 @@ def test_glab_timeout_falls_through() -> None:
             raise subprocess.TimeoutExpired(cmd="glab", timeout=5)
         return _proc('[{"number": 42}]')
 
-    with mock.patch.object(commit.shutil, "which", fake_which), \
-         mock.patch.object(commit.subprocess, "run", side_effect=fake_run):
+    with mock.patch.object(_common.shutil, "which", fake_which), \
+         mock.patch.object(_common.subprocess, "run", side_effect=fake_run):
         assert commit._existing_mr_for_branch("feature/x") == "#42"
 
 
@@ -88,6 +94,6 @@ def test_glab_malformed_json_falls_through() -> None:
             return _proc("[not json")
         return _proc('[{"number": 7}]')
 
-    with mock.patch.object(commit.shutil, "which", fake_which), \
-         mock.patch.object(commit.subprocess, "run", side_effect=fake_run):
+    with mock.patch.object(_common.shutil, "which", fake_which), \
+         mock.patch.object(_common.subprocess, "run", side_effect=fake_run):
         assert commit._existing_mr_for_branch("feature/x") == "#7"

--- a/tests/test_git_common.py
+++ b/tests/test_git_common.py
@@ -1,0 +1,134 @@
+"""Unit tests for presets/git/_git_common.py — shared git helpers."""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+
+PRESET = Path(__file__).parent.parent / "presets" / "git" / "_git_common.py"
+_spec = importlib.util.spec_from_file_location("git_common_mod", PRESET)
+assert _spec is not None and _spec.loader is not None
+common = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(common)
+
+
+def _proc(stdout: str = "", returncode: int = 0):
+    return mock.Mock(stdout=stdout, returncode=returncode, stderr="")
+
+
+# ── _first_error_line ────────────────────────────────────────────────────
+
+def test_first_error_line_picks_error_keyword() -> None:
+    text = "Running pre-commit\nok 12 files\nfatal: hook rejected\nbye"
+    assert common._first_error_line(text) == "fatal: hook rejected"
+
+
+def test_first_error_line_picks_emoji_marker() -> None:
+    assert "❌" in common._first_error_line("step 1\n❌ Push blocked\n")
+
+
+def test_first_error_line_picks_rejected_bracket() -> None:
+    text = "To origin\n ! [rejected] main -> main (non-fast-forward)\ndone"
+    assert "! [rejected]" in common._first_error_line(text)
+
+
+def test_first_error_line_falls_back_to_last_nonempty() -> None:
+    assert common._first_error_line("a\nb\n\n") == "b"
+
+
+def test_first_error_line_empty_input() -> None:
+    assert common._first_error_line("") == ""
+    assert common._first_error_line("\n\n") == ""
+
+
+# ── query_open_mr ────────────────────────────────────────────────────────
+
+def test_query_empty_branch_returns_none() -> None:
+    assert common.query_open_mr("") is None
+    assert common.query_open_mr("HEAD") is None
+
+
+def test_query_glab_match_returns_gitlab_fields() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: "/usr/bin/glab" if c == "glab" else None)
+    fake_run = mock.Mock(return_value=_proc(
+        '[{"iid": 21816, "target_branch": "master", '
+        '"pipeline": {"status": "running"}}]'))
+    with mock.patch.object(common.shutil, "which", fake_which), \
+         mock.patch.object(common.subprocess, "run", fake_run):
+        mr = common.query_open_mr("feature/x")
+    assert mr == {"source": "gitlab", "iid": 21816,
+                  "target": "master", "pipeline": "running"}
+
+
+def test_query_glab_no_pipeline_yields_none_status() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: "/usr/bin/glab" if c == "glab" else None)
+    fake_run = mock.Mock(return_value=_proc('[{"iid": 5, "target_branch": "main"}]'))
+    with mock.patch.object(common.shutil, "which", fake_which), \
+         mock.patch.object(common.subprocess, "run", fake_run):
+        mr = common.query_open_mr("feature/x")
+    assert mr is not None and mr["pipeline"] is None
+
+
+def test_query_gh_fallback_returns_github_fields() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: "/usr/bin/gh" if c == "gh" else None)
+    fake_run = mock.Mock(return_value=_proc('[{"number": 172, "baseRefName": "main"}]'))
+    with mock.patch.object(common.shutil, "which", fake_which), \
+         mock.patch.object(common.subprocess, "run", fake_run):
+        mr = common.query_open_mr("feature/x")
+    assert mr == {"source": "github", "iid": 172,
+                  "target": "main", "pipeline": None}
+
+
+def test_query_no_tool_returns_none() -> None:
+    with mock.patch.object(common.shutil, "which", return_value=None):
+        assert common.query_open_mr("feature/x") is None
+
+
+def test_query_glab_empty_falls_through_to_gh() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: f"/usr/bin/{c}" if c in ("glab", "gh") else None)
+    call_count = {"n": 0}
+
+    def fake_run(*_a, **_k):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _proc("[]")
+        return _proc('[{"number": 9, "baseRefName": "dev"}]')
+
+    with mock.patch.object(common.shutil, "which", fake_which), \
+         mock.patch.object(common.subprocess, "run", side_effect=fake_run):
+        mr = common.query_open_mr("feature/x")
+    assert mr is not None and mr["source"] == "github" and mr["iid"] == 9
+
+
+def test_query_glab_timeout_falls_through() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: f"/usr/bin/{c}" if c in ("glab", "gh") else None)
+    call_count = {"n": 0}
+
+    def fake_run(*_a, **_k):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise subprocess.TimeoutExpired(cmd="glab", timeout=5)
+        return _proc('[{"number": 42, "baseRefName": "main"}]')
+
+    with mock.patch.object(common.shutil, "which", fake_which), \
+         mock.patch.object(common.subprocess, "run", side_effect=fake_run):
+        mr = common.query_open_mr("feature/x")
+    assert mr is not None and mr["iid"] == 42
+
+
+def test_query_glab_malformed_json_falls_through() -> None:
+    fake_which = mock.Mock(side_effect=lambda c: f"/usr/bin/{c}" if c in ("glab", "gh") else None)
+    call_count = {"n": 0}
+
+    def fake_run(*_a, **_k):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _proc("[not json")
+        return _proc('[{"number": 7, "baseRefName": "main"}]')
+
+    with mock.patch.object(common.shutil, "which", fake_which), \
+         mock.patch.object(common.subprocess, "run", side_effect=fake_run):
+        mr = common.query_open_mr("feature/x")
+    assert mr is not None and mr["iid"] == 7

--- a/tests/test_git_push.py
+++ b/tests/test_git_push.py
@@ -102,6 +102,59 @@ def test_main_rejected_push_surfaces_hint(capsys) -> None:
     assert "pull --rebase" in out
 
 
+def test_main_protected_branch_rejection_no_rebase_hint(capsys) -> None:
+    """Server-side rejection (protected branch) must NOT advise pull --rebase."""
+    rejected = ("To origin\n ! [remote rejected] main -> main "
+                "(protected branch hook declined)\nerror: failed to push some refs")
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("main\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/main\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[0] == "push":
+            return _proc("", 1, rejected)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "PUSH REJECTED" in out
+    assert "server-side rule" in out
+    assert "pull --rebase" not in out
+    assert "force-with-lease" not in out
+
+
+def test_main_up_to_date_when_remote_unchanged(capsys) -> None:
+    """Push succeeds but remote SHA is unchanged → 'Already up to date'."""
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)  # same before and after
+        if args[0] == "push":
+            return _proc("", 0)
+        if args[:2] == ["rev-list", "--left-right"]:
+            return _proc("0\t0\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value=None):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Already up to date — nothing to push" in out
+
+
 def test_main_success_receipt_with_mr(capsys) -> None:
     """Happy path: upstream set, remote advances, MR line appended."""
     shas = iter(["aaa1111", "bbb2222"])  # before, after

--- a/tests/test_git_push.py
+++ b/tests/test_git_push.py
@@ -1,0 +1,165 @@
+"""Unit tests for presets/git/push.py — receipt + MR line + guards."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+
+PRESET = Path(__file__).parent.parent / "presets" / "git" / "push.py"
+_spec = importlib.util.spec_from_file_location("git_push", PRESET)
+assert _spec is not None and _spec.loader is not None
+push = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(push)
+
+
+def _proc(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    return mock.Mock(stdout=stdout, returncode=returncode, stderr=stderr)
+
+
+# ── _open_mr_line ────────────────────────────────────────────────────────
+
+def test_mr_line_gitlab_with_pipeline() -> None:
+    with mock.patch.object(push, "query_open_mr", return_value={
+            "source": "gitlab", "iid": 42, "target": "master", "pipeline": "running"}):
+        assert push._open_mr_line("b") == "MR !42 → master | pipeline: running"
+
+
+def test_mr_line_gitlab_no_pipeline_says_triggered() -> None:
+    with mock.patch.object(push, "query_open_mr", return_value={
+            "source": "gitlab", "iid": 42, "target": "master", "pipeline": None}):
+        assert push._open_mr_line("b") == "MR !42 → master | pipeline: triggered"
+
+
+def test_mr_line_github() -> None:
+    with mock.patch.object(push, "query_open_mr", return_value={
+            "source": "github", "iid": 7, "target": "main", "pipeline": None}):
+        assert push._open_mr_line("b") == "PR #7 → main | checks triggered"
+
+
+def test_mr_line_none_is_empty() -> None:
+    with mock.patch.object(push, "query_open_mr", return_value=None):
+        assert push._open_mr_line("b") == ""
+
+
+# ── _remote_sha ──────────────────────────────────────────────────────────
+
+def test_remote_sha_empty_ref() -> None:
+    assert push._remote_sha("") == ""
+
+
+def test_remote_sha_resolves() -> None:
+    with mock.patch.object(push, "_git", return_value=_proc("abc1234\n")):
+        assert push._remote_sha("origin/x") == "abc1234"
+
+
+# ── main() guards ────────────────────────────────────────────────────────
+
+def test_main_not_a_repo(capsys) -> None:
+    with mock.patch.object(push, "_git", return_value=_proc(returncode=1)):
+        rc = push.main()
+    assert rc == 1
+    assert "not inside a git repository" in capsys.readouterr().out
+
+
+def test_main_detached_head(capsys) -> None:
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"]:
+            return _proc("HEAD\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git):
+        rc = push.main()
+    assert rc == 1
+    assert "detached HEAD" in capsys.readouterr().out
+
+
+def test_main_rejected_push_surfaces_hint(capsys) -> None:
+    rejected = ("To origin\n ! [rejected] feat -> feat (non-fast-forward)\n"
+                "error: failed to push some refs")
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[0] == "push":
+            return _proc("", 1, rejected)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "PUSH REJECTED" in out
+    assert "force-with-lease" in out
+    assert "pull --rebase" in out
+
+
+def test_main_success_receipt_with_mr(capsys) -> None:
+    """Happy path: upstream set, remote advances, MR line appended."""
+    shas = iter(["aaa1111", "bbb2222"])  # before, after
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc(next(shas) + "\n", 0)
+        if args[0] == "push":
+            return _proc("", 0)
+        if args[:2] == ["rev-list", "--count"]:
+            return _proc("1\n", 0)
+        if args[:2] == ["rev-list", "--left-right"]:
+            return _proc("0\t0\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value={
+             "source": "gitlab", "iid": 99, "target": "master", "pipeline": "created"}):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Status: pushed ✓" in out
+    assert "aaa1111 → bbb2222 (1 commit(s))" in out
+    assert "vs upstream: in sync" in out
+    assert "MR !99 → master | pipeline: created" in out
+
+
+def test_main_first_push_sets_upstream(capsys) -> None:
+    """No upstream initially → push -u; receipt notes branch created."""
+    calls: list[list[str]] = []
+
+    def fake_git(args, timeout=30):
+        calls.append(list(args))
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            # No upstream the first call, set after push
+            return _proc("origin/feat\n", 0) if any(c[0] == "push" for c in calls) else _proc("", 1)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("ccc3333\n", 0)
+        if args[0] == "push":
+            return _proc("", 0)
+        if args[:2] == ["rev-list", "--left-right"]:
+            return _proc("0\t0\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value=None):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert ["push", "-u", "origin", "HEAD"] in calls
+    assert "branch created" in out


### PR DESCRIPTION
## Context

Closes #288. The `mr` op covers push+create, but updating an **already-open** MR had no op — it dropped to raw `git push -u origin HEAD`. This adds `git-push`.

## What it does

- Pushes the current branch, sets upstream if missing.
- Reports remote SHA before/after + commits pushed, ahead/behind vs upstream.
- Surfaces the open MR/PR for the branch + pipeline status (push triggers a run).
- Non-fast-forward rejections print a `pull --rebase` / `--force-with-lease` hint — never auto-forced (mirrors `git-commit`).

## Refactor

Extracted the bits that were drifting across `commit.py`/`push.py` into `presets/git/_git_common.py`: `_git`, `_first_error_line`, and the glab→gh MR lookup (now `query_open_mr`, structured fields). `commit.py` rewired; `status.py` left as-is (richer, divergent output).

Named `_git_common` (not `_common`) to avoid colliding with the existing `presets/claude-log/_common.py` in the test-suite process.

## Tests

New `test_git_common.py`, `test_git_push.py`; `test_git_commit_existing_mr.py` repointed to `_common`. Full suite: **3290 passed, 34 skipped**. E2E verified against a local bare remote (first push sets upstream, second reports up-to-date).