### PR TITLE
chore: bump 0.16.0 — git-push op (#288)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-22
+
+### Added
+
+- **`git-push` op — update the branch behind an already-open MR.** The `mr` op covers push **and** create; there was no op for the common follow-up — pushing a fix to an MR that already exists — so it dropped to raw `git push -u origin HEAD`. `git-push` pushes the current branch (setting upstream on first push), then prints a verifiable receipt: remote SHA before/after with commits pushed (or "already up to date" / "branch created"), ahead/behind vs upstream, and the open MR/PR for the branch with its pipeline status (the push triggers a run). Non-fast-forward rejections surface a `pull --rebase` / `--force-with-lease` hint; server-side rejections (protected branch / pre-receive hook) get a distinct "a rebase won't help" message instead — never auto-forced, mirroring `git-commit`'s no-silent-bypass philosophy. The glab→gh MR lookup that was drifting across `commit.py` / `push.py` is now a shared `presets/git/_git_common.py` (`query_open_mr`, plus `_git` / `_first_error_line`). Closes [#288](https://github.com/Digital-Process-Tools/claude-supertool/issues/288). See [docs/presets/git.md](docs/presets/git.md).
+
 ## [0.15.0] - 2026-06-22
 
 ### Added

--- a/docs/presets/git.md
+++ b/docs/presets/git.md
@@ -20,6 +20,7 @@ Git investigation and workflow ops. Replaces the 4-6 raw `git` calls you'd norma
 | `git-conflicts` | `git-conflicts` | List all UU files + every conflict block + abort hint |
 | `git-resolve` | `git-resolve:::SIDE:::PATH[,PATH...]` | Pick `ours`/`theirs`/`both` for one file, a comma-separated list, or `all` — stages and prints the continue command. `both` is a union: it strips the conflict markers and keeps both sides (ours then theirs), like git's `merge=union` driver — use it when both branches added different non-overlapping lines |
 | `git-commit` | `git-commit:::MSG[:::PATH...]` | Stage PATHs (or all staged if omitted) and commit with MSG — surfaces hook errors, shows HEAD before/after. Use `MSG=--no-edit` to reuse MERGE_MSG/CHERRY_PICK_HEAD during an in-progress merge or cherry-pick |
+| `git-push` | `git-push` | Push the current branch (sets upstream on first push) — remote SHA before/after with commits pushed, ahead/behind vs upstream, and the open MR/PR + pipeline status. For **updating** an already-open MR; use the `mr` op for push+create. Non-fast-forward gets a `pull --rebase` / `--force-with-lease` hint; server-side rejections (protected branch / hook) a distinct one — never auto-forced |
 
 ## Common workflows
 
@@ -45,6 +46,12 @@ One call gives you branch health + exactly what differs from base — no follow-
 ./supertool 'git-commit:::Merge master into feature/auth'
 ```
 
+**Update an MR that already exists:**
+```bash
+./supertool 'git-commit:::Fix the thing:::src/app/Thing.py' 'git-push'
+```
+`git-commit` shows HEAD before/after; `git-push` updates the remote and reports the open MR + the pipeline the push just triggered — no raw `git push` fallback.
+
 ## Configuration
 
 No project-specific config required. Two environment variables tune `git-investigate` behavior:
@@ -63,8 +70,8 @@ Set via the op's JSON config if you want project-wide defaults:
 }
 ```
 
-`git-status` tries `glab` then `gh` to surface the open MR/PR — skips gracefully if neither is installed.
+`git-status` and `git-push` try `glab` then `gh` to surface the open MR/PR — skip gracefully if neither is installed.
 
 ## Authoring notes
 
-Preset JSON: `presets/git.json`. Helper scripts: `presets/git/` — one Python file per op (`status.py`, `investigate.py`, `trail.py`, etc.). The `{path}` placeholder in `cmd` resolves to `presets/git/` at runtime.
+Preset JSON: `presets/git.json`. Helper scripts: `presets/git/` — one Python file per op (`status.py`, `investigate.py`, `trail.py`, etc.). The `{path}` placeholder in `cmd` resolves to `presets/git/` at runtime. Helpers shared across scripts (`_git`, `_first_error_line`, the glab→gh `query_open_mr` lookup) live in `presets/git/_git_common.py`; each script adds its own dir to `sys.path` then imports from it — named `_git_common` (not `_common`) to avoid colliding with `presets/claude-log/_common.py` when both load in the same test process.

--- a/supertool.py
+++ b/supertool.py
@@ -106,7 +106,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.15.1"
+VERSION = "0.16.0"
 
 
 def _fwd(p: str) -> str:

--- a/tests/test_mcp_config_279.py
+++ b/tests/test_mcp_config_279.py
@@ -47,4 +47,4 @@ def test_plugin_manifest_version_matches_code() -> None:
 
 
 def test_version_is_bumped_for_279() -> None:
-    assert supertool.VERSION == "0.15.1"
+    assert supertool.VERSION == "0.16.0"


### PR DESCRIPTION
## Context

Release bump for the `git-push` op merged in #295 (closes #288). Standard 4-file bump (plugin.json, supertool.py VERSION, version-sync test, CHANGELOG) plus the `docs/presets/git.md` ops-table entry.

New op = minor bump per semver: 0.15.1 → 0.16.0.

## Changes

- `.claude-plugin/plugin.json` + `supertool.py` VERSION → 0.16.0
- `tests/test_mcp_config_279.py` version assertion → 0.16.0
- `CHANGELOG.md` — `[0.16.0]` entry
- `docs/presets/git.md` — `git-push` row, "update an existing MR" workflow, shared-`_git_common` authoring note

Once merged, the installed plugin picks up `git-push` on the next marketplace sync.