### PR TITLE
feat(gl-pipeline): :active / :failed filter modes, collapse manual bulk

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-23
+
+### Added
+
+- **`gl-pipeline` filter modes — `:active` and `:failed`.** Polling a running pipeline across turns re-paid ~90 lines of `manual`/`created` bulk every call. Two filter modes cover the only questions you ask mid-pipeline: `gl-pipeline:ID:active` shows just running/pending jobs ("what's still going"), `gl-pipeline:ID:failed` shows just the failed jobs plus their job IDs/URLs ("what broke"). The default board now collapses the `manual`/`created`/`skipped` bulk to a one-line count (`+60 manual, +10 created (hidden — …)`) instead of one row each, so the running/failed/done jobs aren't buried. The op cmd switched from `{arg}` to `{args}` so the filter token reaches the script. Closes [#298](https://github.com/Digital-Process-Tools/claude-supertool/issues/298).
+
 ## [0.16.0] - 2026-06-22
 
 ### Added

--- a/docs/presets/gitlab.md
+++ b/docs/presets/gitlab.md
@@ -13,7 +13,7 @@ GitLab ops via the `glab` CLI. Replaces the 3-5 separate `glab` calls needed to 
 | `gl-issue` | `gl-issue:NUMBER[:full]` | Issue metadata, description, comments (truncated by default), related MRs. `:full` disables truncation |
 | `gl-mr` | `gl-mr:NUMBER_OR_BRANCH[:status]` | MR dashboard: branch, pipeline, reviewer/approval state, linked issue, diff stat, comments. `:status` returns slim merge-state only |
 | `gl-mrs` | `gl-mrs[:filters,flags]` | MR triage board, sorted failing-first then stalest. Per MR (enriched in parallel): pipeline status (a failure shows the failed **job name** = the failure class), approval state, age, diff size, watch-state cross-reference, and `conflict`/`draft`/`threads` flags — plus an actionable footer. Filters (comma-sep): `author`/`reviewer`/`assignee`/`label`/`milestone`/`state`/`per`. Flags: `nopipe` (skip enrichment), `iids` (bare id list), `failed` (only failing) |
-| `gl-pipeline` | `gl-pipeline:NUMBER` | Pipeline job list grouped by stage with pass/fail status and failed job IDs |
+| `gl-pipeline` | `gl-pipeline:NUMBER[:active\|:failed]` | Pipeline job list grouped by stage with pass/fail status and failed job IDs. The default board collapses the `manual`/`created`/`skipped` bulk to a one-line count so the running/done/failed jobs aren't buried. `:active` shows only running/pending jobs ("what's still going"); `:failed` shows only failed jobs plus their job IDs/URLs ("what broke") |
 | `gl-job` | `gl-job:NUMBER[:raw[:START[:END]]\|:grep:PATTERN]` | Job failure detail: MR context + error pattern search + log tail. `:raw` dumps the full trace; `:raw:START:END` slices lines (1-indexed, inclusive); `:grep:PATTERN` runs an ad-hoc regex over the trace (literal fallback on bad regex, ±context, names the pattern + tail on no-match — never silent-empty) |
 
 ## Common workflows
@@ -26,8 +26,10 @@ Returns approval state, pipeline status, diff stat, and all comments in one call
 
 **Debug a failed pipeline:**
 ```bash
-./supertool 'gl-pipeline:12345'
-# find the failed job ID, then:
+./supertool 'gl-pipeline:12345:failed'   # only the failed jobs + their IDs/URLs
+# or, while it's still running, what's left:
+./supertool 'gl-pipeline:12345:active'   # only running/pending jobs
+# then dig into a failed job by ID:
 ./supertool 'gl-job:67890'
 # if you need more log context:
 ./supertool 'gl-job:67890:raw:1:150'

--- a/presets/gitlab.json
+++ b/presets/gitlab.json
@@ -31,10 +31,10 @@
       "example": "gl-issue-create:@.max/new-issue.json"
     },
     "gl-pipeline": {
-      "cmd": "{python} {path}gitlab/pipeline.py {arg}",
+      "cmd": "{python} {path}gitlab/pipeline.py {args}",
       "timeout": 15,
-      "description": "Pipeline jobs by stage with statuses + failed job IDs",
-      "syntax": "gl-pipeline:NUMBER"
+      "description": "Pipeline jobs by stage with statuses + failed job IDs. Default collapses manual/created/skipped bulk to a count. :active = running/pending only; :failed = failed jobs + IDs/URLs",
+      "syntax": "gl-pipeline:NUMBER[:active|:failed]"
     },
     "gl-job": {
       "cmd": "{python} {path}gitlab/job.py {args}",

--- a/presets/gitlab/pipeline.py
+++ b/presets/gitlab/pipeline.py
@@ -1,10 +1,29 @@
 #!/usr/bin/env python3
-"""GitLab pipeline job list via glab CLI."""
+"""GitLab pipeline job list via glab CLI.
+
+`gl-pipeline:ID` prints every job by stage. When polling a running pipeline
+that's ~90 lines of `manual`/`created` bulk you never read, re-paid every turn.
+Two filter modes cover the only questions you actually ask mid-pipeline:
+
+    gl-pipeline:ID          full board — manual/created/skipped bulk collapsed
+                            to a one-line count
+    gl-pipeline:ID:active   only running/pending jobs — "what's still going"
+    gl-pipeline:ID:failed   only failed jobs + their job IDs/URLs — "what broke"
+"""
 from __future__ import annotations
 
 import json
 import subprocess
 import sys
+from collections import Counter
+
+# Statuses that answer "what's still going on right now".
+_ACTIVE_STATUSES = {"running", "pending"}
+# Bulk statuses that are never what you're polling for — collapsed to a
+# one-line count in the default view instead of one row each.
+_NOISE_STATUSES = {"manual", "created", "skipped"}
+
+_FILTERS = {"full", "active", "failed"}
 
 
 def _format_error(stderr: str, resource: str, identifier: str) -> str:
@@ -19,12 +38,48 @@ def _format_error(stderr: str, resource: str, identifier: str) -> str:
     return f"ERROR: glab failed for {resource} #{identifier}: {stderr.strip()}"
 
 
+def _print_table(jobs: list[dict]) -> None:
+    """Render the job table header + one row per job, with status markers."""
+    print(f"{'Job':<40} {'Stage':<20} {'Status':<12} {'Duration':<10}")
+    print("-" * 82)
+    for job in jobs:
+        name = job.get("name", "?")
+        stage = job.get("stage", "?")
+        status = job.get("status", "?")
+        duration = job.get("duration")
+        duration_str = f"{duration:.0f}s" if duration else "-"
+
+        marker = ""
+        if status == "failed":
+            marker = " <!"
+        elif status == "running":
+            marker = " ..."
+
+        print(f"{name:<40} {stage:<20} {status:<12} {duration_str:<10}{marker}")
+
+
+def _print_failed_detail(failed: list[dict]) -> None:
+    """The failed-job names with job IDs + web URLs — the 'what broke' answer."""
+    print(f"\n## Failed jobs ({len(failed)})")
+    for job in failed:
+        name = job.get("name", "?")
+        job_id = job.get("id", "?")
+        web_url = job.get("web_url", "")
+        print(f"  - {name} (job #{job_id})")
+        if web_url:
+            print(f"    {web_url}")
+
+
 def main() -> int:
     if len(sys.argv) < 2:
-        print("ERROR: usage: pipeline.py PIPELINE_ID")
+        print("ERROR: usage: pipeline.py PIPELINE_ID [active|failed]")
         return 1
 
     pipeline_id = sys.argv[1]
+    mode = sys.argv[2].lower() if len(sys.argv) > 2 and sys.argv[2] else "full"
+    if mode not in _FILTERS:
+        print(f"ERROR: unknown filter {mode!r} — use 'active', 'failed', or omit for the full board")
+        return 1
 
     # glab ci view doesn't support --output json directly for pipelines,
     # so we use the API endpoint
@@ -61,41 +116,45 @@ def main() -> int:
         pipe = jobs[0].get("pipeline", {})
         pipe_status = pipe.get("status", "unknown")
 
-    print(f"# Pipeline #{pipeline_id} — {pipe_status}")
-    print(f"{'Job':<40} {'Stage':<20} {'Status':<12} {'Duration':<10}")
-    print("-" * 82)
-
     # Sort by stage then name
     jobs.sort(key=lambda j: (j.get("stage", ""), j.get("name", "")))
+    failed = [j for j in jobs if j.get("status") == "failed"]
 
-    failed = []
-    for job in jobs:
-        name = job.get("name", "?")
-        stage = job.get("stage", "?")
-        status = job.get("status", "?")
-        duration = job.get("duration")
-        duration_str = f"{duration:.0f}s" if duration else "-"
+    print(f"# Pipeline #{pipeline_id} — {pipe_status}")
 
-        marker = ""
-        if status == "failed":
-            marker = " <!"
-            failed.append(job)
-        elif status == "success":
-            marker = ""
-        elif status == "running":
-            marker = " ..."
+    if mode == "failed":
+        if not failed:
+            print("No failed jobs.")
+            return 0
+        _print_table(failed)
+        _print_failed_detail(failed)
+        return 0
 
-        print(f"{name:<40} {stage:<20} {status:<12} {duration_str:<10}{marker}")
+    if mode == "active":
+        active = [j for j in jobs if j.get("status") in _ACTIVE_STATUSES]
+        if not active:
+            print("No running or pending jobs.")
+            return 0
+        _print_table(active)
+        return 0
+
+    # Full board — collapse the manual/created/skipped bulk to a count line so
+    # the running/failed/done jobs you actually care about aren't buried.
+    shown = [j for j in jobs if j.get("status") not in _NOISE_STATUSES]
+    hidden = [j for j in jobs if j.get("status") in _NOISE_STATUSES]
+
+    _print_table(shown)
+
+    if hidden:
+        counts = Counter(str(j.get("status", "?")) for j in hidden)
+        summary = ", ".join(f"+{n} {status}" for status, n in sorted(counts.items()))
+        print(
+            f"{summary} (hidden — "
+            f"gl-pipeline:{pipeline_id}:active / :failed to filter)"
+        )
 
     if failed:
-        print(f"\n## Failed jobs ({len(failed)})")
-        for job in failed:
-            name = job.get("name", "?")
-            job_id = job.get("id", "?")
-            web_url = job.get("web_url", "")
-            print(f"  - {name} (job #{job_id})")
-            if web_url:
-                print(f"    {web_url}")
+        _print_failed_detail(failed)
 
     return 0
 

--- a/supertool.py
+++ b/supertool.py
@@ -106,7 +106,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.16.0"
+VERSION = "0.17.0"
 
 
 def _fwd(p: str) -> str:

--- a/tests/test_gitlab_pipeline.py
+++ b/tests/test_gitlab_pipeline.py
@@ -1,0 +1,176 @@
+"""Tests for the gl-pipeline op — filter modes and default bulk collapse.
+
+Covers the pure error classifier and the three render modes (full / active /
+failed) by monkeypatching subprocess.run, without hitting the live glab CLI.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+PRESET_PATH = Path(__file__).parent.parent / "presets" / "gitlab" / "pipeline.py"
+_spec = importlib.util.spec_from_file_location("gitlab_pipeline", PRESET_PATH)
+assert _spec is not None and _spec.loader is not None
+pipe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pipe)
+
+
+class _Result:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _jobs(*statuses: str) -> str:
+    """Build a glab jobs JSON payload, one job per status given."""
+    out = []
+    for i, status in enumerate(statuses):
+        out.append({
+            "name": f"job_{i}_{status}",
+            "stage": "test",
+            "status": status,
+            "duration": 5.0,
+            "id": 1000 + i,
+            "web_url": f"https://gl/job/{1000 + i}",
+            "pipeline": {"status": "running"},
+        })
+    return json.dumps(out)
+
+
+def _patch(monkeypatch, payload: str, argv: list[str], returncode: int = 0,
+           stderr: str = "") -> None:
+    monkeypatch.setattr(
+        pipe.subprocess, "run",
+        lambda *a, **k: _Result(payload, stderr, returncode),
+    )
+    monkeypatch.setattr(sys, "argv", argv)
+
+
+# ---------------------------------------------------------------------------
+# _format_error
+# ---------------------------------------------------------------------------
+
+def test_format_error_404() -> None:
+    msg = pipe._format_error("HTTP 404 not found", "Pipeline", "9")
+    assert "not found" in msg
+
+
+def test_format_error_401() -> None:
+    msg = pipe._format_error("401 unauthorized", "Pipeline", "9")
+    assert "glab auth login" in msg
+
+
+def test_format_error_403() -> None:
+    msg = pipe._format_error("403 forbidden", "Pipeline", "9")
+    assert "permission denied" in msg
+
+
+def test_format_error_generic() -> None:
+    msg = pipe._format_error("boom", "Pipeline", "9")
+    assert "glab failed" in msg
+
+
+# ---------------------------------------------------------------------------
+# argument validation
+# ---------------------------------------------------------------------------
+
+def test_no_args_is_usage_error(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "argv", ["pipeline.py"])
+    assert pipe.main() == 1
+    assert "usage" in capsys.readouterr().out.lower()
+
+
+def test_unknown_filter_errors(monkeypatch, capsys) -> None:
+    _patch(monkeypatch, _jobs("success"), ["pipeline.py", "1", "bogus"])
+    assert pipe.main() == 1
+    out = capsys.readouterr().out
+    assert "unknown filter" in out
+    assert "'bogus'" in out
+
+
+# ---------------------------------------------------------------------------
+# full mode — bulk collapse
+# ---------------------------------------------------------------------------
+
+def test_full_collapses_noise_to_count(monkeypatch, capsys) -> None:
+    payload = _jobs("success", "manual", "manual", "created", "skipped")
+    _patch(monkeypatch, payload, ["pipeline.py", "42"])
+    assert pipe.main() == 0
+    out = capsys.readouterr().out
+    # The one real job is shown as a row.
+    assert "job_0_success" in out
+    # The bulk is collapsed to a count line, not one row each.
+    assert "job_1_manual" not in out
+    assert "+2 manual" in out
+    assert "+1 created" in out
+    assert "+1 skipped" in out
+
+
+def test_full_no_noise_prints_no_summary(monkeypatch, capsys) -> None:
+    _patch(monkeypatch, _jobs("success", "failed"), ["pipeline.py", "42"])
+    assert pipe.main() == 0
+    out = capsys.readouterr().out
+    assert "hidden" not in out
+
+
+def test_full_lists_failed_detail(monkeypatch, capsys) -> None:
+    _patch(monkeypatch, _jobs("success", "failed"), ["pipeline.py", "42"])
+    pipe.main()
+    out = capsys.readouterr().out
+    assert "## Failed jobs (1)" in out
+    assert "job #1001" in out
+
+
+# ---------------------------------------------------------------------------
+# active mode
+# ---------------------------------------------------------------------------
+
+def test_active_shows_only_running_pending(monkeypatch, capsys) -> None:
+    payload = _jobs("success", "running", "pending", "manual", "failed")
+    _patch(monkeypatch, payload, ["pipeline.py", "42", "active"])
+    assert pipe.main() == 0
+    out = capsys.readouterr().out
+    assert "job_1_running" in out
+    assert "job_2_pending" in out
+    assert "job_0_success" not in out
+    assert "job_4_failed" not in out
+
+
+def test_active_none_prints_message(monkeypatch, capsys) -> None:
+    _patch(monkeypatch, _jobs("success", "failed"), ["pipeline.py", "42", "active"])
+    assert pipe.main() == 0
+    assert "No running or pending jobs." in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# failed mode
+# ---------------------------------------------------------------------------
+
+def test_failed_shows_only_failed_with_detail(monkeypatch, capsys) -> None:
+    payload = _jobs("success", "failed", "running")
+    _patch(monkeypatch, payload, ["pipeline.py", "42", "failed"])
+    assert pipe.main() == 0
+    out = capsys.readouterr().out
+    assert "job_1_failed" in out
+    assert "job_0_success" not in out
+    assert "## Failed jobs (1)" in out
+    assert "https://gl/job/1001" in out
+
+
+def test_failed_none_prints_message(monkeypatch, capsys) -> None:
+    _patch(monkeypatch, _jobs("success", "running"), ["pipeline.py", "42", "failed"])
+    assert pipe.main() == 0
+    assert "No failed jobs." in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# error passthrough
+# ---------------------------------------------------------------------------
+
+def test_glab_error_returns_1(monkeypatch, capsys) -> None:
+    _patch(monkeypatch, "", ["pipeline.py", "42"], returncode=1, stderr="404 not found")
+    assert pipe.main() == 1
+    assert "not found" in capsys.readouterr().out

--- a/tests/test_mcp_config_279.py
+++ b/tests/test_mcp_config_279.py
@@ -47,4 +47,4 @@ def test_plugin_manifest_version_matches_code() -> None:
 
 
 def test_version_is_bumped_for_279() -> None:
-    assert supertool.VERSION == "0.16.0"
+    assert supertool.VERSION == "0.17.0"


### PR DESCRIPTION
Closes #298.

`gl-pipeline:ID` printed ~90 lines of `manual`/`created` bulk every poll. Adds two filter modes and collapses the noise:

- `gl-pipeline:ID:active` — running/pending jobs only ("what's still going")
- `gl-pipeline:ID:failed` — failed jobs + their IDs/URLs ("what broke")
- default board — `manual`/`created`/`skipped` collapsed to a one-line count

Op cmd switched `{arg}`→`{args}` so the filter token reaches the script.

## Files
- `presets/gitlab/pipeline.py` — filter modes + bulk collapse
- `presets/gitlab.json` — `{args}` + syntax/description
- `tests/test_gitlab_pipeline.py` — 14 tests (new)
- `docs/presets/gitlab.md` — op table + workflow
- version bump 0.16.0 → 0.17.0 (plugin.json, supertool.VERSION, CHANGELOG, #279 guard test)

## Verified
- Full suite green (pre-push hook), 14 new tests pass
- Live on real DVSI pipelines: full collapse, `:active`, `:failed` (with failed job + URL)