### PR TITLE
chore(tests): drop hardcoded-version guard

### DIFF
--- a/tests/test_mcp_config_279.py
+++ b/tests/test_mcp_config_279.py
@@ -44,7 +44,3 @@ def test_plugin_manifest_version_matches_code() -> None:
         f"plugin.json version {manifest['version']!r} != "
         f"supertool.VERSION {supertool.VERSION!r}"
     )
-
-
-def test_version_is_bumped_for_279() -> None:
-    assert supertool.VERSION == "0.17.0"


### PR DESCRIPTION
Removes `test_version_is_bumped_for_279`, which asserted `VERSION == "0.X.0"` and had to be hand-edited on every release for zero signal. `test_plugin_manifest_version_matches_code` already enforces the real invariant (manifest version == code VERSION). Follow-up to #300.