### PR TITLE
fix(git-push): report hook amend-and-push as PUSHED, embed non-ff recovery (#297)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-23
+
+### Fixed
+
+- **`git-push` no longer misreports a pre-push hook's amend-and-push as `PUSH REJECTED`.** A pre-push hook that auto-formats commonly amends HEAD, pushes the corrected commit itself, then exits non-zero so git won't also push the stale pre-amend ref — that non-zero is *success*, not failure. `git-push` now trusts the live remote SHA (`ls-remote`) over the exit code: when the remote already matches local HEAD it reports `PUSHED (pre-push hook amended HEAD)` with the rewritten SHA, instead of `REJECTED`. And `_first_error_line` no longer picks a green `✅ … 0 errors` / `pushed successfully` line as the "first error" (the substring `errors` was matching the error scan). Closes [#297](https://github.com/Digital-Process-Tools/claude-supertool/issues/297).
+
+### Added
+
+- **`git-push` embeds non-fast-forward recovery.** When the remote has moved ahead, `git-push` now fetches, surfaces the **incoming remote commits** (short SHA, author, subject — the signal for force-vs-integrate, since forcing over a teammate's commit destroys it) with the ahead/behind counts, then rebases your work onto the remote and re-pushes in the same call — no manual `pull --rebase` → `git-push` round-trip. Computing is cheap; LLM round-trips are not. On conflict it leaves the rebase **paused** (never silently aborted or force-pushed), lists the conflicting files, warns to check the incoming authors before forcing, and points at `git-conflicts` to inspect plus the exact keep-both / cancel (`git rebase --abort`) / force paths — the resolution stays the caller's decision.
+- **`git-push` post-push receipt surfaces the next decision.** A push isn't the end of an action, it's the start of "get this MR merged" — so the receipt now carries the signals you'd otherwise spend round-trips discovering, all riding calls already made: **mergeability** (warns loudly if the MR now `cannot_be_merged` with its target — caught at push time, not 20 min later at merge), **stale base** (`N commit(s) behind origin/<target>`), **uncommitted leftovers** (`git status --porcelain` — the "I fixed two things, committed one, pushed" catch), the **pipeline id + url** on the MR line, and a ready **`watch:gitlab-mr:<iid>`** command to hand the pipeline to a background poller. `:force-with-lease` additionally reports **what it discarded** (author + subject of the overwritten remote commits — the receipt for "did I just nuke a teammate's work"). Watching stays opt-in: the receipt recommends the command by default; `git-push:watch` spawns the poller for the push you're actually iterating on (no stray daemons on WIP pushes).
+- **`git-push:force-with-lease` and `git-push:no-verify` variants.** `:force-with-lease` is the safe force (overwrite only if the remote hasn't moved since you fetched) and suppresses the auto-rebase, since the force is your explicit decision; `:no-verify` skips the local pre-push hook, the documented escape when a local formatter legitimately diverges from CI. The op cmd switched from `{arg}` to `{args}` so the flag tokens reach the script. Part of [#297](https://github.com/Digital-Process-Tools/claude-supertool/issues/297).
+
 ## [0.17.0] - 2026-06-23
 
 ### Added

--- a/docs/presets/git.md
+++ b/docs/presets/git.md
@@ -20,7 +20,7 @@ Git investigation and workflow ops. Replaces the 4-6 raw `git` calls you'd norma
 | `git-conflicts` | `git-conflicts` | List all UU files + every conflict block + abort hint |
 | `git-resolve` | `git-resolve:::SIDE:::PATH[,PATH...]` | Pick `ours`/`theirs`/`both` for one file, a comma-separated list, or `all` — stages and prints the continue command. `both` is a union: it strips the conflict markers and keeps both sides (ours then theirs), like git's `merge=union` driver — use it when both branches added different non-overlapping lines |
 | `git-commit` | `git-commit:::MSG[:::PATH...]` | Stage PATHs (or all staged if omitted) and commit with MSG — surfaces hook errors, shows HEAD before/after. Use `MSG=--no-edit` to reuse MERGE_MSG/CHERRY_PICK_HEAD during an in-progress merge or cherry-pick |
-| `git-push` | `git-push` | Push the current branch (sets upstream on first push) — remote SHA before/after with commits pushed, ahead/behind vs upstream, and the open MR/PR + pipeline status. For **updating** an already-open MR; use the `mr` op for push+create. Non-fast-forward gets a `pull --rebase` / `--force-with-lease` hint; server-side rejections (protected branch / hook) a distinct one — never auto-forced |
+| `git-push` | `git-push[:force-with-lease][:no-verify]` | Push the current branch (sets upstream on first push) — remote SHA before/after with commits pushed, ahead/behind vs upstream, and the open MR/PR + pipeline status. For **updating** an already-open MR; use the `mr` op for push+create. **Non-fast-forward** is handled in-op: it fetches, surfaces the **incoming remote commits** (SHA, author, subject) so you can see whose work you'd be rebasing over, then rebases your work onto the remote and re-pushes; on conflict it leaves the rebase **paused**, warns to check the incoming authors before forcing, and points you at `git-conflicts` + the keep-both/cancel/force paths — never auto-forced, never silently rewritten. A **pre-push hook that amends HEAD and pushes** the fixed commit itself (exiting non-zero) is reported as `PUSHED`, not `REJECTED`, since the live remote ref already matches HEAD. The **post-push receipt** carries the next-decision signals (all on calls already made): MR **mergeability** (warns if it now `cannot_be_merged` with target), **stale base** (`N behind origin/<target>`), **uncommitted leftovers** (changes not in this push), the **pipeline id + url**, and a ready `watch:gitlab-mr:<iid>` command. `:force-with-lease` also reports **what it discarded** (author + subject of overwritten remote commits). Flags: `:force-with-lease` (safe force — overwrite only if the remote hasn't moved; skips the auto-rebase, and lists discarded commits), `:no-verify` (skip the local pre-push hook, e.g. when a local formatter diverges from CI), `:watch` (spawn a background pipeline poller instead of just recommending the command) |
 
 ## Common workflows
 
@@ -51,6 +51,19 @@ One call gives you branch health + exactly what differs from base — no follow-
 ./supertool 'git-commit:::Fix the thing:::src/app/Thing.py' 'git-push'
 ```
 `git-commit` shows HEAD before/after; `git-push` updates the remote and reports the open MR + the pipeline the push just triggered — no raw `git push` fallback.
+
+**Push when the remote has moved ahead (non-fast-forward):**
+```bash
+./supertool 'git-push'
+```
+`git-push` rebases your work onto the remote and re-pushes in the same call — no manual `pull --rebase` round-trip. If the rebase conflicts, it stops with the rebase **paused** and the conflicting files listed, then points you at `git-conflicts`:
+```bash
+./supertool 'git-conflicts'                       # inspect the blocks
+./supertool 'git-resolve:::ours:::src/app/X.py'   # decide
+# then continue the rebase and push:
+git rebase --continue && ./supertool 'git-push'
+```
+To **cancel** and get back to exactly where you were before the push (your commits intact, nothing pushed), `git rebase --abort`. To overwrite the remote intentionally (your history wins), `git rebase --abort` then `./supertool 'git-push:force-with-lease'`. To skip a local pre-push hook that diverges from CI, `./supertool 'git-push:no-verify'`.
 
 ## Configuration
 

--- a/presets/git.json
+++ b/presets/git.json
@@ -63,10 +63,10 @@
       "syntax": "git-commit:::MSG[:::PATH...]"
     },
     "git-push": {
-      "cmd": "{python} {path}git/push.py",
+      "cmd": "{python} {path}git/push.py {args}",
       "timeout": 120,
-      "description": "Push current branch (sets upstream if missing) — remote before/after, ahead/behind, open MR/PR + pipeline. For updating an existing MR; use mr op for push+create",
-      "syntax": "git-push"
+      "description": "Push current branch (sets upstream if missing). Receipt: remote before/after, ahead/behind, MR/PR + pipeline, mergeability, behind-target, uncommitted leftovers, watch cmd. Non-ff auto-rebases (conflict → paused + git-conflicts). Hook amend+push reported as PUSHED. Flags: :force-with-lease, :no-verify, :watch",
+      "syntax": "git-push[:force-with-lease][:no-verify][:watch]"
     }
   }
 }

--- a/presets/git/_git_common.py
+++ b/presets/git/_git_common.py
@@ -24,30 +24,59 @@ def _git(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess[str]
     )
 
 
+def _looks_like_success(line: str) -> bool:
+    """True for lines that report success — must never be picked as an error.
+
+    Pre-push / pre-receive hooks that auto-format print green '✅ … 0 errors.'
+    lines and 'pushed successfully' notices; the substrings 'errors' /
+    'fatal' would otherwise match the error scan and surface a success line
+    as the "first error".
+    """
+    s = line.strip()
+    if not s:
+        return False
+    if "✅" in s or "✓" in s:
+        return True
+    low = s.lower()
+    return any(m in low for m in (
+        "0 errors", "no errors", "pushed successfully", "successfully pushed",
+    ))
+
+
 def _first_error_line(text: str) -> str:
-    """First line mentioning an error/rejection, else last non-empty line."""
-    for line in text.splitlines():
+    """First line mentioning an error/rejection, else last non-empty line.
+
+    Skips success lines (green ✅, '0 errors', 'pushed successfully') so a
+    hook's success banner is never misreported as the failure cause.
+    """
+    lines = text.splitlines()
+    for line in lines:
         s = line.strip()
-        if not s:
+        if not s or _looks_like_success(s):
             continue
         low = s.lower()
         if ("error" in low or "fatal" in low or "rejected" in low
                 or "aborted" in low or "failed" in low
                 or "! [" in s or "❌" in s):
             return s
-    for line in reversed(text.splitlines()):
-        if line.strip():
-            return line.strip()
+    for line in reversed(lines):
+        s = line.strip()
+        if s and not _looks_like_success(s):
+            return s
     return ""
 
 
 def query_open_mr(branch: str) -> Optional[dict]:
     """Open MR/PR for `branch`, or None when none / no tool available.
 
-    Returns {source, iid, target, pipeline}. `pipeline` is the GitLab
-    pipeline status when known, else None (gh list carries no cheap check
-    state). Tries glab (GitLab) first, falls back to gh (GitHub). All
-    failures swallowed — this is advisory output, never blocking.
+    Returns {source, iid, target, pipeline, pipeline_id, pipeline_url,
+    merge_status}. `pipeline` is the GitLab pipeline status when known, else
+    None (gh list carries no cheap check state). `merge_status` is the
+    server's view of mergeability ('can_be_merged' / 'cannot_be_merged' /
+    None). The extra fields ride the same call — no added round-trip — and
+    are best-effort: absent on a glab version that doesn't emit them. Tries
+    glab (GitLab) first, falls back to gh (GitHub). All failures swallowed —
+    this is advisory output, never blocking.
     """
     if not branch or branch == "HEAD":
         return None
@@ -68,6 +97,10 @@ def query_open_mr(branch: str) -> Optional[dict]:
                         "iid": mr.get("iid") or mr.get("number") or "?",
                         "target": mr.get("target_branch", "?"),
                         "pipeline": pipeline.get("status"),
+                        "pipeline_id": pipeline.get("id"),
+                        "pipeline_url": pipeline.get("web_url"),
+                        "merge_status": mr.get("detailed_merge_status")
+                        or mr.get("merge_status"),
                     }
         except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
             pass
@@ -75,18 +108,25 @@ def query_open_mr(branch: str) -> Optional[dict]:
         try:
             res = subprocess.run(
                 ["gh", "pr", "list", "--head", branch, "--state", "open",
-                 "--json", "number,baseRefName", "--limit", "1"],
+                 "--json", "number,baseRefName,mergeable", "--limit", "1"],
                 capture_output=True, text=True, timeout=5,
             )
             if res.returncode == 0 and res.stdout.strip().startswith("["):
                 prs = json.loads(res.stdout)
                 if prs:
                     pr = prs[0]
+                    # gh: mergeable is CONFLICTING / MERGEABLE / UNKNOWN
+                    gh_merge = pr.get("mergeable")
+                    merge_status = ("cannot_be_merged"
+                                    if gh_merge == "CONFLICTING" else None)
                     return {
                         "source": "github",
                         "iid": pr.get("number", "?"),
                         "target": pr.get("baseRefName", "?"),
                         "pipeline": None,
+                        "pipeline_id": None,
+                        "pipeline_url": None,
+                        "merge_status": merge_status,
                     }
         except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
             pass

--- a/presets/git/_git_common.py
+++ b/presets/git/_git_common.py
@@ -35,12 +35,18 @@ def _looks_like_success(line: str) -> bool:
     s = line.strip()
     if not s:
         return False
-    if "✅" in s or "✓" in s:
-        return True
     low = s.lower()
-    return any(m in low for m in (
-        "0 errors", "no errors", "pushed successfully", "successfully pushed",
-    ))
+    has_success = ("✅" in s or "✓" in s or any(m in low for m in (
+        "0 errors", "no errors", "pushed successfully", "successfully pushed")))
+    if not has_success:
+        return False
+    # A success marker doesn't win if the same line also carries a hard error
+    # signal (e.g. 'lint ✓ — push blocked: error: …'). 'error:' (with colon)
+    # avoids matching the '0 errors' / 'no errors' success phrases.
+    has_error = any(k in low for k in (
+        "error:", "fatal", "rejected", "aborted", "failed", "declined")) \
+        or "! [" in s or "❌" in s
+    return not has_error
 
 
 def _first_error_line(text: str) -> str:

--- a/presets/git/push.py
+++ b/presets/git/push.py
@@ -10,19 +10,52 @@ Receipt always shows:
   - ahead/behind vs the remote afterwards
   - open MR/PR for the branch + pipeline status (push triggers a run)
 
-Non-fast-forward rejections are surfaced loudly with a hint, never
-auto-forced — mirrors git-commit's no-silent-bypass philosophy.
+Philosophy — embed the mechanical recovery, surface only the decision.
+A non-fast-forward (remote moved ahead) is the routine recoverable case:
+instead of bailing with a hint and costing a round-trip, this op rebases
+local work onto the remote itself. Clean → it pushes. Conflict → it leaves
+the rebase paused (explicitly, with the conflicting files + the exact
+continue/abort commands), so `git-conflicts` can inspect the blocks and
+the resolution decision stays with the caller. History is never rewritten
+silently and never force-pushed for you.
+
+Flags (colon-appended: `git-push:force-with-lease:no-verify`):
+  - force-with-lease — overwrite the remote only if it hasn't moved since
+    we last fetched. The safe force, for legitimate history rewrites.
+    Suppresses auto-rebase (the explicit force is your decision).
+  - no-verify — skip the local pre-push hook. Documented escape when a
+    local formatter legitimately diverges from CI.
+
+A pre-push hook that auto-fixes files commonly amends HEAD, pushes the
+corrected commit itself, then exits non-zero so git won't also push the
+stale pre-amend ref. That non-zero exit is *success*, not failure — the
+ref moved. We trust the live remote SHA over the exit code: when the
+remote already matches local HEAD, we report PUSHED, not REJECTED.
 """
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
+from typing import Optional
 
 # Sibling import: runtime puts this dir on sys.path[0]; the test harness
 # loads scripts via importlib (no dir on path), so add it explicitly.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _git_common import _first_error_line, _git, query_open_mr  # noqa: E402
+
+_KNOWN_FLAGS = ("force-with-lease", "no-verify")
+
+
+def _parse_flags(argv: list[str]) -> set[str]:
+    """Collect known flags from colon-split argv tokens; ignore the rest."""
+    flags: set[str] = set()
+    for tok in argv:
+        t = tok.strip().lower()
+        if t in _KNOWN_FLAGS:
+            flags.add(t)
+    return flags
 
 
 def _upstream_ref() -> str:
@@ -38,67 +71,133 @@ def _remote_sha(ref: str) -> str:
     return r.stdout.strip() if r.returncode == 0 else ""
 
 
-def _open_mr_line(branch: str) -> str:
+def _local_head() -> str:
+    """Full SHA of local HEAD (a pre-push hook may rewrite it mid-push)."""
+    r = _git(["rev-parse", "HEAD"])
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
+def _live_remote_sha(remote: str, ref: str) -> str:
+    """Authoritative remote SHA via ls-remote (full sha), or empty.
+
+    Reads the real remote, not the local remote-tracking ref — a hook that
+    pushes on our behalf moves the remote without us having fetched.
+    """
+    if not remote or not ref:
+        return ""
+    r = _git(["ls-remote", remote, ref], timeout=30)
+    if r.returncode == 0 and r.stdout.strip():
+        return r.stdout.split()[0]
+    return ""
+
+
+def _split_upstream(upstream: str, branch: str) -> tuple[str, str]:
+    """(remote, ref) from an upstream like 'origin/foo'; fall back to origin."""
+    if "/" in upstream:
+        remote, ref = upstream.split("/", 1)
+        return remote, ref
+    return "origin", branch
+
+
+def _is_non_fast_forward(combined: str) -> bool:
+    low = combined.lower()
+    return ("non-fast-forward" in low
+            or "fetch first" in low
+            or "tip of your current branch is behind" in low)
+
+
+_LEFTOVER_CAP = 8
+
+
+def _open_mr_line(mr: Optional[dict]) -> str:
     """One-line MR/PR summary for the post-push receipt, or empty."""
-    mr = query_open_mr(branch)
     if not mr:
         return ""
     if mr["source"] == "gitlab":
-        return (f"MR !{mr['iid']} → {mr['target']} | "
-                f"pipeline: {mr['pipeline'] or 'triggered'}")
+        pipe = mr.get("pipeline") or "triggered"
+        if mr.get("pipeline_id"):
+            pipe += f" #{mr['pipeline_id']}"
+        line = f"MR !{mr['iid']} → {mr['target']} | pipeline: {pipe}"
+        if mr.get("pipeline_url"):
+            line += f"\n  {mr['pipeline_url']}"
+        return line
     return f"PR #{mr['iid']} → {mr['target']} | checks triggered"
 
 
-def main() -> int:
-    if _git(["rev-parse", "--git-dir"]).returncode != 0:
-        print("ERROR: not inside a git repository.")
-        return 1
+def _watch_target(mr: Optional[dict]) -> Optional[tuple[str, str]]:
+    """(watch-source, id) for the open MR/PR, or None."""
+    if not mr or mr.get("iid") in (None, "?"):
+        return None
+    source = "gitlab-mr" if mr["source"] == "gitlab" else "github-pr"
+    return source, str(mr["iid"])
 
-    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
-    if not branch or branch == "HEAD":
-        print("ERROR: detached HEAD — checkout a branch before pushing.")
-        return 1
 
-    upstream = _upstream_ref()
-    has_upstream = bool(upstream)
-    remote_before = _remote_sha(upstream) if has_upstream else ""
+def _spawn_watch(source: str, iid: str) -> bool:
+    """Fire-and-forget a background watch poller via the repo-root supertool."""
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    st = os.path.join(root, "supertool")
+    try:
+        subprocess.Popen([st, f"watch:{source}:{iid}"],
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except OSError:
+        return False
 
-    print(f"# git-push on {branch}")
-    if has_upstream:
-        print(f"Upstream: {upstream}" + (f" @ {remote_before}" if remote_before else ""))
-    else:
-        print("Upstream: none — setting on first push (origin)")
 
-    if has_upstream:
-        result = _git(["push"], timeout=120)
-    else:
-        result = _git(["push", "-u", "origin", "HEAD"], timeout=120)
+def _uncommitted_leftovers() -> list[str]:
+    """Working-tree changes NOT in this push — the 'forgot to commit X' catch."""
+    r = _git(["status", "--porcelain"])
+    return [ln for ln in r.stdout.splitlines() if ln.strip()]
 
-    combined = (result.stdout or "") + "\n" + (result.stderr or "")
 
-    if result.returncode != 0:
-        print("Status: PUSH REJECTED ✗")
-        err = _first_error_line(combined)
-        if err:
-            print(f"First error: {err}")
-        low = combined.lower()
-        if "non-fast-forward" in low:
-            print("Hint: remote has commits you lack — `git pull --rebase` then "
-                  "retry, or force only if intentional: "
-                  "`git push --force-with-lease`")
-        elif "rejected" in low or "declined" in low:
-            print("Hint: rejected by a server-side rule (protected branch / hook), "
-                  "not a divergence — check branch protection or the hook output "
-                  "above. A rebase will not help.")
-        print("\n--- git output ---")
-        print(combined.strip() or "(no output)")
-        return result.returncode
+def _discarded_by_force(old_remote_sha: str) -> list[str]:
+    """Commits that were on the old remote tip but are now off the branch."""
+    if not old_remote_sha:
+        return []
+    r = _git(["log", "--format=%h %an: %s", old_remote_sha, "--not", "HEAD"])
+    if r.returncode != 0:
+        return []
+    return [ln for ln in r.stdout.splitlines() if ln.strip()]
 
-    # Success — recompute upstream (now set if it was the first push)
+
+def _post_push_advisories(mr: Optional[dict], flags: set[str]) -> None:
+    """Surface the next-decision signals: mergeability, stale base, leftovers, watch."""
+    if mr and mr.get("merge_status") in ("cannot_be_merged", "conflict", "broken_status"):
+        print(f"⚠ MR conflicts with {mr.get('target', 'target')} — "
+              "won't merge until rebased/resolved")
+
+    target = mr.get("target") if mr else ""
+    if target and target != "?":
+        cnt = _git(["rev-list", "--count", f"HEAD..origin/{target}"])
+        if cnt.returncode == 0 and cnt.stdout.strip().isdigit():
+            behind = int(cnt.stdout.strip())
+            if behind:
+                print(f"⚠ {behind} commit(s) behind origin/{target} — "
+                      "consider rebasing (stale base under review)")
+
+    leftovers = _uncommitted_leftovers()
+    if leftovers:
+        print(f"⚠ {len(leftovers)} change(s) NOT in this push (uncommitted):")
+        for ln in leftovers[:_LEFTOVER_CAP]:
+            print(f"  {ln}")
+        if len(leftovers) > _LEFTOVER_CAP:
+            print(f"  … +{len(leftovers) - _LEFTOVER_CAP} more")
+
+    wt = _watch_target(mr)
+    if wt:
+        source, iid = wt
+        if "watch" in flags and _spawn_watch(source, iid):
+            print(f"Watching → notifies on pipeline finish/fail "
+                  f"(unwatch: ./supertool 'unwatch:{source}:{iid}')")
+        else:
+            print(f"Watch pipeline: ./supertool 'watch:{source}:{iid}'")
+
+
+def _success_receipt(branch: str, remote_before: str, upstream: str,
+                     flags: set[str]) -> None:
+    """Shared 'what landed' tail — remote diff, ahead/behind, MR line, advisories."""
     upstream = upstream or _upstream_ref()
     remote_after = _remote_sha(upstream)
-
-    print("Status: pushed ✓")
     if remote_before and remote_after and remote_before != remote_after:
         rng = _git(["rev-list", "--count", f"{remote_before}..{remote_after}"])
         n = rng.stdout.strip() if rng.returncode == 0 else "?"
@@ -112,7 +211,6 @@ def main() -> int:
         # (shallow clone, odd remote layout). Don't claim up-to-date.
         print("Pushed — remote ref not locally resolvable for a before/after diff")
 
-    # Ahead/behind vs upstream after the push (should be in sync on success)
     ab = _git(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"])
     if ab.returncode == 0:
         parts = ab.stdout.strip().split()
@@ -123,10 +221,187 @@ def main() -> int:
             else:
                 print("vs upstream: in sync")
 
-    mr_line = _open_mr_line(branch)
+    mr = query_open_mr(branch)
+    mr_line = _open_mr_line(mr)
+    if mr_line:
+        print(mr_line)
+    _post_push_advisories(mr, flags)
+
+
+def _report_hook_pushed(head_before: str, head_after: str,
+                        remote: str, ref: str, remote_sha: str,
+                        branch: str) -> None:
+    """Receipt for the 'non-zero exit but the ref actually moved' case."""
+    if head_after != head_before:
+        print("Status: PUSHED (pre-push hook amended HEAD) ✓")
+        print(f"Local HEAD rewritten {head_before[:7]} → {head_after[:7]}")
+    else:
+        print("Status: pushed ✓ (pre-push hook exited non-zero; "
+              "remote already matches HEAD)")
+    print(f"Remote {remote}/{ref} now at {remote_sha[:7]}")
+    mr_line = _open_mr_line(query_open_mr(branch))
     if mr_line:
         print(mr_line)
 
+
+_INCOMING_CAP = 5
+
+
+def _incoming_commits() -> tuple[list[str], int, int]:
+    """After a fetch: (incoming commit lines, #remote-added, #local-to-replay).
+
+    Incoming = commits the remote has that we lack (HEAD..@{upstream}), each
+    as 'sha author: subject' — the authorship is what tells force-vs-integrate
+    apart: forcing over a teammate's commit destroys it.
+    """
+    log = _git(["log", "--format=%h %an: %s", "HEAD..@{upstream}"])
+    incoming = [ln for ln in log.stdout.splitlines() if ln.strip()]
+    mine = _git(["rev-list", "--count", "@{upstream}..HEAD"])
+    ahead = int(mine.stdout.strip()) if mine.returncode == 0 and mine.stdout.strip().isdigit() else 0
+    return incoming, len(incoming), ahead
+
+
+def _recover_by_rebase(branch: str, remote_before: str, upstream: str,
+                       flags: set[str]) -> int:
+    """Remote moved ahead — rebase local work onto it, then push.
+
+    Fetches first so the incoming remote commits (author + subject) can be
+    surfaced — that's the signal for force-vs-integrate. Clean rebase →
+    push + normal receipt. Conflict → leave the rebase paused, list the
+    conflicting files, and point at git-conflicts: the resolve/continue/
+    abort decision is the caller's, not the tool's.
+    """
+    print("Remote moved ahead — fetching to rebase onto it…")
+    _git(["fetch"], timeout=120)
+    incoming, behind, ahead = _incoming_commits()
+    if behind:
+        print(f"Remote added {behind} commit(s) you lack; replaying {ahead} of yours:")
+        for ln in incoming[:_INCOMING_CAP]:
+            print(f"  {ln}")
+        if behind > _INCOMING_CAP:
+            print(f"  … +{behind - _INCOMING_CAP} more")
+
+    rebase = _git(["rebase"], timeout=120)
+    if rebase.returncode != 0:
+        # Leave the rebase paused at the conflict (don't abort) so git-conflicts
+        # can read the blocks. The state is non-clean but explicit — the receipt
+        # names the files and the exact way forward or back out.
+        unmerged = _git(["diff", "--name-only", "--diff-filter=U"])
+        files = [f for f in unmerged.stdout.splitlines() if f.strip()]
+        print("Status: REBASE PAUSED ✗ — conflict (remote and local both changed):")
+        if files:
+            for f in files:
+                print(f"  {f}")
+        else:
+            err = _first_error_line((rebase.stdout or "") + "\n" + (rebase.stderr or ""))
+            if err:
+                print(f"  {err}")
+        print("Inspect: ./supertool 'git-conflicts'  — every conflict block + abort hint")
+        if behind:
+            print("Before you force: that would discard the remote commit(s) listed "
+                  "above — check the author first.")
+        print("Then decide:")
+        print("  • keep both — resolve, then `git rebase --continue` && `git-push`")
+        print("  • cancel — `git rebase --abort` (back to before the push, nothing changed)")
+        print("  • force yours over remote — `git rebase --abort`, then `git-push:force-with-lease`")
+        return 1
+
+    print("Rebase clean — pushing rebased work")
+    push_args = ["push"]
+    if "no-verify" in flags:
+        push_args.append("--no-verify")
+    result = _git(push_args, timeout=120)
+    if result.returncode != 0:
+        combined = (result.stdout or "") + "\n" + (result.stderr or "")
+        print("Status: PUSH REJECTED ✗ (after rebase)")
+        err = _first_error_line(combined)
+        if err:
+            print(f"First error: {err}")
+        print("\n--- git output ---")
+        print(combined.strip() or "(no output)")
+        return result.returncode
+
+    print("Status: pushed ✓ (rebased onto remote)")
+    _success_receipt(branch, remote_before, upstream, flags)
+    return 0
+
+
+def main() -> int:
+    if _git(["rev-parse", "--git-dir"]).returncode != 0:
+        print("ERROR: not inside a git repository.")
+        return 1
+
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+    if not branch or branch == "HEAD":
+        print("ERROR: detached HEAD — checkout a branch before pushing.")
+        return 1
+
+    flags = _parse_flags(sys.argv[1:])
+    upstream = _upstream_ref()
+    has_upstream = bool(upstream)
+    remote_before = _remote_sha(upstream) if has_upstream else ""
+    remote_name, remote_ref = _split_upstream(upstream, branch)
+    head_before = _local_head()
+
+    print(f"# git-push on {branch}")
+    if has_upstream:
+        print(f"Upstream: {upstream}" + (f" @ {remote_before}" if remote_before else ""))
+    else:
+        print("Upstream: none — setting on first push (origin)")
+    if flags:
+        print(f"Flags: {', '.join(sorted(flags))}")
+
+    push_args = ["push"]
+    if "force-with-lease" in flags:
+        push_args.append("--force-with-lease")
+    if "no-verify" in flags:
+        push_args.append("--no-verify")
+    if not has_upstream:
+        push_args += ["-u", "origin", "HEAD"]
+    result = _git(push_args, timeout=120)
+
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+
+    if result.returncode != 0:
+        # The exit code may lie: a pre-push hook that amends HEAD and pushes
+        # the fixed commit itself exits non-zero on purpose. Ground truth is
+        # the remote ref — if it already matches our (possibly rewritten)
+        # HEAD, the content is on the remote. Report honestly.
+        head_after = _local_head()
+        live = _live_remote_sha(remote_name, remote_ref)
+        if live and head_after and live == head_after:
+            _report_hook_pushed(head_before, head_after,
+                                 remote_name, remote_ref, live, branch)
+            return 0
+
+        # Routine recoverable case: remote moved ahead. Rebase onto it and
+        # push — unless the caller already chose to force (their decision).
+        if _is_non_fast_forward(combined) and "force-with-lease" not in flags:
+            return _recover_by_rebase(branch, remote_before, upstream, flags)
+
+        print("Status: PUSH REJECTED ✗")
+        err = _first_error_line(combined)
+        if err:
+            print(f"First error: {err}")
+        low = combined.lower()
+        if "rejected" in low or "declined" in low:
+            print("Hint: rejected by a server-side rule (protected branch / hook), "
+                  "not a divergence — check branch protection or the hook output "
+                  "above. A rebase will not help.")
+        print("\n--- git output ---")
+        print(combined.strip() or "(no output)")
+        return result.returncode
+
+    print("Status: pushed ✓")
+    if "force-with-lease" in flags and remote_before:
+        discarded = _discarded_by_force(remote_before)
+        if discarded:
+            print(f"Force discarded {len(discarded)} remote commit(s) — now off the branch:")
+            for d in discarded[:_INCOMING_CAP]:
+                print(f"  {d}")
+            if len(discarded) > _INCOMING_CAP:
+                print(f"  … +{len(discarded) - _INCOMING_CAP} more")
+    _success_receipt(branch, remote_before, upstream, flags)
     return 0
 
 

--- a/presets/git/push.py
+++ b/presets/git/push.py
@@ -230,7 +230,7 @@ def _success_receipt(branch: str, remote_before: str, upstream: str,
 
 def _report_hook_pushed(head_before: str, head_after: str,
                         remote: str, ref: str, remote_sha: str,
-                        branch: str) -> None:
+                        branch: str, flags: set[str]) -> None:
     """Receipt for the 'non-zero exit but the ref actually moved' case."""
     if head_after != head_before:
         print("Status: PUSHED (pre-push hook amended HEAD) ✓")
@@ -239,41 +239,58 @@ def _report_hook_pushed(head_before: str, head_after: str,
         print("Status: pushed ✓ (pre-push hook exited non-zero; "
               "remote already matches HEAD)")
     print(f"Remote {remote}/{ref} now at {remote_sha[:7]}")
-    mr_line = _open_mr_line(query_open_mr(branch))
+    # This IS a landed push — surface the same next-decision signals as the
+    # normal success path (mergeability, stale base, leftovers, watch).
+    mr = query_open_mr(branch)
+    mr_line = _open_mr_line(mr)
     if mr_line:
         print(mr_line)
+    _post_push_advisories(mr, flags)
 
 
 _INCOMING_CAP = 5
 
 
-def _incoming_commits() -> tuple[list[str], int, int]:
+def _incoming_commits(ref: str) -> tuple[list[str], int, int]:
     """After a fetch: (incoming commit lines, #remote-added, #local-to-replay).
 
-    Incoming = commits the remote has that we lack (HEAD..@{upstream}), each
-    as 'sha author: subject' — the authorship is what tells force-vs-integrate
-    apart: forcing over a teammate's commit destroys it.
+    Incoming = commits `ref` has that we lack (HEAD..ref), each as
+    'sha author: subject' — the authorship is what tells force-vs-integrate
+    apart: forcing over a teammate's commit destroys it. `ref` is an explicit
+    remote ref (origin/foo), not @{upstream}, so this works on a first push
+    that has no tracking ref yet.
     """
-    log = _git(["log", "--format=%h %an: %s", "HEAD..@{upstream}"])
+    log = _git(["log", "--format=%h %an: %s", f"HEAD..{ref}"])
     incoming = [ln for ln in log.stdout.splitlines() if ln.strip()]
-    mine = _git(["rev-list", "--count", "@{upstream}..HEAD"])
+    mine = _git(["rev-list", "--count", f"{ref}..HEAD"])
     ahead = int(mine.stdout.strip()) if mine.returncode == 0 and mine.stdout.strip().isdigit() else 0
     return incoming, len(incoming), ahead
 
 
 def _recover_by_rebase(branch: str, remote_before: str, upstream: str,
-                       flags: set[str]) -> int:
+                       remote_name: str, remote_ref: str, flags: set[str]) -> int:
     """Remote moved ahead — rebase local work onto it, then push.
 
     Fetches first so the incoming remote commits (author + subject) can be
-    surfaced — that's the signal for force-vs-integrate. Clean rebase →
+    surfaced — that's the signal for force-vs-integrate. Rebases onto the
+    explicit remote ref so it works with or without a tracking ref. Clean →
     push + normal receipt. Conflict → leave the rebase paused, list the
     conflicting files, and point at git-conflicts: the resolve/continue/
     abort decision is the caller's, not the tool's.
     """
-    print("Remote moved ahead — fetching to rebase onto it…")
-    _git(["fetch"], timeout=120)
-    incoming, behind, ahead = _incoming_commits()
+    target = f"{remote_name}/{remote_ref}"
+    print(f"Remote moved ahead — fetching to rebase onto {target}…")
+    fetched = _git(["fetch", remote_name, remote_ref], timeout=120)
+    if fetched.returncode != 0:
+        combined = (fetched.stdout or "") + "\n" + (fetched.stderr or "")
+        print(f"Status: PUSH REJECTED ✗ — fetch of {target} failed, cannot rebase")
+        err = _first_error_line(combined)
+        if err:
+            print(f"First error: {err}")
+        print("Hint: remote unreachable or ref gone — check connectivity, then retry.")
+        return fetched.returncode or 1
+
+    incoming, behind, ahead = _incoming_commits(target)
     if behind:
         print(f"Remote added {behind} commit(s) you lack; replaying {ahead} of yours:")
         for ln in incoming[:_INCOMING_CAP]:
@@ -281,21 +298,27 @@ def _recover_by_rebase(branch: str, remote_before: str, upstream: str,
         if behind > _INCOMING_CAP:
             print(f"  … +{behind - _INCOMING_CAP} more")
 
-    rebase = _git(["rebase"], timeout=120)
+    rebase = _git(["rebase", target], timeout=120)
     if rebase.returncode != 0:
-        # Leave the rebase paused at the conflict (don't abort) so git-conflicts
-        # can read the blocks. The state is non-clean but explicit — the receipt
-        # names the files and the exact way forward or back out.
+        # Distinguish a real merge conflict (unmerged paths → leave paused for
+        # git-conflicts) from a rebase that never started (bad ref, etc.).
         unmerged = _git(["diff", "--name-only", "--diff-filter=U"])
         files = [f for f in unmerged.stdout.splitlines() if f.strip()]
-        print("Status: REBASE PAUSED ✗ — conflict (remote and local both changed):")
-        if files:
-            for f in files:
-                print(f"  {f}")
-        else:
-            err = _first_error_line((rebase.stdout or "") + "\n" + (rebase.stderr or ""))
+        combined = (rebase.stdout or "") + "\n" + (rebase.stderr or "")
+        if not files:
+            _git(["rebase", "--abort"])  # nothing to keep paused; restore clean
+            print(f"Status: PUSH REJECTED ✗ — rebase onto {target} could not start")
+            err = _first_error_line(combined)
             if err:
-                print(f"  {err}")
+                print(f"First error: {err}")
+            print("\n--- git output ---")
+            print(combined.strip() or "(no output)")
+            return rebase.returncode
+        # Real conflict — leave it paused (don't abort) so git-conflicts can
+        # read the blocks. Non-clean but explicit; the receipt names the way out.
+        print("Status: REBASE PAUSED ✗ — conflict (remote and local both changed):")
+        for f in files:
+            print(f"  {f}")
         print("Inspect: ./supertool 'git-conflicts'  — every conflict block + abort hint")
         if behind:
             print("Before you force: that would discard the remote commit(s) listed "
@@ -310,6 +333,8 @@ def _recover_by_rebase(branch: str, remote_before: str, upstream: str,
     push_args = ["push"]
     if "no-verify" in flags:
         push_args.append("--no-verify")
+    if not upstream:
+        push_args += ["-u", remote_name, "HEAD"]
     result = _git(push_args, timeout=120)
     if result.returncode != 0:
         combined = (result.stdout or "") + "\n" + (result.stderr or "")
@@ -371,20 +396,27 @@ def main() -> int:
         live = _live_remote_sha(remote_name, remote_ref)
         if live and head_after and live == head_after:
             _report_hook_pushed(head_before, head_after,
-                                 remote_name, remote_ref, live, branch)
+                                 remote_name, remote_ref, live, branch, flags)
             return 0
 
         # Routine recoverable case: remote moved ahead. Rebase onto it and
         # push — unless the caller already chose to force (their decision).
         if _is_non_fast_forward(combined) and "force-with-lease" not in flags:
-            return _recover_by_rebase(branch, remote_before, upstream, flags)
+            return _recover_by_rebase(branch, remote_before, upstream,
+                                      remote_name, remote_ref, flags)
 
         print("Status: PUSH REJECTED ✗")
         err = _first_error_line(combined)
         if err:
             print(f"First error: {err}")
         low = combined.lower()
-        if "rejected" in low or "declined" in low:
+        if "force-with-lease" in flags and ("stale info" in low or "stale" in low):
+            # The lease check failed — the remote moved since you fetched.
+            # NOT a server-side rule; a rebase isn't the fix either.
+            print("Hint: the lease is stale — remote moved since you last fetched. "
+                  "`git fetch` to review the new commits, then retry "
+                  "`git-push:force-with-lease`.")
+        elif "rejected" in low or "declined" in low:
             print("Hint: rejected by a server-side rule (protected branch / hook), "
                   "not a divergence — check branch protection or the hook output "
                   "above. A rebase will not help.")

--- a/supertool.py
+++ b/supertool.py
@@ -106,7 +106,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.17.0"
+VERSION = "0.18.0"
 
 
 def _fwd(p: str) -> str:

--- a/tests/test_git_common.py
+++ b/tests/test_git_common.py
@@ -43,6 +43,26 @@ def test_first_error_line_empty_input() -> None:
     assert common._first_error_line("\n\n") == ""
 
 
+def test_first_error_line_skips_green_success_banner() -> None:
+    # '0 errors' contains 'error' — must not be picked over the real failure.
+    text = "✅ Prettier done. 0 errors.\nerror: failed to push some refs"
+    assert common._first_error_line(text) == "error: failed to push some refs"
+
+
+def test_first_error_line_all_success_returns_empty() -> None:
+    # A hook fatal whose message is 'pushed successfully' is success noise.
+    assert common._first_error_line(
+        "Fatal: Uncaught RuntimeException: pushed successfully.") == ""
+
+
+def test_looks_like_success_markers() -> None:
+    assert common._looks_like_success("✅ done")
+    assert common._looks_like_success("formatted, 0 errors")
+    assert common._looks_like_success("branch pushed successfully")
+    assert not common._looks_like_success("error: failed to push")
+    assert not common._looks_like_success("")
+
+
 # ── query_open_mr ────────────────────────────────────────────────────────
 
 def test_query_empty_branch_returns_none() -> None:
@@ -59,7 +79,9 @@ def test_query_glab_match_returns_gitlab_fields() -> None:
          mock.patch.object(common.subprocess, "run", fake_run):
         mr = common.query_open_mr("feature/x")
     assert mr == {"source": "gitlab", "iid": 21816,
-                  "target": "master", "pipeline": "running"}
+                  "target": "master", "pipeline": "running",
+                  "pipeline_id": None, "pipeline_url": None,
+                  "merge_status": None}
 
 
 def test_query_glab_no_pipeline_yields_none_status() -> None:
@@ -78,7 +100,9 @@ def test_query_gh_fallback_returns_github_fields() -> None:
          mock.patch.object(common.subprocess, "run", fake_run):
         mr = common.query_open_mr("feature/x")
     assert mr == {"source": "github", "iid": 172,
-                  "target": "main", "pipeline": None}
+                  "target": "main", "pipeline": None,
+                  "pipeline_id": None, "pipeline_url": None,
+                  "merge_status": None}
 
 
 def test_query_no_tool_returns_none() -> None:

--- a/tests/test_git_common.py
+++ b/tests/test_git_common.py
@@ -49,10 +49,15 @@ def test_first_error_line_skips_green_success_banner() -> None:
     assert common._first_error_line(text) == "error: failed to push some refs"
 
 
-def test_first_error_line_all_success_returns_empty() -> None:
-    # A hook fatal whose message is 'pushed successfully' is success noise.
-    assert common._first_error_line(
-        "Fatal: Uncaught RuntimeException: pushed successfully.") == ""
+def test_first_error_line_pure_success_returns_empty() -> None:
+    assert common._first_error_line("✅ format done. 0 errors.") == ""
+
+
+def test_first_error_line_hard_error_wins_over_success_marker() -> None:
+    # A line carrying a hard error keyword is surfaced even if it also has a
+    # success phrase — suppressing a real error is the worse failure.
+    line = "Fatal: Uncaught RuntimeException: pushed successfully."
+    assert common._first_error_line(line) == line
 
 
 def test_looks_like_success_markers() -> None:

--- a/tests/test_git_push.py
+++ b/tests/test_git_push.py
@@ -106,9 +106,9 @@ def test_main_non_ff_rebase_clean_pushes(capsys) -> None:
             return _proc("", 0)
         if args[:2] == ["log", "--format=%h %an: %s"]:
             return _proc("bbb2222 cj.adams: fix wallet rounding\n", 0)
-        if args[:2] == ["rev-list", "--count"] and "@{upstream}..HEAD" in args:
+        if args[:2] == ["rev-list", "--count"] and "origin/feat..HEAD" in args:
             return _proc("1\n", 0)
-        if args == ["rebase"]:
+        if args[:2] == ["rebase", "origin/feat"]:
             return _proc("Successfully rebased\n", 0)
         if args[0] == "push":
             return next(pushes)
@@ -151,9 +151,9 @@ def test_main_non_ff_rebase_conflict_leaves_paused_and_points_to_git_conflicts(c
             return _proc("", 0)
         if args[:2] == ["log", "--format=%h %an: %s"]:
             return _proc("ddd4444 cj.adams: refactor wallet\n", 0)
-        if args[:2] == ["rev-list", "--count"] and "@{upstream}..HEAD" in args:
+        if args[:2] == ["rev-list", "--count"] and "origin/feat..HEAD" in args:
             return _proc("2\n", 0)
-        if args == ["rebase"]:
+        if args[:2] == ["rebase", "origin/feat"]:
             return _proc("", 1, "CONFLICT (content): Merge conflict in src/foo.php")
         if args[:2] == ["diff", "--name-only"]:
             return _proc("src/foo.php\n", 0)
@@ -290,11 +290,10 @@ def test_first_error_line_skips_green_success_line() -> None:
         "error: failed to push some refs to 'origin'")
 
 
-def test_first_error_line_ignores_pushed_successfully_fatal() -> None:
-    # A hook stack trace whose message ends 'pushed successfully' is a
-    # success notice, not the failure cause — never surface it.
+def test_first_error_line_surfaces_fatal_despite_success_phrase() -> None:
+    # Hard error keyword wins over a success phrase — don't hide a real fatal.
     text = "Fatal error: Uncaught RuntimeException: branch pushed successfully."
-    assert push._first_error_line(text) == ""
+    assert push._first_error_line(text) == text
 
 
 # ── hook amended HEAD + pushed, exited non-zero (issue #297) ─────────────
@@ -498,6 +497,149 @@ def test_advisories_autowatch_flag_spawns(capsys) -> None:
     sp.assert_called_once_with("gitlab-mr", "42")
     assert "Watching →" in out
     assert "Watch pipeline" not in out
+
+
+def test_main_non_ff_fetch_failure_rejects_not_false_clean(capsys) -> None:
+    """Non-ff, but the fetch fails → REJECTED with the real cause, no false clean."""
+    rejected = ("To origin\n ! [rejected] feat -> feat (non-fast-forward)\n"
+                "error: failed to push some refs")
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc("localhead000\n", 0)
+        if args[0] == "ls-remote":
+            return _proc("remotehead999\trefs/heads/feat\n", 0)
+        if args[0] == "fetch":
+            return _proc("", 1, "fatal: unable to access 'origin': could not resolve host")
+        if args[0] == "push":
+            return _proc("", 1, rejected)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc != 0
+    assert "fetch of origin/feat failed" in out
+    assert "Rebase clean" not in out
+    assert "REBASE PAUSED" not in out
+
+
+def test_main_force_with_lease_stale_gives_correct_hint(capsys) -> None:
+    """A stale-lease rejection must NOT get the 'protected branch' hint."""
+    rejected = ("To origin\n ! [rejected] feat -> feat (stale info)\n"
+                "error: failed to push some refs")
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc("localhead000\n", 0)
+        if args[0] == "ls-remote":
+            return _proc("remotehead999\trefs/heads/feat\n", 0)
+        if args[0] == "push":
+            return _proc("", 1, rejected)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push.sys, "argv", ["push.py", "force-with-lease"]):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc != 0
+    assert "lease is stale" in out
+    assert "protected branch" not in out
+    assert "REBASE PAUSED" not in out  # force suppresses auto-rebase
+
+
+def test_main_non_ff_rebase_cannot_start_aborts_not_phantom_paused(capsys) -> None:
+    """Rebase fails to start (no unmerged paths) → abort + 'could not start', not PAUSED."""
+    rejected = ("To origin\n ! [rejected] feat -> feat (non-fast-forward)\n"
+                "error: failed to push some refs")
+    aborted: list[bool] = []
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc("localhead000\n", 0)
+        if args[0] == "ls-remote":
+            return _proc("remotehead999\trefs/heads/feat\n", 0)
+        if args[0] == "fetch":
+            return _proc("", 0)
+        if args[:2] == ["log", "--format=%h %an: %s"]:
+            return _proc("", 0)
+        if args[:2] == ["rev-list", "--count"]:
+            return _proc("0\n", 0)
+        if args[:2] == ["rebase", "origin/feat"]:
+            return _proc("", 128, "fatal: invalid upstream 'origin/feat'")
+        if args[:2] == ["diff", "--name-only"]:
+            return _proc("", 0)  # no unmerged paths — rebase never started
+        if args[:2] == ["rebase", "--abort"]:
+            aborted.append(True)
+            return _proc("", 0)
+        if args[0] == "push":
+            return _proc("", 1, rejected)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc != 0
+    assert "could not start" in out
+    assert "REBASE PAUSED" not in out
+    assert aborted, "must restore a clean tree when the rebase never started"
+
+
+def test_main_hook_amended_head_surfaces_advisories(capsys) -> None:
+    """Hook-amend success path carries the post-push advisories (watch, mergeability)."""
+    heads = iter(["old0000aaaa", "new1111bbbb"])
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc(next(heads) + "\n", 0)
+        if args[0] == "push":
+            return _proc("", 1, "! [rejected]\n✅ done. 0 errors.")
+        if args[0] == "ls-remote":
+            return _proc("new1111bbbb\trefs/heads/feat\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value={
+             "source": "gitlab", "iid": 42, "target": "master",
+             "merge_status": "cannot_be_merged"}):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "PUSHED (pre-push hook amended HEAD)" in out
+    assert "watch:gitlab-mr:42" in out
+    assert "conflicts with master" in out
 
 
 def test_main_force_aftermath_lists_discarded(capsys) -> None:

--- a/tests/test_git_push.py
+++ b/tests/test_git_push.py
@@ -20,26 +20,33 @@ def _proc(stdout: str = "", returncode: int = 0, stderr: str = ""):
 # ── _open_mr_line ────────────────────────────────────────────────────────
 
 def test_mr_line_gitlab_with_pipeline() -> None:
-    with mock.patch.object(push, "query_open_mr", return_value={
-            "source": "gitlab", "iid": 42, "target": "master", "pipeline": "running"}):
-        assert push._open_mr_line("b") == "MR !42 → master | pipeline: running"
+    assert push._open_mr_line({
+        "source": "gitlab", "iid": 42, "target": "master", "pipeline": "running"
+    }) == "MR !42 → master | pipeline: running"
 
 
 def test_mr_line_gitlab_no_pipeline_says_triggered() -> None:
-    with mock.patch.object(push, "query_open_mr", return_value={
-            "source": "gitlab", "iid": 42, "target": "master", "pipeline": None}):
-        assert push._open_mr_line("b") == "MR !42 → master | pipeline: triggered"
+    assert push._open_mr_line({
+        "source": "gitlab", "iid": 42, "target": "master", "pipeline": None
+    }) == "MR !42 → master | pipeline: triggered"
+
+
+def test_mr_line_gitlab_includes_pipeline_id_and_url() -> None:
+    line = push._open_mr_line({
+        "source": "gitlab", "iid": 42, "target": "master", "pipeline": "running",
+        "pipeline_id": 147316, "pipeline_url": "https://gl/x/-/pipelines/147316"})
+    assert "pipeline: running #147316" in line
+    assert "https://gl/x/-/pipelines/147316" in line
 
 
 def test_mr_line_github() -> None:
-    with mock.patch.object(push, "query_open_mr", return_value={
-            "source": "github", "iid": 7, "target": "main", "pipeline": None}):
-        assert push._open_mr_line("b") == "PR #7 → main | checks triggered"
+    assert push._open_mr_line({
+        "source": "github", "iid": 7, "target": "main", "pipeline": None
+    }) == "PR #7 → main | checks triggered"
 
 
 def test_mr_line_none_is_empty() -> None:
-    with mock.patch.object(push, "query_open_mr", return_value=None):
-        assert push._open_mr_line("b") == ""
+    assert push._open_mr_line(None) == ""
 
 
 # ── _remote_sha ──────────────────────────────────────────────────────────
@@ -76,7 +83,54 @@ def test_main_detached_head(capsys) -> None:
     assert "detached HEAD" in capsys.readouterr().out
 
 
-def test_main_rejected_push_surfaces_hint(capsys) -> None:
+def test_main_non_ff_rebase_clean_pushes(capsys) -> None:
+    """Non-ff → fetch, surface incoming commits, rebase clean → re-push."""
+    rejected = ("To origin\n ! [rejected] feat -> feat (non-fast-forward)\n"
+                "error: failed to push some refs")
+    pushes = iter([_proc("", 1, rejected), _proc("", 0)])  # first non-ff, then ok
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc("localhead000\n", 0)
+        if args[0] == "ls-remote":
+            return _proc("remotehead999\trefs/heads/feat\n", 0)  # != HEAD
+        if args[0] == "fetch":
+            return _proc("", 0)
+        if args[:2] == ["log", "--format=%h %an: %s"]:
+            return _proc("bbb2222 cj.adams: fix wallet rounding\n", 0)
+        if args[:2] == ["rev-list", "--count"] and "@{upstream}..HEAD" in args:
+            return _proc("1\n", 0)
+        if args == ["rebase"]:
+            return _proc("Successfully rebased\n", 0)
+        if args[0] == "push":
+            return next(pushes)
+        if args[:2] == ["rev-list", "--left-right"]:
+            return _proc("0\t0\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value=None):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "fetching to rebase" in out
+    assert "Remote added 1 commit(s) you lack; replaying 1 of yours" in out
+    assert "cj.adams: fix wallet rounding" in out
+    assert "Rebase clean" in out
+    assert "pushed ✓ (rebased onto remote)" in out
+    assert "REJECTED" not in out
+
+
+def test_main_non_ff_rebase_conflict_leaves_paused_and_points_to_git_conflicts(capsys) -> None:
+    """Non-ff → rebase conflicts → leave paused, list files, recommend git-conflicts."""
     rejected = ("To origin\n ! [rejected] feat -> feat (non-fast-forward)\n"
                 "error: failed to push some refs")
 
@@ -89,6 +143,22 @@ def test_main_rejected_push_surfaces_hint(capsys) -> None:
             return _proc("origin/feat\n", 0)
         if args[0] == "rev-parse" and args[1] == "--short":
             return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc("localhead000\n", 0)
+        if args[0] == "ls-remote":
+            return _proc("remotehead999\trefs/heads/feat\n", 0)
+        if args[0] == "fetch":
+            return _proc("", 0)
+        if args[:2] == ["log", "--format=%h %an: %s"]:
+            return _proc("ddd4444 cj.adams: refactor wallet\n", 0)
+        if args[:2] == ["rev-list", "--count"] and "@{upstream}..HEAD" in args:
+            return _proc("2\n", 0)
+        if args == ["rebase"]:
+            return _proc("", 1, "CONFLICT (content): Merge conflict in src/foo.php")
+        if args[:2] == ["diff", "--name-only"]:
+            return _proc("src/foo.php\n", 0)
+        if args[:2] == ["rebase", "--abort"]:
+            raise AssertionError("must NOT abort — leave paused for git-conflicts")
         if args[0] == "push":
             return _proc("", 1, rejected)
         return _proc("", 0)
@@ -97,9 +167,16 @@ def test_main_rejected_push_surfaces_hint(capsys) -> None:
         rc = push.main()
     out = capsys.readouterr().out
     assert rc == 1
-    assert "PUSH REJECTED" in out
+    assert "REBASE PAUSED" in out
+    assert "src/foo.php" in out
+    assert "Remote added 1 commit(s) you lack; replaying 2 of yours" in out
+    assert "cj.adams: refactor wallet" in out  # who I'd be forcing over
+    assert "check the author" in out
+    assert "git-conflicts" in out
+    assert "rebase --continue" in out
+    assert "rebase --abort" in out  # cancel path is surfaced explicitly
+    assert "cancel" in out
     assert "force-with-lease" in out
-    assert "pull --rebase" in out
 
 
 def test_main_protected_branch_rejection_no_rebase_hint(capsys) -> None:
@@ -188,6 +265,136 @@ def test_main_success_receipt_with_mr(capsys) -> None:
     assert "MR !99 → master | pipeline: created" in out
 
 
+# ── flag parsing ─────────────────────────────────────────────────────────
+
+def test_parse_flags_collects_known_ignores_rest() -> None:
+    assert push._parse_flags(["force-with-lease", "no-verify"]) == {
+        "force-with-lease", "no-verify"}
+    assert push._parse_flags(["FORCE-WITH-LEASE"]) == {"force-with-lease"}
+    assert push._parse_flags(["bogus", "42", ""]) == set()
+
+
+def test_split_upstream() -> None:
+    assert push._split_upstream("origin/feat", "feat") == ("origin", "feat")
+    assert push._split_upstream("up/team/x", "x") == ("up", "team/x")
+    assert push._split_upstream("", "feat") == ("origin", "feat")
+
+
+# ── _first_error_line skips success banners (issue #297) ─────────────────
+
+def test_first_error_line_skips_green_success_line() -> None:
+    text = ("To origin\n"
+            "✅ Formatting done. 0 errors.\n"
+            "error: failed to push some refs to 'origin'")
+    assert push._first_error_line(text) == (
+        "error: failed to push some refs to 'origin'")
+
+
+def test_first_error_line_ignores_pushed_successfully_fatal() -> None:
+    # A hook stack trace whose message ends 'pushed successfully' is a
+    # success notice, not the failure cause — never surface it.
+    text = "Fatal error: Uncaught RuntimeException: branch pushed successfully."
+    assert push._first_error_line(text) == ""
+
+
+# ── hook amended HEAD + pushed, exited non-zero (issue #297) ─────────────
+
+def test_main_hook_amended_head_reports_pushed(capsys) -> None:
+    """Non-zero push, but the remote already matches the rewritten HEAD."""
+    heads = iter(["old0000aaaa", "new1111bbbb"])  # before, after-amend
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc(next(heads) + "\n", 0)
+        if args[0] == "push":
+            return _proc("", 1, "! [rejected]\n✅ format done. 0 errors.")
+        if args[0] == "ls-remote":
+            return _proc("new1111bbbb\trefs/heads/feat\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value=None):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "PUSHED (pre-push hook amended HEAD)" in out
+    assert "Local HEAD rewritten old0000 → new1111" in out
+    assert "now at new1111" in out
+    assert "REJECTED" not in out
+
+
+def test_main_hook_pushed_without_amend_reports_pushed(capsys) -> None:
+    """Non-zero push, HEAD unchanged, but remote already matches it."""
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc("same000cccc\n", 0)
+        if args[0] == "push":
+            return _proc("", 1, "hook exited 1")
+        if args[0] == "ls-remote":
+            return _proc("same000cccc\trefs/heads/feat\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value=None):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "remote already matches HEAD" in out
+    assert "Local HEAD rewritten" not in out
+    assert "REJECTED" not in out
+
+
+def test_main_force_with_lease_and_no_verify_flags(capsys) -> None:
+    """Flags reach the git push invocation and the receipt header."""
+    calls: list[list[str]] = []
+
+    def fake_git(args, timeout=30):
+        calls.append(list(args))
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc("aaa1111\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc("h0000000\n", 0)
+        if args[0] == "push":
+            return _proc("", 0)
+        if args[:2] == ["rev-list", "--left-right"]:
+            return _proc("0\t0\n", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value=None), \
+         mock.patch.object(push.sys, "argv",
+                           ["push.py", "force-with-lease", "no-verify"]):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    push_calls = [c for c in calls if c and c[0] == "push"]
+    assert push_calls and "--force-with-lease" in push_calls[0]
+    assert "--no-verify" in push_calls[0]
+    assert "Flags: force-with-lease, no-verify" in out
+
+
 def test_main_first_push_sets_upstream(capsys) -> None:
     """No upstream initially → push -u; receipt notes branch created."""
     calls: list[list[str]] = []
@@ -216,3 +423,115 @@ def test_main_first_push_sets_upstream(capsys) -> None:
     assert rc == 0
     assert ["push", "-u", "origin", "HEAD"] in calls
     assert "branch created" in out
+
+
+# ── post-push advisories ─────────────────────────────────────────────────
+
+def test_watch_target_maps_source() -> None:
+    assert push._watch_target({"source": "gitlab", "iid": 42}) == ("gitlab-mr", "42")
+    assert push._watch_target({"source": "github", "iid": 7}) == ("github-pr", "7")
+    assert push._watch_target(None) is None
+    assert push._watch_target({"source": "gitlab", "iid": "?"}) is None
+
+
+def test_uncommitted_leftovers_lists_porcelain() -> None:
+    with mock.patch.object(push, "_git", return_value=_proc(" M a.py\n?? b.py\n")):
+        assert push._uncommitted_leftovers() == [" M a.py", "?? b.py"]
+
+
+def test_discarded_by_force_lists_commits() -> None:
+    with mock.patch.object(push, "_git",
+                           return_value=_proc("abc cj.adams: x\ndef theminh: y\n")):
+        assert push._discarded_by_force("old123") == [
+            "abc cj.adams: x", "def theminh: y"]
+
+
+def test_discarded_by_force_empty_sha() -> None:
+    assert push._discarded_by_force("") == []
+
+
+def _advisory_git(rev_list_count: str = "", porcelain: str = ""):
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-list", "--count"]:
+            return _proc(rev_list_count, 0)
+        if args[:2] == ["status", "--porcelain"]:
+            return _proc(porcelain, 0)
+        return _proc("", 0)
+    return fake_git
+
+
+def test_advisories_mergeability_warn(capsys) -> None:
+    mr = {"source": "gitlab", "iid": 42, "target": "master",
+          "merge_status": "cannot_be_merged"}
+    with mock.patch.object(push, "_git", side_effect=_advisory_git()):
+        push._post_push_advisories(mr, set())
+    out = capsys.readouterr().out
+    assert "conflicts with master" in out
+    assert "Watch pipeline: ./supertool 'watch:gitlab-mr:42'" in out
+
+
+def test_advisories_behind_target_warn(capsys) -> None:
+    mr = {"source": "gitlab", "iid": 42, "target": "master"}
+    with mock.patch.object(push, "_git",
+                           side_effect=_advisory_git(rev_list_count="3\n")):
+        push._post_push_advisories(mr, set())
+    out = capsys.readouterr().out
+    assert "3 commit(s) behind origin/master" in out
+
+
+def test_advisories_uncommitted_leftovers_warn(capsys) -> None:
+    mr = {"source": "gitlab", "iid": 42, "target": "master"}
+    with mock.patch.object(push, "_git",
+                           side_effect=_advisory_git(porcelain=" M x.py\n?? y.py\n")):
+        push._post_push_advisories(mr, set())
+    out = capsys.readouterr().out
+    assert "2 change(s) NOT in this push" in out
+    assert " M x.py" in out
+
+
+def test_advisories_autowatch_flag_spawns(capsys) -> None:
+    mr = {"source": "gitlab", "iid": 42, "target": "master"}
+    with mock.patch.object(push, "_git", side_effect=_advisory_git()), \
+         mock.patch.object(push, "_spawn_watch", return_value=True) as sp:
+        push._post_push_advisories(mr, {"watch"})
+    out = capsys.readouterr().out
+    sp.assert_called_once_with("gitlab-mr", "42")
+    assert "Watching →" in out
+    assert "Watch pipeline" not in out
+
+
+def test_main_force_aftermath_lists_discarded(capsys) -> None:
+    """force-with-lease success → reports the remote commits it overwrote."""
+    shas = iter(["aaa1111", "bbb2222"])  # remote before, after
+
+    def fake_git(args, timeout=30):
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return _proc(".git\n", 0)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "@{upstream}" not in args:
+            return _proc("feat\n", 0)
+        if args[0] == "rev-parse" and "@{upstream}" in args:
+            return _proc("origin/feat\n", 0)
+        if args[0] == "rev-parse" and args[1] == "--short":
+            return _proc(next(shas) + "\n", 0)
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return _proc("head000\n", 0)
+        if args[0] == "push":
+            return _proc("", 0)
+        if args[:3] == ["log", "--format=%h %an: %s", "aaa1111"]:
+            return _proc("zzz9999 cj.adams: work I just nuked\n", 0)
+        if args[:2] == ["rev-list", "--count"] and "@{upstream}" in args[-1]:
+            return _proc("", 0)
+        if args[:2] == ["rev-list", "--left-right"]:
+            return _proc("0\t0\n", 0)
+        if args[:2] == ["status", "--porcelain"]:
+            return _proc("", 0)
+        return _proc("", 0)
+
+    with mock.patch.object(push, "_git", side_effect=fake_git), \
+         mock.patch.object(push, "query_open_mr", return_value=None), \
+         mock.patch.object(push.sys, "argv", ["push.py", "force-with-lease"]):
+        rc = push.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Force discarded 1 remote commit(s)" in out
+    assert "cj.adams: work I just nuked" in out


### PR DESCRIPTION
Closes #297. On a repo whose pre-push hook auto-formats, `git-push` produced a self-contradictory receipt: `PUSH REJECTED ✗`, a green `✅ … 0 errors` line surfaced as the "First error", and a fatal stack trace — yet the remote **had** updated (the hook amended HEAD and pushed the corrected commit itself, then exited non-zero so git wouldn't also push the stale ref). The non-zero exit is *success*, not failure.

The fix trusts ground truth over the exit code, and — per the issue's "compact the operations, leave the decision to the caller" ask — the op now does the mechanical recovery itself and hands back a clean decision.

## What changed

**Fix (#297):**
- After a non-zero push, query the **live remote SHA** (`ls-remote`). If it already matches local HEAD, report `PUSHED (pre-push hook amended HEAD)` with the rewritten SHA — not `REJECTED`. Surfaces that local HEAD was rewritten.
- `_first_error_line` skips success banners (`✅`, `0 errors`, `pushed successfully`) so a hook's green line is never misreported as the failure.

**Embedded non-fast-forward recovery:**
- Remote moved ahead → `fetch`, surface the **incoming commits' authors + subjects** (the signal for force-vs-integrate), rebase onto the remote, re-push — one call instead of three.
- On conflict: leave the rebase **paused** (not auto-aborted, so `git-conflicts` can read the blocks), list the files, and print the exact **keep-both / cancel / force** commands. No silent rewrite, no force-push.

**Post-push receipt** (next-decision signals, all on calls already made):
- MR **mergeability** (`cannot_be_merged` caught at push time), **behind-target** count, **uncommitted leftovers**, pipeline **id + url**, and a ready `watch:gitlab-mr:<iid>` command.
- `:force-with-lease` reports **what it discarded** (author + subject of overwritten commits).

**Variants:** `:force-with-lease` (safe force, suppresses auto-rebase), `:no-verify` (skip local hook), `:watch` (opt-in: spawn the pipeline poller; recommend-only by default — no stray daemons on WIP pushes).

## Tests

+14 tests across `test_git_push.py` / `test_git_common.py`. Full suite green: **3326 passed, 34 skipped**.

🤖 Generated by Max — the push knows more than the exit code; now it says so.