### PR TITLE
fix(git-checkout): report real blocker when #267 FETCH_HEAD checkout fails

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/presets/git/checkout.py
+++ b/presets/git/checkout.py
@@ -98,6 +98,14 @@ def main() -> int:
                     result = cob
                     stderr = ""
                     s = ""
+                else:
+                    # ref WAS found and fetched — the `-B FETCH_HEAD` checkout
+                    # itself failed (commonly a dirty tree blocking the switch).
+                    # Surface that real error instead of the stale "pathspec"
+                    # one, so the reporter below names the true blocker.
+                    result = cob
+                    stderr = cob.stderr.strip() or cob.stdout.strip()
+                    s = stderr.lower()
     if result.returncode != 0:
         if "not a git repository" in s:
             print("ERROR: not inside a git repository.")

--- a/supertool.py
+++ b/supertool.py
@@ -106,7 +106,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "0.18.0"
+VERSION = "0.18.1"
 
 
 def _fwd(p: str) -> str:

--- a/tests/test_git_checkout.py
+++ b/tests/test_git_checkout.py
@@ -120,6 +120,44 @@ def test_narrowed_refspec_recovers_via_single_ref_fetch(monkeypatch, capsys) -> 
     assert "→ feature" in out
 
 
+def test_narrowed_refspec_dirty_tree_reports_real_blocker(monkeypatch, capsys) -> None:
+    """#267 fetch succeeds but `checkout -B <branch> FETCH_HEAD` is blocked by a
+    dirty working tree. The error must name the real blocker (uncommitted
+    changes), NOT the stale 'not found after fetch' from the first attempt."""
+    calls: list[list[str]] = []
+
+    def fake(args, timeout=10):
+        calls.append(args)
+        if args[:2] == ["rev-parse", "--abbrev-ref"] and "--symbolic-full-name" not in args:
+            return _fake_run("master\n")
+        if args[:2] == ["rev-parse", "--short"]:
+            return _fake_run("abc1234\n")
+        if args[:3] == ["rev-parse", "--abbrev-ref", "--symbolic-full-name"]:
+            return _fake_run("", "", 1)
+        if args[0] == "checkout" and args[1] == "-B":
+            return _fake_run(
+                "",
+                "error: Your local changes to the following files would be "
+                "overwritten by checkout:\n\tdocs/dvsi.sql\n"
+                "Please commit your changes or stash them before you switch branches.",
+                1,
+            )
+        if args[0] == "checkout":
+            return _fake_run("", "error: pathspec 'feature' did not match any file(s)", 1)
+        if args[0] == "fetch":
+            return _fake_run()
+        return _fake_run()
+
+    monkeypatch.setattr(checkout, "_git", fake)
+    monkeypatch.setattr(checkout.sys, "argv", ["checkout.py", "feature"])
+    rc = checkout.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert ["checkout", "-B", "feature", "FETCH_HEAD"] in calls
+    assert "uncommitted changes" in out.lower() or "stash" in out.lower()
+    assert "not found even after fetch" not in out
+
+
 def test_checkout_worktree_locked_suggests_path(monkeypatch, capsys) -> None:
     """When ref is checked out in another worktree, suggest cd <path>."""
     err = (


### PR DESCRIPTION
## Problem

`git-checkout` on a remote branch failed with a **misleading** error when the working tree was dirty:

```
ERROR: ref '<branch>' not found even after fetch.
```

The ref *was* found and fetched — the real blocker was uncommitted changes.

## Root cause

The `#267` narrowed-refspec fallback fetches `origin <ref>`, then runs `git checkout -B <ref> FETCH_HEAD`. When **that** checkout fails (commonly a dirty tree blocking the switch), the `else` branch was missing: `stderr`/`s` kept the stale `"pathspec did not match"` from the first attempt, so the reporter fell through to the wrong message.

## Fix

Propagate the real stderr from the failed `-B FETCH_HEAD` checkout, so the reporter names the true blocker:

```
ERROR: uncommitted changes block checkout. Stash or commit first.
error: Your local changes to the following files would be overwritten by checkout:
	.claude/remember/team/max/2026-06.md
Please commit your changes or stash them before you switch branches.
```

No auto-stash — which changes to stash is the user's call, not the tool's.

## Tests

- TDD: new `test_narrowed_refspec_dirty_tree_reports_real_blocker` — red before, green after.
- Full checkout + git silent-data-loss suites: **26 passed**.
- Verified against the real repo that originally surfaced this.

Bump `0.18.0 → 0.18.1`.

🤖 Co-authored with Max