### PR TITLE
feat(git): git-diff review op + dogfood pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Pre-commit hook: advisory review of staged changes — dogfoods the git-diff op.
+# Scans staged content for red flags (debug code, conflict markers) and other
+# warnings, then prints them. NEVER blocks: the commit always proceeds.
+# Enable once per clone with: git config core.hooksPath .githooks
+
+cd "$(git rev-parse --show-toplevel)" || exit 0
+
+# Degrade cleanly if the supertool entrypoint isn't present/executable.
+[ -x ./supertool ] || exit 0
+
+review=$(./supertool 'git-diff:staged' 2>/dev/null)
+# Gate on ASCII section titles (not the multibyte ⚠) so a C/POSIX locale can't
+# silently swallow the warnings; awk prints from the first warning to the end.
+if echo "$review" | grep -q "Red flags\|Forbidden paths\|New source without"; then
+    echo ""
+    echo "$review" | awk '/Red flags|Forbidden paths|New source without/{p=1} p'
+    echo ""
+    echo "(advisory — commit proceeds; nothing to bypass)"
+fi
+
+exit 0

--- a/.supertool.json
+++ b/.supertool.json
@@ -213,7 +213,16 @@
       "example": "rename:oldName:newName:supertool.py"
     }
   },
-  "ops": {},
+  "ops": {
+    "git-diff": {
+      "red_flags_extra": [
+        { "pattern": "\\bbreakpoint\\s*\\(", "ext": ".py", "label": "breakpoint()" },
+        { "pattern": "pdb\\.set_trace", "ext": ".py", "label": "pdb.set_trace" },
+        { "pattern": "\\bimport i?pdb\\b", "ext": ".py", "label": "import pdb" },
+        { "pattern": "\\bfrom i?pdb\\b", "ext": ".py", "label": "from pdb import" }
+      ]
+    }
+  },
   "aliases": {},
   "notifiers": {
     "cursor-witness": {

--- a/docs/presets/git.md
+++ b/docs/presets/git.md
@@ -16,9 +16,10 @@ Git investigation and workflow ops. Replaces the 4-6 raw `git` calls you'd norma
 | `git-blame` | `git-blame:PATH:LINE[:N]` | Blame for N lines (default 5) around a specific line number |
 | `git-checkout` | `git-checkout:REF` | Switch to branch/tag/SHA — reports tracking state, dirty files, last commits after switch |
 | `git-diverge` | `git-diverge:BRANCH[:BASE]` | Branch vs base: ahead/behind counts, commit list, changed files, +/− line totals |
+| `git-diff` | `git-diff[:staged\|:branch[:BASE]\|:PATH]` | Review-aware diff (working / `staged` / `branch` merge-base / `PATH`): files grouped by kind + shortstat, red-flag scan of **added** lines (debug code, conflict markers; reported `file:line`), forbidden-path guard, missing-test pairing, next-step hints. Generic defaults built in; project policy via config (below) |
 | `git-merge` | `git-merge:REF` | Merge REF — on conflict surfaces the UU file list, conflict markers, and ours/theirs SHAs |
 | `git-conflicts` | `git-conflicts` | List all UU files + every conflict block + abort hint |
-| `git-resolve` | `git-resolve:::SIDE:::PATH[,PATH...]` | Pick `ours`/`theirs`/`both` for one file, a comma-separated list, or `all` — stages and prints the continue command. `both` is a union: it strips the conflict markers and keeps both sides (ours then theirs), like git's `merge=union` driver — use it when both branches added different non-overlapping lines |
+| `git-resolve` | `git-resolve:::SIDE:::PATH[,PATH...]` | Pick `ours`/`theirs`/`both` for one file, a comma-separated list, or `all` — stages and prints the continue command. `both` is a union: it strips the conflict markers and keeps both sides (ours then theirs), like git's `merge=union` driver — use it when both branches added different non-overlapping lines. **Self-verifies before staging:** a leftover `<<<<<<<` / `>>>>>>>` is a hard fail (file left unstaged), and each resolved file's receipt carries a warn-only validator digest (`markers: clean \| validate: ok`) |
 | `git-commit` | `git-commit:::MSG[:::PATH...]` | Stage PATHs (or all staged if omitted) and commit with MSG — surfaces hook errors, shows HEAD before/after. Use `MSG=--no-edit` to reuse MERGE_MSG/CHERRY_PICK_HEAD during an in-progress merge or cherry-pick |
 | `git-push` | `git-push[:force-with-lease][:no-verify]` | Push the current branch (sets upstream on first push) — remote SHA before/after with commits pushed, ahead/behind vs upstream, and the open MR/PR + pipeline status. For **updating** an already-open MR; use the `mr` op for push+create. **Non-fast-forward** is handled in-op: it fetches, surfaces the **incoming remote commits** (SHA, author, subject) so you can see whose work you'd be rebasing over, then rebases your work onto the remote and re-pushes; on conflict it leaves the rebase **paused**, warns to check the incoming authors before forcing, and points you at `git-conflicts` + the keep-both/cancel/force paths — never auto-forced, never silently rewritten. A **pre-push hook that amends HEAD and pushes** the fixed commit itself (exiting non-zero) is reported as `PUSHED`, not `REJECTED`, since the live remote ref already matches HEAD. The **post-push receipt** carries the next-decision signals (all on calls already made): MR **mergeability** (warns if it now `cannot_be_merged` with target), **stale base** (`N behind origin/<target>`), **uncommitted leftovers** (changes not in this push), the **pipeline id + url**, and a ready `watch:gitlab-mr:<iid>` command. `:force-with-lease` also reports **what it discarded** (author + subject of overwritten remote commits). Flags: `:force-with-lease` (safe force — overwrite only if the remote hasn't moved; skips the auto-rebase, and lists discarded commits), `:no-verify` (skip the local pre-push hook, e.g. when a local formatter diverges from CI), `:watch` (spawn a background pipeline poller instead of just recommending the command) |
 
@@ -45,6 +46,29 @@ One call gives you branch health + exactly what differs from base — no follow-
 ./supertool 'git-resolve:::both:::src/app/Config.py'
 ./supertool 'git-commit:::Merge master into feature/auth'
 ```
+Every resolve **self-verifies before it stages**: it scans the resolved file for
+leftover conflict markers (`<<<<<<<` / `>>>>>>>`) and then runs the file-type
+validator (xmllint / phplint / …) so the receipt tells you the resolution is
+actually clean — the routine you'd otherwise run by hand:
+```text
+# git-resolve: ours (1 file(s))
+  ✓ src/app/Config.py
+      markers: clean | validate: ok
+Resolved: 1 | Failed: 0 | Remaining: 0
+Next: ./supertool 'git-commit:::Merge resolved' (or git merge --continue)
+```
+A marker left behind is a **hard fail** — the file is *not* staged, so a broken
+merge can never reach a commit:
+```text
+  ✗ src/app/Config.py: conflict markers remain at line(s) 63 — not staged
+```
+The validate line is **advisory** (warn-only): `validate: ⚠ phplint 2 err` flags
+syntax to look at but never blocks the resolve — an "invalid" file is often just
+a merge that needs the next hunk resolved, not a corrupt write. It is scoped to
+**parser/compiler** validators (phplint, xmllint, jsonlint, …), never semantic or
+style ones (lsp-diag, pyright, prettier), since only a parse break is something a
+side-pick can introduce — and it is omitted entirely when no syntax validator is
+configured for that file type (you'll just see `markers: clean`).
 
 **Update an MR that already exists:**
 ```bash
@@ -67,7 +91,7 @@ To **cancel** and get back to exactly where you were before the push (your commi
 
 ## Configuration
 
-No project-specific config required. Two environment variables tune `git-investigate` behavior:
+Most ops need no project config. `git-investigate` takes two env vars (below); `git-diff` takes optional review policy (see **git-diff policy** below).
 
 | Variable | Default | Effect |
 |----------|---------|--------|
@@ -84,6 +108,42 @@ Set via the op's JSON config if you want project-wide defaults:
 ```
 
 `git-status` and `git-push` try `glab` then `gh` to surface the open MR/PR — skip gracefully if neither is installed.
+
+### git-diff policy
+
+`git-diff` ships generic red-flag defaults (debug-code and conflict markers) and reads optional **project policy** from its op config, surfaced to the script as `SUPERTOOL_*` env vars — the same mechanism `gl-job` uses for `job_patterns`. All four keys are optional.
+
+| Key | Shape | Effect |
+|-----|-------|--------|
+| `forbidden_paths` | `[{pattern, reason}]` | Warn when a changed file's path matches `pattern` (regex); `reason` is printed verbatim. |
+| `test_pairing` | `[{src, test}]` | For each **added** source file matching `src` (regex with named groups), warn if the derived `test` path exists neither in the diff nor on disk. `test` is a template — `{name}` placeholders are filled from `src`'s named captures. |
+| `hints` | `[{added, message}]` | Print `message` once if any **added** path matches `added` (regex) — for follow-up reminders. |
+| `red_flags_extra` | `[{pattern, ext?, label}]` | Extra added-line red flags on top of the defaults. `pattern` (regex) is tested per added line; optional `ext` (e.g. `.js`) scopes it to one extension; `label` names the hit. |
+
+```json
+{
+  "ops": {
+    "git-diff": {
+      "forbidden_paths": [
+        { "pattern": "/Generated/", "reason": "generated — edit the source class, not this" }
+      ],
+      "test_pairing": [
+        { "src": "src2/(?P<rest>.+)\\.class\\.php$", "test": "tests/unit/{rest}Test.php" }
+      ],
+      "hints": [
+        { "added": "src2/.+\\.class\\.php$", "message": "new class — regenerate XSD + autoload cache" }
+      ],
+      "red_flags_extra": [
+        { "pattern": "^\\s*var\\b", "ext": ".js", "label": "var (use const/let)" }
+      ]
+    }
+  }
+}
+```
+
+The `test_pairing` capture→template pairing is the one non-obvious bit: `src2/(?P<rest>.+)\.class\.php$` captures `rest` (e.g. `SiFoo/Bar`), and `tests/unit/{rest}Test.php` expands to `tests/unit/SiFoo/BarTest.php`. Pairing fires only for **added** files classified as source — renames, edits, and non-source files are never flagged.
+
+**Dogfood:** this repo's own `.githooks/pre-commit` runs `git-diff:staged` as an advisory review (never blocks). Wire it into any project the same way.
 
 ## Authoring notes
 

--- a/presets/git.json
+++ b/presets/git.json
@@ -14,6 +14,12 @@
       "description": "File history: commits, uncommitted, blame hotspots",
       "syntax": "git-investigate:PATH"
     },
+    "git-diff": {
+      "cmd": "{python} {path}git/diff.py {args}",
+      "timeout": 15,
+      "description": "Review-aware diff: classified files + +/-, red-flag scan of added lines (debug code/conflict markers w/ file:line), forbidden-path guard, missing-test pairing, next hints. Policy via .supertool.json ops.git-diff.{red_flags_extra,forbidden_paths,test_pairing,hints}",
+      "syntax": "git-diff[:staged|:branch[:BASE]|:PATH]"
+    },
     "git-trail": {
       "cmd": "{python} {path}git/trail.py {args}",
       "timeout": 15,

--- a/presets/git/diff.py
+++ b/presets/git/diff.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Git diff with review intelligence — the questions you ask the diff, pre-answered.
+
+Raw `git diff` hands back a blob you then scan by eye or pipe through grep.
+This op answers the follow-ups in the same call:
+
+  - classified file list + +/- totals (what kind of change, how heavy)
+  - red-flag scan of ADDED lines (debug code, conflict markers) with file:line
+  - forbidden-path guard (project rules: generated files, secrets, install-only)
+  - missing-test pairing (a new source class with no test file)
+  - next-move hints (new class added → regenerate caches, etc.)
+
+The engine is generic; project policy lives in `.supertool.json` under
+`ops.git-diff.*` and arrives here as SUPERTOOL_* env vars (same mechanism as
+gl-job's job_patterns). Generic defaults are universal — var_dump, console.log,
+conflict markers — so the op is useful out of the box with no config.
+
+Modes (first arg):
+  (none)   working tree vs HEAD  — staged + unstaged tracked changes
+  staged   index vs HEAD         — what a commit would capture
+  branch   merge-base(base)..HEAD — the reviewer's diff (base: master|main|$2)
+  PATH     working tree vs HEAD, scoped to PATH
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+MAX_FILES = 60
+MAX_FLAGS = 40
+
+# Generic, universal red flags — debug leftovers + conflict markers. Project
+# config (red_flags_extra) adds language/house-rule patterns on top.
+DEFAULT_RED_FLAGS = [
+    {"pattern": r"\bvar_dump\s*\(", "label": "var_dump"},
+    {"pattern": r"\bprint_r\s*\(", "label": "print_r"},
+    {"pattern": r"\bvar_export\s*\(", "label": "var_export"},
+    {"pattern": r"\bconsole\.(log|debug|warn)\s*\(", "label": "console.*"},
+    {"pattern": r"\bdebugger\s*;", "label": "debugger"},
+    {"pattern": r"<<<<<<<", "label": "conflict marker"},
+    {"pattern": r">>>>>>>", "label": "conflict marker"},
+    {"pattern": r"\|\|\|\|\|\|\|", "label": "conflict marker"},
+]
+
+
+def _git(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git"] + args, capture_output=True, text=True, timeout=timeout)
+
+
+def _json_env(key: str) -> list:
+    """Read a JSON-list config value from SUPERTOOL_<KEY>; [] on absent/malformed."""
+    raw = os.environ.get(key, "")
+    if not raw.strip():
+        return []
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, list) else []
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+
+def _resolve_base(arg: str) -> str:
+    if arg:
+        return arg
+    for c in ("master", "main"):
+        if _git(["rev-parse", "--verify", "--quiet", c]).returncode == 0:
+            return c
+    return "master"
+
+
+def _classify(path: str) -> str:
+    """Generic file classification — informational grouping, not policy."""
+    low = path.lower()
+    base = path.rsplit("/", 1)[-1]
+    ext = "." + base.rsplit(".", 1)[-1] if "." in base else ""
+    if "/generated/" in low:
+        return "generated"
+    if re.search(r"(?:^|/)migrations?/", low):
+        return "migration"
+    is_test = (
+        "/test/" in low or "/tests/" in low
+        or base.endswith(("Test.php", "Test.class.php", "_test.py"))
+        or re.search(r"\.(test|spec)\.[jt]sx?$", base) is not None
+    )
+    if is_test:
+        return "test"
+    if "i18n" in low and ext == ".xml":
+        return "i18n"
+    if ext in (".scss", ".css", ".less"):
+        return "styles"
+    if ext in (".js", ".ts", ".jsx", ".tsx", ".vue"):
+        return "js"
+    if ext in (".php", ".py", ".rb", ".go", ".java", ".rs"):
+        return "src"
+    if ext in (".json", ".ini", ".yaml", ".yml", ".neon", ".toml", ".xml"):
+        return "config"
+    return "other"
+
+
+def _changed_files(diff_args: list[str]) -> list[tuple[str, str]]:
+    """[(status, path)] from name-status. R/C entries report the new path."""
+    res = _git(["-c", "core.quotepath=false", "diff", "--name-status"] + diff_args)
+    out: list[tuple[str, str]] = []
+    if res.returncode != 0:
+        return out
+    for line in res.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0][0]  # R100/C75 → R/C
+        path = parts[-1]      # new path for renames/copies
+        out.append((status, path))
+    return out
+
+
+def _scan_red_flags(diff_args: list[str], patterns: list[dict]) -> list[str]:
+    """Scan ADDED lines (unified=0) for red-flag patterns. Returns 'path:line label'."""
+    res = _git(["-c", "core.quotepath=false", "diff", "--unified=0", "--no-color"] + diff_args)
+    if res.returncode != 0:
+        return []
+    compiled = []
+    for p in patterns:
+        pat = p.get("pattern")
+        if not pat:
+            continue
+        try:
+            compiled.append((re.compile(pat), p.get("label", pat), p.get("ext")))
+        except re.error:
+            continue
+    hits: list[str] = []
+    cur_path = ""
+    new_line = 0
+    for line in res.stdout.splitlines():
+        if line.startswith('+++ "b/'):
+            cur_path = line[7:].rstrip('"')
+            continue
+        if line.startswith("+++ b/"):
+            cur_path = line[6:]
+            continue
+        if line.startswith("+++ "):
+            cur_path = line[4:]
+            continue
+        m = re.match(r"@@ -\d+(?:,\d+)? \+(\d+)", line)
+        if m:
+            new_line = int(m.group(1))
+            continue
+        if line.startswith("+") and not line.startswith("+++ "):
+            content = line[1:]
+            for rx, label, ext in compiled:
+                if ext and not cur_path.endswith(ext):
+                    continue
+                if rx.search(content):
+                    hits.append(f"{cur_path}:{new_line}  {label}  →  {content.strip()[:80]}")
+            new_line += 1
+    return hits
+
+
+def _check_forbidden(paths: list[str], rules: list[dict]) -> list[str]:
+    out = []
+    for p in paths:
+        for rule in rules:
+            pat = rule.get("pattern", "")
+            if not pat:
+                continue
+            try:
+                hit = re.search(pat, p) is not None
+            except re.error:
+                hit = pat in p
+            if hit:
+                out.append(f"{p}  —  {rule.get('reason', 'forbidden path')}")
+                break
+    return out
+
+
+def _check_test_pairing(changed: list[tuple[str, str]], rules: list[dict]) -> list[str]:
+    """Flag ADDED source files whose expected test exists neither in diff nor on disk."""
+    if not rules:
+        return []
+    changed_set = {p for _, p in changed}
+    out = []
+    for status, path in changed:
+        if status != "A" or _classify(path) != "src":
+            continue
+        for rule in rules:
+            src_re = rule.get("src", "")
+            tmpl = rule.get("test", "")
+            if not src_re or not tmpl:
+                continue
+            try:
+                m = re.search(src_re, path)
+            except re.error:
+                m = None
+            if not m:
+                continue
+            try:
+                expected = tmpl.format(**m.groupdict())
+            except (KeyError, IndexError):
+                continue
+            on_disk = os.path.exists(expected)
+            if expected not in changed_set and not on_disk:
+                out.append(f"{path}  —  no test ({expected})")
+            break
+    return out
+
+
+def _path_hints(changed: list[tuple[str, str]], rules: list[dict]) -> list[str]:
+    """Emit a message once if any ADDED path matches a hint trigger."""
+    out = []
+    added = [p for s, p in changed if s == "A"]
+    for rule in rules:
+        pat = rule.get("added", "")
+        msg = rule.get("message", "")
+        if not pat or not msg:
+            continue
+        try:
+            if any(re.search(pat, p) for p in added):
+                out.append(msg)
+        except re.error:
+            continue
+    return out
+
+
+def main() -> int:
+    arg1 = sys.argv[1] if len(sys.argv) > 1 else ""
+    arg2 = sys.argv[2] if len(sys.argv) > 2 else ""
+
+    if _git(["rev-parse", "--is-inside-work-tree"]).returncode != 0:
+        print("ERROR: not inside a git repository.")
+        return 1
+
+    if arg1 == "staged":
+        mode, scope, diff_args = "staged", "index vs HEAD", ["--cached"]
+    elif arg1 == "branch":
+        base = _resolve_base(arg2)
+        if _git(["rev-parse", "--verify", "--quiet", base]).returncode != 0:
+            print(f"ERROR: base ref {base!r} not found. Did you fetch?")
+            return 1
+        mode, scope, diff_args = "branch", f"merge-base({base})..HEAD", [f"{base}...HEAD"]
+    elif arg1:
+        mode, scope, diff_args = "path", f"working vs HEAD — {arg1}", ["HEAD", "--", arg1]
+    else:
+        mode, scope, diff_args = "working", "working tree vs HEAD", ["HEAD"]
+
+    print(f"# git-diff ({mode})")
+    print(f"Scope: {scope}")
+
+    changed = _changed_files(diff_args)
+    if not changed:
+        print("No changes.")
+        return 0
+
+    shortstat = _git(["diff", "--shortstat"] + diff_args)
+    if shortstat.returncode == 0 and shortstat.stdout.strip():
+        print(shortstat.stdout.strip())
+
+    # Files grouped by classification
+    groups: dict[str, list[str]] = {}
+    for status, path in changed:
+        groups.setdefault(_classify(path), []).append(f"{status}  {path}")
+    print(f"\n## Files changed ({len(changed)})")
+    shown = 0
+    for label in ("src", "test", "i18n", "config", "js", "styles", "migration",
+                  "generated", "other"):
+        rows = groups.get(label)
+        if not rows:
+            continue
+        print(f"\n### {label} ({len(rows)})")
+        for r in rows:
+            if shown >= MAX_FILES:
+                break
+            print(f"  {r}")
+            shown += 1
+        if shown >= MAX_FILES:
+            print(f"  … truncated at {MAX_FILES} files")
+            break
+
+    # Policy from .supertool.json (env), generic defaults otherwise
+    red_flags = DEFAULT_RED_FLAGS + _json_env("SUPERTOOL_RED_FLAGS_EXTRA")
+    forbidden = _json_env("SUPERTOOL_FORBIDDEN_PATHS")
+    pairing = _json_env("SUPERTOOL_TEST_PAIRING")
+    hints_cfg = _json_env("SUPERTOOL_HINTS")
+
+    paths = [p for _, p in changed]
+
+    forbidden_hits = _check_forbidden(paths, forbidden)
+    if forbidden_hits:
+        print(f"\n## ⚠ Forbidden paths ({len(forbidden_hits)})")
+        for h in forbidden_hits:
+            print(f"  {h}")
+
+    flag_hits = _scan_red_flags(diff_args, red_flags)
+    if flag_hits:
+        print(f"\n## ⚠ Red flags in added lines ({len(flag_hits)})")
+        for h in flag_hits[:MAX_FLAGS]:
+            print(f"  {h}")
+        if len(flag_hits) > MAX_FLAGS:
+            print(f"  … {len(flag_hits) - MAX_FLAGS} more")
+
+    pairing_hits = _check_test_pairing(changed, pairing)
+    if pairing_hits:
+        print(f"\n## ⚠ New source without a test ({len(pairing_hits)})")
+        for h in pairing_hits:
+            print(f"  {h}")
+
+    hint_msgs = _path_hints(changed, hints_cfg)
+    if hint_msgs:
+        print("\n## Next")
+        for m in hint_msgs:
+            print(f"  {m}")
+
+    if not (forbidden_hits or flag_hits or pairing_hits):
+        print("\n✓ No red flags, forbidden paths, or missing tests.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/presets/git/diff.py
+++ b/presets/git/diff.py
@@ -227,6 +227,11 @@ def _path_hints(changed: list[tuple[str, str]], rules: list[dict]) -> list[str]:
 
 
 def main() -> int:
+    # Windows stdout defaults to cp1252, which can't encode the ⚠/✓ glyphs we
+    # print — force UTF-8 so the op doesn't crash with UnicodeEncodeError on a
+    # non-UTF-8 console.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
     arg1 = sys.argv[1] if len(sys.argv) > 1 else ""
     arg2 = sys.argv[2] if len(sys.argv) > 2 else ""
 

--- a/presets/git/diff.py
+++ b/presets/git/diff.py
@@ -40,9 +40,12 @@ DEFAULT_RED_FLAGS = [
     {"pattern": r"\bvar_export\s*\(", "label": "var_export"},
     {"pattern": r"\bconsole\.(log|debug|warn)\s*\(", "label": "console.*"},
     {"pattern": r"\bdebugger\s*;", "label": "debugger"},
-    {"pattern": r"<<<<<<<", "label": "conflict marker"},
-    {"pattern": r">>>>>>>", "label": "conflict marker"},
-    {"pattern": r"\|\|\|\|\|\|\|", "label": "conflict marker"},
+    # Anchored to line start: a real git conflict marker is always at column 0.
+    # Matching the bare substring would false-positive on any file that merely
+    # mentions markers (resolve.py, its tests, these very docs).
+    {"pattern": r"^<<<<<<<", "label": "conflict marker"},
+    {"pattern": r"^>>>>>>>", "label": "conflict marker"},
+    {"pattern": r"^\|\|\|\|\|\|\|", "label": "conflict marker"},
 ]
 
 

--- a/presets/git/resolve.py
+++ b/presets/git/resolve.py
@@ -7,8 +7,19 @@ Receipt shows which files were resolved and how many conflicts remain.
 """
 from __future__ import annotations
 
+import os
+import re
 import subprocess
 import sys
+from pathlib import Path
+from typing import Optional
+
+
+# Unambiguous conflict markers — `<<<<<<<` / `>>>>>>>` at line start. A bare row
+# of `=======` is intentionally NOT matched: it is legitimate decoration (RST/MD
+# underlines, comment rules) and a real leftover always carries the angle markers
+# too, so the angle scan never misses an actual unresolved hunk.
+_MARKER_RE = re.compile(r"^(<{7,}|>{7,})(\s|$)")
 
 
 def _git(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
@@ -86,6 +97,83 @@ def _union_file(path: str) -> tuple[bool, str]:
     return True, ""
 
 
+def _scan_markers(path: str) -> list[int]:
+    """1-indexed line numbers carrying a leftover conflict marker, else [].
+
+    Reads bytes and decodes UTF-8 — a binary (non-decodable) file scans clean
+    (a text marker can't live in it). Used as a hard gate before staging:
+    `checkout --ours/theirs` cannot leave markers, but `both`/union and any
+    future per-hunk path can, and a staged marker is a broken commit.
+    """
+    try:
+        with open(path, "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return []
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return []
+    return [i for i, line in enumerate(text.splitlines(), 1) if _MARKER_RE.match(line)]
+
+
+# Parser/compiler validators only — the class of check a side-pick can actually
+# break. Semantic/diagnostic/style validators (lsp-diag, pyright, psr, tsc-check,
+# prettier-check, git-status, …) are deliberately excluded: they report the
+# file's pre-existing state, not what the resolve introduced, so they'd cry wolf
+# on every resolve. The stack's normal before/after diffing can't filter that
+# here — the "before" is a marker-filled conflicted file — so we scope by name.
+# A name not present in the live config is simply skipped (safe degradation: no
+# digest line rather than a false "ok").
+_SYNTAX_VALIDATORS = (
+    "phplint", "xmllint", "jsonlint", "node-check", "py-compile",
+    "bash-check", "yaml-check", "yaml-check-yaml", "inilint", "tomllint",
+    "ruby-check", "terraform-check", "gofmt-check",
+)
+
+
+def _validate_path(path: str) -> Optional[str]:
+    """Warn-only post-resolve syntax digest, via the declarative validator stack.
+
+    Shells back into supertool's `validate` op (the single source of truth for
+    which validator runs on which file type), scoped to syntax/parser validators
+    only, and condenses its rows into one receipt line. Returns ``None`` when
+    nothing applies (no supertool, no file, no syntax validator for this type,
+    or timeout): advisory only — it never blocks or fails the resolve.
+    """
+    if not os.path.isfile(path):
+        return None
+    st = Path(__file__).resolve().parents[2] / "supertool.py"
+    if not st.is_file():
+        return None
+    tool_filter = ",".join(_SYNTAX_VALIDATORS)
+    try:
+        res = subprocess.run(
+            [sys.executable, str(st), f"validate:{path}:{tool_filter}"],
+            capture_output=True, text=True, timeout=90,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    out = res.stdout
+    # No syntax validator configured/matched for this file type → no digest line.
+    if "no validators" in out:
+        return None
+    fails: list[str] = []
+    ran = False
+    for line in out.splitlines():
+        m = re.match(r"^([\w-]+)\s*:\s*(ok|(\d+) err)\b", line)
+        if not m:
+            continue
+        ran = True
+        if m.group(3):
+            fails.append(f"{m.group(1)} {m.group(3)} err")
+    if not ran:
+        return None
+    if fails:
+        return "validate: ⚠ " + ", ".join(fails)
+    return "validate: ok"
+
+
 def main() -> int:
     if len(sys.argv) < 3:
         print("ERROR: usage: resolve.py SIDE PATH[,PATH...]")
@@ -126,6 +214,7 @@ def main() -> int:
 
     resolved: list[str] = []
     failed: list[tuple[str, str]] = []
+    digests: dict[str, Optional[str]] = {}
     for path in targets:
         if side == "both":
             ok, err = _union_file(path)
@@ -137,14 +226,24 @@ def main() -> int:
             if co.returncode != 0:
                 failed.append((path, co.stderr.strip() or co.stdout.strip()))
                 continue
+        # HARD GATE — never stage a file that still carries a conflict marker.
+        marker_lines = _scan_markers(path)
+        if marker_lines:
+            shown = ", ".join(str(n) for n in marker_lines[:5])
+            more = f" (+{len(marker_lines) - 5} more)" if len(marker_lines) > 5 else ""
+            failed.append((path, f"conflict markers remain at line(s) {shown}{more} — not staged"))
+            continue
         add = _git(["add", "--", path])
         if add.returncode != 0:
             failed.append((path, add.stderr.strip() or add.stdout.strip()))
             continue
         resolved.append(path)
+        digests[path] = _validate_path(path)
 
     for path in resolved:
         print(f"  ✓ {path}")
+        digest = digests.get(path)
+        print(f"      markers: clean | {digest}" if digest else "      markers: clean")
     for path, err in failed:
         print(f"  ✗ {path}: {err}")
 

--- a/tests/test_git_diff.py
+++ b/tests/test_git_diff.py
@@ -125,6 +125,21 @@ def test_added_line_starting_with_plusplus_is_scanned(tmp_path: Path) -> None:
     assert "var_dump" in out
 
 
+def test_ext_filter_on_red_flags_extra(tmp_path: Path) -> None:
+    """A red_flags_extra entry with an `ext` filter fires only on that extension."""
+    _init_repo(tmp_path)
+    _write(tmp_path, "app.js", "const x = 1;\nbreakpoint();\n")
+    _write(tmp_path, "app.py", "x = 1\nbreakpoint()\n")
+    subprocess.run(["git", "add", "-A"], check=True, cwd=tmp_path)
+
+    flags = json.dumps([{"pattern": r"\bbreakpoint\s*\(", "ext": ".py", "label": "bp"}])
+    out = _run(tmp_path, "staged", env_extra={"SUPERTOOL_RED_FLAGS_EXTRA": flags})
+
+    # Red flags print "path:line"; the file list prints "status  path" (no colon).
+    assert "app.py:2" in out   # .py matches the ext filter -> flagged
+    assert "app.js:" not in out  # .js excluded by the ext filter
+
+
 def test_not_a_git_repo(tmp_path: Path) -> None:
     res = subprocess.run(
         [sys.executable, str(DIFF), "staged"],

--- a/tests/test_git_diff.py
+++ b/tests/test_git_diff.py
@@ -1,0 +1,134 @@
+"""Tests for presets/git/diff.py — the review-aware git-diff op.
+
+Runs diff.py as a subprocess against throwaway repos in tmp_path, with project
+policy supplied via SUPERTOOL_* env vars (the same way the dispatcher feeds it).
+Covers: mode dispatch, classification, red-flag scan, forbidden-path guard,
+test-pairing, clean-silence, plus regression guards for the two bugs found in
+review (the `+++ ` added-line guard and the migration substring misclassify).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+DIFF = Path(__file__).parent.parent / "presets" / "git" / "diff.py"
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.invalid"], check=True, cwd=path)
+    subprocess.run(["git", "config", "user.name", "T"], check=True, cwd=path)
+    (path / "seed.txt").write_text("seed\n")
+    subprocess.run(["git", "add", "seed.txt"], check=True, cwd=path)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], check=True, cwd=path)
+
+
+def _write(path: Path, rel: str, content: str) -> None:
+    f = path / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(content)
+
+
+def _run(repo: Path, *args: str, env_extra: dict | None = None) -> str:
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    res = subprocess.run(
+        [sys.executable, str(DIFF), *args],
+        capture_output=True, text=True, cwd=repo, env=env,
+    )
+    assert res.returncode == 0, res.stderr
+    return res.stdout
+
+
+DVSI_PAIRING = json.dumps([
+    {"src": r"src2/(?P<rest>.+)\.class\.php$", "test": "tests/unit/{rest}Test.php"}
+])
+DVSI_FORBIDDEN = json.dumps([
+    {"pattern": "/Generated/", "reason": "generated — edit the source class"}
+])
+
+
+def test_staged_red_flag_forbidden_and_missing_test(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _write(tmp_path, "src2/SiFoo/Foo.class.php",
+           "<?php\nclass Foo {\n    function go() { var_dump($this); }\n}\n")
+    _write(tmp_path, "src2/Generated/Bar.class.php", "<?php\nclass Bar {}\n")
+    subprocess.run(["git", "add", "-A"], check=True, cwd=tmp_path)
+
+    out = _run(tmp_path, "staged",
+               env_extra={"SUPERTOOL_FORBIDDEN_PATHS": DVSI_FORBIDDEN,
+                          "SUPERTOOL_TEST_PAIRING": DVSI_PAIRING})
+
+    assert "git-diff (staged)" in out
+    assert "var_dump" in out and "Foo.class.php:3" in out
+    assert "Forbidden paths" in out and "Generated/Bar.class.php" in out
+    # Foo is a new src class with no test -> flagged; Generated file is exempt.
+    assert "tests/unit/SiFoo/FooTest.php" in out
+
+
+def test_clean_diff_is_silent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _write(tmp_path, "src2/SiFoo/Foo.class.php", "<?php\nclass Foo {}\n")
+    _write(tmp_path, "tests/unit/SiFoo/FooTest.php", "<?php\nclass FooTest {}\n")
+    subprocess.run(["git", "add", "-A"], check=True, cwd=tmp_path)
+
+    out = _run(tmp_path, "staged", env_extra={"SUPERTOOL_TEST_PAIRING": DVSI_PAIRING})
+
+    assert "No red flags" in out
+    assert "⚠" not in out
+
+
+def test_branch_mode_scope(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    subprocess.run(["git", "checkout", "-q", "-b", "feature"], check=True, cwd=tmp_path)
+    _write(tmp_path, "src2/SiFoo/Foo.class.php", "<?php\nclass Foo {}\n")
+    subprocess.run(["git", "add", "-A"], check=True, cwd=tmp_path)
+    subprocess.run(["git", "commit", "-q", "-m", "feat"], check=True, cwd=tmp_path)
+
+    out = _run(tmp_path, "branch", "main")
+
+    assert "git-diff (branch)" in out
+    assert "merge-base(main)..HEAD" in out
+    assert "Foo.class.php" in out
+
+
+def test_migration_path_not_flagged_but_module_is(tmp_path: Path) -> None:
+    """Bug 2 regression: 'migration' substring must not exempt real source classes."""
+    _init_repo(tmp_path)
+    # A real migration under a migrations/ path -> classified migration, exempt.
+    _write(tmp_path, "src2/Migrations/V1/V1.class.php", "<?php\nclass V1 {}\n")
+    # A module whose NAME contains 'migration' -> still a source class, must be flagged.
+    _write(tmp_path, "src2/SiMigration/SiMigrationModule.class.php",
+           "<?php\nclass SiMigrationModule {}\n")
+    subprocess.run(["git", "add", "-A"], check=True, cwd=tmp_path)
+
+    out = _run(tmp_path, "staged", env_extra={"SUPERTOOL_TEST_PAIRING": DVSI_PAIRING})
+
+    assert "SiMigrationModuleTest.php" in out  # module flagged
+    assert "V1Test.php" not in out             # real migration exempt
+
+
+def test_added_line_starting_with_plusplus_is_scanned(tmp_path: Path) -> None:
+    """Bug 1 regression: an added line whose content starts with '++' renders as
+    '+++...' in the diff and must NOT be mistaken for a '+++ ' header."""
+    _init_repo(tmp_path)
+    # Content line begins at column 0 with '++', so the diff line is '+++x...'.
+    _write(tmp_path, "src2/SiFoo/Foo.class.php", "<?php\n++var_dump($x);\n")
+    subprocess.run(["git", "add", "-A"], check=True, cwd=tmp_path)
+
+    out = _run(tmp_path, "staged")
+
+    assert "var_dump" in out
+
+
+def test_not_a_git_repo(tmp_path: Path) -> None:
+    res = subprocess.run(
+        [sys.executable, str(DIFF), "staged"],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    assert res.returncode == 1
+    assert "not inside a git repository" in res.stdout

--- a/tests/test_git_diff.py
+++ b/tests/test_git_diff.py
@@ -140,6 +140,19 @@ def test_ext_filter_on_red_flags_extra(tmp_path: Path) -> None:
     assert "app.js:" not in out  # .js excluded by the ext filter
 
 
+def test_conflict_marker_only_at_line_start(tmp_path: Path) -> None:
+    """A real conflict marker (column 0) flags; a mid-line mention does not."""
+    _init_repo(tmp_path)
+    _write(tmp_path, "note.txt", "ok\n# discusses <<<<<<< in prose\n")  # mention
+    _write(tmp_path, "conflict.txt", "ok\n<<<<<<< HEAD\n")              # real marker
+    subprocess.run(["git", "add", "-A"], check=True, cwd=tmp_path)
+
+    out = _run(tmp_path, "staged")
+
+    assert "conflict.txt:2" in out  # real marker at BOL -> flagged
+    assert "note.txt:" not in out   # mid-line mention -> not flagged
+
+
 def test_not_a_git_repo(tmp_path: Path) -> None:
     res = subprocess.run(
         [sys.executable, str(DIFF), "staged"],

--- a/tests/test_git_resolve.py
+++ b/tests/test_git_resolve.py
@@ -66,6 +66,7 @@ def test_comma_separated_paths(monkeypatch, capsys) -> None:
         return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(resolve, "_git", fake_git)
+    monkeypatch.setattr(resolve, "_validate_path", lambda p: None)
     monkeypatch.setattr(resolve.sys, "argv", ["resolve.py", "theirs", "a.php,b.php"])
     rc = resolve.main()
     out = capsys.readouterr().out
@@ -192,6 +193,7 @@ def test_both_end_to_end(monkeypatch, capsys, tmp_path) -> None:
         return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(resolve, "_git", fake_git)
+    monkeypatch.setattr(resolve, "_validate_path", lambda p: None)
     monkeypatch.setattr(resolve.sys, "argv", ["resolve.py", "both", str(f)])
     rc = resolve.main()
     out = capsys.readouterr().out
@@ -205,3 +207,137 @@ def test_both_end_to_end(monkeypatch, capsys, tmp_path) -> None:
     # Both annotations survived
     txt = f.read_text(encoding="utf-8")
     assert "@typesAudit" in txt and "@see" in txt
+
+
+# ----- post-resolve marker scan (_scan_markers) -----
+
+
+def test_scan_markers_detects_leftover(tmp_path) -> None:
+    """A file still carrying <<<<<<< / >>>>>>> is flagged with 1-indexed lines."""
+    f = tmp_path / "a.php"
+    f.write_text("clean\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> x\n", encoding="utf-8")
+    lines = resolve._scan_markers(str(f))
+    assert lines == [2, 6]
+
+
+def test_scan_markers_ignores_bare_equals(tmp_path) -> None:
+    """A row of === decoration (no <<< / >>>) is NOT a false positive."""
+    f = tmp_path / "b.md"
+    f.write_text("Title\n=======\nbody\n", encoding="utf-8")
+    assert resolve._scan_markers(str(f)) == []
+
+
+def test_scan_markers_binary_is_safe(tmp_path) -> None:
+    """Non-UTF-8 (binary) files scan clean — no crash."""
+    f = tmp_path / "c.bin"
+    f.write_bytes(b"\xff\xfe<<<<<<<\x00")
+    assert resolve._scan_markers(str(f)) == []
+
+
+def test_marker_leftover_blocks_staging(monkeypatch, capsys, tmp_path) -> None:
+    """HARD GATE: a resolve that leaves a conflict marker is NOT staged."""
+    import subprocess
+    f = tmp_path / "x.php"
+    # checkout 'succeeds' but leaves a marker behind (simulated corruption)
+    f.write_text("ok\n<<<<<<< HEAD\nbad\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_git(args, timeout=10):
+        calls.append(args)
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=".git\n", stderr="")
+        if args[:3] == ["diff", "--name-only", "--diff-filter=U"]:
+            n = len([c for c in calls if c[:3] == ["diff", "--name-only", "--diff-filter=U"]])
+            stdout = f"{f}\n" if n == 1 else f"{f}\n"  # still conflicted (never staged)
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(resolve, "_git", fake_git)
+    monkeypatch.setattr(resolve.sys, "argv", ["resolve.py", "ours", str(f)])
+    rc = resolve.main()
+    out = capsys.readouterr().out
+
+    assert rc == 1
+    assert "conflict markers remain" in out
+    # never staged
+    assert not any(c[:2] == ["add", "--"] for c in calls)
+
+
+def test_validate_digest_in_receipt(monkeypatch, capsys, tmp_path) -> None:
+    """A clean resolve shows 'markers: clean' + the validate digest per file."""
+    import subprocess
+    f = tmp_path / "x.php"
+    f.write_text("clean php\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_git(args, timeout=10):
+        calls.append(args)
+        if args[:2] == ["rev-parse", "--git-dir"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=".git\n", stderr="")
+        if args[:3] == ["diff", "--name-only", "--diff-filter=U"]:
+            n = len([c for c in calls if c[:3] == ["diff", "--name-only", "--diff-filter=U"]])
+            stdout = f"{f}\n" if n == 1 else ""
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(resolve, "_git", fake_git)
+    monkeypatch.setattr(resolve, "_validate_path", lambda p: "validate: ok")
+    monkeypatch.setattr(resolve.sys, "argv", ["resolve.py", "ours", str(f)])
+    rc = resolve.main()
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "markers: clean | validate: ok" in out
+
+
+def test_validate_digest_parses_err_rows(monkeypatch) -> None:
+    """_validate_path digests validator 'N err' rows into a warn line."""
+    import subprocess
+    sample = "validate: x.php\nxmllint     : ok          (5ms)\nphplint     : 2 err       (9ms)\n"
+    monkeypatch.setattr(
+        resolve.subprocess, "run",
+        lambda *a, **k: subprocess.CompletedProcess(args=a, returncode=0, stdout=sample, stderr=""),
+    )
+    # path must exist for the guard; use this test file itself
+    digest = resolve._validate_path(__file__)
+    assert digest is not None
+    assert "⚠" in digest and "phplint 2 err" in digest
+
+
+def test_validate_scopes_to_syntax_validators(monkeypatch) -> None:
+    """The validate call filters to parser validators — semantic ones excluded."""
+    import subprocess
+    seen: dict[str, list] = {}
+
+    def fake_run(cmd, *a, **k):
+        seen["cmd"] = cmd
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="validate: x\nphplint     : ok\n", stderr="")
+
+    monkeypatch.setattr(resolve.subprocess, "run", fake_run)
+    resolve._validate_path(__file__)
+    arg = seen["cmd"][-1]  # validate:PATH:tool1,tool2,...
+    assert arg.startswith("validate:")
+    assert "phplint" in arg and "xmllint" in arg
+    # noisy semantic/diagnostic validators must NOT be requested
+    for noisy in ("lsp-diag", "pyright", "psr", "tsc-check", "prettier-check", "git-status"):
+        assert noisy not in arg
+
+
+def test_validate_no_matching_validator_returns_none(monkeypatch) -> None:
+    """No syntax validator for this file type → None (no false 'ok' line)."""
+    import subprocess
+    monkeypatch.setattr(
+        resolve.subprocess, "run",
+        lambda *a, **k: subprocess.CompletedProcess(args=a, returncode=0, stdout="no validators matched filter\n", stderr=""),
+    )
+    assert resolve._validate_path(__file__) is None
+
+
+def test_validate_all_ok_returns_ok(monkeypatch) -> None:
+    """All parser rows ok → 'validate: ok'."""
+    import subprocess
+    monkeypatch.setattr(
+        resolve.subprocess, "run",
+        lambda *a, **k: subprocess.CompletedProcess(args=a, returncode=0, stdout="validate: x\nxmllint     : ok          (5ms)\n", stderr=""),
+    )
+    assert resolve._validate_path(__file__) == "validate: ok"


### PR DESCRIPTION
## What

A new `git-diff` op that turns `git diff` into a review pass — it answers the questions you'd otherwise grep the diff for next turn.

**Modes:** `git-diff` (working vs HEAD), `:staged`, `:branch[:BASE]` (merge-base..HEAD — the reviewer's diff), `:PATH`.

**Output:** classified files + shortstat, red-flag scan of *added* lines (debug code, conflict markers; reported `file:line`), forbidden-path guard, missing-test pairing, and path-triggered hints.

**Generic engine, project policy in config:** ships universal defaults (var_dump, console.*, conflict markers); project rules arrive via `.supertool.json` `ops.git-diff.{forbidden_paths,test_pairing,hints,red_flags_extra}` as `SUPERTOOL_*` env vars — same mechanism as `gl-job.job_patterns`.

## Dogfood

Adds an advisory `.githooks/pre-commit` that runs `git-diff:staged` on every commit (never blocks, exit 0, degrades cleanly without supertool). Gated on ASCII section titles so a C/POSIX locale can't swallow the warnings. Adds python-debugger red flags (`breakpoint()`, `pdb.set_trace`, `import pdb`, `from pdb import`) to the repo's own `.supertool.json`.

## Tests

`tests/test_git_diff.py` — 7 cases: classification + red-flag + forbidden + pairing, clean-is-silent, branch-mode scope, ext-filter, not-a-repo, plus regression guards for two review-found bugs (the `+++ ` added-line guard and the migration-substring misclassify).

Co-Authored-By: Max <noreply>