### PR TITLE
feat(validators): label pre-existing errors and surface them in receipt

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -8954,8 +8954,22 @@ def _validator_render_diff(before: Optional[Dict[str, Any]], after: Dict[str, An
                 status = f"ok {primary[0]}={primary[1]}"
                 return [f"{tool:12s}: {status:<10}  {'(unchanged)':<11}  {time_col:>5}"]
         status = "ok" if a_ok else f"{a_count} err"
-        marker_col = "(timeout)" if after.get("timeout") else "(unchanged)"
-        return [f"{tool:12s}: {status:<10}  {marker_col:<11}  {time_col:>5}"]
+        if a_ok:
+            marker_col = "(unchanged)"
+        elif after.get("timeout"):
+            marker_col = "(timeout)"
+        else:
+            marker_col = "(pre-existing — not from this edit)"
+        out = [f"{tool:12s}: {status:<10}  {marker_col}  {time_col:>5}"]
+        if not a_ok and not after.get("timeout"):
+            for e in (after.get("errors") or [])[:5]:
+                line_n = f"L{e['line']}" if e.get("line") else "  "
+                code = e.get("code") or ""
+                msg = (e.get("msg") or "").strip().replace("\n", " ")[:120]
+                out.append(f"  {line_n} {code}  {msg}")
+            if len(after.get("errors") or []) > 5:
+                out.append(f"  ... +{len(after['errors']) - 5} more")
+        return out
     marker = "✓" if a_ok else ("⚠" if delta < 0 else "✗")
     arrow = f"{b_count} → {a_count}"
     sign = f"({'+' if delta >= 0 else ''}{delta})"

--- a/tests/test_validator_render_diff.py
+++ b/tests/test_validator_render_diff.py
@@ -68,13 +68,30 @@ def test_render_diff_unchanged_timeout_marker() -> None:
     assert "(unchanged)" not in joined
 
 
-def test_render_diff_unchanged_real_err_still_unchanged() -> None:
-    """Real persisting error keeps '(unchanged)' marker — no timeout flag set."""
-    before = {"tool": "phpstan", "count": 1, "ok": False,
-              "errors": [{"code": "E001", "msg": "real error"}]}
-    after = {"tool": "phpstan", "count": 1, "ok": False,
-             "errors": [{"code": "E001", "msg": "real error"}]}
+def test_render_diff_unchanged_real_err_labelled_pre_existing() -> None:
+    """Issue #307 — a persisting error is labelled pre-existing, not '(unchanged)',
+    and the error message is surfaced inline so the count is actionable."""
+    before = {"tool": "jsonlint", "count": 1, "ok": False,
+              "errors": [{"line": 4, "code": "E001", "msg": "trailing comma"}]}
+    after = {"tool": "jsonlint", "count": 1, "ok": False,
+             "errors": [{"line": 4, "code": "E001", "msg": "trailing comma"}]}
     rows = supertool._validator_render_diff(before, after)
     joined = "".join(rows)
-    assert "(unchanged)" in joined
+    assert "pre-existing" in joined
+    assert "not from this edit" in joined
+    assert "(unchanged)" not in joined
     assert "(timeout)" not in joined
+    # Error detail surfaced inline.
+    assert "trailing comma" in joined
+    assert "L4" in joined
+
+
+def test_render_diff_pre_existing_caps_errors_at_five() -> None:
+    """More than 5 persisting errors are capped with a '+N more' line."""
+    errors = [{"line": i, "code": "E", "msg": f"err {i}"} for i in range(7)]
+    before = {"tool": "phpstan", "count": 7, "ok": False, "errors": errors}
+    after = {"tool": "phpstan", "count": 7, "ok": False, "errors": errors}
+    rows = supertool._validator_render_diff(before, after)
+    joined = "".join(rows)
+    assert "pre-existing" in joined
+    assert "+2 more" in joined


### PR DESCRIPTION
Closes #307

## What

After a mutating op, when the validator error count is unchanged from a pre-existing baseline, the receipt previously rendered an ambiguous `(unchanged)` marker with no error detail — reading like the edit caused the failure.

This changes the truly-unchanged branch of `_validator_render_diff` so that, when the count is non-zero (and not a timeout):

- the marker reads `(pre-existing — not from this edit)` instead of `(unchanged)`;
- the persisting error line(s) are surfaced inline (capped at 5, with a `+N more` tail, matching the existing new-error rendering in the same function).

OK rows and timeout rows are unaffected.

## Why

Per the issue: `N err (unchanged)` reads as "your edit produced N errors" and shows no message, forcing a wasted round-trip to re-verify the file and guess what the error is.

## Tests

- Updated `test_render_diff_unchanged_real_err_*` to assert the new pre-existing wording + inline message (`L4`, `trailing comma`).
- Added `test_render_diff_pre_existing_caps_errors_at_five` for the `+N more` cap.
- `python3 -m pytest tests/test_validator_render_diff.py` → 8 passed. Full suite green except 3 pre-existing `test_xml.py::TestDispatchEndToEnd` failures that fail identically on the unmodified tree (missing `supertool` symlink in this worktree — unrelated to this change).