### PR TITLE
fix(git-commit): recommend git-push op in Next hint, not raw git push

### DIFF
--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -119,7 +119,7 @@ def main() -> int:
             if existing:
                 print(f"Next: git push (updates {existing})")
             else:
-                print("Next: git push (or ./supertool 'mr:.max/mr.md|TIME|LABELS' for push+MR)")
+                print("Next: ./supertool 'git-push' (or ./supertool 'mr:.max/mr.md|TIME|LABELS' for push+MR)")
         else:
             print("Next: git push -u origin HEAD (no upstream set)")
         return 0

--- a/tests/test_git_commit.py
+++ b/tests/test_git_commit.py
@@ -60,6 +60,37 @@ def test_no_edit_outside_merge_rejected(monkeypatch, capsys, tmp_path) -> None:
     assert "MERGE_HEAD" in out or "merge" in out.lower()
 
 
+def test_next_hint_recommends_git_push_op(monkeypatch, capsys, tmp_path) -> None:
+    """With an upstream set and no existing MR, the Next hint points at the
+    git-push op — not raw `git push` (issue #310)."""
+    import subprocess
+    remote = tmp_path / "remote.git"
+    work = tmp_path / "work"
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(work)], check=True)
+    monkeypatch.chdir(work)
+    subprocess.run(["git", "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "config", "user.name", "t"], check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], check=True)
+    (work / "a.txt").write_text("hi\n")
+    subprocess.run(["git", "add", "a.txt"], check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "push", "-q", "-u", "origin", "main"], check=True)
+
+    # Stage a new change to commit via the preset.
+    (work / "a.txt").write_text("hi\nmore\n")
+    subprocess.run(["git", "add", "a.txt"], check=True)
+
+    monkeypatch.setattr(commit, "_existing_mr_for_branch", lambda branch: None)
+    monkeypatch.setattr(commit.sys, "argv", ["commit.py", "second"])
+
+    rc = commit.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Next: ./supertool 'git-push'" in out
+    assert "Next: git push (" not in out
+
+
 def test_no_edit_during_merge_uses_prepared_message(monkeypatch, capsys, tmp_path) -> None:
     """With MERGE_HEAD present, --no-edit calls `git commit --no-edit`."""
     import subprocess


### PR DESCRIPTION
Closes #310

## Change

After a successful `git-commit` (upstream set, no existing MR), the "Next:" hint recommended raw `git push`. It now recommends the `git-push` op:

```
Next: ./supertool 'git-push' (or ./supertool 'mr:.max/mr.md|TIME|LABELS' for push+MR)
```

Raw `git push` skips what the op carries: pre-push validators, ahead/behind + upstream tracking, the `:watch` modifier, and the uncommitted-changes safety warning. Recommending it trained users back into the Unix reflex the tool replaces.

One-line change in `presets/git/commit.py:122` (the no-MR branch).

## Tests

Added `test_next_hint_recommends_git_push_op` in `tests/test_git_commit.py`: builds a real repo with a bare remote (upstream tracking), stubs `_existing_mr_for_branch` to None to reach the else branch, runs `main()`, asserts the new wording is present and raw `Next: git push (` is absent. Targeted suite (9 tests) green; full suite passes the 86% coverage gate (pre-existing unrelated `test_xml.py` dispatch failures aside).