### PR TITLE
fix(job-grep): reword regex fallback to neutral "(literal match)"

### DIFF
--- a/presets/github/job.py
+++ b/presets/github/job.py
@@ -286,7 +286,7 @@ def main() -> int:
             shown_pattern = grep_pattern
         except re.error:
             rx = re.compile(re.escape(grep_pattern))
-            shown_pattern = f"{grep_pattern} (literal — regex failed to compile)"
+            shown_pattern = f"{grep_pattern} (literal match)"
         ctx = config["error_context"]
         hits: set[int] = set()
         for i, line in enumerate(lines):

--- a/presets/gitlab/job.py
+++ b/presets/gitlab/job.py
@@ -323,7 +323,7 @@ def main() -> int:
             shown_pattern = grep_pattern
         except re.error:
             rx = re.compile(re.escape(grep_pattern))
-            shown_pattern = f"{grep_pattern} (literal — regex failed to compile)"
+            shown_pattern = f"{grep_pattern} (literal match)"
         ctx = config["error_context"]
         hits: set[int] = set()
         for i, line in enumerate(lines):

--- a/tests/test_github_job.py
+++ b/tests/test_github_job.py
@@ -151,12 +151,13 @@ def test_grep_no_match_falls_back_to_tail(monkeypatch, capsys) -> None:
 
 def test_grep_bad_regex_falls_back_to_literal(monkeypatch, capsys) -> None:
     """An invalid regex is matched literally instead of crashing."""
-    lines = ["before", "value[0] = 1", "after"]
-    rc = _run_main(monkeypatch, ["job.py", "123", "grep", "value["], lines)
+    lines = ["before", "1) FooTest::testBar", "after"]
+    rc = _run_main(monkeypatch, ["job.py", "123", "grep", "1)"], lines)
     out = capsys.readouterr().out
     assert rc == 0
-    assert "literal — regex failed to compile" in out
-    assert "value[0] = 1" in out
+    assert "(literal match)" in out
+    assert "regex failed to compile" not in out
+    assert "1) FooTest::testBar" in out
 
 
 def test_grep_missing_pattern_returns_error(monkeypatch, capsys) -> None:

--- a/tests/test_gitlab_job.py
+++ b/tests/test_gitlab_job.py
@@ -189,12 +189,13 @@ def test_grep_no_match_falls_back_to_tail(monkeypatch, capsys) -> None:
 
 def test_grep_bad_regex_falls_back_to_literal(monkeypatch, capsys) -> None:
     """An invalid regex is matched literally instead of crashing."""
-    lines = ["before", "value[0] = 1", "after"]
-    rc = _run_main(monkeypatch, ["job.py", "123", "grep", "value["], lines)
+    lines = ["before", "1) FooTest::testBar", "after"]
+    rc = _run_main(monkeypatch, ["job.py", "123", "grep", "1)"], lines)
     out = capsys.readouterr().out
     assert rc == 0
-    assert "literal — regex failed to compile" in out
-    assert "value[0] = 1" in out
+    assert "(literal match)" in out
+    assert "regex failed to compile" not in out
+    assert "1) FooTest::testBar" in out
 
 
 def test_grep_missing_pattern_returns_error(monkeypatch, capsys) -> None:


### PR DESCRIPTION
Closes #299

## Problem

`gl-job:ID:grep:PATTERN` (and `gh-job`) with an unbalanced-paren pattern like `1)` printed:

```
## grep /1) (literal — regex failed to compile)/ — 11 matching lines
```

It already falls back to literal matching correctly, but the phrase "regex failed to compile" reads like a tool error while triaging a red pipeline. `1)` is a natural pattern (PHPUnit numbers failures `1)`, `2)`).

## Change

Reworded the fallback label from `(literal — regex failed to compile)` to `(literal match)` in both grep-capable job presets. Logic is unchanged — invalid regex still falls back to `re.escape` literal matching.

- `presets/gitlab/job.py`
- `presets/github/job.py`

## Tests

Updated `test_grep_bad_regex_falls_back_to_literal` in `tests/test_gitlab_job.py` and `tests/test_github_job.py` to use the `1)` pattern, assert the neutral `(literal match)` wording, assert the alarming phrasing is gone, and confirm the literal fallback still finds the matching line.

Full suite: 3340 passed (coverage 87.69%, gate 86%). The only failures are 3 pre-existing `test_dispatch_xml_*` cases that expect a `supertool` launcher absent in this worktree — unrelated to this change.