### PR TITLE
test(conftest): guard against tests corrupting the suite repo's git state (#319)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,92 @@ def pytest_configure(config):  # noqa: ARG001
     os.environ.setdefault("SUPERTOOL_NO_PUBLISH_CONFIRM", "1")
 
 
+_GIT_DIRS_CACHE = "unset"
+
+
+def _repo_git_dirs():
+    """Locate the real suite repo's git dirs, or None when not in a repo.
+
+    Returns ``(common_dir, git_dir)``. In a normal clone both are ``.git``; in
+    a worktree ``common_dir`` is the shared ``.git`` (where ``config`` and
+    ``refs/heads`` live) and ``git_dir`` is the per-worktree dir (where ``HEAD``
+    lives). The corruption we guard against — ``core.bare=true`` + junk commits
+    on master from a test running git against an ambient repo — lands in the
+    common dir, so that is what we fingerprint.
+
+    Cached after the first call: the dirs never move during a run, and the two
+    ``git rev-parse`` subprocesses would otherwise fire once per test (~7k
+    spawns over the suite — minutes of pure overhead).
+    """
+    global _GIT_DIRS_CACHE
+    if _GIT_DIRS_CACHE != "unset":
+        return _GIT_DIRS_CACHE
+    import subprocess
+    root = Path(__file__).resolve().parent.parent
+    result = None
+    try:
+        common = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+        gitdir = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--git-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if common.returncode == 0 and gitdir.returncode == 0:
+            result = (
+                (root / common.stdout.strip()).resolve(),
+                (root / gitdir.stdout.strip()).resolve(),
+            )
+    except (OSError, subprocess.SubprocessError):
+        result = None
+    _GIT_DIRS_CACHE = result
+    return result
+
+
+def _git_state_fingerprint(dirs):
+    """Hash the bits a leaking test would mutate: config, HEAD, and every head ref."""
+    import hashlib
+    common_dir, git_dir = dirs
+    h = hashlib.sha256()
+    for p in (common_dir / "config", git_dir / "HEAD", common_dir / "packed-refs"):
+        try:
+            h.update(p.read_bytes())
+        except OSError:
+            h.update(b"<absent>")
+    heads = common_dir / "refs" / "heads"
+    if heads.is_dir():
+        for ref in sorted(heads.rglob("*")):
+            if ref.is_file():
+                h.update(str(ref.relative_to(heads)).encode())
+                h.update(ref.read_bytes())
+    return h.hexdigest()
+
+
+@pytest.fixture(autouse=True)
+def _guard_repo_git_state():
+    """Fail any test that mutates the suite repo's own git state (#319).
+
+    Tests must build git fixtures inside ``tmp_path`` and run every git call
+    with ``cwd=tmp_path`` (or ``git -C tmp_path``). A test that runs ``git
+    init``/``commit``/``config`` against the ambient cwd corrupts the real repo
+    — and when the suite runs inside a *worktree* (shared ``.git``), it
+    corrupts the main checkout too (``core.bare=true``, junk commits on master).
+    A standalone clone hides this; this guard surfaces the culprit by name.
+    """
+    dirs = _repo_git_dirs()
+    before = _git_state_fingerprint(dirs) if dirs else None
+    yield
+    if before is None:
+        return
+    after = _git_state_fingerprint(dirs)
+    assert before == after, (
+        "test mutated the suite repo's git state (config/HEAD/refs changed) — "
+        "build git fixtures in tmp_path and pass cwd=tmp_path to every git call. "
+        "See conftest._guard_repo_git_state / issue #319."
+    )
+
+
 @pytest.fixture(autouse=True)
 def _disable_rtk_and_config():
     """Disable RTK delegation, config cache, tree-sitter, and ctags in tests."""

--- a/tests/test_git_state_guard.py
+++ b/tests/test_git_state_guard.py
@@ -1,0 +1,64 @@
+"""Tests for the conftest git-state guard (#319).
+
+The guard fingerprints the suite repo's config/HEAD/refs before and after every
+test and fails any test that mutates them — the tripwire for a test (or an agent
+running the suite in a worktree) corrupting the real repo with `core.bare=true`
+or junk commits on master. These tests exercise the fingerprint logic against a
+synthetic git layout, never the real repo.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import conftest
+
+
+def _fake_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a minimal (common_dir, git_dir) layout the fingerprint reads."""
+    common = tmp_path / ".git"
+    (common / "refs" / "heads").mkdir(parents=True)
+    (common / "config").write_text("[core]\n\tbare = false\n")
+    (common / "HEAD").write_text("ref: refs/heads/master\n")
+    (common / "refs" / "heads" / "master").write_text("a" * 40 + "\n")
+    return common, common
+
+
+def test_fingerprint_stable_when_unchanged(tmp_path: Path) -> None:
+    dirs = _fake_repo(tmp_path)
+    assert conftest._git_state_fingerprint(dirs) == conftest._git_state_fingerprint(dirs)
+
+
+def test_fingerprint_detects_core_bare_flip(tmp_path: Path) -> None:
+    dirs = _fake_repo(tmp_path)
+    before = conftest._git_state_fingerprint(dirs)
+    (dirs[0] / "config").write_text("[core]\n\tbare = true\n")
+    assert conftest._git_state_fingerprint(dirs) != before
+
+
+def test_fingerprint_detects_junk_commit_on_a_branch(tmp_path: Path) -> None:
+    dirs = _fake_repo(tmp_path)
+    before = conftest._git_state_fingerprint(dirs)
+    (dirs[0] / "refs" / "heads" / "master").write_text("b" * 40 + "\n")
+    assert conftest._git_state_fingerprint(dirs) != before
+
+
+def test_fingerprint_detects_new_branch_ref(tmp_path: Path) -> None:
+    dirs = _fake_repo(tmp_path)
+    before = conftest._git_state_fingerprint(dirs)
+    (dirs[0] / "refs" / "heads" / "junk").write_text("c" * 40 + "\n")
+    assert conftest._git_state_fingerprint(dirs) != before
+
+
+def test_fingerprint_detects_head_move(tmp_path: Path) -> None:
+    dirs = _fake_repo(tmp_path)
+    before = conftest._git_state_fingerprint(dirs)
+    (dirs[1] / "HEAD").write_text("ref: refs/heads/other\n")
+    assert conftest._git_state_fingerprint(dirs) != before
+
+
+def test_repo_git_dirs_resolves_real_repo() -> None:
+    """Sanity: the suite repo is discoverable and its config is readable."""
+    dirs = conftest._repo_git_dirs()
+    assert dirs is not None
+    common_dir, _ = dirs
+    assert (common_dir / "config").is_file()


### PR DESCRIPTION
## Why

During this cycle the local clone got corrupted: `git config core.bare` flipped to `true` and ~11 junk commits ("init" ×8, "x", "initial", "side work") landed on `master`. Those messages are fixture-setup commits from the git test files — i.e. a test ran git against an ambient repo instead of an isolated `tmp_path`.

**A standalone clone hides this** — the full suite is hermetic there (3408 pass, repo clean after). The footgun only bites when the suite runs inside a git **worktree**: worktrees share the `.git` object store + config with the main checkout, so a leaking test mutates the main checkout's `core.bare` and refs.

## What

An autouse `conftest` fixture that fingerprints the suite repo's own git state — common-dir `config` (catches `core.bare`), `HEAD`, and every `refs/heads/*` (catches stray commits) — **before and after every test**, and fails the offender **by name** if it changes.

- Watches a **fixed repo-root path** (`git rev-parse --git-common-dir`), so a test that `chdir`s into `tmp_path` is still measured against the real repo, not its temp one.
- The dir lookup is **cached** — 2 `git rev-parse` subprocesses once per session, not per test (else ~7k spawns / minutes of overhead).
- `tests/test_git_state_guard.py` proves the fingerprint detects a `core.bare` flip, a moved branch ref, a new branch, and a `HEAD` move — and is stable when nothing changes.

## Validation

- Full suite with the guard active: **3408 passed, 34 skipped, 0 failed** — no existing test trips it (suite confirmed hermetic).
- Guard unit tests: 6/6.

No test is "fixed" here because none currently leak — this is the **tripwire** that turns a future silent corruption (the kind that bit us this cycle) into a named, actionable failure.

Co-Authored-By: Max <noreply>
