### PR TITLE
feat(grep): add :no-auto-read flag (parity with glob) (#320)

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -67,8 +67,8 @@
       "example": "read:src/app/Module.py:::grep=class"
     },
     "grep": {
-      "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]]",
-      "description": "Search (10 results def). CONTEXT=N lines around match",
+      "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]][:no-auto-read]",
+      "description": "Search (10 results def). CONTEXT=N lines around match. :no-auto-read suppresses single-file auto-read",
       "example": "grep:class:src/app/:20",
       "max_results": 10,
       "extensions": []

--- a/.supertool.json
+++ b/.supertool.json
@@ -41,8 +41,8 @@
       "hint": true
     },
     "grep": {
-      "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]]",
-      "description": "Search (10 results def). CONTEXT=N lines around match",
+      "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]][:no-auto-read]",
+      "description": "Search (10 results def). CONTEXT=N lines around match. :no-auto-read suppresses single-file auto-read",
       "example": "grep:dispatch:supertool.py:10:2"
     },
     "grep-count": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`grep` gained a `:no-auto-read` flag** — `grep:PATTERN:PATH:no-auto-read` suppresses the single-small-file auto-read so only the matching line(s) are emitted, mirroring `glob`'s existing flag. Default behavior (auto-read a concrete file < 20KB on a match) is unchanged. The flag is order-independent with `:count` and any `LIMIT`/`CONTEXT` args. Avoids silently dumping 10-18KB of unrequested file content when the caller only wants the hit. Closes [#320](https://github.com/Digital-Process-Tools/claude-supertool/issues/320).
+
 ## [0.19.0] - 2026-06-24
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,8 @@ Create a `.supertool.json` in your project root. Supertool walks up from cwd to 
       "example": "read:src/app/Module.py:::grep=class"
     },
     "grep": {
-      "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]]",
-      "description": "Search (10 results def). CONTEXT=N lines around match",
+      "syntax": "grep:PATTERN:PATH[:LIMIT[:CONTEXT]][:no-auto-read]",
+      "description": "Search (10 results def). CONTEXT=N lines around match. :no-auto-read suppresses single-file auto-read",
       "example": "grep:def handle:src/:20:2"
     },
     "map": {

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -19,7 +19,7 @@
 |----|--------|--------------|
 | `read` | `read:PATH` or `read:PATH:OFFSET:LIMIT` | 300 lines / 20KB cap |
 | `read` (filter) | `read:PATH:OFFSET:LIMIT:grep=PATTERN` | Only show lines matching PATTERN (original line numbers preserved). Use `read:PATH:::grep=PATTERN` for defaults. |
-| `grep` | `grep:PATTERN:PATH` or `grep:PATTERN:PATH:LIMIT` | 10 results default, code + doc extensions only. **Auto-reads** full file if PATH is a concrete file < 20KB with a match. |
+| `grep` | `grep:PATTERN:PATH` or `grep:PATTERN:PATH:LIMIT` | 10 results default, code + doc extensions only. **Auto-reads** full file if PATH is a concrete file < 20KB with a match. Append `:no-auto-read` to suppress (parity with `glob`). |
 | `grep` (context) | `grep:PATTERN:PATH:LIMIT:CONTEXT` | Show CONTEXT lines before/after each match (like `grep -C`). Match lines: `path:lineno:content`. Context lines: `path-lineno-content`. Non-adjacent groups separated by `--`. |
 | `grep` (count) | `grep:PATTERN:PATH:LIMIT:CONTEXT:count` | Return match counts per file instead of content. Output: `filepath:COUNT` per line. |
 | `glob` | `glob:PATTERN` | `**` supported. **Auto-reads** if PATTERN is a concrete file path (no wildcards). |

--- a/docs/operations/search.md
+++ b/docs/operations/search.md
@@ -6,7 +6,7 @@ Pattern-based ops for finding content across files or zooming into a known locat
 
 | Op | Syntax | What it does |
 |----|--------|--------------|
-| `grep` | `grep:PATTERN:PATH` or `grep:PATTERN:PATH:LIMIT` | 10 results default, code + doc extensions only. **Auto-reads** full file if PATH is a concrete file < 20KB with a match. |
+| `grep` | `grep:PATTERN:PATH` or `grep:PATTERN:PATH:LIMIT` | 10 results default, code + doc extensions only. **Auto-reads** full file if PATH is a concrete file < 20KB with a match. Append `:no-auto-read` to suppress (parity with `glob`). |
 | `grep` (context) | `grep:PATTERN:PATH:LIMIT:CONTEXT` | Show CONTEXT lines before/after each match (like `grep -C`). Match lines: `path:lineno:content`. Context lines: `path-lineno-content`. Non-adjacent groups separated by `--`. |
 | `grep` (count) | `grep:PATTERN:PATH:LIMIT:CONTEXT:count` | Return match counts per file instead of content. Output: `filepath:COUNT` per line. |
 | `grep_around` | `grep_around:PATTERN:PATH` or `grep_around:PATTERN:PATH:N:LIMIT` | Every match across files with N lines context (default N=3, LIMIT=10). Alias for `grep:PATTERN:PATH:LIMIT:CONTEXT` with sane defaults — useful for "show me how everyone uses this". Output capped at ~16KB (see below). |

--- a/supertool.py
+++ b/supertool.py
@@ -42,6 +42,9 @@ OPERATIONS
     grep:PATTERN:PATH          Search pattern (10 results default).
                                 Auto-reads full file if PATH is a concrete
                                 file < 20KB with a match.
+    grep:PATTERN:PATH:no-auto-read
+                               Suppress the single-file auto-read — only the
+                                matching line(s) are emitted (parity with glob).
     grep:PATTERN:PATH:LIMIT    Search with custom result limit
     grep:PATTERN:PATH:LIMIT:CONTEXT
                                Search with context lines (like grep -C).
@@ -1228,7 +1231,7 @@ def _literal_note(pattern: str, count: int) -> str:
 
 def op_grep(pattern: str, path: str = ".", limit: int = 0,
             context: int = 0, count_only: bool = False,
-            no_exclude: bool = False) -> str:
+            no_exclude: bool = False, no_auto_read: bool = False) -> str:
     """Search pattern recursively. Auto-reads small single file on match.
 
     When context > 0, emits N lines before/after each match in grep -C style:
@@ -1238,6 +1241,9 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
     Auto-read is skipped when context > 0 (output already contains context).
 
     When count_only=True, returns match counts per file instead of content.
+
+    When no_auto_read=True, suppresses the single-small-file auto-read so only
+    the matching line(s) are emitted (parity with glob's :no-auto-read flag).
     """
     if limit <= 0:
         limit = _get_op_int("grep", "max_results", MAX_GREP_RESULTS)
@@ -1358,7 +1364,8 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
     out.append("\n")
 
     # Auto-read: single small file + at least one match → emit full file
-    if (count > 0
+    if (not no_auto_read
+            and count > 0
             and os.path.isfile(path)
             and os.path.getsize(path) < _get_op_int("read", "max_bytes", MAX_READ_BYTES)):
         out.append(f"[auto-read: single file < {_get_op_int('read', 'max_bytes', MAX_READ_BYTES)} bytes, "
@@ -2912,12 +2919,16 @@ def _parse_grep_args(parts: List[str]) -> tuple:
     # parts[0] is 'grep', work with parts[1:]
     args = parts[1:]
     if not args:
-        return ("", ".", _get_op_int("grep", "max_results", MAX_GREP_RESULTS), 0, False)
+        return ("", ".", _get_op_int("grep", "max_results", MAX_GREP_RESULTS), 0, False, False)
 
-    # Peel known trailing fields from the right
+    # Peel known trailing string flags from the right (order-independent)
     count_only = False
-    if args and args[-1] == "count":
-        count_only = True
+    no_auto_read = False
+    while args and args[-1] in ("count", "no-auto-read"):
+        if args[-1] == "count":
+            count_only = True
+        else:
+            no_auto_read = True
         args = args[:-1]
 
     # Peel trailing ints: format is ...PATH:LIMIT:CONTEXT
@@ -2944,7 +2955,7 @@ def _parse_grep_args(parts: List[str]) -> tuple:
         pattern = args[0] if args else ""
         path = "."
 
-    return (pattern, path, limit, context, count_only)
+    return (pattern, path, limit, context, count_only, no_auto_read)
 
 
 def _parse_around_args(parts: List[str]) -> tuple:
@@ -10972,9 +10983,10 @@ def _dispatch_impl(arg: str) -> str:
                 grep_filter = parts[4][5:]
             body = op_read(path, offset, limit, grep_filter, force_full)
         elif op == "grep":
-            pattern, path, limit, context, count_only = _parse_grep_args(parts)
+            pattern, path, limit, context, count_only, no_auto_read = \
+                _parse_grep_args(parts)
             body = op_grep(pattern, path, limit, context, count_only,
-                           no_exclude=no_exclude)
+                           no_exclude=no_exclude, no_auto_read=no_auto_read)
         elif op == "grep_around":
             # grep_around:PATTERN:PATH[:N[:LIMIT]] — every match with N lines
             # context. Sane defaults for "show me how everyone uses this".

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -308,7 +308,7 @@ def test_split_arg_comma_multipath_unix_unaffected() -> None:
 
 def test_parse_grep_args_simple() -> None:
     parts = ["grep", "TODO", "src/", "10"]
-    pattern, path, limit, context, count_only = supertool._parse_grep_args(parts)
+    pattern, path, limit, context, count_only, _ = supertool._parse_grep_args(parts)
     assert pattern == "TODO"
     assert path == "src/"
     assert limit == 10
@@ -321,7 +321,7 @@ def test_parse_grep_args_double_colon_pattern() -> None:
     parts = supertool._split_arg(
         "grep:TransmissionStatus::STATUS_PENDING:Dvsi/**/*.php:50:1"
     )
-    pattern, path, limit, context, count_only = supertool._parse_grep_args(parts)
+    pattern, path, limit, context, count_only, _ = supertool._parse_grep_args(parts)
     assert pattern == "TransmissionStatus::STATUS_PENDING"
     assert path == "Dvsi/**/*.php"
     assert limit == 50
@@ -333,7 +333,7 @@ def test_parse_grep_args_double_colon_with_count() -> None:
     parts = supertool._split_arg(
         "grep:Foo::BAR:src/:20:0:count"
     )
-    pattern, path, limit, context, count_only = supertool._parse_grep_args(parts)
+    pattern, path, limit, context, count_only, _ = supertool._parse_grep_args(parts)
     assert pattern == "Foo::BAR"
     assert path == "src/"
     assert limit == 20
@@ -343,7 +343,7 @@ def test_parse_grep_args_double_colon_with_count() -> None:
 
 def test_parse_grep_args_no_limit_no_context() -> None:
     parts = ["grep", "pattern", "path/"]
-    pattern, path, limit, context, count_only = supertool._parse_grep_args(parts)
+    pattern, path, limit, context, count_only, _ = supertool._parse_grep_args(parts)
     assert pattern == "pattern"
     assert path == "path/"
     assert limit == supertool.MAX_GREP_RESULTS
@@ -352,14 +352,14 @@ def test_parse_grep_args_no_limit_no_context() -> None:
 
 def test_parse_grep_args_pattern_only() -> None:
     parts = ["grep", "TODO"]
-    pattern, path, limit, context, count_only = supertool._parse_grep_args(parts)
+    pattern, path, limit, context, count_only, _ = supertool._parse_grep_args(parts)
     assert pattern == "TODO"
     assert path == "."
 
 
 def test_parse_grep_args_empty() -> None:
     parts = ["grep"]
-    pattern, path, limit, context, count_only = supertool._parse_grep_args(parts)
+    pattern, path, limit, context, count_only, _ = supertool._parse_grep_args(parts)
     assert pattern == ""
     assert path == "."
 
@@ -367,7 +367,7 @@ def test_parse_grep_args_empty() -> None:
 def test_parse_grep_args_pattern_and_path_only() -> None:
     """Two tokens after 'grep' — pattern + path, no trailing ints."""
     parts = ["grep", "TODO", "src/"]
-    pattern, path, limit, context, count_only = supertool._parse_grep_args(parts)
+    pattern, path, limit, context, count_only, _ = supertool._parse_grep_args(parts)
     assert pattern == "TODO"
     assert path == "src/"
     assert limit == supertool.MAX_GREP_RESULTS
@@ -379,7 +379,7 @@ def test_parse_grep_args_triple_colon_pattern() -> None:
     parts = supertool._split_arg(
         "grep:A::B::C:src/:5"
     )
-    pattern, path, limit, context, count_only = supertool._parse_grep_args(parts)
+    pattern, path, limit, context, count_only, _ = supertool._parse_grep_args(parts)
     assert pattern == "A::B::C"
     assert path == "src/"
     assert limit == 5

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -100,6 +100,60 @@ def test_grep_no_auto_read_on_large_file(tmp_path: Path, monkeypatch) -> None:
     assert "[auto-read:" not in out
 
 
+def test_grep_no_auto_read_flag_suppresses_auto_read(tmp_path: Path) -> None:
+    f = tmp_path / "small.py"
+    f.write_text("found_it = True\n")
+    out = supertool.op_grep("found_it", str(f), no_auto_read=True)
+    # Match still reported, but the full file is not dumped
+    assert "[auto-read:" not in out
+    assert "found_it" in out
+    assert "1:found_it = True" in out
+
+
+def test_grep_dispatch_no_auto_read_flag(tmp_path: Path) -> None:
+    f = tmp_path / "small.py"
+    f.write_text("found_it = True\n")
+    out = supertool.dispatch(f"grep:found_it:{f}:no-auto-read")
+    assert "[auto-read:" not in out
+    assert "found_it" in out
+
+
+def test_grep_dispatch_no_auto_read_with_limit(tmp_path: Path) -> None:
+    f = tmp_path / "small.py"
+    f.write_text("found_it = True\n")
+    out = supertool.dispatch(f"grep:found_it:{f}:5:no-auto-read")
+    assert "[auto-read:" not in out
+    assert "found_it" in out
+
+
+def test_grep_dispatch_default_still_auto_reads(tmp_path: Path) -> None:
+    f = tmp_path / "small.py"
+    f.write_text("found_it = True\n")
+    out = supertool.dispatch(f"grep:found_it:{f}")
+    assert "[auto-read:" in out
+
+
+def test_parse_grep_args_peels_no_auto_read(tmp_path: Path) -> None:
+    pattern, path, limit, context, count_only, no_auto_read = \
+        supertool._parse_grep_args(["grep", "needle", "src/", "no-auto-read"])
+    assert pattern == "needle"
+    assert path == "src/"
+    assert no_auto_read is True
+    assert count_only is False
+
+
+def test_parse_grep_args_no_auto_read_with_count_and_ints(tmp_path: Path) -> None:
+    pattern, path, limit, context, count_only, no_auto_read = \
+        supertool._parse_grep_args(
+            ["grep", "needle", "src/", "5", "2", "count", "no-auto-read"])
+    assert pattern == "needle"
+    assert path == "src/"
+    assert limit == 5
+    assert context == 2
+    assert count_only is True
+    assert no_auto_read is True
+
+
 # ---------------------------------------------------------------------------
 # op_grep with context lines
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`grep` auto-reads the **entire** matched file on a single match under the size threshold, silently inflating the caller's context by 10-18KB when only the matching line was wanted — the opposite of the round-trip/context discipline supertool exists for.

## Fix (option 1 from #320)

Add a `:no-auto-read` flag, mirroring `glob`'s existing flag. Lowest-surprise — opt-out preserves current default.

```
grep:found_it:Agency.class.php:no-auto-read   # only the matching line(s)
```

- `op_grep` gains a `no_auto_read` param guarding the auto-read block
- `_parse_grep_args` peels the flag (order-independent with `:count` and any `LIMIT`/`CONTEXT`), returns a 6-tuple; dispatcher unpacks + passes through
- help text, `.supertool.json` / `.supertool.example.json`, `docs/operations/{search,index}.md`, `docs/configuration.md`, CHANGELOG

## Tests

TDD — written first, seen red, then green. 154 pass (`test_grep` + `test_dispatch` + `test_meta_ops`).

- op-level suppression, dispatch round-trip (`:no-auto-read` alone + with `LIMIT`), parse-level peel (incl. combined with `:count` + ints), default-still-auto-reads
- existing `_parse_grep_args` tests updated to 6-tuple unpack

## Not included

Option 2 (window-only auto-read as the *default*) — deliberately skipped; it changes behavior for every existing caller. Worth a follow-up if we want the smarter default.

Default behavior unchanged. Closes #320.