### PR TITLE
fix(git-commit): don't abort on already-staged deletions (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`grep` gained a `:no-auto-read` flag** — `grep:PATTERN:PATH:no-auto-read` suppresses the single-small-file auto-read so only the matching line(s) are emitted, mirroring `glob`'s existing flag. Default behavior (auto-read a concrete file < 20KB on a match) is unchanged. The flag is order-independent with `:count` and any `LIMIT`/`CONTEXT` args. Avoids silently dumping 10-18KB of unrequested file content when the caller only wants the hit. Closes [#320](https://github.com/Digital-Process-Tools/claude-supertool/issues/320).
 
+### Fixed
+
+- **`git-commit` no longer aborts on an already-staged deletion** — listing a `git rm`'d path (gone from disk) alongside present files made the op's `git add` step fail with `pathspec did not match any files`, killing the whole commit. The op now drops paths that are already staged as deletions from the `git add` step (their deletion is already staged and gets committed), so a mixed changeset of modifications + new files + deletions lands in one commit. Genuinely-unknown paths still error as before. Closes [#324](https://github.com/Digital-Process-Tools/claude-supertool/issues/324).
+
 ## [0.19.0] - 2026-06-24
 
 ### Added

--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -114,12 +114,20 @@ def main() -> int:
     print(f"# git-commit on {branch}")
     print(f"HEAD before: {head_before}")
 
-    # Stage PATHS if given
+    # Stage PATHS if given. A path that's already a staged deletion (gone from
+    # disk after `git rm`) would make `git add` abort with "pathspec did not
+    # match any files" — so drop those from the add list; their deletion is
+    # already staged and will be committed (issue #324). Genuinely-unknown
+    # paths stay in the list, so they still error as before.
     if paths:
-        add = _git(["add", "--"] + paths)
-        if add.returncode != 0:
-            print(f"ERROR: git add failed: {add.stderr.strip() or add.stdout.strip()}")
-            return 1
+        deleted = _git(["diff", "--cached", "--diff-filter=D", "--name-only"])
+        staged_deletions = {l for l in deleted.stdout.splitlines() if l.strip()}
+        to_add = [p for p in paths if p not in staged_deletions]
+        if to_add:
+            add = _git(["add", "--"] + to_add)
+            if add.returncode != 0:
+                print(f"ERROR: git add failed: {add.stderr.strip() or add.stdout.strip()}")
+                return 1
         print(f"Staged: {len(paths)} path(s)")
 
     # Pre-commit staged check

--- a/tests/test_edge_cases_git_commit.py
+++ b/tests/test_edge_cases_git_commit.py
@@ -194,6 +194,42 @@ def test_nonexistent_path_gives_clean_error(
 
 
 # ---------------------------------------------------------------------------
+# 5b. Staged deletion among the paths → commit must include it (issue #324)
+# ---------------------------------------------------------------------------
+
+def test_staged_deletion_path_committed(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """A `git rm`'d path (gone from disk, staged as deletion) listed alongside
+    present files must not abort the commit — the deletion lands in one commit.
+    """
+    _init_repo(tmp_path)
+    # Commit a file we will later delete
+    (tmp_path / "doomed.txt").write_text("delete me\n")
+    subprocess.run(["git", "add", "--", "doomed.txt"], check=True, cwd=tmp_path)
+    subprocess.run(["git", "commit", "-q", "-m", "add doomed"], check=True, cwd=tmp_path)
+
+    # Stage the deletion (file now absent from disk) + a new present file
+    subprocess.run(["git", "rm", "-q", "--", "doomed.txt"], check=True, cwd=tmp_path)
+    (tmp_path / "new.txt").write_text("new\n")
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(commit.sys, "argv",
+                        ["commit.py", "delete + add", "new.txt", "doomed.txt"])
+    rc = commit.main()
+    out = capsys.readouterr().out
+
+    assert rc == 0, f"commit with staged deletion failed:\n{out}"
+
+    files = subprocess.run(
+        ["git", "show", "--name-status", "--format=", "HEAD"],
+        capture_output=True, text=True, cwd=tmp_path, check=True,
+    ).stdout
+    assert "D\tdoomed.txt" in files, f"deletion not in commit:\n{files}"
+    assert "A\tnew.txt" in files, f"new file not in commit:\n{files}"
+
+
+# ---------------------------------------------------------------------------
 # 6. Path outside repo → should reject cleanly
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
`git-commit` ran `git add -- <paths>`; a listed path that was a `git rm`'d deletion (gone from disk) made `git add` fail with `pathspec did not match any files`, aborting the whole commit — even though the deletion was already staged.

## Fix
Before adding, query staged deletions (`git diff --cached --diff-filter=D --name-only`) and drop those paths from the `git add` list. Their deletion is already staged and gets committed. Genuinely-unknown paths stay in the list, so they still error as before.

Not `git add -A -- <file>` — that still errors on a named deleted file; `-A` only stages deletions for directory pathspecs.

## Tests
- New `test_staged_deletion_path_committed` (red→green): D + A both land in one commit.
- Existing `test_nonexistent_path_gives_clean_error` still green (unknown path still errors).
- Full commit suite: 63 passed.

Closes #324