### PR TITLE
DX: `:fail` suffix on gl-job/gh-job for the blocks-only failure view (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gl-job` / `gh-job` gained a `:fail` suffix** — `gl-job:ID:fail` (alias `:errors`) prints only the matched failure blocks with no tail, the tight triage view. It applies the same per-job pattern table as the default mode (rector → diff lines, phpstan → 🪪/type markers, unit → `FAILURES!`/`Failed asserting`), so a red job shows just its actionable failures instead of the default's blocks-plus-80-line-tail. This names the discoverable front door for a behavior that previously only existed as the undocumented `:errors` mode on `gl-job` (and was entirely absent on `gh-job`); `:errors` stays as a back-compat alias. The default (no suffix), `:grep:PATTERN`, and `:raw` are unchanged. Closes [#326](https://github.com/Digital-Process-Tools/claude-supertool/issues/326).
 - **`grep` gained a `:no-auto-read` flag** — `grep:PATTERN:PATH:no-auto-read` suppresses the single-small-file auto-read so only the matching line(s) are emitted, mirroring `glob`'s existing flag. Default behavior (auto-read a concrete file < 20KB on a match) is unchanged. The flag is order-independent with `:count` and any `LIMIT`/`CONTEXT` args. Avoids silently dumping 10-18KB of unrequested file content when the caller only wants the hit. Closes [#320](https://github.com/Digital-Process-Tools/claude-supertool/issues/320).
 
 ### Fixed

--- a/presets/github.json
+++ b/presets/github.json
@@ -39,8 +39,8 @@
     "gh-job": {
       "cmd": "{python} {path}github/job.py {args}",
       "timeout": 30,
-      "description": "Why did this job fail? PR context + error pattern search + log tail. :raw dumps full trace; :raw:START[:END] slices lines (1-indexed, inclusive); :grep:PATTERN ad-hoc regex over the log (literal fallback, context, tail on no-match)",
-      "syntax": "gh-job:NUMBER[:raw[:START[:END]]|:grep:PATTERN]",
+      "description": "Why did this job fail? PR context + error pattern search + log tail. :fail (alias :errors) = matched failure blocks only, no tail — the tight triage view, per-job patterns; :raw dumps full trace; :raw:START[:END] slices lines (1-indexed, inclusive); :grep:PATTERN ad-hoc regex over the log (literal fallback, context, tail on no-match)",
+      "syntax": "gh-job:NUMBER[:fail|:raw[:START[:END]]|:grep:PATTERN]",
       "lines": 80,
       "error_patterns": "ERROR,FAILED,Error:,Failed,fatal:,##[error]",
       "error_context": 5

--- a/presets/github/job.py
+++ b/presets/github/job.py
@@ -144,6 +144,7 @@ def main() -> int:
     job_id = sys.argv[1]
     raw_mode = len(sys.argv) > 2 and sys.argv[2] == "raw"
     grep_mode = len(sys.argv) > 2 and sys.argv[2] == "grep"
+    errors_mode = len(sys.argv) > 2 and sys.argv[2] in ("errors", "fail")
     grep_pattern = sys.argv[3] if grep_mode and len(sys.argv) > 3 else None
     if grep_mode and not grep_pattern:
         print("ERROR: usage: gh-job:JOB_ID:grep:PATTERN")
@@ -321,6 +322,22 @@ def main() -> int:
         if resolution else ""
     )
     error_sections = _find_error_sections(lines, patterns, config["error_context"])
+
+    # fail/errors mode — dump ALL matched blocks, no tail cap
+    if errors_mode:
+        if not error_sections:
+            print("\n## No error patterns matched")
+            return 0
+        matched_count = len([e for e in error_sections if e[0] > 0])
+        print(f"\n## All error blocks ({matched_count} lines matched, no tail truncation)")
+        for line_num, text in error_sections:
+            if line_num == -1:
+                print(text)
+            else:
+                print(f"  {line_num:>5} | {text}")
+        if resolution_line:
+            print(f"\n{resolution_line}")
+        return 0
 
     if error_sections and display_status == "failure":
         print(f"\n## Error context ({len([e for e in error_sections if e[0] > 0])} lines matched)")

--- a/presets/gitlab.json
+++ b/presets/gitlab.json
@@ -39,8 +39,8 @@
     "gl-job": {
       "cmd": "{python} {path}gitlab/job.py {args}",
       "timeout": 30,
-      "description": "Why job failed: MR ctx + error patterns + log tail. :raw dumps full trace; :raw:START[:END] slices lines (1-indexed, inclusive); :grep:PATTERN ad-hoc regex over the trace (literal fallback, context, tail on no-match)",
-      "syntax": "gl-job:NUMBER[:raw[:START[:END]]|:grep:PATTERN]",
+      "description": "Why job failed: MR ctx + error patterns + log tail. :fail (alias :errors) = matched failure blocks only, no tail — the tight triage view, per-job patterns; :raw dumps full trace; :raw:START[:END] slices lines (1-indexed, inclusive); :grep:PATTERN ad-hoc regex over the trace (literal fallback, context, tail on no-match)",
+      "syntax": "gl-job:NUMBER[:fail|:raw[:START[:END]]|:grep:PATTERN]",
       "lines": 80,
       "error_patterns": "ERROR,FAILURES!,Fatal,Failed asserting,PHP Warning,PHP Notice,PHP Deprecated",
       "error_context": 5

--- a/presets/gitlab/job.py
+++ b/presets/gitlab/job.py
@@ -147,7 +147,7 @@ def main() -> int:
 
     job_id = sys.argv[1]
     raw_mode = len(sys.argv) > 2 and sys.argv[2] == "raw"
-    errors_mode = len(sys.argv) > 2 and sys.argv[2] == "errors"
+    errors_mode = len(sys.argv) > 2 and sys.argv[2] in ("errors", "fail")
     grep_mode = len(sys.argv) > 2 and sys.argv[2] == "grep"
     grep_pattern = sys.argv[3] if grep_mode and len(sys.argv) > 3 else None
     if grep_mode and not grep_pattern:

--- a/tests/test_github_job.py
+++ b/tests/test_github_job.py
@@ -125,6 +125,41 @@ def test_default_mode_runs_smart_filter(monkeypatch, capsys) -> None:
     assert "Log: 3 lines total" in out
 
 
+def test_fail_mode_shows_all_matched_blocks(monkeypatch, capsys) -> None:
+    """`:fail` shows every error block with no tail truncation."""
+    lines = ["build start"] + [f"line {i}" for i in range(150)] + [
+        "##[error]Process completed with exit code 1",
+    ] + [f"trail {i}" for i in range(40)]
+    rc = _run_main(monkeypatch, ["job.py", "123", "fail"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "All error blocks" in out
+    assert "exit code 1" in out
+    assert "Tail (last" not in out
+
+
+def test_fail_mode_no_matches(monkeypatch, capsys) -> None:
+    """`:fail` prints a clear message when nothing matched."""
+    lines = ["build started", "all good", "build done"]
+    rc = _run_main(monkeypatch, ["job.py", "123", "fail"], lines)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "No error patterns matched" in out
+
+
+def test_fail_is_alias_of_errors(monkeypatch, capsys) -> None:
+    """`:fail` produces byte-identical output to `:errors` — pure alias."""
+    lines = ["build start"] + [f"line {i}" for i in range(150)] + [
+        "##[error]Process completed with exit code 1",
+    ] + [f"trail {i}" for i in range(40)]
+    _run_main(monkeypatch, ["job.py", "123", "errors"], lines)
+    errors_out = capsys.readouterr().out
+    _run_main(monkeypatch, ["job.py", "123", "fail"], lines)
+    fail_out = capsys.readouterr().out
+    assert fail_out == errors_out
+    assert "All error blocks" in fail_out
+
+
 def test_grep_matches_with_context(monkeypatch, capsys) -> None:
     """grep mode returns matching lines plus surrounding context."""
     lines = [f"line {i}" for i in range(20)] + [

--- a/tests/test_gitlab_job.py
+++ b/tests/test_gitlab_job.py
@@ -145,6 +145,22 @@ def test_errors_mode_no_matches(monkeypatch, capsys) -> None:
     assert "No error patterns matched" in out
 
 
+def test_fail_is_alias_of_errors(monkeypatch, capsys) -> None:
+    """`:fail` produces byte-identical output to `:errors` — pure alias."""
+    lines = ["build start"] + [f"line {i}" for i in range(150)] + [
+        " ------ ---- ",
+        "    🪪  generics.notSubtype ",
+        " ------ ---- ",
+    ] + [f"trail {i}" for i in range(40)]
+    _run_main(monkeypatch, ["job.py", "123", "errors"], lines)
+    errors_out = capsys.readouterr().out
+    _run_main(monkeypatch, ["job.py", "123", "fail"], lines)
+    fail_out = capsys.readouterr().out
+    assert fail_out == errors_out
+    assert "All error blocks" in fail_out
+    assert "generics.notSubtype" in fail_out
+
+
 def test_phpstan_identifier_marker_matches_default(monkeypatch, capsys) -> None:
     """🪪 marker (phpstan identifier) is in default patterns."""
     lines = [


### PR DESCRIPTION
## What

Adds `gl-job:ID:fail` / `gh-job:ID:fail` — prints **only the matched failure blocks, no tail**: the tight CI-triage view. `:fail` is a pure alias of the existing (but undocumented) `:errors` mode, and applies the same per-job pattern table as the default (rector → diff lines, phpstan → 🪪/type markers, unit → `FAILURES!`/`Failed asserting`).

## Why

Root cause from #326: triaging a red pipeline, we reached for `:grep:PATTERN` and got buried in ~30KB of header/env noise — when the default already filters per-job. The clean failure view *existed* (`:errors`) but was undocumented on gl-job and **entirely missing on gh-job**, so nobody reached for it. This names the front door and ports it to GitHub.

Mental model after this:

| op | output |
|----|--------|
| `gl-job:ID` | failure blocks + tail (full triage) |
| `gl-job:ID:fail` | failure blocks only, no tail (tight) |
| `:grep:PATTERN` | custom search (escape hatch) |
| `:raw` | full trace |

## Changes

- `presets/{gitlab,github}/job.py` — `:fail` parses as alias of `:errors`. gitlab: 1-line (mode existed); github: added the blocks-only early-return it never had.
- `presets/{gitlab,github}.json` — `:fail` in syntax + description (also documents `:errors`).
- tests — 4 new, incl. byte-identical `:fail`≡`:errors` alias proof. 58 passed (job + presets).
- CHANGELOG.

## Compat

`:errors` stays as a back-compat alias. Default / `:grep` / `:raw` unchanged.

Refs #326 (ships the `:fail` part — item 4; items 1/2/3/5 stay open)