### PR TITLE
chore: bump version to 0.20.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-10
+
 ### Added
 
 - **`phpmd` validator auto-detects the project's CI rulesets so local findings match CI** — the adapter ran phpmd with a fixed built-in ruleset list (`cleancode,codesize,…`), while DVSI's CI runs phpmd with the project's own `gitlab-ci/md/*.xml` rulesets — so an edit could pass the local validator and then fail the CI `phpmd` job on a rule the project tuned, or vice-versa. When `PHPMD_RULESETS` is unset, the adapter now walks up from the file being validated for a `gitlab-ci/md/*.xml` directory and, if found, runs phpmd with those project XMLs plus the built-in categories the project does not override (a project `design.xml` supersedes the built-in `design`), mirroring CI. A new `PHPMD_NO_AUTODETECT=1` env var opts out (back to the built-in default), and setting `PHPMD_RULESETS` explicitly still wins and disables detection. Every emitted result carries a `ruleset_source` field — `"project"`, `"env"`, or `"default"` — so which ruleset ran is visible in the output. Closes [#356](https://github.com/Digital-Process-Tools/claude-supertool/issues/356).
@@ -160,6 +162,7 @@ All three adapters share the same shape: auto-spawn UDS daemon via `presets/mcp/
 
 Initial public changelog. See git history for prior versions.
 
-[Unreleased]: https://github.com/Digital-Process-Tools/claude-supertool/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/Digital-Process-Tools/claude-supertool/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/Digital-Process-Tools/claude-supertool/releases/tag/v0.20.0
 [0.13.0]: https://github.com/Digital-Process-Tools/claude-supertool/releases/tag/v0.13.0
 [0.11.0]: https://github.com/Digital-Process-Tools/claude-supertool/releases/tag/v0.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-supertool"
-version = "0.19.0"
+version = "0.20.0"
 description = "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/supertool.py
+++ b/supertool.py
@@ -109,7 +109,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-VERSION = "0.19.0"
+VERSION = "0.20.0"
 
 
 def _fwd(p: str) -> str:


### PR DESCRIPTION
Bumps version 0.19.0 → 0.20.0 (SemVer minor — new features shipped since 0.19.0).

Bundles this release's merged work under CHANGELOG `[0.20.0]`:
- #365 git-diff `:full` mode
- #366 auto-read line cap
- #367 `watch:gl-pipeline` source
- #368 glab paginated JSON (+ review fix: keep unexpected-format guard)
- #369 batch `:::` structured routing
- #371 phpmd CI ruleset auto-detect

Bumps all three version constants (pyproject.toml, supertool.py, plugin.json) and stamps the CHANGELOG.