### PR TITLE
fix(grep): report scanned file count on every result, zero or not

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -1420,27 +1420,35 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
             # Empty RTK result + regexy pattern: fall through to the native
             # walker so the zero-hit literal fallback below can run.
 
+    # Resolved once and threaded through so a zero-result report can state how
+    # many files were actually scanned (#407) — without it, "0 results" is
+    # ambiguous between "searched everything, found nothing" and "path/glob
+    # resolved to nothing, so nothing was searched".
+    candidates = _grep_candidates(path, excl)
+    scanned = len(candidates)
+
     if count_only:
-        counts = _grep_count(pattern, path, limit, excl)
+        counts = _grep_count(pattern, path, limit, excl, candidates=candidates)
         literal_note = ""
         if not counts and _is_regexy(pattern):
-            counts = _grep_count(re.escape(pattern), path, limit, excl)
+            counts = _grep_count(re.escape(pattern), path, limit, excl, candidates=candidates)
             if counts:
                 literal_note = _literal_note(pattern, sum(counts.values()))
         total = sum(counts.values())
         file_count = len(counts)
-        out = [literal_note, f"({total} total matches across {file_count} files)\n"]
+        out = [literal_note,
+               f"({total} total matches across {file_count} files{_scanned_suffix(scanned)})\n"]
         for fp, cnt in sorted(counts.items()):
             out.append(f"{_fwd(fp)}:{cnt}\n")
         out.append("\n")
         return "".join(out)
 
     if context > 0:
-        groups = _grep_recursive_context(pattern, path, limit, context, excl)
+        groups = _grep_recursive_context(pattern, path, limit, context, excl, candidates=candidates)
         literal_note = ""
         if not groups and _is_regexy(pattern):
             groups = _grep_recursive_context(
-                re.escape(pattern), path, limit, context, excl)
+                re.escape(pattern), path, limit, context, excl, candidates=candidates)
             if groups:
                 hit_count = sum(
                     1 for g in groups for line in g if line[2] == "match")
@@ -1449,7 +1457,7 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
             1 for g in groups for line in g if line[2] == "match"
         )
         file_count = len({g[0][0] for g in groups if g})
-        out = [literal_note, f"({count} results in {file_count} files, "
+        out = [literal_note, f"({count} results in {file_count} files{_scanned_suffix(scanned)}, "
                f"limit {limit}, context {context})\n"]
         current_file: str = ""
         first_group = True
@@ -1471,16 +1479,17 @@ def op_grep(pattern: str, path: str = ".", limit: int = 0,
         out.append("\n")
         return _cap_context_window("".join(out), "grep_around")
 
-    hits = _grep_recursive(pattern, path, limit, excl)
+    hits = _grep_recursive(pattern, path, limit, excl, candidates=candidates)
     literal_note = ""
     if not hits and _is_regexy(pattern):
-        hits = _grep_recursive(re.escape(pattern), path, limit, excl)
+        hits = _grep_recursive(re.escape(pattern), path, limit, excl, candidates=candidates)
         if hits:
             literal_note = _literal_note(pattern, len(hits))
     count = len(hits)
     file_count = len({fp for fp, _, _ in hits})
 
-    out = [literal_note, f"({count} results in {file_count} files, limit {limit})\n"]
+    out = [literal_note,
+           f"({count} results in {file_count} files{_scanned_suffix(scanned)}, limit {limit})\n"]
     current_file = ""
     for fp, lineno, content in hits:
         if fp != current_file:
@@ -2746,9 +2755,21 @@ def op_map(path: str, no_exclude: bool = False) -> str:
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _scanned_suffix(scanned: int) -> str:
+    """Report format's ", scanned N files" clause (#407).
+
+    A zero scanned count means the path/glob resolved to nothing, so the
+    zero-result report above it must not read like a completed search.
+    """
+    if scanned == 0:
+        return ", scanned 0 files — nothing matched the path/glob"
+    return f", scanned {scanned} files"
+
+
 def _grep_count(
     pattern: str, path: str, limit: int,
-    exclude_paths: Tuple[str, ...] = ()
+    exclude_paths: Tuple[str, ...] = (),
+    candidates: Optional[List[str]] = None,
 ) -> Dict[str, int]:
     """Return match counts per file as {filepath: count}."""
     try:
@@ -2757,7 +2778,8 @@ def _grep_count(
         regex = re.compile(re.escape(pattern))
 
     counts: Dict[str, int] = {}
-    candidates = _grep_candidates(path, exclude_paths)
+    if candidates is None:
+        candidates = _grep_candidates(path, exclude_paths)
 
     for file_path in candidates:
         cnt = 0
@@ -2807,7 +2829,8 @@ def _grep_candidates(
 
 def _grep_recursive(
     pattern: str, path: str, limit: int,
-    exclude_paths: Tuple[str, ...] = ()
+    exclude_paths: Tuple[str, ...] = (),
+    candidates: Optional[List[str]] = None,
 ) -> List[Tuple[str, int, str]]:
     """Return up to `limit` matches as (file_path, lineno, content) tuples.
 
@@ -2823,7 +2846,8 @@ def _grep_recursive(
         regex = re.compile(re.escape(pattern))
 
     results: List[Tuple[str, int, str]] = []
-    candidates = _grep_candidates(path, exclude_paths)
+    if candidates is None:
+        candidates = _grep_candidates(path, exclude_paths)
 
     for file_path in candidates:
         if len(results) >= limit:
@@ -2846,7 +2870,8 @@ def _grep_recursive(
 
 def _grep_recursive_context(
     pattern: str, path: str, limit: int, context: int,
-    exclude_paths: Tuple[str, ...] = ()
+    exclude_paths: Tuple[str, ...] = (),
+    candidates: Optional[List[str]] = None,
 ) -> List[List[Tuple[str, int, str, str]]]:
     """Return match groups with surrounding context lines.
 
@@ -2861,7 +2886,8 @@ def _grep_recursive_context(
     except re.error:
         regex = re.compile(re.escape(pattern))
 
-    candidates = _grep_candidates(path, exclude_paths)
+    if candidates is None:
+        candidates = _grep_candidates(path, exclude_paths)
     groups: List[List[Tuple[str, int, str, str]]] = []
     match_count = 0
 

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -460,3 +460,69 @@ def test_dispatch_grep_around_custom_n(tmp_path: Path) -> None:
     # Beyond context not shown
     assert "  1-a" not in out
     assert "  5-e" not in out
+
+
+# ---------------------------------------------------------------------------
+# Scanned-file count on zero results (#407)
+# ---------------------------------------------------------------------------
+
+def test_grep_zero_results_reports_scanned_count(tmp_path: Path) -> None:
+    """0 results over 3 real files must say 3 were scanned, not read like an
+    empty/wrong-path search."""
+    (tmp_path / "a.py").write_text("nothing here\n")
+    (tmp_path / "b.py").write_text("still nothing\n")
+    (tmp_path / "c.py").write_text("more nothing\n")
+    out = supertool.op_grep("NOTHINGMATCHES_XYZZY", str(tmp_path))
+    assert "(0 results in 0 files, scanned 3 files, limit 10)\n" in out
+    assert "nothing matched the path/glob" not in out
+
+
+def test_grep_zero_results_on_empty_dir_flags_nothing_scanned(tmp_path: Path) -> None:
+    """0 results over an empty directory must be distinguishable from 0
+    results over a directory that was actually searched."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    out = supertool.op_grep("anything", str(empty_dir))
+    assert ("(0 results in 0 files, scanned 0 files "
+            "— nothing matched the path/glob, limit 10)\n") in out
+
+
+def test_grep_nonzero_results_still_reports_scanned_count(tmp_path: Path) -> None:
+    """Existing output format for real matches is not disturbed — the scanned
+    count is appended, not swapped in."""
+    (tmp_path / "a.txt").write_text("MATCH\n")
+    (tmp_path / "b.txt").write_text("no match here\n")
+    out = supertool.op_grep("MATCH", str(tmp_path))
+    assert "(1 results in 1 files, scanned 2 files, limit 10)\n" in out
+    assert "a.txt\n  1:MATCH\n" in out
+
+
+def test_grep_count_only_zero_results_reports_scanned_count(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("nothing here\n")
+    (tmp_path / "b.py").write_text("still nothing\n")
+    out = supertool.op_grep("NOTHINGMATCHES_XYZZY", str(tmp_path), count_only=True)
+    assert "(0 total matches across 0 files, scanned 2 files)\n" in out
+
+
+def test_grep_count_only_empty_dir_flags_nothing_scanned(tmp_path: Path) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    out = supertool.op_grep("anything", str(empty_dir), count_only=True)
+    assert ("(0 total matches across 0 files, scanned 0 files "
+            "— nothing matched the path/glob)\n") in out
+
+
+def test_grep_context_zero_results_reports_scanned_count(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("nothing here\n")
+    (tmp_path / "b.py").write_text("still nothing\n")
+    (tmp_path / "c.py").write_text("more nothing\n")
+    out = supertool.op_grep("NOTHINGMATCHES_XYZZY", str(tmp_path), context=1)
+    assert "(0 results in 0 files, scanned 3 files, limit 10, context 1)\n" in out
+
+
+def test_grep_context_empty_dir_flags_nothing_scanned(tmp_path: Path) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    out = supertool.op_grep("anything", str(empty_dir), context=1)
+    assert ("(0 results in 0 files, scanned 0 files "
+            "— nothing matched the path/glob, limit 10, context 1)\n") in out


### PR DESCRIPTION
## Before / after

Before, a zero-result grep header was identical regardless of what was actually searched:

```
(0 results in 0 files, limit 5)
```

whether the path resolved to 400 real files that genuinely didn't contain the pattern, or to nothing at all (stale cwd, typo'd path, empty glob, `cd` earlier in a compound command shifting the search root).

After:

```
(0 results in 0 files, scanned 47 files, limit 5)
(0 results in 0 files, scanned 0 files — nothing matched the path/glob, limit 5)
```

The scanned count is now reported on **every** grep call — matches or not — so the existing non-zero format also gains the suffix:

```
(3 results in 2 files, scanned 47 files, limit 5)
```

`count_only` and `context` (grep_around) modes get the same treatment:

```
(3 total matches across 2 files, scanned 47 files)
(0 results in 0 files, scanned 47 files, limit 5, context 3)
```

## Scanned-vs-resolved judgment call

"Scanned" = the file list `_grep_candidates()` resolves from the path/glob (post exclude-dir pruning, pre per-file open). I did **not** additionally distinguish files that were resolved but then skipped for an OSError (permission denied, broken symlink) — those still count as "scanned" here.

Reasoning: the ambiguity this issue is about is binary — did the path/glob resolve to a real search surface or not. `_grep_candidates` walks the filesystem and is exactly the boundary where "wrong cwd / typo'd path / empty glob" collapses to zero. Per-file open failures are a separate, much rarer failure mode (a handful of unreadable files inside an otherwise-real result set) that doesn't change the caller's next action — they'd still trust "0 results, scanned 400 files" the same way whether 2 of those 400 failed to open. Adding a third number for that would be reporting-subsystem territory for a case that doesn't change what the caller does next, so I left it alone.

## Known gap — RTK fast-path untouched

`op_grep` has an RTK delegation branch (`_rtk_enabled() and _has_rtk()`, used for plain literal/regex searches without `context`/`count_only`) that shells out to the `rtk` binary and returns its output directly. That path is unaffected by this fix — supertool doesn't have a scan count for output it doesn't produce, and re-walking the directory ourselves just to get a scanned count would double the filesystem walk for every RTK-delegated call, defeating the point of delegating. Tests disable RTK (`SUPERTOOL_NO_RTK=1`, set in `conftest.py`) so this branch isn't exercised by the suite either.

In practice this means: users without `rtk` on PATH, or hitting `context`/`count_only`, or whose exclude prefixes are multi-segment (falls through to the native walker), get the fix immediately. Users with `rtk` installed doing a plain literal grep will still see the old ambiguous zero on that fast path. Flagging this for a follow-up issue if it's worth closing — happy to open one.

## Testing

Added 7 tests to `tests/test_grep.py`, pinned to fixture file counts (not "contains a digit" — the exact string `"(0 results in 0 files, scanned 3 files, limit 10)\n"` etc.):

- zero results over 3 real files → states `scanned 3 files`, and asserts the "nothing matched" phrase is *absent*
- zero results over an empty directory → states `scanned 0 files — nothing matched the path/glob`
- non-zero results → existing format preserved, scanned count appended
- same three shapes repeated for `count_only=True` and `context=1`

Ran the full suite: `3779 passed, 34 skipped`, coverage 88.37% (gate 86%).

Closes #407
