### PR TITLE
feat(gh-prs): give each PR row its branch and its full title

### DIFF
--- a/presets/_board.py
+++ b/presets/_board.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Triage-board row layout, shared by every board a human reads.
+
+`gl-mrs`, `radar` and `gh-prs` render different objects with different
+vocabularies (iid vs number, pipeline vs checks, source_branch vs
+headRefName), but they are one board to the reader: same columns, same
+widths, same two-line shape. That layout is the only thing they share, and
+it is exactly what this module owns.
+
+The contract is deliberately stringly-typed: callers compute their own cells
+in their own vocabulary and hand over finished strings. No provider field
+name reaches this file, so unifying the layout costs no shared field model.
+
+Line 1 is the status line and ends with the branch pair; line 2 carries the
+full title. One line cannot hold both, and the old single line resolved that
+by truncating the title — which cut rows mid-word, exactly where the
+disambiguating detail lives (#421, #424). Branch wins the status line
+because branch is actionable and title is context.
+"""
+from __future__ import annotations
+
+EYE = "👁"
+TITLE_INDENT = " " * 8
+STATUS_WIDTH = 16
+IDENT_WIDTH = 6
+
+
+def branch_pair(source: object, target: object) -> str:
+    """`source -> target`, the field a human acts on (checkout, worktree add).
+
+    Empty when neither side is known — a bare '? -> ?' would be noise, not
+    information.
+    """
+    src = str(source or "")
+    tgt = str(target or "")
+    if not src and not tgt:
+        return ""
+    return f"{src or '?'} -> {tgt or '?'}"
+
+
+def render_row(
+    *,
+    sigil: str,
+    ident: str,
+    watched: bool,
+    status: str,
+    appr: str,
+    age: str,
+    changes: str,
+    branches: str,
+    flags: str = "",
+    title: str = "",
+    suffix: str = "",
+) -> str:
+    """One triage row, two lines — the single definition of the board format.
+
+    `suffix` is appended to the status line so callers that annotate rows
+    (radar's drift/healed marks) land their marks there rather than on the
+    title line.
+    """
+    eye = EYE if watched else " "
+    head = (
+        f"{eye} {status:<{STATUS_WIDTH}} {appr} {age:>3} {changes:>5}  "
+        f"{sigil}{ident:<{IDENT_WIDTH}} {branches}{flags}{suffix}"
+    ).rstrip()
+    title = title.strip()
+    return f"{head}\n{TITLE_INDENT}{title}" if title else head

--- a/presets/github/prs.py
+++ b/presets/github/prs.py
@@ -33,7 +33,9 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from pr import _gh, _fetch_review_threads  # noqa: E402  (reuse the gh-pr helpers)
+import _board  # noqa: E402  (the board layout shared with gl-mrs / radar)
 
 WATCH_SOURCE = "github-pr"
 STATE_DIR = "/tmp"
@@ -315,6 +317,42 @@ def _flags(p: dict) -> str:
     return f" [{','.join(flags)}]" if flags else ""
 
 
+TITLE_INDENT = _board.TITLE_INDENT
+
+
+def _branches(p: dict) -> str:
+    """`head -> base`, the field a human acts on (checkout, worktree add).
+
+    Both keys already ship in the single `gh pr list --json` response this op
+    parses (`headRefName`/`baseRefName` are in _LIST_FIELDS), so the branch
+    pair costs no extra API call.
+    """
+    return _board.branch_pair(p.get("headRefName"), p.get("baseRefName"))
+
+
+def _row(p: dict, watched: set[str], suffix: str = "") -> str:
+    """One triage row, rendered through the shared board layout so `gh-prs`,
+    `gl-mrs` and `radar` cannot drift apart.
+
+    Everything GitHub-specific — the number, the check-rollup cell, the ref
+    names — is resolved here; `_board.render_row` only decides the shape.
+    """
+    chg = p.get("_changes")
+    return _board.render_row(
+        sigil="#",
+        ident=str(p.get("number", "?")),
+        watched=str(p.get("number", "?")) in watched,
+        status=_check_cell(p),
+        appr=_appr_cell(p),
+        age=_age(str(p.get("updatedAt", ""))),
+        changes=f"{chg}Δ" if isinstance(chg, int) else "",
+        branches=_branches(p),
+        flags=_flags(p),
+        title=str(p.get("title", "")),
+        suffix=suffix,
+    )
+
+
 def _render_table(prs: list[dict], watched: set[str]) -> str:
     """Triage table: checks (+ failed check), approval, age, diff size, flags.
 
@@ -322,20 +360,7 @@ def _render_table(prs: list[dict], watched: set[str]) -> str:
     """
     if not prs:
         return "No PRs match."
-    lines = []
-    for p in sorted(prs, key=_sort_key):
-        number = str(p.get("number", "?"))
-        eye = "👁" if number in watched else " "
-        check = _check_cell(p)
-        appr = _appr_cell(p)
-        age = _age(str(p.get("updatedAt", "")))
-        chg = p.get("_changes")
-        chg_s = f"{chg}Δ" if isinstance(chg, int) else ""
-        title = str(p.get("title", ""))[:42]
-        lines.append(
-            f"{eye} {check:<16} {appr} {age:>3} {chg_s:>5}  #{number:<6} {title}{_flags(p)}"
-        )
-    return "\n".join(lines)
+    return "\n".join(_row(p, watched) for p in sorted(prs, key=_sort_key))
 
 
 def _footer(prs: list[dict], watched: set[str]) -> str:

--- a/presets/gitlab/mrs.py
+++ b/presets/gitlab/mrs.py
@@ -24,6 +24,11 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))  # for _board
+
+import _board  # noqa: E402
 
 WATCH_SOURCE = "gitlab-mr"
 STATE_DIR = "/tmp"
@@ -324,51 +329,39 @@ def _flags(m: dict) -> str:
     return f" [{','.join(flags)}]" if flags else ""
 
 
-TITLE_INDENT = " " * 8
+TITLE_INDENT = _board.TITLE_INDENT
 
 
 def _branches(m: dict) -> str:
     """`source -> target`, the field a human acts on (checkout, worktree add).
 
     Both keys ship in the `glab mr list` response this op already parses, so
-    the branch pair costs no extra API call. Empty when neither is present —
-    a bare '? -> ?' would be noise, not information.
+    the branch pair costs no extra API call.
     """
-    src = str(m.get("source_branch") or "")
-    tgt = str(m.get("target_branch") or "")
-    if not src and not tgt:
-        return ""
-    return f"{src or '?'} -> {tgt or '?'}"
+    return _board.branch_pair(m.get("source_branch"), m.get("target_branch"))
 
 
 def _row(m: dict, watched: set[str], show_pipe: bool, suffix: str = "") -> str:
-    """One triage row, two lines. The single definition of the board's line
-    format — the `radar` op renders through here so the two boards stay
-    identical.
+    """One triage row, rendered through the shared board layout so `gl-mrs`,
+    `radar` and `gh-prs` cannot drift apart.
 
-    Line 1 is the status line and ends with the branch pair; line 2 carries the
-    full title. One line cannot hold both, and the old single line resolved
-    that by truncating the title at 42 chars — which cut rows mid-word, exactly
-    where the disambiguating detail lives. Branch wins the status line because
-    branch is actionable and title is context.
-
-    `suffix` is appended to the status line so callers that annotate rows
-    (radar's drift/healed marks) land their marks there rather than on the
-    title line.
+    Everything GitLab-specific — iid, pipeline cell, branch keys — is resolved
+    here; `_board.render_row` only decides the shape.
     """
-    iid = str(m.get("iid", "?"))
-    eye = "👁" if iid in watched else " "
-    pipe = _pipe_cell(m, show_pipe)
-    appr = _appr_cell(m)
-    age = _age(str(m.get("updated_at", "")))
     chg = m.get("_changes")
-    chg_s = f"{chg}Δ" if isinstance(chg, int) else ""
-    head = (
-        f"{eye} {pipe:<16} {appr} {age:>3} {chg_s:>5}  "
-        f"!{iid:<6} {_branches(m)}{_flags(m)}{suffix}"
-    ).rstrip()
-    title = str(m.get("title", "")).strip()
-    return f"{head}\n{TITLE_INDENT}{title}" if title else head
+    return _board.render_row(
+        sigil="!",
+        ident=str(m.get("iid", "?")),
+        watched=str(m.get("iid", "?")) in watched,
+        status=_pipe_cell(m, show_pipe),
+        appr=_appr_cell(m),
+        age=_age(str(m.get("updated_at", ""))),
+        changes=f"{chg}Δ" if isinstance(chg, int) else "",
+        branches=_branches(m),
+        flags=_flags(m),
+        title=str(m.get("title", "")),
+        suffix=suffix,
+    )
 
 
 def _render_table(mrs: list[dict], watched: set[str], show_pipe: bool) -> str:

--- a/tests/test_board_row.py
+++ b/tests/test_board_row.py
@@ -1,0 +1,113 @@
+"""Tests for the shared triage-board row layout (presets/_board.py).
+
+The layout is shared on purpose: `gl-mrs`, `radar` and `gh-prs` are one board
+to the reader. #421 fixed the truncated-title / missing-branch defect on the
+GitLab side; #424 existed only because the same layout had been copied into
+`gh-prs`. These tests pin the layout itself, and pin that both boards render
+through it — so the defect cannot be reintroduced in one board alone.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+PRESETS = Path(__file__).parent.parent / "presets"
+
+
+def _load(name: str, relpath: str):
+    spec = importlib.util.spec_from_file_location(name, PRESETS / relpath)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+board = _load("board", "_board.py")
+mrs = _load("gitlab_mrs", "gitlab/mrs.py")
+prs = _load("github_prs", "github/prs.py")
+
+
+# ---------------------------------------------------------------------------
+# branch_pair
+# ---------------------------------------------------------------------------
+
+def test_branch_pair_renders_source_arrow_target() -> None:
+    assert board.branch_pair("max/foo", "master") == "max/foo -> master"
+
+
+def test_branch_pair_marks_a_missing_side() -> None:
+    assert board.branch_pair("max/foo", None) == "max/foo -> ?"
+    assert board.branch_pair("", "master") == "? -> master"
+
+
+def test_branch_pair_is_empty_when_neither_side_is_known() -> None:
+    assert board.branch_pair(None, "") == ""
+
+
+# ---------------------------------------------------------------------------
+# render_row
+# ---------------------------------------------------------------------------
+
+def _row(**over) -> str:
+    args = dict(
+        sigil="!", ident="33173", watched=False, status="✗ phpstan2",
+        appr="✓", age="1h", changes="4Δ", branches="max/gen -> master",
+        flags="", title="Make the Generator module loadable and coverable",
+    )
+    args.update(over)
+    return board.render_row(**args)
+
+
+def test_row_is_two_lines_status_then_the_full_title() -> None:
+    title = "Make the Generator module loadable and coverable"
+    assert len(title) > 42, "fixture must exceed the old truncation budget"
+    head, title_line = _row().split("\n")
+    assert head == "  ✗ phpstan2       ✓  1h    4Δ  !33173  max/gen -> master"
+    assert title_line == "        " + title
+
+
+def test_row_without_a_title_stays_on_one_line() -> None:
+    row = _row(title="")
+    assert "\n" not in row
+    assert row.endswith("max/gen -> master")
+
+
+def test_row_marks_a_watched_row_with_the_eye() -> None:
+    assert _row(watched=True).startswith("👁 ")
+    assert _row(watched=False).startswith("  ")
+
+
+def test_row_suffix_lands_on_the_status_line_not_the_title() -> None:
+    head, title_line = _row(suffix="  [healed]").split("\n")
+    assert head.endswith("[healed]")
+    assert "healed" not in title_line
+
+
+def test_row_trailing_whitespace_is_stripped_from_the_status_line() -> None:
+    head = _row(branches="", flags="", title="").rstrip("\n")
+    assert head == head.rstrip()
+    assert head.endswith("!33173")
+
+
+# ---------------------------------------------------------------------------
+# both boards render through the shared layout — they may not drift apart
+# ---------------------------------------------------------------------------
+
+def test_gl_and_gh_rows_are_byte_identical_apart_from_the_sigil() -> None:
+    """One reader, one board shape. The only difference a GitHub row is
+    allowed is '#' where GitLab writes '!'."""
+    title = "give each board row its branch and its full title"
+    mr = {"iid": 423, "title": title, "source_branch": "feat/421", "target_branch": "master",
+          "updated_at": "", "_pipeline": "", "_changes": 12}
+    pr = {"number": 423, "title": title, "headRefName": "feat/421", "baseRefName": "master",
+          "updatedAt": "", "_checks": "", "_changes": 12}
+    gl = mrs._row(mr, {"423"}, True)
+    gh = prs._row(pr, {"423"})
+    assert "\n" in gl, "a row is two lines: status, then the full title"
+    assert title in gl and title in gh
+    assert gh == gl.replace("!423", "#423")
+
+
+def test_both_boards_reuse_the_shared_title_indent() -> None:
+    assert mrs.TITLE_INDENT == board.TITLE_INDENT
+    assert prs.TITLE_INDENT == board.TITLE_INDENT

--- a/tests/test_github_prs.py
+++ b/tests/test_github_prs.py
@@ -325,6 +325,70 @@ def test_render_table_empty() -> None:
     assert prs._render_table([], set()) == "No PRs match."
 
 
+# ---------------------------------------------------------------------------
+# _branches / two-line rows — a human reads this board (#424)
+# ---------------------------------------------------------------------------
+
+def test_branches_renders_head_arrow_base() -> None:
+    p = {"headRefName": "feat/421-radar-legible-board", "baseRefName": "master"}
+    assert prs._branches(p) == "feat/421-radar-legible-board -> master"
+
+
+def test_branches_marks_a_missing_side_rather_than_dropping_the_pair() -> None:
+    assert prs._branches({"headRefName": "max/foo"}) == "max/foo -> ?"
+    assert prs._branches({"baseRefName": "master"}) == "? -> master"
+
+
+def test_branches_is_empty_when_neither_side_is_known() -> None:
+    assert prs._branches({}) == ""
+    assert prs._branches({"headRefName": "", "baseRefName": None}) == ""
+
+
+def test_row_renders_a_long_title_in_full_on_its_own_line() -> None:
+    """The reported bug: titles were cut at 42 chars, mid-word, exactly where
+    the disambiguating detail lives."""
+    title = "give each board row its branch and its full title"
+    assert len(title) > 42, "fixture must exceed the old truncation budget"
+    row = prs._row(
+        {"number": 423, "title": title,
+         "headRefName": "feat/421-radar-legible-board", "baseRefName": "master"},
+        set(),
+    )
+    head, title_line = row.split("\n")
+    assert head.endswith("#423    feat/421-radar-legible-board -> master")
+    assert title_line == f"{prs.TITLE_INDENT}{title}"
+
+
+def test_row_keeps_flags_on_the_status_line() -> None:
+    row = prs._row({"number": 1, "title": "t", "headRefName": "b",
+                    "baseRefName": "master", "isDraft": True}, set())
+    head, title_line = row.split("\n")
+    assert head.endswith("[draft]")
+    assert title_line == f"{prs.TITLE_INDENT}t"
+
+
+def test_row_without_a_title_is_a_single_line() -> None:
+    row = prs._row({"number": 1, "headRefName": "b", "baseRefName": "master"}, set())
+    assert "\n" not in row
+    assert row.endswith("b -> master")
+
+
+def test_row_suffix_is_appended_to_the_status_line_not_the_title() -> None:
+    row = prs._row({"number": 1, "title": "prose", "headRefName": "b",
+                    "baseRefName": "master"}, set(), "  [mark]")
+    head, title_line = row.split("\n")
+    assert head.endswith("[mark]")
+    assert title_line == f"{prs.TITLE_INDENT}prose"
+
+
+def test_render_table_emits_two_lines_per_pr() -> None:
+    pr_list = [
+        {"number": 1, "title": "a", "headRefName": "x", "baseRefName": "master"},
+        {"number": 2, "title": "b", "headRefName": "y", "baseRefName": "master"},
+    ]
+    assert len(prs._render_table(pr_list, set()).splitlines()) == 4
+
+
 def test_footer_points_at_first_unwatched_failure() -> None:
     pr_list = [
         {"number": 10, "_checks": "failed"},
@@ -386,6 +450,30 @@ def test_main_failed_filters_to_failing(monkeypatch, capsys) -> None:
     out = capsys.readouterr().out
     assert rc == 0
     assert out.split() == ["10"]
+
+
+def test_board_costs_no_extra_api_call_for_the_branch(monkeypatch, capsys) -> None:
+    """headRefName/baseRefName ride along in the single `gh pr list` response,
+    so the branch column adds no request."""
+    calls = []
+
+    def _run(cmd, capture_output=True, text=True, timeout=30):
+        calls.append(cmd)
+        payload = (
+            '[{"number": 423, "title": "give each board row its branch",'
+            ' "headRefName": "feat/421-radar-legible-board",'
+            ' "baseRefName": "master", "updatedAt": ""}]'
+        )
+        return subprocess.CompletedProcess(cmd, 0, payload, "")
+
+    monkeypatch.setattr(sys, "argv", ["prs.py", "nopipe"])
+    monkeypatch.setattr(prs.subprocess, "run", _run)
+    monkeypatch.setattr(prs, "_watched_numbers", lambda *a, **k: set())
+    assert prs.main() == 0
+    out = capsys.readouterr().out
+    assert len(calls) == 1
+    assert "feat/421-radar-legible-board -> master" in out
+    assert "give each board row its branch" in out
 
 
 def test_main_gh_error_returns_1(monkeypatch) -> None:


### PR DESCRIPTION
## The report

`presets/github/prs.py` carried the defect [#421](https://github.com/Digital-Process-Tools/claude-supertool/issues/421) fixed on the GitLab side: the title cut at 42 chars, and no branch. #421's summary was a human reading a board cold — *"what is 33173. I am not a robot"* — and the GitHub board answered the same question with `#415` and half a title.

## Before / after

Same four PRs from this repo, same moment, rendered by the old and new code:

```
===== BEFORE =====
  ✓ ok                2h  624Δ  #415    fix(payload,git-commit): inline arrays on
  ✓ ok                1h 1249Δ  #419    feat(watch): radar reconcile op + watch ev
  ✓ ok               46m  352Δ  #420    fix(githooks,tests): stop git's hook env f
  ✓ ok               36m  189Δ  #423    feat(gl-mrs,radar): give each board row it

===== AFTER =====
  ✓ ok                2h  624Δ  #415    feat/400-git-commit-payload-route -> master
        fix(payload,git-commit): inline arrays on py<3.11, UTF-8 preset stdout, and end-to-end message pins
  ✓ ok                1h 1249Δ  #419    feat/417-radar -> master
        feat(watch): radar reconcile op + watch every open MR (#417 items 1/2/4/5)
  ✓ ok               46m  352Δ  #420    fix/416-prepush-gitdir-leak -> master
        fix(githooks,tests): stop git's hook env from redirecting tests at the real repo
  ✓ ok               36m  189Δ  #423    feat/421-radar-legible-board -> master
        feat(gl-mrs,radar): give each board row its branch and its full title
```

`#415` is the case that makes it: `inline arrays on` truncates one word before `py<3.11`, which is the whole subject of the PR.

## The design call — unify, and here is why

**Unified.** The layout now lives in `presets/_board.py`, and `gl-mrs`, `radar` and `gh-prs` all render through `render_row`.

The decisive evidence is this issue's own existence. #423 fixed truncation once; #424 was opened within hours because the identical eight lines had been copied into a second file. Duplication has already cost us one issue, and a third board (or the next layout change) would cost another. Layout is the shared concern, and it is the *only* shared concern.

The counter-argument in the issue is real — GitLab MRs and GitHub PRs have genuinely different field sets — so the contract is drawn to avoid exactly that trap. `_board` is **layout-only and stringly-typed**:

```python
render_row(*, sigil, ident, watched, status, appr, age, changes,
           branches, flags="", title="", suffix="") -> str
```

No provider field name reaches it. `iid` vs `number`, `_pipeline` vs `_checks`, `source_branch` vs `headRefName`, `show_pipe` — all stay in their own preset, which computes its cells and hands over finished strings. There is no shared field model to get wrong, because there is no shared field model. `branch_pair(source, target)` is shared for the same reason: the `? -> master` fallback is a display decision, not a data one.

On the coupling objection: yes, a `radar`-adjacent layout change can now reach the GitHub board. That is the intent, not the accident. A change to column widths or the two-line shape *should* hit both boards, because they have one reader. What must not leak across is provider semantics, and the signature makes that impossible.

There is precedent for the file's location — `presets/_publish_safety.py` is already a presets-root helper shared across three provider directories, imported the same way.

## No extra API call — confirmed, not assumed

`headRefName` and `baseRefName` were **already** in `_LIST_FIELDS`, so `gh pr list --json` was fetching them and throwing them away. Verified against the live endpoint:

```
$ gh pr list --json number,headRefName,baseRefName --limit 2
[{"baseRefName":"master","headRefName":"feat/421-radar-legible-board","number":423}, ...]
```

`test_board_costs_no_extra_api_call_for_the_branch` pins it: one `subprocess.run`, and the branch pair still renders.

## Tests

Full suite: **3902 passed, 34 skipped, 6 deselected**. Coverage **88.48%** vs the 86% gate.

Mutation-checked, 12 behaviours, 12 caught. Every mutant makes tests fail, and the restored baseline passes. The checker was a throwaway and is not committed.

| Mutant | Result |
| --- | --- |
| restore the 42-char title truncation | 2 failed |
| gh branch column always empty | 6 failed |
| gh drops the base branch | 6 failed |
| gh row collapses back to one line | 6 failed |
| gh row swallows its suffix | 1 failed |
| shared row drops the suffix | 7 failed |
| gh sigil becomes GitLab's | 3 failed |
| shared row drops the second line | 14 failed |
| shared title indent shrinks | 2 failed |
| shared `branch_pair` hides a missing side | 3 failed |
| watched eye never lights | 4 failed |
| shared status-column width changes | 1 failed |
| *(restored baseline)* | 166 passed |

Assertions pin values, not markers: the long title is asserted present **in full** (`give each board row its branch and its full title`), the status line pins the exact `#423    feat/421-radar-legible-board -> master`, and `test_row_is_two_lines_status_then_the_full_title` pins the entire status line byte-for-byte including column padding — which is what caught the width mutant.

The #423 shared-identity test is **strengthened, not deleted**. `test_rows_use_the_shared_gl_mrs_row_format` in `test_watch_radar.py` is untouched and still passes, and `test_board_row.py` adds the cross-provider version:

```python
assert gh == gl.replace("!423", "#423")
```

Two boards, same fixture, byte-identical apart from the sigil. A layout change in one that is not made in the other now fails the suite rather than silently diverging — which is precisely the failure that produced #424.

## Notes

- Pushed normally; the pre-push hook fix from #420 held, full pytest ran green under it.
- `_row` is now the unit under test on both boards, so `_render_table` stayed a two-line function.

Closes #424
