### PR TITLE
feat(phpstan-mcp): PHPSTAN_MCP_PATHS — skip an out-of-scope file locally (#412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`PHPSTAN_MCP_PATHS` — skip an out-of-scope file without the 9.2s daemon round trip.** Set it to the analysis roots (`os.pathsep`- or comma-separated) and `phpstan-mcp` answers `skipped` locally for a target outside every root, never opening the socket to `mcp-phpstan-warm`. Measured in the session that produced [#406](https://github.com/Digital-Process-Tools/claude-supertool/issues/406): 9.2s per edited file, spent to be told phpstan would not look at it. In a multi-file batch that is 9.2s per unique path. Closes [#412](https://github.com/Digital-Process-Tools/claude-supertool/issues/412).
+
+  **Re-measured before building, against the real daemon**, since the filed figure predated a lot of work: an out-of-scope DVSI test file on an already-warm `mcp-phpstan-warm` cost **4.8s** (`duration_ms: 4804`), returning the refusal verbatim — `analyse: path is outside the configured --paths allowlist.`, still thrown by `PhpstanRunner::assertPathAllowed()`. So 9.2s is a cold/loaded reading and 4.8s a warm one; the same run with `PHPSTAN_MCP_PATHS` set returns `duration_ms: 0`.
+
+  **Opt-in, and the daemon stays authoritative when unset — because the two failure directions are not symmetric.** Skipping a file that IS in scope loses the analysis silently: the file looks handled and is not. Analysing a file that is NOT in scope wastes a round trip and still returns the right answer. So the scope is never inferred, never read out of `phpstan.neon`, and never defaulted on; unset, behaviour is byte-identical to before, and a blank or whitespace-only value is treated as unset rather than as an empty allowlist that would skip the entire repo. The var is the repo stating that it knows the scope.
+
+  **The skip reason names the env var, not phpstan** — `path outside PHPSTAN_MCP_PATHS allowlist`, not `path outside --paths allowlist`. A wrong skip is caused by this configuration; pointing at a tool that never saw the file sends the reader to the wrong file to fix it. The receipt is the ordinary third state (`validators/common/refusal.py`, `docs/validators.md`), so the core's existing no-rollback / no-delta / no-cache handling applies with no second code path.
+
+  **Matching is `os.path.abspath` with an `os.sep` boundary**, not a prefix compare — `/srcbad/Foo.php` is not inside `/src`. Empty entries between separators are dropped rather than `abspath()`ed into the working directory, where one stray separator would silently widen the allowlist to everything; relative roots resolve against the working directory, like every other path in a committed `.supertool.json`.
+
+  **The helper is generic; the second env var is not shipped.** `refusal.outside_roots(file_path, env_var)` takes the variable name as an argument, so `phpmd-mcp` or any future MCP adapter is one call away — but nothing declares `PHPMD_MCP_PATHS` until a second adapter actually asks for it. An opt-in nobody requested is an opt-in nobody can be surprised by.
+
+  Red first: 10 of 15 new tests failed against the unmodified adapter, and the load-bearing one failed by *reporting that the daemon had been contacted*. Both directions are pinned by monkeypatching `ensure_daemon`/`ndjson_call` — to raise, so an out-of-scope path that still dials the daemon fails; and to record, so an in-scope path that silently stops reaching it fails too. A third test pins the unset case against the same recorder.
+
 ### Fixed
 
 - **`gl-mr`'s conflict hunk preview vanished with no note when `git merge-tree` timed out.** `_get_conflict_hunks` returned a bare `{}` on `TimeoutExpired`, and the caller rendered the `## Conflicts` section with the file list and nothing else — output indistinguishable from a conflict whose hunks were genuinely empty. Twelfth filing of the same class in this repo: an absence produced by the tool, read as an absence in the world. Closes [#507](https://github.com/Digital-Process-Tools/claude-supertool/issues/507).

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -104,6 +104,18 @@ Skips never enter the before/after delta, never render a `✗`, are never cached
 
 `phpstan-mcp`, `phpmd-mcp` and the cold `phpstan` adapter recognise their tool's own refusal messages (`--paths` allowlist, "no files found to analyse"). An exit they cannot explain still reports as an error — swallowing an unknown failure is the same category mistake pointing the other way. Teach an adapter a house-specific refusal with `PHPSTAN_MCP_SKIP_PATTERNS` / `PHPMD_MCP_SKIP_PATTERNS` / `PHPSTAN_SKIP_PATTERNS`: extra comma-separated, case-insensitive substrings.
 
+**`PHPSTAN_MCP_PATHS` — decide the refusal locally instead of paying for it.** Recognising the refusal still costs the full daemon round trip that produced it: ~9.2s per edited file, spent to be told phpstan would not look at it (#412). Set `PHPSTAN_MCP_PATHS` to the analysis roots — `os.pathsep`- or comma-separated, absolute or relative to the working directory — and `phpstan-mcp` answers `skipped (path outside PHPSTAN_MCP_PATHS allowlist)` without opening the socket:
+
+```json
+"phpstan": {
+  "cmd": "PHPSTAN_MCP_PATHS=src:lib MCP_PHPSTAN_BIN=… {python} {supertool_dir}/validators/phpstan-mcp/phpstan-mcp.py {file}"
+}
+```
+
+It is opt-in, and it must stay that way, because the two ways it can be wrong are not equally bad. **Skipping a file that IS in scope loses the analysis silently** — the file looks handled and is not. **Analysing a file that is NOT in scope** wastes a round trip and still returns the right answer. So the adapter never infers the scope, never reads it out of `phpstan.neon`, and never defaults it on: unset (or blank) means "no local knowledge, the daemon decides", exactly as before. Setting the var is the repo asserting it knows the scope, and the skip reason names the var rather than `--paths` so a wrong skip points at this line of config instead of at a tool that never saw the file. Matching is on `os.path.abspath` with an `os.sep` boundary, so `/srcbad/Foo.php` is not inside `/src`.
+
+Two things to keep in mind when setting it. It belongs on the **validator entry**, not the shell — each `.supertool.json` entry pins its own daemon and its own scope, so `phpstan` and `phpstan-fwk` need different values. And do not set it on an entry that uses `resolve` to hand the adapter a **temporary** file (the `phpstan-component` pattern): the resolved path lives outside the repo, would fall outside every root, and every such edit would skip.
+
 **Silence is the refusal that hides best.** PHPStan does not announce a declined file on stdout at all — it writes `[ERROR] No files found to analyse.` to stderr, exits non-zero, and leaves stdout empty. Any adapter that treats "no output" as "no findings" turns that into `ok: true, count: 0` (#263), and a green meaning *"I analysed nothing"* is byte-identical to one meaning *"I analysed it and it is fine"*. An adapter with no parseable result must therefore decide between three outcomes and never default into the fourth: a recognised refusal is `skipped`, an unexplained non-zero exit is an error naming the exit code, and only a genuinely quiet success — empty output, exit 0 — keeps the clean verdict. When quoting the tool's words back as the skip reason, quote **the line that refused**, not the first line printed: analysers open with preamble (`Note: Using configuration file ...`) that names the config and explains nothing.
 
 ## Bundled validators

--- a/tests/test_validators_phpstan_paths_412.py
+++ b/tests/test_validators_phpstan_paths_412.py
@@ -1,0 +1,290 @@
+"""#412 — PHPSTAN_MCP_PATHS: don't pay 9.2s to be told the file is out of scope.
+
+The adapter cannot read phpstan's `--paths`: that scope lives in the daemon's
+own configuration and the adapter has no parser for it. So the knowledge has to
+arrive from outside, and the two failure directions are not symmetric:
+
+- **Skipping a file that IS in scope** — silent loss of analysis. The file looks
+  handled and is not. Unacceptable.
+- **Analysing a file that is NOT in scope** — 9.2s wasted, correct result.
+  Merely slow.
+
+Which is why this is opt-in and never inferred. Unset, the adapter must behave
+byte-identically to before this feature existed — the daemon stays the only
+authority on scope. Set, it is the repo making an explicit statement.
+
+These tests pin the three claims the issue names, and each fails loudly if the
+implementation does nothing: the daemon is genuinely NOT contacted for an
+out-of-scope path (contacting it raises), an in-scope file still reaches it,
+and an unset var reaches it for any path at all.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+_ADAPTER = Path(__file__).parent.parent / "validators" / "phpstan-mcp" / "phpstan-mcp.py"
+_REFUSAL = Path(__file__).parent.parent / "validators" / "common" / "refusal.py"
+
+PATHS_ENV = "PHPSTAN_MCP_PATHS"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _adapter():
+    return _load(_ADAPTER, "phpstan_mcp_adapter_412")
+
+
+def _refusal_mod():
+    return _load(_REFUSAL, "refusal_412")
+
+
+def _mcp_clean() -> dict:
+    return {"jsonrpc": "2.0", "id": 2,
+            "result": {"structuredContent": {"errors": [], "exit_code": 0}}}
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, target: Path,
+              *, contacted: list) -> dict:
+    """Drive `main` with a daemon that RECORDS contact instead of doing work.
+
+    The point of the recorder is that a no-op implementation cannot pass: an
+    out-of-scope run that still dials the daemon leaves a mark here.
+    """
+    mod = _adapter()
+
+    def _ensure(cwd):
+        contacted.append(("ensure_daemon", cwd))
+        return "/sock"
+
+    def _call(sock, fpath):
+        contacted.append(("ndjson_call", fpath))
+        return _mcp_clean()
+
+    monkeypatch.setattr(mod, "ensure_daemon", _ensure)
+    monkeypatch.setattr(mod, "ndjson_call", _call)
+    captured: list = []
+    monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
+    assert mod.main(["phpstan-mcp.py", str(target)]) == 0
+    return json.loads(captured[-1])
+
+
+def _run_main_exploding(monkeypatch: pytest.MonkeyPatch, target: Path) -> dict:
+    """Same, but any contact with the daemon is a hard failure.
+
+    `main` swallows exceptions into an `adapter` error result, so a raise does
+    not propagate — it shows up as a receipt with code `adapter`, which the
+    assertions below reject just as loudly.
+    """
+    mod = _adapter()
+
+    def _boom(*a, **k):
+        raise AssertionError("daemon was contacted for an out-of-scope path")
+
+    monkeypatch.setattr(mod, "ensure_daemon", _boom)
+    monkeypatch.setattr(mod, "ndjson_call", _boom)
+    captured: list = []
+    monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
+    assert mod.main(["phpstan-mcp.py", str(target)]) == 0
+    return json.loads(captured[-1])
+
+
+def _php(tmp_path: Path, *parts: str) -> Path:
+    f = tmp_path.joinpath(*parts)
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("<?php\n")
+    return f
+
+
+# ---------------------------------------------------------------------------
+# The three claims
+# ---------------------------------------------------------------------------
+
+def test_out_of_scope_path_never_opens_the_socket(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The whole point: no daemon round trip for a file we know is out of scope."""
+    monkeypatch.setenv(PATHS_ENV, str(tmp_path / "src"))
+    target = _php(tmp_path, "tests", "FooTest.php")
+    data = _run_main_exploding(monkeypatch, target)
+    assert data.get("skipped"), f"expected a skip, got {data!r}"
+    assert not any(e.get("code") == "adapter" for e in data.get("errors") or []), (
+        "the adapter reached the daemon and turned the refusal into an error: "
+        + json.dumps(data))
+    assert data["count"] == 0
+    assert data["errors"] == []
+
+
+def test_in_scope_path_still_reaches_the_daemon(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The unacceptable direction, pinned: an in-scope file is still analysed."""
+    monkeypatch.setenv(PATHS_ENV, str(tmp_path / "src"))
+    target = _php(tmp_path, "src", "Foo.php")
+    contacted: list = []
+    data = _run_main(monkeypatch, target, contacted=contacted)
+    assert "skipped" not in data, f"an in-scope file was silently skipped: {data!r}"
+    assert [c[0] for c in contacted] == ["ensure_daemon", "ndjson_call"]
+    assert data["ok"] is True
+
+
+def test_unset_var_behaves_exactly_as_before(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Unset = no local knowledge = the daemon decides, for ANY path."""
+    monkeypatch.delenv(PATHS_ENV, raising=False)
+    target = _php(tmp_path, "somewhere", "else", "Foo.php")
+    contacted: list = []
+    data = _run_main(monkeypatch, target, contacted=contacted)
+    assert "skipped" not in data
+    assert [c[0] for c in contacted] == ["ensure_daemon", "ndjson_call"]
+
+
+def test_blank_var_is_treated_as_unset(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An empty or whitespace value is not an empty allowlist that skips
+    everything — that would turn a stray `export PHPSTAN_MCP_PATHS=` into a
+    repo-wide silent loss of analysis."""
+    monkeypatch.setenv(PATHS_ENV, "   ")
+    target = _php(tmp_path, "anything", "Foo.php")
+    contacted: list = []
+    data = _run_main(monkeypatch, target, contacted=contacted)
+    assert "skipped" not in data
+    assert contacted
+
+
+# ---------------------------------------------------------------------------
+# The skip reason points at the config that caused it
+# ---------------------------------------------------------------------------
+
+def test_skip_reason_names_the_env_var_not_phpstan(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A wrong skip is a supertool misconfiguration. The reason must say so —
+    blaming `--paths` sends the reader to a tool that never saw the file."""
+    monkeypatch.setenv(PATHS_ENV, str(tmp_path / "src"))
+    target = _php(tmp_path, "tests", "FooTest.php")
+    data = _run_main_exploding(monkeypatch, target)
+    reason = data["skipped"]
+    assert PATHS_ENV in reason, reason
+    assert "--paths" not in reason, reason
+    assert "phpstan" not in reason.replace(PATHS_ENV, "").lower(), reason
+
+
+def test_skip_is_reported_through_the_shared_third_state(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Same receipt shape as every other skip, so the core's no-rollback,
+    no-delta, no-cache handling applies without a second code path."""
+    monkeypatch.setenv(PATHS_ENV, str(tmp_path / "src"))
+    target = _php(tmp_path, "tests", "FooTest.php")
+    data = _run_main_exploding(monkeypatch, target)
+    assert data["tool"] == "phpstan-mcp"
+    assert data["ok"] is True and data["count"] == 0 and data["errors"] == []
+    assert isinstance(data["duration_ms"], int)
+
+
+# ---------------------------------------------------------------------------
+# Root matching: the boundary is a separator, not a prefix
+# ---------------------------------------------------------------------------
+
+def test_sibling_directory_sharing_a_prefix_is_outside(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`/srcbad/Foo.php` is not inside `/src`. A bare `startswith` says it is."""
+    monkeypatch.setenv(PATHS_ENV, str(tmp_path / "src"))
+    target = _php(tmp_path, "srcbad", "Foo.php")
+    data = _run_main_exploding(monkeypatch, target)
+    assert data.get("skipped")
+
+
+def test_prefix_sibling_the_other_way_round_is_in_scope(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """And the mirror: a root that is a prefix of nothing still matches itself."""
+    monkeypatch.setenv(PATHS_ENV, str(tmp_path / "srcbad"))
+    target = _php(tmp_path, "srcbad", "Foo.php")
+    contacted: list = []
+    data = _run_main(monkeypatch, target, contacted=contacted)
+    assert "skipped" not in data
+    assert contacted
+
+
+def test_trailing_separator_on_a_root_is_harmless(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(PATHS_ENV, str(tmp_path / "src") + os.sep)
+    target = _php(tmp_path, "src", "Foo.php")
+    contacted: list = []
+    data = _run_main(monkeypatch, target, contacted=contacted)
+    assert "skipped" not in data
+    assert contacted
+
+
+def test_relative_root_resolves_against_the_working_directory(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`.supertool.json` entries are committed and shared — a root written as
+    `src` must mean this checkout's `src`, like every other path in the file."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(PATHS_ENV, "src")
+    inside = _php(tmp_path, "src", "Foo.php")
+    outside = _php(tmp_path, "tests", "FooTest.php")
+    contacted: list = []
+    assert "skipped" not in _run_main(monkeypatch, inside, contacted=contacted)
+    assert contacted
+    assert _run_main_exploding(monkeypatch, outside).get("skipped")
+
+
+# ---------------------------------------------------------------------------
+# The helper itself — generic by construction, so phpmd-mcp can reuse it
+# ---------------------------------------------------------------------------
+
+def test_helper_takes_the_env_var_name_so_a_second_adapter_can_reuse_it(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The helper must not hardcode PHPSTAN_MCP_PATHS. No second env var is
+    shipped until a second adapter asks for one — but the seam is here."""
+    ref = _refusal_mod()
+    monkeypatch.setenv("SOME_OTHER_MCP_PATHS", str(tmp_path / "src"))
+    outside = str(tmp_path / "tests" / "FooTest.php")
+    inside = str(tmp_path / "src" / "Foo.php")
+    reason = ref.outside_roots(outside, "SOME_OTHER_MCP_PATHS")
+    assert reason and "SOME_OTHER_MCP_PATHS" in reason
+    assert ref.outside_roots(inside, "SOME_OTHER_MCP_PATHS") is None
+
+
+def test_helper_accepts_both_pathsep_and_comma_separated_roots(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ref = _refusal_mod()
+    a, b = tmp_path / "src", tmp_path / "lib"
+    for sep in (os.pathsep, ","):
+        monkeypatch.setenv(PATHS_ENV, f"{a}{sep}{b}")
+        assert ref.outside_roots(str(a / "Foo.php"), PATHS_ENV) is None
+        assert ref.outside_roots(str(b / "Bar.php"), PATHS_ENV) is None
+        assert ref.outside_roots(str(tmp_path / "t" / "T.php"), PATHS_ENV)
+
+
+def test_helper_ignores_empty_entries_between_separators(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A stray separator must not become a root — an empty string abspath()s to
+    the working directory and would quietly widen the allowlist to everything."""
+    ref = _refusal_mod()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(PATHS_ENV, f"{tmp_path / 'src'}{os.pathsep}{os.pathsep},")
+    assert ref.outside_roots(str(tmp_path / "tests" / "T.php"), PATHS_ENV)
+
+
+def test_helper_matches_the_root_directory_itself(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ref = _refusal_mod()
+    root = tmp_path / "src"
+    monkeypatch.setenv(PATHS_ENV, str(root))
+    assert ref.outside_roots(str(root), PATHS_ENV) is None
+
+
+def test_helper_returns_none_when_the_var_is_absent(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ref = _refusal_mod()
+    monkeypatch.delenv(PATHS_ENV, raising=False)
+    assert ref.outside_roots(str(tmp_path / "anything.php"), PATHS_ENV) is None

--- a/validators/common/refusal.py
+++ b/validators/common/refusal.py
@@ -40,6 +40,49 @@ def is_refusal(msg: str, env_var: str = "") -> bool:
     return any(p in lowered for p in patterns)
 
 
+def outside_roots(file_path: str, env_var: str) -> str | None:
+    """Is `file_path` outside every analysis root named by `$env_var`? (#412)
+
+    Returns a skip reason when the adapter can answer "not analysed" locally,
+    and `None` whenever it cannot — which is the answer for an unset or blank
+    var. That asymmetry is the whole design: an adapter cannot read the
+    analyser's own scope (it lives in `phpstan.neon`, daemon flags, a config
+    this module has no parser for and no business duplicating), so the two
+    mistakes it could make are not equally bad.
+
+    - Skipping a file that IS in scope loses the analysis silently. The file
+      looks handled and is not. Unacceptable.
+    - Analysing a file that is NOT in scope wastes a daemon round trip and
+      still returns the right answer. Merely slow.
+
+    So the scope is never inferred and never defaulted on. `$env_var` is an
+    explicit statement by the repo that it knows the scope, and unset means
+    "no local knowledge — the analyser decides", exactly as before.
+
+    Roots are `os.pathsep`- or comma-separated, absolute or relative to the
+    working directory. Matching is on `os.path.abspath` with an `os.sep`
+    boundary: a bare prefix compare would read `/srcbad/Foo.php` as inside
+    `/src`. Empty entries are dropped rather than abspath()ed into the working
+    directory, where a stray separator would widen the allowlist to everything.
+
+    The reason names `env_var`, not the analyser: a wrong skip is caused by
+    this configuration, and pointing at a tool that never saw the file sends
+    the reader to the wrong file to fix it.
+    """
+    raw = os.environ.get(env_var, "")
+    if not raw.strip():
+        return None
+    entries = [e.strip() for part in raw.split(os.pathsep) for e in part.split(",")]
+    roots = [os.path.normcase(os.path.abspath(e)) for e in entries if e]
+    if not roots:
+        return None
+    target = os.path.normcase(os.path.abspath(file_path))
+    for root in roots:
+        if target == root or target.startswith(root.rstrip(os.sep) + os.sep):
+            return None
+    return f"path outside {env_var} allowlist"
+
+
 def skipped(tool: str, file_path: str, reason: str, dur_ms: int) -> dict:
     """A SCHEMA.md result in the third state: not clean, not broken, not looked at.
 

--- a/validators/phpstan-mcp/phpstan-mcp.py
+++ b/validators/phpstan-mcp/phpstan-mcp.py
@@ -29,6 +29,11 @@ CALL_TIMEOUT_SEC = 180
 # Extra refusal substrings (comma-separated), opt-in per repo.
 SKIP_PATTERNS_ENV = "PHPSTAN_MCP_SKIP_PATTERNS"
 
+# Analysis roots, opt-in per repo (#412). Set, a target outside every root is
+# skipped here instead of costing a ~9s daemon round trip to be told the same.
+# Unset, the daemon stays the only authority on scope — see refusal.outside_roots.
+PATHS_ENV = "PHPSTAN_MCP_PATHS"
+
 
 # #148: use the shared presets/mcp/_paths helper so client + daemon agree on
 # the runtime dir (was /tmp/, now $XDG_RUNTIME_DIR/supertool/mcp/ etc.).
@@ -198,6 +203,11 @@ def main(argv: list[str]) -> int:
         return 2
     file_path = argv[1]
     t0 = time.monotonic()
+    out_of_scope = _refusal.outside_roots(file_path, PATHS_ENV)
+    if out_of_scope:
+        print(json.dumps(skipped(file_path, out_of_scope,
+                                 int((time.monotonic() - t0) * 1000))))
+        return 0
     try:
         sock = ensure_daemon(WORKING_DIR)
         resp = ndjson_call(sock, os.path.abspath(file_path))


### PR DESCRIPTION
Gives `phpstan-mcp` an opt-in `PHPSTAN_MCP_PATHS` env var listing the analysis roots (`os.pathsep`- or comma-separated). When it is set and the target resolves outside every root, the adapter emits `skipped` immediately and never opens the socket to `mcp-phpstan-warm`.

Closes #412

## Pre-flight — the issue still holds, with two corrections

- `validators/common/refusal.py` exists and is the right home. `is_refusal()` + `skipped()` both live there, `phpstan-mcp` and `phpmd-mcp` both import it. The new helper sits next to them.
- The `skipped` three-state contract is what the adapter emits today. `#345`/`#263` did not change it; `docs/validators.md`'s "Declining instead of guessing" material sits in the same section and is consistent.
- The refusal message is **verbatim intact**: `analyse: path is outside the configured --paths allowlist.`, still thrown by `PhpstanRunner::assertPathAllowed()` in `dpt/mcp-phpstan-warm`.
- **The 9.2s figure re-measured at 4.8s.** Against the real daemon, already warm, on an out-of-scope DVSI test file: `duration_ms: 4804`. 9.2s was a cold/loaded reading; 4.8s is the warm floor. The same run with `PHPSTAN_MCP_PATHS` set returns `duration_ms: 0`. The cost is real and the fix removes it; only the magnitude moved, and the changelog says both numbers rather than quietly restating the filed one.
- **One inconsistency found and deliberately not touched.** `docs/validators.md` line 97 says an adapter with no verdict "should omit `ok`/`count`/`errors` entirely rather than pad them with `ok: true`", while `refusal.skipped()` returns exactly that padded shape — and its docstring argues *for* it (a consumer ignoring `skipped` must not read a refusal as a failure). The tests pin the padded shape. This PR follows the code and the tests; the doc/helper disagreement predates it and deserves its own issue rather than a drive-by resolution inside a performance change.

## The asymmetry, preserved

- Skipping a file that **is** in scope — silent loss of analysis. Unacceptable.
- Analysing a file that is **not** in scope — one wasted round trip, correct result. Merely slow.

So: unset is byte-identical to today, blank/whitespace is treated as unset (a stray `export PHPSTAN_MCP_PATHS=` must not become an empty allowlist that skips the whole repo), the scope is never inferred from `phpstan.neon` and never defaulted on. The skip reason names the env var — `path outside PHPSTAN_MCP_PATHS allowlist` — because a wrong skip is caused by this config, not by a tool that never saw the file. Matching is `os.path.abspath` with an `os.sep` boundary, so `/srcbad/Foo.php` is not inside `/src`; empty entries between separators are dropped rather than `abspath()`ed into the working directory, where one stray separator would widen the allowlist to everything.

## The judgment call: generalise now

`refusal.outside_roots(file_path, env_var)` takes the variable name as an argument, so `phpmd-mcp` is one call away. **No second env var is shipped.** Nothing declares `PHPMD_MCP_PATHS` until a second adapter asks for it.

The reasoning: the helper is intrinsically generic — its inputs are a path and a list of roots, and neither has anything phpstan-shaped about it. Hardcoding `PHPSTAN_MCP_PATHS` inside it would take deliberate extra work to make it *less* usable, and `refusal.py` is already the module both adapters import. The cost of generality here is one parameter. What is *not* generalised is the surface: no unused variable, no unused config, nothing a user can discover and be confused by.

## Tests — red first

15 new tests in `tests/test_validators_phpstan_paths_412.py`; **10 failed** against the unmodified adapter. The load-bearing one failed by reporting, in its own assertion message, that the daemon had been contacted:

```
>       assert data.get("skipped"), f"expected a skip, got {data!r}"
E       AssertionError: expected a skip, got {'tool': 'phpstan-mcp', ..., 'ok': False, 'count': 1,
E       'errors': [{'code': 'adapter', 'msg': 'AssertionError: daemon was contacted for an
E       out-of-scope path | trace: ...'}], 'duration_ms': 1}
```

Both directions are pinned, plus the unset case:

- **out of scope → the daemon is genuinely not contacted.** `ensure_daemon`/`ndjson_call` monkeypatched to raise. `main` swallows exceptions into an `adapter` error result, so the raise does not propagate — the test rejects that receipt explicitly as well as the missing `skipped`.
- **in scope → still reaches the daemon.** Same seams monkeypatched to *record*; the test asserts the exact call sequence `["ensure_daemon", "ndjson_call"]`. An implementation that skips too eagerly fails here.
- **unset → behaves exactly as today.** Same recorder, a path far outside anything.

Plus: blank var is not an empty allowlist; the reason names the env var and not phpstan; the receipt is the ordinary third state; `/srcbad` vs `/src` both ways round; trailing separator; relative root resolving against the working directory; and the helper's own contract (env-var-name parameter, both separators, empty entries dropped, root matches itself, absent var returns `None`).

Full suite green: **4406 passed, 35 skipped**. Coverage 88.83% against the 86% gate — unmoved, as expected, since the gate measures `supertool.py` only and nothing here is in it.

## Docs

- `CHANGELOG.md` — new `### Added` entry under Unreleased.
- `docs/validators.md` — documented in the "Graceful skip" section immediately after the `*_SKIP_PATTERNS` knobs, with a `.supertool.json` example and two operational warnings: the var belongs on the **validator entry**, not the shell (each entry pins its own daemon and its own scope, so `phpstan` and `phpstan-fwk` need different values), and it must **not** be set on an entry that uses `resolve` to hand the adapter a temporary file (the `phpstan-component` pattern) — the resolved path is outside the repo, would fall outside every root, and every such edit would skip.
- `validators/phpstan-mcp/README.md` does not exist; not created.
