### PR TITLE
chore(release): 0.22.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "supertool",
   "description": "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip. Includes session-start prompt injection and an opt-in enforcement mode that blocks competing tools.",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-29
+
 ### Added
 
 - **A syntax floor guard that runs a real old interpreter, because no amount of AST reasoning on a new one can do it.** `_syntax_floor_check(paths)` compiles every given `.py` under an interpreter older than the one running the suite, and `tests/test_syntax_floor_478.py` runs it over the repo. Closes [#478](https://github.com/Digital-Process-Tools/claude-supertool/issues/478).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-supertool"
-version = "0.21.0"
+version = "0.22.0"
 description = "Batched file operations for autonomous Claude Code runs. Collapses N reads/greps/globs into one Bash round-trip."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/supertool.py
+++ b/supertool.py
@@ -110,7 +110,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-VERSION = "0.21.0"
+VERSION = "0.22.0"
 
 
 def _fwd(p: str) -> str:

--- a/tests/test_pyproject_version_522.py
+++ b/tests/test_pyproject_version_522.py
@@ -1,0 +1,37 @@
+"""`pyproject.toml`'s version must match the code, like the manifest already does.
+
+Two of the three places the version lives were pinned to each other:
+`test_mcp_config_279.py::test_plugin_manifest_version_matches_code` ties
+`.claude-plugin/plugin.json` to `supertool.VERSION`, and `test_version.py` ties
+the `version` op's output to it.
+
+`pyproject.toml` was pinned to nothing. It could drift silently, and the failure
+would be the quiet kind this repository keeps filing: a wheel built from it
+carries one version while every other surface agrees on another, and nothing
+says so. Found while preparing 0.22.0 — the release is exactly when a bump gets
+applied to two files out of three.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import supertool
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject_version() -> str:
+    text = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match, "pyproject.toml has no top-level version = \"...\" line"
+    return match.group(1)
+
+
+def test_pyproject_version_matches_code() -> None:
+    assert _pyproject_version() == supertool.VERSION, (
+        f'pyproject.toml version {_pyproject_version()!r} != '
+        f"supertool.VERSION {supertool.VERSION!r} — a release bump must move "
+        "pyproject.toml, supertool.py and .claude-plugin/plugin.json together"
+    )


### PR DESCRIPTION
**Not merging this — release flow is yours.** Prepped to one click: review, merge, tag `v0.22.0`, publish.

## What this does

| file | 0.21.0 → 0.22.0 |
|---|---|
| `.claude-plugin/plugin.json` | the shipping mechanism — the updater compares the manifest and nothing else |
| `supertool.py:113` | `VERSION` |
| `pyproject.toml:3` | the package |

Plus `## [Unreleased]` → `## [0.22.0] - 2026-07-29`, with a fresh empty Unreleased above it. **89 entries.**

## Why minor rather than patch

New public surface: the **`gc`** op, the built-in **`py-syntax`** validator, the **`PHPSTAN_MCP_PATHS`** and **`warm_unsafe`** config keys, eight **`observed_*`** fields on `gitlab-mr` events, and the **`raw:-N`** tail form on `gl-job`/`gh-job`. Behaviour changes a user will notice: the `benchmark` marker moves wall-clock tests out of the pre-push hook, `[conflict]` now requires a diff, validators roll back on a Python syntax regression, and a validator that cannot answer says `skipped` instead of `ok`.

Correction to an earlier count of mine: **`tally` is not a new op.** It is `presets/_checks.py`, the shared CI-check classifier behind the `Checks: N total: …` line. Its output changed visibly; nothing new became callable.

## The extra test, and why it belongs in a release commit

`tests/test_pyproject_version_522.py` pins `pyproject.toml`'s version to `supertool.VERSION`.

The version lives in three files. Two were already tied to each other — `plugin.json` ↔ `supertool.VERSION` (`test_mcp_config_279`) and the `version` op's output ↔ the same (`test_version.py`). **`pyproject.toml` was pinned to nothing.** It could drift silently, and a wheel built from it would carry one version while every other surface agreed on another, with nothing to say so.

That is the defect class this release is largely *about* — an absence produced by the tool, read as an absence in the world, filed twelve times over three days — sitting unnoticed in the release path itself. And a release is exactly the moment it would bite, because a bump is when someone applies a change to two files out of three.

Verified both directions: green when the three agree, red on a drift introduced deliberately and then reverted.

## What this release is actually for

An install observed at **`0.8.1` contains no `watch` preset at all**, while this repo is at `0.21.0`. Thirteen minor versions of work — including all 23 PRs merged on 2026-07-29 — currently exist only in this repository. Publishing is what makes any of it exist for another machine.

[#520](https://github.com/Digital-Process-Tools/claude-supertool/issues/520) is the follow-up that makes it *installable* without three silent failure modes.

## Verification

Full suite through the pre-push hook: **4475 passed, 36 skipped**. Prepared in a worktree, because the main clone holds unrelated work in progress (`presets/gitlab/runners.py`, `presets/watch/sources/gl-runners/`) that was left untouched.
