### PR TITLE
feat(gl-runners): runner fleet op, watch source, and a radar tier registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ The `watch` preset spawns background pollers that emit events when external stat
 
 ### Two layers
 
-1. **`watch` preset** — `watch:SOURCE:ID` spawns a detached poller. Events emit to a UDS socket, a status file, and macOS Notification Center. Bundled sources: `github-pr`, `gitlab-mr`, and `gitlab-mr-feed` for discovery. Write your own source in ~50 lines.
+1. **`watch` preset** — `watch:SOURCE:ID` spawns a detached poller. Events emit to a UDS socket, a status file, and macOS Notification Center. Bundled sources: `github-pr`, `gitlab-mr`, `gitlab-mr-feed` for discovery, and `gl-runners` for CI runner health. Write your own source in ~50 lines. [What is worth watching, and what is not](docs/presets/watch.md#what-can-be-watched-and-what-cannot).
 2. **`claude-channel` MCP server** — TypeScript / Bun. Binds the UDS socket and pushes events into a running Claude Code session via the [Channels feature](https://code.claude.com/docs/en/channels.md) (research preview, v2.1.80+). Optional — the watch preset is useful even without it.
 
 Events are fire-and-forget and pollers die with the machine, so at session start an event-driven view knows nothing — and "knows nothing" looks exactly like "all green". That is what `./supertool 'radar'` is for: one idempotent op that treats live GitLab as authoritative, respawns watchers for open MRs that lost theirs, keeps a feed poller alive so MRs opened mid-session are still discovered, and prints the board. Run it on every session start.

--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -203,6 +203,45 @@ That last part is a considered rejection of the obvious symmetry. A `pipeline_fa
 
 **Why not classify infra failures automatically?** Because a classifier that decides "this red is not your fault" is wrong in the confident direction, silently, for every MR, with no audit trail — the [#445](https://github.com/Digital-Process-Tools/claude-supertool/issues/445) defect with more reach. An exclusion is at least *declared*: it names an iid, carries a reason, sits in a file under review, and prints itself on every board. And half of !19509's red is a merge conflict against `master` that no trace-scanner can classify — it is a genuine problem the operator has chosen not to fix, which is a decision, not a detection.
 
+## Radar tiers — registered, never default
+
+Radar's core is the MR board and the discovery feed. Anything beyond that is a **tier**, and a tier only runs when it is registered:
+
+```json
+{
+  "ops": {
+    "radar": {
+      "radar_tiers": {
+        "gl-runners": { "window": 1800, "quiet_when_healthy": true }
+      }
+    }
+  }
+}
+```
+
+**The empty default is the design, not laziness.** Radar is an MR reconcile tool for most of the people who install this. Plenty of them sit below Maintainer, or on shared runners, where reading `projects/:id/runners` is a 403 — and a tier shipped on by default would hand every one of them a standing WARNING about infrastructure they neither own nor can read. That is a regression delivered as a feature.
+
+A tier is just an op that exposes `radar_report(options) -> (lines, healthy)`:
+
+```python
+RADAR_OPTIONS = {"window", "quiet_when_healthy"}   # validated; a typo is reported
+
+def radar_report(options=None):
+    ...
+    return ["radar: FLEET — 14 pending job(s) cannot start"], False
+```
+
+Names resolve through the preset that declares the op, so there is no second table to drift when a file moves. Registering an op with no `radar_report`, or passing an option it does not declare, is **reported on the board** rather than silently ignored — a dropped option is how someone comes to believe they configured a threshold they did not.
+
+Silence rules, and they are deliberate:
+
+- a **healthy** tier says nothing (`quiet_when_healthy`, default `true`) — a green line per tier per run is what trains people to skim past the red one
+- an **unhealthy** tier speaks on **every** run, never delta-suppressed, because it is a current fact rather than a transition
+- a **misconfigured** tier always speaks, since that output is the only route to getting it fixed
+- a tier that **raises** is caught and named; the MR board is what radar exists for and an optional tier must never be able to cost the reader their board
+
+A tier may also declare a background watcher, spawned only when the tier is registered — so an unregistered tier costs no poller and no API call.
+
 ## Bundled sources
 
 | Source | Polls | Events |
@@ -210,8 +249,59 @@ That last part is a considered rejection of the obvious symmetry. A `pipeline_fa
 | `github-pr` | `gh pr view <N> --json state,mergeable,reviewDecision,statusCheckRollup,comments,...` | `checks_failed`, `checks_succeeded`, `checks_pending`, `review_approved`, `review_changes_requested`, `comment_added`, `merged`, `closed`, `conflicts_appeared` |
 | `gitlab-mr` | `glab api projects/:id/merge_requests/<iid>` | `pipeline_failed`, `pipeline_succeeded`, `pipeline_running`, `merged`, `closed`, `conflicts_appeared` |
 | `gitlab-mr-feed` | `glab mr list` for a whole filter | `mr_opened`, `mr_merged`, `mr_closed`, `mr_left_feed` |
+| `gl-runners` | `glab api projects/:id/runners` + the pending/running job queue | `runner_silent`, `runner_recovered`, `runner_starved`, `queue_cleared`, `runner_paused`, `runner_added`, `runner_vanished` |
 
 Each source declares its event vocabulary in `presets/watch/sources/<NAME>/events.json` for introspection.
+
+## What can be watched, and what cannot
+
+A watcher is worth writing when **state changes without you, and finding out late costs something**. That is the whole test, and it is narrower than "the op returns data".
+
+An op qualifies when all four hold:
+
+1. **The state lives somewhere else.** A remote service, another machine, another person's action.
+2. **It changes on its own timeline.** Nothing you type causes the transition.
+3. **The change has a moment.** There is a before and an after worth naming, not a continuously drifting number.
+4. **Learning late has a cost.** A pipeline that failed 40 minutes ago, an MR that picked up a conflict, a runner that stopped taking work.
+
+| Watchable | Why | Status |
+|---|---|---|
+| `gl-pipeline` | a run transitions to success/failed while you do something else | shipped |
+| `gitlab-mr` / `github-pr` | pipelines, reviews, conflicts, merges — all moved by other people | shipped |
+| `gl-mrs` (population) | MRs open after your session started | shipped as `gitlab-mr-feed` |
+| `gl-runners` | a runner stops taking work; GitLab keeps calling it `online` | shipped |
+| `gl-issue` / `gh-issue` | labels, assignment and comments change; agent workflows key off labels | not yet |
+| `gh-run` | the GitHub-side mirror of `gl-pipeline` | not yet |
+| `devto_comments` / `bluesky` | replies and reactions arrive from strangers | not yet |
+
+| Not watchable | Why |
+|---|---|
+| `read`, `grep`, `glob`, `ls`, `tail`, `map`, `between`, `tree` | pure functions of local files — the answer only changes when you change the file |
+| `edit`, `replace`, `paste`, `vim`, `replace_lines` | synchronous mutations you initiated; the result is already in the return value |
+| `phpstan`, `phpunit`, `rector`, `validate`, `format` | local analysis. Nothing transitions while you wait; just run it again |
+| `git-status`, `git-diff`, `git-blame` | local repo state, moved by you |
+| `mysql_read` | technically remote, but there is no transition worth naming — polling a table is a cron job, not a watcher |
+| `mr`, `gl-issue-create` | one-shot actions. What they create may be watchable; the act is not |
+
+The trap is criterion 3. Plenty of remote state changes constantly without producing an *event* — a row count, a queue depth, a token balance. Watching those yields a stream with no edges, and a signal that fires continuously is one people learn to ignore. If you cannot name the before and the after in a sentence, it is a metric, not an event.
+
+Criterion 4 has its own trap, learned the expensive way: see `gl-runners` below, where a first version keyed on a field that looked like a transition and fired on the entire healthy fleet.
+
+### `gl-runners` — silence is only news when work is stuck behind it
+
+The op exists because GitLab reports a wedged runner as `status: online, job_execution_status: idle`, which is byte-identical to a healthy runner between jobs. Work pinned to that runner's exclusive tag queues behind it, no other runner is permitted to take it, and nothing turns red.
+
+Liveness is judged on evidence in **descending strength**, and the order is load-bearing:
+
+1. **jobs completed in the throughput window** — the runner demonstrably took work and returned results
+2. **`job_execution_status == "active"`**, or the runner owning a job in `scope[]=running`
+3. **`contacted_at` age**, last, at 30 minutes
+
+Step 3 is last because **GitLab throttles `contacted_at` writes**. Measured on a live fleet: one runner's `contacted_at` stayed frozen at the same millisecond across 7 samples spanning 2 minutes, drifting to ~10 minutes of apparent staleness while the fleet completed jobs throughout. A first version keyed on it alone, at 5 minutes, and fired `runner_silent` on **6 of 6 online runners within the hour**. A signal that fires on the whole healthy fleet does not merely fail to inform — it buries the one event that was real.
+
+So `runner_silent` gates on consequence: not taking work **and** work queued for it. A quiet runner with an empty queue has nothing to do, which is not a fault. `runner_starved` is the same correlation at the queue level, and it is the signal that earned its keep — it found 14 jobs pinned behind a runner GitLab had advertised as online for an hour.
+
+Job history is filtered by `finished_at`, never `created_at`. Ids order by creation and the two are **not monotonic**: a test job created hours ago finishes after jobs created since, so scanning by creation drops exactly the long jobs whose completion is the best evidence.
 
 ### `conflicts_appeared` is edge-triggered, and stays re-armable ([#463](https://github.com/Digital-Process-Tools/claude-supertool/issues/463))
 

--- a/presets/gitlab.json
+++ b/presets/gitlab.json
@@ -36,6 +36,15 @@
       "description": "Pipeline jobs by stage with statuses + failed job IDs. Default collapses manual/created/skipped bulk to a count. :active = running/pending only; :failed = failed jobs + IDs/URLs",
       "syntax": "gl-pipeline:NUMBER[:active|:failed]"
     },
+    "gl-runners": {
+      "cmd": "{python} {path}gitlab/runners.py {args}",
+      "timeout": 45,
+      "description": "Runner fleet health: one row per runner with type, status, heartbeat age, live job count and queue depth, sorted worst-health first. Joins the runner list with per-runner detail (tags, run_untagged, contacted_at) and the pending/running job queue to derive STARVED — pending jobs whose tags match only runners that stopped heartbeating, which GitLab still reports as online+idle. :full adds project scope, timeouts, versions; :queue groups pending/running jobs by the runners allowed to take them. Per-runner detail calls run in parallel.",
+      "syntax": "gl-runners[:full|:queue]",
+      "example": "gl-runners",
+      "heartbeat_warn_seconds": 300,
+      "detail_workers": 8
+    },
     "gl-job": {
       "cmd": "{python} {path}gitlab/job.py {args}",
       "timeout": 30,

--- a/presets/gitlab/runners.py
+++ b/presets/gitlab/runners.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""GitLab runner fleet state via glab CLI.
+
+`glab api projects/:id/runners` answers "which runners exist", which is never
+the question. The questions are "is anything stuck" and "why is my job not
+starting" — and the fleet list alone cannot answer either, because a runner
+that stopped polling an hour ago still reports `status: online` until GitLab's
+offline threshold trips, and still reports `job_execution_status: idle`
+because it is, technically, idle. Idle and dead look identical.
+
+So this op joins three sources the fleet list keeps apart:
+
+    runners list  ->  who exists, shared vs project
+    runners/:id   ->  tags, run_untagged, last contact
+    jobs (queue)  ->  what is waiting, and for which tags
+
+and derives the one line you actually want:
+
+    gl-runners           fleet table + queue depth + starvation warnings
+    gl-runners:full      adds project scope, timeouts, runner managers
+    gl-runners:queue     pending/running jobs grouped by the runner that can take them
+
+STARVED is the finding this exists for: pending jobs whose tags match only
+runners that have stopped heartbeating. Those jobs cannot move, no other
+runner is allowed to take them, and nothing in the GitLab UI says so.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+
+# GitLab does not write contacted_at on every poll — it throttles the update.
+# Measured on a live fleet: one runner's contacted_at stayed frozen at the same
+# millisecond across 7 samples spanning 2 minutes, drifting to ~10 minutes of
+# apparent staleness while the runner was healthy and the fleet was completing
+# jobs throughout. A threshold below that granularity does not measure runner
+# health, it measures GitLab's write policy — and it fired on 6 of 6 online
+# runners when it was set to 300s. 30 minutes sits well clear of the observed
+# throttle while still catching a genuinely wedged runner long before GitLab's
+# own `stale` (~3 months) would.
+_HEARTBEAT_WARN_SECONDS = 1800
+
+# Staleness alone is not evidence: a fleet with nothing queued is allowed to be
+# quiet. A job only counts toward starvation once it has waited longer than a
+# normal scheduling delay, so a pipeline that started seconds ago is never
+# mistaken for blocked work.
+_STARVED_MIN_QUEUE_SECONDS = 300
+
+# Completed work is the strongest liveness evidence available: a runner that
+# finished jobs inside this window is alive, whatever contacted_at claims and
+# whether or not it happens to be executing something at this instant. It also
+# answers the capacity question — jobs per runner over a fixed window is what
+# "is one of these doing all the work" actually means.
+_THROUGHPUT_WINDOW_SECONDS = 1800
+
+# The jobs endpoint returns newest-first by id, which orders by created_at —
+# and finished_at is NOT monotonic with it. A test job created 09:17 and still
+# running at 11:45 finishes long after jobs created an hour later. Stopping the
+# scan the moment created_at leaves the window therefore misses exactly the
+# long jobs whose completion is the most interesting evidence. So the scan
+# reaches back a further allowance covering the longest plausible job, and
+# filters on finished_at rather than on where it stopped.
+_LONG_JOB_ALLOWANCE_SECONDS = 4 * 3600
+
+# Hard cap so a busy fleet cannot turn one op into an unbounded crawl. Hitting
+# it makes the counts a lower bound, which the caller is told about rather than
+# left to assume — a truncated count that reads as complete is worse than no
+# count at all.
+_MAX_HISTORY_PAGES = 5
+
+_MODES = {"full", "queue"}
+
+_MAX_DETAIL_WORKERS = 8
+
+
+def _format_error(stderr: str, resource: str) -> str:
+    """Classify glab errors into actionable messages for LLMs."""
+    s = stderr.lower()
+    if "404" in s or "not found" in s or "could not resolve" in s:
+        return f"ERROR: {resource} not found. Verify you're in the right repo."
+    if "401" in s or "unauthorized" in s or "authenticate" in s or "bad token" in s or "token expired" in s:
+        return "ERROR: glab not authenticated. Run: glab auth login"
+    if "403" in s or "forbidden" in s:
+        return (
+            f"ERROR: permission denied reading {resource}. Instance-wide runner data "
+            "needs admin; project-scoped runners need Maintainer."
+        )
+    return f"ERROR: glab failed reading {resource}: {stderr.strip()}"
+
+
+def _parse_paginated_json(raw: str) -> list[dict]:
+    """Parse glab's `--paginate` output — one JSON array per page, concatenated.
+
+    glab emits each page's body back-to-back with no separator, e.g.
+    `[{a}][{b},{c}]`. A single `json.loads` chokes on the second `[`.
+    """
+    decoder = json.JSONDecoder()
+    merged: list[dict] = []
+    idx = 0
+    length = len(raw)
+    while idx < length:
+        while idx < length and raw[idx].isspace():
+            idx += 1
+        if idx >= length:
+            break
+        doc, end = decoder.raw_decode(raw, idx)
+        if not isinstance(doc, list):
+            raise ValueError("expected a JSON array per page")
+        merged.extend(doc)
+        idx = end
+    return merged
+
+
+def _api(endpoint: str, paginate: bool = False, timeout: int = 20):
+    """One glab API call. Returns (data, error_message)."""
+    cmd = ["glab", "api", endpoint]
+    if paginate:
+        cmd.append("--paginate")
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+            encoding="utf-8", errors="replace",
+        )
+    except FileNotFoundError:
+        return None, "ERROR: glab not found — install from https://gitlab.com/gitlab-org/cli"
+    except subprocess.TimeoutExpired:
+        return None, f"ERROR: glab timed out reading {endpoint}"
+
+    if result.returncode != 0:
+        return None, _format_error(result.stderr, endpoint)
+
+    try:
+        if paginate:
+            return _parse_paginated_json(result.stdout), None
+        return json.loads(result.stdout), None
+    except (json.JSONDecodeError, ValueError):
+        return None, f"ERROR: invalid JSON from glab for {endpoint}"
+
+
+def _age_seconds(timestamp: str | None) -> float | None:
+    """Seconds since an ISO-8601 GitLab timestamp, or None if unparseable."""
+    if not timestamp:
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (datetime.now(timezone.utc) - parsed).total_seconds()
+
+
+def _human_age(seconds: float | None) -> str:
+    """Compact age: 45s, 12m, 3h, 5d."""
+    if seconds is None:
+        return "-"
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    if seconds < 3600:
+        return f"{seconds / 60:.0f}m"
+    if seconds < 86400:
+        return f"{seconds / 3600:.0f}h"
+    return f"{seconds / 86400:.0f}d"
+
+
+def _fetch_details(runners: list[dict]) -> dict[int, dict]:
+    """Per-runner detail (tags, contacted_at, run_untagged) fetched in parallel.
+
+    The list endpoint omits tag_list and contacted_at, which are exactly the two
+    fields the starvation check needs, so one call per runner is unavoidable.
+    """
+    def one(runner: dict) -> tuple[int, dict]:
+        data, _err = _api(f"runners/{runner['id']}", timeout=15)
+        return runner["id"], (data or {})
+
+    workers = min(_MAX_DETAIL_WORKERS, max(1, len(runners)))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        return dict(pool.map(one, runners))
+
+
+def _can_serve(runner: dict, job_tags: list[str]) -> bool:
+    """GitLab job-to-runner matching: a runner needs ALL of a job's tags.
+
+    Untagged jobs only go to runners with run_untagged enabled.
+    """
+    runner_tags = set(runner.get("tag_list") or [])
+    if not job_tags:
+        return bool(runner.get("run_untagged"))
+    return set(job_tags).issubset(runner_tags)
+
+
+def _is_responsive(runner: dict) -> bool:
+    """Able to pick up queued work right now.
+
+    Evidence in descending strength, and the order is the whole point:
+
+    1. It finished jobs inside the throughput window. Work completed is proof
+       no inference can beat — the runner demonstrably took work and returned
+       results.
+    2. `job_execution_status == "active"`. GitLab says it is executing a job at
+       this instant.
+    3. contacted_at age. Consulted last and at a deliberately loose threshold,
+       because it is the throttled field: GitLab does not write it every poll,
+       so a runner taking jobs continuously still reads minutes stale. Testing
+       it first is how a fleet-wide false alarm gets built.
+
+    1 and 2 require `annotate_recent_work` / `annotate_live_jobs` to have run;
+    without them this degrades to 3 alone, which is exactly the broken version.
+    """
+    if runner.get("paused") or not runner.get("active", True):
+        return False
+    if runner.get("status") in {"offline", "stale", "never_contacted"}:
+        return False
+    if runner.get("_recent_jobs"):
+        return True
+    if runner.get("job_execution_status") == "active":
+        return True
+    age = _age_seconds(runner.get("contacted_at"))
+    return age is not None and age <= _HEARTBEAT_WARN_SECONDS
+
+
+def fetch_recent_finished(
+    window_seconds: int = _THROUGHPUT_WINDOW_SECONDS,
+) -> tuple[list[dict], bool]:
+    """(jobs finished inside the window, truncated). ([], False) on failure.
+
+    An empty list is safe here in a way it is not elsewhere: a missing history
+    only costs the throughput evidence, and liveness falls through to the
+    weaker tests below it rather than flipping a healthy runner to dead.
+
+    `truncated` is True when the page cap was reached with more history still
+    to read, so the counts are a floor rather than a total.
+    """
+    collected: list[dict] = []
+    truncated = True
+    for page in range(1, _MAX_HISTORY_PAGES + 1):
+        batch, err = _api(f"projects/:id/jobs?per_page=100&page={page}")
+        if err or not batch:
+            truncated = False
+            break
+        collected.extend(batch)
+        oldest = _age_seconds(batch[-1].get("created_at"))
+        # Reach past the window by the long-job allowance: a job that finished
+        # a minute ago may have been created hours before it.
+        if oldest is not None and oldest > window_seconds + _LONG_JOB_ALLOWANCE_SECONDS:
+            truncated = False
+            break
+    return (
+        [
+            job for job in collected
+            if job.get("finished_at")
+            and (_age_seconds(job["finished_at"]) or float("inf")) <= window_seconds
+        ],
+        truncated,
+    )
+
+
+def annotate_recent_work(runners: list[dict], finished: list[dict]) -> list[dict]:
+    """Record per-runner completed-job counts on the runner records, in place."""
+    done: dict[int, int] = {}
+    for job in finished:
+        rid = (job.get("runner") or {}).get("id")
+        if rid is not None:
+            done[rid] = done.get(rid, 0) + 1
+    for runner in runners:
+        runner["_recent_jobs"] = done.get(runner.get("id"), 0)
+    return runners
+
+
+def annotate_live_jobs(runners: list[dict], running: list[dict]) -> list[dict]:
+    """Mark runners the job list shows executing work as active, in place.
+
+    Belt and braces over `job_execution_status`: the runner object and the job
+    list are two independent reads, and a runner named as owning a running job
+    is alive whatever its own record claims. Cheap, and it closes the window
+    where the runner detail is a moment staler than the queue.
+    """
+    busy = {(job.get("runner") or {}).get("id") for job in running}
+    for runner in runners:
+        if runner.get("id") in busy:
+            runner["job_execution_status"] = "active"
+    return runners
+
+
+def starved_tags(runners: list[dict], pending: list[dict]) -> dict[str, int]:
+    """{tag_key: count} for pending work no responsive runner is allowed to take.
+
+    The one signal in this module that earned its keep: it correlates two facts
+    that are each meaningless alone — a runner that stopped heartbeating, and
+    work queued behind it — into a condition GitLab's own API actively denies
+    by reporting the runner `online: true, job_execution_status: idle`.
+
+    Shared by the op, the watcher and radar so all three can never disagree
+    about what "stuck" means.
+    """
+    blocked: dict[str, int] = {}
+    for job in pending:
+        queued = _age_seconds(job.get("created_at"))
+        if queued is not None and queued < _STARVED_MIN_QUEUE_SECONDS:
+            continue
+        tags = job.get("tag_list") or []
+        if any(_can_serve(r, tags) and _is_responsive(r) for r in runners):
+            continue
+        key = ",".join(sorted(tags)) or "(untagged)"
+        blocked[key] = blocked.get(key, 0) + 1
+    return blocked
+
+
+def waiting_for(runner: dict, pending: list[dict]) -> int:
+    """How many pending jobs this runner is permitted to take."""
+    return sum(1 for job in pending if _can_serve(runner, job.get("tag_list") or []))
+
+
+# Options this tier understands from ops.radar.radar_tiers["gl-runners"].
+# Anything else is a typo or a stale key, and a silently-ignored option is how
+# someone ends up believing they configured a threshold they did not.
+RADAR_OPTIONS = {"window", "quiet_when_healthy"}
+
+
+def radar_report(options: dict | None = None) -> tuple[list[str], bool]:
+    """(lines, healthy) — this op's contribution to radar. Registered, not default.
+
+    Radar is an MR reconcile tool for most of its users, and plenty of them are
+    on shared runners or below Maintainer, where reading project runners is a
+    403. Turning that into a standing WARNING on every run for people who never
+    asked about runners would be a regression shipped as a feature, so this only
+    runs when explicitly registered in ops.radar.radar_tiers.
+    """
+    options = options or {}
+    window = options.get("window", _THROUGHPUT_WINDOW_SECONDS)
+
+    listed, err = _api("projects/:id/runners?per_page=100", paginate=True)
+    if err and ("403" in err or "permission denied" in err.lower()):
+        return ([
+            "radar: gl-runners tier is registered but this token cannot read project "
+            "runners (needs Maintainer). Grant access, or drop 'gl-runners' from "
+            "ops.radar.radar_tiers."
+        ], False)
+    if err or not listed:
+        return ([f"radar: WARNING — runner fleet unreadable ({err or 'no runners listed'}). "
+                 f"Runner health is UNKNOWN, not green."], False)
+
+    details = _fetch_details(listed)
+    runners = [{**r, **details.get(r["id"], {})} for r in listed]
+
+    pending, err_pending = _api("projects/:id/jobs?scope[]=pending&per_page=100", paginate=True)
+    if err_pending:
+        return ([f"radar: WARNING — runner queue unreadable ({err_pending}). "
+                 f"{len(runners)} runners listed; starvation is UNKNOWN."], False)
+    pending = pending or []
+
+    running, err_running = _api("projects/:id/jobs?scope[]=running&per_page=100", paginate=True)
+    annotate_live_jobs(runners, [] if err_running else (running or []))
+    # The history scan only buys evidence about work that is waiting. With an
+    # empty queue there is no starvation question, so five pages of job history
+    # answer nothing — skip them and keep a registered tier cheap.
+    if pending:
+        annotate_recent_work(runners, fetch_recent_finished(window)[0])
+
+    blocked = starved_tags(runners, pending)
+    live = [r for r in runners if _is_responsive(r)]
+
+    if not blocked:
+        return ([f"radar: fleet ok — {len(live)}/{len(runners)} runners live, "
+                 f"{len(pending)} pending, none blocked"], True)
+
+    total = sum(blocked.values())
+    lines = [f"radar: FLEET — {total} pending job(s) cannot start "
+             f"({len(live)}/{len(runners)} runners live)"]
+    for tags, count in sorted(blocked.items(), key=lambda kv: -kv[1]):
+        owners = [r for r in runners
+                  if _can_serve(r, [] if tags == "(untagged)" else tags.split(","))]
+        who = ", ".join(
+            f"{r.get('description')} (seen {_human_age(_age_seconds(r.get('contacted_at')))} ago)"
+            for r in owners) or "NO runner carries these tags"
+        lines.append(f"  [{tags}] {count} job(s) -> {who}")
+    lines.append("  Pinned to an exclusive tag: no other runner may take them. "
+                 "A red board below may be this, not your code.")
+    return (lines, False)
+
+
+def _runner_type(runner: dict) -> str:
+    raw = runner.get("runner_type") or ""
+    return {"instance_type": "shared", "group_type": "group", "project_type": "project"}.get(raw, raw or "?")
+
+
+def _print_fleet(runners: list[dict], pending: list[dict], running: list[dict]) -> None:
+    """The fleet table — one row per runner, sorted worst-health first."""
+    running_by_runner: dict[int, int] = {}
+    for job in running:
+        rid = (job.get("runner") or {}).get("id")
+        if rid is not None:
+            running_by_runner[rid] = running_by_runner.get(rid, 0) + 1
+
+    # A pending job is attributed to every runner permitted to take it, since
+    # any one of them could be the one that unblocks it.
+    waiting_by_runner: dict[int, int] = {}
+    for job in pending:
+        for runner in runners:
+            if _can_serve(runner, job.get("tag_list") or []):
+                waiting_by_runner[runner["id"]] = waiting_by_runner.get(runner["id"], 0) + 1
+
+    window_minutes = _THROUGHPUT_WINDOW_SECONDS // 60
+    print(f"{'ID':<5} {'DESCRIPTION':<22} {'TYPE':<8} {'STATUS':<9} {'JOB':<7} {'SEEN':<7} "
+          f"{'RUN':<4} {f'DONE/{window_minutes}m':<9} {'WAIT':<5} TAGS")
+    print("-" * 118)
+
+    def sort_key(runner: dict) -> tuple:
+        return (_is_responsive(runner), -(waiting_by_runner.get(runner["id"], 0)), runner["id"])
+
+    for runner in sorted(runners, key=sort_key):
+        rid = runner["id"]
+        age = _age_seconds(runner.get("contacted_at"))
+        responsive = _is_responsive(runner)
+        waiting = waiting_by_runner.get(rid, 0)
+
+        marker = ""
+        if not responsive and waiting:
+            marker = "  <! STARVED"
+        elif not responsive:
+            marker = "  <! silent"
+
+        status = runner.get("status", "?")
+        if runner.get("paused"):
+            status = "paused"
+
+        tags = ",".join(runner.get("tag_list") or []) or ("untagged-ok" if runner.get("run_untagged") else "-")
+        print(
+            f"{rid:<5} {(runner.get('description') or '?')[:22]:<22} {_runner_type(runner):<8} "
+            f"{status:<9} {(runner.get('job_execution_status') or '-'):<7} {_human_age(age):<7} "
+            f"{running_by_runner.get(rid, 0):<4} {runner.get('_recent_jobs', 0):<9} "
+            f"{waiting:<5} {tags[:34]}{marker}"
+        )
+
+
+def _print_diagnosis(runners: list[dict], pending: list[dict]) -> None:
+    """Name the blocked work: pending jobs no responsive runner can take."""
+    blocked = starved_tags(runners, pending)
+
+    if not blocked:
+        if pending:
+            print(f"\nQueue: {len(pending)} pending, all have a responsive runner. Waiting on capacity, not routing.")
+        return
+
+    total = sum(blocked.values())
+    print(f"\n## STARVED — {total} pending job(s) no live runner can take")
+    for tags, count in sorted(blocked.items(), key=lambda kv: -kv[1]):
+        owners = [r for r in runners if _can_serve(r, tags.split(",") if tags != "(untagged)" else [])]
+        if owners:
+            names = ", ".join(
+                f"{r.get('description')} (seen {_human_age(_age_seconds(r.get('contacted_at')))} ago)"
+                for r in owners
+            )
+            print(f"  - {count} job(s) tagged [{tags}] -> only {names}")
+        else:
+            print(f"  - {count} job(s) tagged [{tags}] -> NO runner carries these tags at all")
+    print("\n  Jobs pinned to an exclusive tag cannot fall back to another runner.")
+    print("  Fix the runner host, or change the tag in .gitlab-ci.yml.")
+
+
+def _print_queue(runners: list[dict], pending: list[dict], running: list[dict]) -> None:
+    """Queue-focused view: what is waiting and what is executing, by tag."""
+    print(f"## Running ({len(running)})")
+    for job in sorted(running, key=lambda j: j.get("name", "")):
+        runner = (job.get("runner") or {}).get("description", "-")
+        print(f"  {job.get('name', '?'):<44} {job.get('ref', '?'):<24} on {runner}")
+
+    print(f"\n## Pending ({len(pending)})")
+    by_tags: dict[str, list[dict]] = {}
+    for job in pending:
+        by_tags.setdefault(",".join(sorted(job.get("tag_list") or [])) or "(untagged)", []).append(job)
+    for tags, jobs in sorted(by_tags.items(), key=lambda kv: -len(kv[1])):
+        live = [r for r in runners if _can_serve(r, tags.split(",") if tags != "(untagged)" else []) and _is_responsive(r)]
+        verdict = f"{len(live)} live runner(s)" if live else "NO live runner  <!"
+        print(f"  [{tags}] {len(jobs)} job(s) -> {verdict}")
+        for job in jobs[:5]:
+            print(f"      {job.get('name', '?'):<40} {job.get('ref', '?')}")
+        if len(jobs) > 5:
+            print(f"      ... and {len(jobs) - 5} more")
+
+
+def _print_full(runners: list[dict]) -> None:
+    """Extra per-runner detail that does not fit the table."""
+    print("\n## Detail")
+    for runner in sorted(runners, key=lambda r: r["id"]):
+        print(f"\n  #{runner['id']} {runner.get('description') or '?'}")
+        print(f"    type        : {_runner_type(runner)}  (locked={runner.get('locked')}, paused={runner.get('paused')})")
+        print(f"    tags        : {', '.join(runner.get('tag_list') or []) or '-'}")
+        print(f"    run_untagged: {runner.get('run_untagged')}")
+        print(f"    contacted   : {runner.get('contacted_at') or '-'}")
+        timeout = runner.get("maximum_timeout")
+        print(f"    max timeout : {f'{timeout}s' if timeout else 'project default'}")
+        projects = runner.get("projects") or []
+        if projects:
+            names = ", ".join(p.get("path_with_namespace", "?") for p in projects[:6])
+            more = f" (+{len(projects) - 6})" if len(projects) > 6 else ""
+            print(f"    projects    : {names}{more}")
+        version = runner.get("version")
+        if version:
+            print(f"    version     : {version}  {runner.get('platform') or ''} {runner.get('architecture') or ''}".rstrip())
+
+
+def main() -> int:
+    mode = sys.argv[1].lower() if len(sys.argv) > 1 and sys.argv[1] else ""
+    if mode and mode not in _MODES:
+        print(f"ERROR: unknown mode {mode!r} — use 'full', 'queue', or omit for the fleet table")
+        return 1
+
+    listed, err = _api("projects/:id/runners?per_page=100", paginate=True)
+    if err:
+        print(err)
+        return 1
+    if not listed:
+        print("No runners available to this project.")
+        return 0
+
+    details = _fetch_details(listed)
+    runners = [{**runner, **details.get(runner["id"], {})} for runner in listed]
+
+    pending, err_pending = _api("projects/:id/jobs?scope[]=pending&per_page=100", paginate=True)
+    running, err_running = _api("projects/:id/jobs?scope[]=running&per_page=100", paginate=True)
+    # A queue read failing is not fatal — the fleet table is still worth printing.
+    queue_warning = err_pending or err_running
+    pending = pending or []
+    running = running or []
+
+    annotate_live_jobs(runners, running)
+    finished, throughput_truncated = fetch_recent_finished()
+    annotate_recent_work(runners, finished)
+
+    if mode == "queue":
+        _print_queue(runners, pending, running)
+    else:
+        _print_fleet(runners, pending, running)
+        _print_diagnosis(runners, pending)
+        if mode == "full":
+            _print_full(runners)
+
+    if throughput_truncated:
+        print(f"\nNOTE: job history hit the {_MAX_HISTORY_PAGES}-page scan cap — "
+              f"DONE counts are a lower bound, not a total.")
+    if queue_warning:
+        print(f"\nNOTE: queue data unavailable — {queue_warning}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/presets/watch/README.md
+++ b/presets/watch/README.md
@@ -42,6 +42,7 @@ on every session start. Details in [docs/presets/watch.md](../../docs/presets/wa
 | `github-pr`       | GitHub PR number               | PR merged or closed                            |
 | `gl-pipeline`     | GitLab CI pipeline id          | pipeline success / failed / canceled / skipped |
 | `gitlab-mr-feed`  | scope (`@me`, `@reviewer`, …)  | never — discovery has no end state             |
+| `gl-runners`      | scope (`fleet`)                | never — a fleet has no end state               |
 
 Every source but the last polls **one known id**, so none of them can discover
 an MR that did not exist when they were spawned. `gitlab-mr-feed` polls the

--- a/presets/watch/README.md
+++ b/presets/watch/README.md
@@ -44,6 +44,11 @@ on every session start. Details in [docs/presets/watch.md](../../docs/presets/wa
 | `gitlab-mr-feed`  | scope (`@me`, `@reviewer`, …)  | never — discovery has no end state             |
 | `gl-runners`      | scope (`fleet`)                | never — a fleet has no end state               |
 
+`gl-runners` is a **registered radar tier**, not a default one: radar only spawns it
+when `ops.radar.radar_tiers` names it. See
+[docs/presets/watch.md](../../docs/presets/watch.md) for the tier contract and for
+which ops are worth watching at all.
+
 Every source but the last polls **one known id**, so none of them can discover
 an MR that did not exist when they were spawned. `gitlab-mr-feed` polls the
 whole population instead: new iids get a `gitlab-mr` watcher and an

--- a/presets/watch/radar.py
+++ b/presets/watch/radar.py
@@ -141,12 +141,27 @@ def _load(name: str, path: Path):
 
 
 mrs = _load("radar_gitlab_mrs", _HERE.parents[1] / "presets" / "gitlab" / "mrs.py")
+runners_op = _load("radar_gitlab_runners", _HERE.parents[1] / "presets" / "gitlab" / "runners.py")
 dispatcher = _load("radar_watch_dispatcher", _HERE / "dispatcher.py")
 
 SOURCE = defaults.DEFAULT_SOURCE
 FEED_SOURCE = defaults.DEFAULT_FEED_SOURCE
 FEED_SCOPE = defaults.DEFAULT_FEED_SCOPE
 SNAPSHOT_PREFIX = "supertool-radar"
+
+# The fleet tier. Scope-free, unlike the feed: there is one runner fleet behind
+# every filter, so this is not keyed by the board's population.
+FLEET_SOURCE = "gl-runners"
+FLEET_SCOPE = "fleet"
+
+# ops.radar.radar_tiers, JSON-encoded into the env by the op runner — the same
+# route ops.radar.radar_exclusions takes.
+TIERS_ENV = "SUPERTOOL_RADAR_TIERS"
+
+# A registered tier that also wants a background watcher names it here. Only
+# consulted for tiers actually registered, so an unregistered tier costs no
+# poller and no API call.
+_TIER_WATCH_SOURCES = {"gl-runners": (FLEET_SOURCE, FLEET_SCOPE)}
 
 # ops.radar.radar_exclusions in .supertool.json, JSON-encoded into the env by
 # the op runner — the same route ops.gl-job.job_patterns takes.
@@ -499,6 +514,198 @@ def feed_error(scope: str = FEED_SCOPE) -> str:
 
 
 # ---------------------------------------------------------------------------
+# 3c. fleet — the tier that says whether the board is even the right question
+# ---------------------------------------------------------------------------
+
+def ensure_watcher(source: str, scope: str) -> str:
+    """Guarantee exactly one live poller for a tier. "alive"|"spawned"|"failed".
+
+    Same idempotence contract as `ensure_feed`, for the same reason: radar runs
+    on a loop, and n pollers over one source means n copies of every event.
+    `start_poller` claims the slot before the fork.
+    """
+    if dispatcher._load_source(source) is None:
+        return "failed"
+    return dispatcher.start_poller(source, scope, [])[0]
+
+
+def ensure_fleet() -> str:
+    """Back-compat alias for the fleet tier's watcher."""
+    return ensure_watcher(FLEET_SOURCE, FLEET_SCOPE)
+
+
+def read_tiers(raw: str | None = None) -> tuple[dict[str, dict], list[str]]:
+    """({op_name: options}, complaints) from ops.radar.radar_tiers.
+
+    Empty by default, and that default is the point. Radar is an MR reconcile
+    tool for most of the people who install it; a tier that reaches for runners,
+    or any other privileged resource, must be asked for. Shipping one on by
+    default would hand every stranger a standing WARNING about infrastructure
+    they do not own and cannot read.
+
+    Nothing here raises. A config this cannot parse yields no tiers plus a
+    complaint, which renders as the ordinary board it was trying to extend.
+    """
+    raw = os.environ.get(TIERS_ENV, "") if raw is None else raw
+    raw = raw.strip()
+    if not raw:
+        return {}, []
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {}, [f"radar: WARNING — radar_tiers is not valid JSON ({exc.msg}). "
+                    f"No tiers loaded."]
+    if not isinstance(loaded, dict):
+        return {}, ["radar: WARNING — radar_tiers must be an object keyed by op name, "
+                    "e.g. {'gl-runners': {}}. No tiers loaded."]
+
+    out: dict[str, dict] = {}
+    problems: list[str] = []
+    for name, opts in loaded.items():
+        if opts is None:
+            opts = {}
+        if not isinstance(opts, dict):
+            problems.append(f"radar: WARNING — tier '{name}' options must be an object; "
+                            f"got {type(opts).__name__}. Tier skipped.")
+            continue
+        out[str(name)] = opts
+    return out, problems
+
+
+def _tier_module(name: str):
+    """Resolve a registered op name to the module implementing it, or None.
+
+    Read out of the preset that declares the op rather than from a second
+    hardcoded table: the op's `cmd` already names its script, and a mapping
+    kept alongside it is one that drifts the first time a file moves.
+    """
+    presets_dir = _HERE.parent
+    for preset in sorted(presets_dir.glob("*.json")):
+        try:
+            with open(preset, encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        entry = (data.get("ops") or {}).get(name)
+        if not isinstance(entry, dict):
+            continue
+        for token in str(entry.get("cmd") or "").split():
+            if token.endswith(".py"):
+                script = presets_dir / token.replace("{path}", "")
+                if script.is_file():
+                    return _load(f"radar_tier_{name.replace('-', '_')}", script)
+    return None
+
+
+def tier_reports() -> tuple[list[str], bool]:
+    """(lines, all_healthy) from every registered tier, in registration order.
+
+    A healthy tier is silent by default (`quiet_when_healthy`): the reader of a
+    board wants to know what is wrong, and a green line per tier per run is the
+    noise that trains people to skim past the red one. An unhealthy tier always
+    speaks, on every run, because it is a current fact rather than a transition.
+    """
+    tiers, lines = read_tiers()
+    all_ok = True
+
+    for name, opts in tiers.items():
+        module = _tier_module(name)
+        report = getattr(module, "radar_report", None) if module else None
+        if report is None:
+            lines.append(f"radar: WARNING — tier '{name}' is registered but exposes no "
+                         f"radar_report(); it contributes nothing. Check the name.")
+            all_ok = False
+            continue
+
+        unknown = set(opts) - set(getattr(module, "RADAR_OPTIONS", set()))
+        if unknown:
+            lines.append(f"radar: WARNING — tier '{name}' has unknown option(s) "
+                         f"{sorted(unknown)}; ignored. Check for a typo.")
+
+        try:
+            tier_lines, ok = report(opts)
+        except Exception as exc:  # noqa: BLE001 — a broken tier must not take radar down
+            lines.append(f"radar: WARNING — tier '{name}' failed: "
+                         f"{exc.__class__.__name__}: {exc}")
+            all_ok = False
+            continue
+
+        all_ok = all_ok and ok
+        if ok and opts.get("quiet_when_healthy", True):
+            continue
+        lines.extend(tier_lines)
+
+    return lines, all_ok
+
+
+def fleet_report() -> tuple[list[str], bool]:
+    """(lines, healthy) describing runner capacity, read from live GitLab.
+
+    Deliberately not read from the poller's state file. Silent runners are a
+    standing condition rather than a transition, and a poller radar just
+    respawned re-baselines on its first tick — so every runner that went quiet
+    while nothing was watching is recorded as history and announced to nobody.
+    Reading live is the same authority split radar already applies to MRs:
+    GitLab is the truth, the state file is a cache.
+
+    Unreadable is reported as unknown, never as healthy. A board that answers
+    "is the infrastructure fine?" with silence when it could not check is the
+    one failure mode this whole tier exists to remove.
+    """
+    listed, err = runners_op._api("projects/:id/runners?per_page=100", paginate=True)
+    if err or not listed:
+        return ([f"radar: WARNING — runner fleet unreadable ({err or 'no runners listed'}). "
+                 f"Runner health is UNKNOWN, not green."], False)
+
+    details = runners_op._fetch_details(listed)
+    runners = [{**r, **details.get(r["id"], {})} for r in listed]
+
+    pending, err_pending = runners_op._api(
+        "projects/:id/jobs?scope[]=pending&per_page=100", paginate=True)
+    if err_pending:
+        return ([f"radar: WARNING — runner queue unreadable ({err_pending}). "
+                 f"{len(runners)} runners listed; starvation is UNKNOWN."], False)
+    pending = pending or []
+
+    running, err_running = runners_op._api(
+        "projects/:id/jobs?scope[]=running&per_page=100", paginate=True)
+    # A runner executing a job right now is alive whatever contacted_at says —
+    # that field is throttled, and trusting it alone reported healthy runners
+    # as wedged. Folded in before anything is judged.
+    runners_op.annotate_live_jobs(runners, [] if err_running else (running or []))
+    runners_op.annotate_recent_work(runners, runners_op.fetch_recent_finished()[0])
+
+    blocked = runners_op.starved_tags(runners, pending)
+
+    live = [r for r in runners if runners_op._is_responsive(r)]
+    paused = [r for r in runners if r.get("paused")]
+
+    if not blocked:
+        summary = (f"radar: fleet ok — {len(live)}/{len(runners)} runners live"
+                   f"{f', {len(paused)} paused' if paused else ''}"
+                   f", {len(pending)} pending, none blocked")
+        return ([summary], True)
+
+    total = sum(blocked.values())
+    lines = [f"radar: FLEET — {total} pending job(s) cannot start "
+             f"({len(live)}/{len(runners)} runners live)"]
+    for tags, count in sorted(blocked.items(), key=lambda kv: -kv[1]):
+        owners = [r for r in runners if runners_op._can_serve(
+            r, [] if tags == "(untagged)" else tags.split(","))]
+        if owners:
+            who = ", ".join(
+                f"{r.get('description')} (seen "
+                f"{runners_op._human_age(runners_op._age_seconds(r.get('contacted_at')))} ago)"
+                for r in owners)
+        else:
+            who = "NO runner carries these tags"
+        lines.append(f"  [{tags}] {count} job(s) -> {who}")
+    lines.append("  Pinned to an exclusive tag: no other runner may take them. "
+                 "A red board below may be this, not your code.")
+    return (lines, False)
+
+
+# ---------------------------------------------------------------------------
 # 4. report
 # ---------------------------------------------------------------------------
 
@@ -760,7 +967,9 @@ def render(open_mrs: list[dict], covered: set[str], healed: list[str],
            feed: str = "alive", feed_err: str = "", label: str = "",
            excluded: set[str] | None = None, notes: list[str] | None = None,
            other_scopes: list[str] | None = None,
-           losses: list[str] | None = None) -> str:
+           losses: list[str] | None = None,
+           fleet_lines: list[str] | None = None,
+           fleet_ok: bool = True) -> str:
     """Full board on cold start; changed + standing-problem rows afterwards.
 
     `label` names the population on every board, the default one included
@@ -799,6 +1008,14 @@ def render(open_mrs: list[dict], covered: set[str], healed: list[str],
                      feed, label, len(excluded))
 
     lines = _feed_warnings(feed, feed_err, other_scopes) + list(losses or [])
+    # Printed as given. Tiers decide their own silence in `tier_reports` — a
+    # healthy tier already returned nothing unless it was asked to speak — so
+    # re-gating here swallowed two things that must never be swallowed: a tier
+    # explicitly configured to report when healthy, and the WARNING lines about
+    # a misconfigured tier, which are exactly the output a misconfiguration
+    # needs in order to get fixed.
+    if fleet_lines:
+        lines.extend(fleet_lines)
     if cold:
         lines.append("radar: cold start — no prior snapshot, full board")
     if shown:
@@ -841,6 +1058,12 @@ def main(argv: list[str] | None = None) -> int:
     feed = ensure_feed(scope)
     feed_err = feed_error(scope) if feed == "alive" else ""
 
+    registered, _tier_problems = read_tiers()
+    for tier_name, (watch_source, watch_scope) in _TIER_WATCH_SOURCES.items():
+        if tier_name in registered:
+            ensure_watcher(watch_source, watch_scope)
+    fleet_lines, fleet_ok = tier_reports()
+
     exclusions, excl_problems = read_exclusions()
     excluded, excl_lines = resolve_exclusions(open_mrs, exclusions, covered)
 
@@ -853,7 +1076,8 @@ def main(argv: list[str] | None = None) -> int:
     previous = read_snapshot(multi)
     print(render(open_mrs, covered, healed, drifted, pruned, uncovered, previous,
                  feed, feed_err, label, excluded, excl_problems + excl_lines,
-                 other_feed_scopes(scope), loss_warnings(healed, refused)))
+                 other_feed_scopes(scope), loss_warnings(healed, refused),
+                 fleet_lines, fleet_ok))
     # The snapshot records the whole population, excluded rows included:
     # keyed on what is true, not on what was printed. Otherwise the run after
     # an exclusion is lifted reports a months-old MR as new.

--- a/presets/watch/radar.py
+++ b/presets/watch/radar.py
@@ -169,7 +169,8 @@ EXCLUSIONS_ENV = "SUPERTOOL_RADAR_EXCLUSIONS"
 
 _FIX_HINT = "remove it from ops.radar.radar_exclusions in .supertool.json"
 
-FEED_LABEL = {"alive": "feed ok", "spawned": "feed respawned", "failed": "feed DOWN"}
+FEED_LABEL = {"alive": "feed ok", "spawned": "feed respawned", "failed": "feed DOWN",
+              "capped": "feed DOWN (respawn capped)"}
 
 
 class RadarError(RuntimeError):
@@ -476,8 +477,7 @@ def ensure_feed(scope: str = FEED_SCOPE) -> str:
     if dispatcher._load_source(FEED_SOURCE) is None:
         return "failed"
     only = [e for e in defaults.DEFAULT_FEED_ONLY.split(",") if e]
-    status, _pid = dispatcher.start_poller(FEED_SOURCE, scope, only)
-    return status
+    return ensure_watcher(FEED_SOURCE, scope, only)
 
 
 def other_feed_scopes(scope: str = FEED_SCOPE) -> list[str]:
@@ -517,21 +517,43 @@ def feed_error(scope: str = FEED_SCOPE) -> str:
 # 3c. fleet — the tier that says whether the board is even the right question
 # ---------------------------------------------------------------------------
 
-def ensure_watcher(source: str, scope: str) -> str:
-    """Guarantee exactly one live poller for a tier. "alive"|"spawned"|"failed".
+def ensure_watcher(source: str, scope: str, only: list[str] | None = None) -> str:
+    """One live poller for a slot. "alive"|"spawned"|"failed"|"capped".
 
-    Same idempotence contract as `ensure_feed`, for the same reason: radar runs
-    on a loop, and n pollers over one source means n copies of every event.
+    Same idempotence contract as the per-MR heal, for the same reason: radar
+    runs on a loop, and n pollers over one slot means n copies of every event.
     `start_poller` claims the slot before the fork.
+
+    The death cap from #513 is applied here rather than only in `heal`. That
+    bound lived on the per-MR path alone, so every other spawner — the feed,
+    and any tier watcher — would respawn a poller that dies on every tick,
+    forever, silently. Reproducing a fixed defect in a new tier is how it comes
+    back, so the cap belongs at the one place that spawns.
     """
     if dispatcher._load_source(source) is None:
         return "failed"
-    return dispatcher.start_poller(source, scope, [])[0]
+    if len(transport.deaths(source, scope)) >= transport.DEATH_RESPAWN_LIMIT:
+        return "capped"
+    return dispatcher.start_poller(source, scope, only or [])[0]
 
 
 def ensure_fleet() -> str:
     """Back-compat alias for the fleet tier's watcher."""
     return ensure_watcher(FLEET_SOURCE, FLEET_SCOPE)
+
+
+def watcher_cap_warnings(statuses: dict[str, str]) -> list[str]:
+    """Name every slot radar has stopped respawning. Never silent about it.
+
+    A capped slot is not being watched, and the whole lesson of #513 is that a
+    monitoring surface going quiet reads exactly like nothing being wrong.
+    """
+    return [
+        f"radar: WARNING — stopped respawning {name}: it has died "
+        f"{transport.DEATH_RESPAWN_LIMIT}+ times and nothing is polling it. "
+        f"Fix it, then re-arm with `watch:{name}`."
+        for name, status in sorted(statuses.items()) if status == "capped"
+    ]
 
 
 def read_tiers(raw: str | None = None) -> tuple[dict[str, dict], list[str]]:
@@ -636,73 +658,6 @@ def tier_reports() -> tuple[list[str], bool]:
         lines.extend(tier_lines)
 
     return lines, all_ok
-
-
-def fleet_report() -> tuple[list[str], bool]:
-    """(lines, healthy) describing runner capacity, read from live GitLab.
-
-    Deliberately not read from the poller's state file. Silent runners are a
-    standing condition rather than a transition, and a poller radar just
-    respawned re-baselines on its first tick — so every runner that went quiet
-    while nothing was watching is recorded as history and announced to nobody.
-    Reading live is the same authority split radar already applies to MRs:
-    GitLab is the truth, the state file is a cache.
-
-    Unreadable is reported as unknown, never as healthy. A board that answers
-    "is the infrastructure fine?" with silence when it could not check is the
-    one failure mode this whole tier exists to remove.
-    """
-    listed, err = runners_op._api("projects/:id/runners?per_page=100", paginate=True)
-    if err or not listed:
-        return ([f"radar: WARNING — runner fleet unreadable ({err or 'no runners listed'}). "
-                 f"Runner health is UNKNOWN, not green."], False)
-
-    details = runners_op._fetch_details(listed)
-    runners = [{**r, **details.get(r["id"], {})} for r in listed]
-
-    pending, err_pending = runners_op._api(
-        "projects/:id/jobs?scope[]=pending&per_page=100", paginate=True)
-    if err_pending:
-        return ([f"radar: WARNING — runner queue unreadable ({err_pending}). "
-                 f"{len(runners)} runners listed; starvation is UNKNOWN."], False)
-    pending = pending or []
-
-    running, err_running = runners_op._api(
-        "projects/:id/jobs?scope[]=running&per_page=100", paginate=True)
-    # A runner executing a job right now is alive whatever contacted_at says —
-    # that field is throttled, and trusting it alone reported healthy runners
-    # as wedged. Folded in before anything is judged.
-    runners_op.annotate_live_jobs(runners, [] if err_running else (running or []))
-    runners_op.annotate_recent_work(runners, runners_op.fetch_recent_finished()[0])
-
-    blocked = runners_op.starved_tags(runners, pending)
-
-    live = [r for r in runners if runners_op._is_responsive(r)]
-    paused = [r for r in runners if r.get("paused")]
-
-    if not blocked:
-        summary = (f"radar: fleet ok — {len(live)}/{len(runners)} runners live"
-                   f"{f', {len(paused)} paused' if paused else ''}"
-                   f", {len(pending)} pending, none blocked")
-        return ([summary], True)
-
-    total = sum(blocked.values())
-    lines = [f"radar: FLEET — {total} pending job(s) cannot start "
-             f"({len(live)}/{len(runners)} runners live)"]
-    for tags, count in sorted(blocked.items(), key=lambda kv: -kv[1]):
-        owners = [r for r in runners if runners_op._can_serve(
-            r, [] if tags == "(untagged)" else tags.split(","))]
-        if owners:
-            who = ", ".join(
-                f"{r.get('description')} (seen "
-                f"{runners_op._human_age(runners_op._age_seconds(r.get('contacted_at')))} ago)"
-                for r in owners)
-        else:
-            who = "NO runner carries these tags"
-        lines.append(f"  [{tags}] {count} job(s) -> {who}")
-    lines.append("  Pinned to an exclusive tag: no other runner may take them. "
-                 "A red board below may be this, not your code.")
-    return (lines, False)
 
 
 # ---------------------------------------------------------------------------
@@ -1059,10 +1014,13 @@ def main(argv: list[str] | None = None) -> int:
     feed_err = feed_error(scope) if feed == "alive" else ""
 
     registered, _tier_problems = read_tiers()
+    watcher_statuses: dict[str, str] = {}
     for tier_name, (watch_source, watch_scope) in _TIER_WATCH_SOURCES.items():
         if tier_name in registered:
-            ensure_watcher(watch_source, watch_scope)
+            watcher_statuses[f"{watch_source}:{watch_scope}"] = ensure_watcher(
+                watch_source, watch_scope)
     fleet_lines, fleet_ok = tier_reports()
+    fleet_lines = watcher_cap_warnings(watcher_statuses) + fleet_lines
 
     exclusions, excl_problems = read_exclusions()
     excluded, excl_lines = resolve_exclusions(open_mrs, exclusions, covered)

--- a/presets/watch/sources/gl-runners/events.json
+++ b/presets/watch/sources/gl-runners/events.json
@@ -1,0 +1,12 @@
+{
+  "source": "gl-runners",
+  "events": [
+    {"key": "runner_silent",    "label": "A runner stopped taking work while jobs are queued for it, and GitLab still reports it online"},
+    {"key": "runner_recovered", "label": "A wedged runner started taking work again"},
+    {"key": "runner_starved",   "label": "Pending jobs whose tags match only wedged runners"},
+    {"key": "queue_cleared",    "label": "A starved queue drained"},
+    {"key": "runner_paused",    "label": "A runner was paused or unpaused"},
+    {"key": "runner_added",     "label": "A runner joined the fleet"},
+    {"key": "runner_vanished",  "label": "A runner left the fleet"}
+  ]
+}

--- a/presets/watch/sources/gl-runners/poller.py
+++ b/presets/watch/sources/gl-runners/poller.py
@@ -1,0 +1,289 @@
+"""gl-runners watcher source — continuous health watch over the runner fleet.
+
+The failure this exists for: a runner stops polling GitLab, and GitLab keeps
+reporting it `status: online, job_execution_status: idle` for the best part of
+an hour, because idle and dead are the same two fields. Jobs pinned to that
+runner's exclusive tag queue up behind it and cannot fall back to any other
+runner. Nothing turns red. You find out when someone asks why the pipeline is
+slow today.
+
+Like `gitlab-mr-feed`, the id here is a *scope*, not a member — the interesting
+events are about runners you are not watching yet, including ones added after
+the poller started. Never terminal: a fleet has no end state.
+
+    state    {runners: {id: snapshot}, starved: {tagkey: count}}
+    silent   not taking work AND work is waiting for it — a wedge
+    starved  pending jobs whose tags match only wedged runners
+    fleet    membership and paused-flag changes
+
+`runner_silent` gates on consequence, and that is not a refinement — it is the
+whole difference between a signal and noise. Built on heartbeat staleness alone
+it fired on 6 of 6 online runners in its first hour, because GitLab throttles
+its contacted_at writes and a runner taking jobs continuously still reads
+minutes stale. A signal that fires on the entire healthy fleet does not just
+fail to inform, it buries the one event that was real. So liveness is judged
+first on job_execution_status and the running-jobs list — direct proof — and
+silence is only reported when jobs are actually queued behind it.
+
+Baseline handling is deliberately asymmetric on the first tick. Membership,
+silence and paused flags are recorded quietly, because announcing a transition
+that happened before the watcher existed is history, not news. Starvation is
+announced immediately, because it is not a transition — it is a condition that
+is still true right now, and staying silent about jobs that cannot move would
+make a freshly-spawned watcher indistinguishable from a healthy fleet.
+
+Source plugin contract:
+- INTERVAL: int seconds between polls
+- poll(state, ctx) -> (events, new_state)
+- is_terminal(state) -> bool
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+# Runner state moves on infrastructure timescales, not CI timescales, and each
+# tick costs one list call plus one detail call per runner plus two queue
+# calls. A minute keeps the silent-runner alert inside the window where it is
+# still actionable without hammering the API.
+INTERVAL = 60
+
+_PRESETS_DIR = Path(__file__).parents[3]
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# One source of truth for "responsive" and "can this runner take this job".
+# If the op and the watcher ever disagreed on those, the table would say
+# STARVED while the watcher stayed quiet, and neither would be obviously wrong.
+runners_op = _load("watch_gl_runners_op", _PRESETS_DIR / "gitlab" / "runners.py")
+
+
+def _fetch_fleet() -> tuple[list[dict], list[dict] | None, list[dict]] | None:
+    """(runners, pending_jobs, running_jobs) with detail merged. None on failure.
+
+    None is deliberately not an empty list: an unreachable GitLab must never
+    read as "every runner vanished", which would fire a departure event for
+    each of them and a recovery event for none.
+
+    The running list is fetched before anything is judged, because a runner
+    executing a job is alive regardless of what its throttled contacted_at
+    says — `annotate_live_jobs` folds that proof into the runner records.
+    """
+    listed, err = runners_op._api("projects/:id/runners?per_page=100", paginate=True)
+    if err or listed is None:
+        return None
+
+    details = runners_op._fetch_details(listed)
+    merged = [{**runner, **details.get(runner["id"], {})} for runner in listed]
+
+    running, err_running = runners_op._api(
+        "projects/:id/jobs?scope[]=running&per_page=100", paginate=True)
+    running = [] if err_running else (running or [])
+    runners_op.annotate_live_jobs(merged, running)
+    runners_op.annotate_recent_work(merged, runners_op.fetch_recent_finished()[0])
+
+    pending, err_pending = runners_op._api(
+        "projects/:id/jobs?scope[]=pending&per_page=100", paginate=True
+    )
+    if err_pending:
+        # The fleet half is still usable; treat the queue as unknown rather
+        # than empty, so a queue outage cannot read as "starvation cleared".
+        return merged, None, running
+    return merged, (pending or []), running
+
+
+def _snapshot(runner: dict, pending: list[dict], running: list[dict]) -> dict[str, Any]:
+    """The fields whose changes are worth an event.
+
+    `waiting` and `running` ride on every snapshot rather than only the starved
+    one: those two counts are exactly what separates a runner that is idle from
+    one that is wedged, and leaving them off forces whoever reads the event to
+    go and fetch them by hand before they can act on it.
+    """
+    responsive = runners_op._is_responsive(runner)
+    waiting = runners_op.waiting_for(runner, pending)
+    return {
+        "description": runner.get("description") or f"#{runner.get('id')}",
+        "responsive": responsive,
+        "paused": bool(runner.get("paused")),
+        "tags": sorted(runner.get("tag_list") or []),
+        "contacted_at": runner.get("contacted_at"),
+        "waiting": waiting,
+        "running": sum(1 for job in running
+                       if (job.get("runner") or {}).get("id") == runner.get("id")),
+        "recent_jobs": runner.get("_recent_jobs", 0),
+        # Silence is only news when work is stuck behind it. A quiet runner with
+        # an empty queue is a runner with nothing to do, and alerting on that
+        # fires on the whole fleet every time the pipeline goes idle.
+        "blocked": (not responsive) and waiting > 0,
+    }
+
+
+def _fleet_events(
+    previous: dict[str, dict], current: dict[str, dict], first_tick: bool,
+    queue_known: bool = True,
+) -> list[dict]:
+    """Membership, blocked-silence and paused transitions. Quiet on first tick.
+
+    The silence transition is on `blocked`, not on `responsive`. Heartbeat
+    staleness alone fires on healthy runners — GitLab throttles its
+    contacted_at writes, so a busy runner routinely reads as minutes stale —
+    and a signal that fires on the whole fleet buries the one that matters.
+    """
+    if first_tick:
+        return []
+
+    events: list[dict] = []
+
+    for rid, now in current.items():
+        was = previous.get(rid)
+        name = now["description"]
+
+        counts = {"pending_for_it": now["waiting"], "running_on_it": now["running"],
+                  "completed_recently": now.get("recent_jobs", 0)}
+
+        if was is None:
+            events.append({
+                "event": "runner_added",
+                "payload": {"runner_id": rid, "description": name, "tags": now["tags"],
+                            **counts},
+                "notify_title": f"runner {name} joined",
+                "notify_message": ", ".join(now["tags"]) or "untagged",
+            })
+            continue
+
+        if queue_known and now["blocked"] and not was.get("blocked"):
+            age = runners_op._human_age(runners_op._age_seconds(now["contacted_at"]))
+            events.append({
+                "event": "runner_silent",
+                "payload": {"runner_id": rid, "description": name, "last_seen": age,
+                            "tags": now["tags"], **counts},
+                "notify_title": f"runner {name} wedged — {now['waiting']} job(s) waiting",
+                "notify_message": f"last contact {age} ago, {now['running']} running "
+                                  f"— GitLab still reports it online",
+            })
+        elif queue_known and was.get("blocked") and now["responsive"]:
+            events.append({
+                "event": "runner_recovered",
+                "payload": {"runner_id": rid, "description": name, **counts},
+                "notify_title": f"runner {name} is back",
+                "notify_message": f"heartbeat resumed, {now['waiting']} pending",
+            })
+
+        if now["paused"] != was["paused"]:
+            events.append({
+                "event": "runner_paused",
+                "payload": {"runner_id": rid, "description": name, "paused": now["paused"],
+                            **counts},
+                "notify_title": f"runner {name} {'paused' if now['paused'] else 'unpaused'}",
+                "notify_message": ", ".join(now["tags"]) or "untagged",
+            })
+
+    for rid, was in previous.items():
+        if rid not in current:
+            events.append({
+                "event": "runner_vanished",
+                "payload": {"runner_id": rid, "description": was["description"]},
+                "notify_title": f"runner {was['description']} left the fleet",
+                "notify_message": "no longer listed for this project",
+            })
+
+    return events
+
+
+def _queue_events(
+    previous: dict[str, int], current: dict[str, int], runners: list[dict]
+) -> list[dict]:
+    """Starvation appearing, deepening, or clearing.
+
+    Emitted on the first tick too — see the module docstring. A deepening queue
+    re-fires only when it grows, so a stuck backlog does not notify every
+    minute for as long as it stays stuck.
+    """
+    events: list[dict] = []
+
+    for tags, count in current.items():
+        before = previous.get(tags, 0)
+        if count <= before:
+            continue
+
+        owners = [
+            r for r in runners
+            if runners_op._can_serve(r, [] if tags == "(untagged)" else tags.split(","))
+        ]
+        if owners:
+            who = ", ".join(
+                f"{r.get('description')} (seen "
+                f"{runners_op._human_age(runners_op._age_seconds(r.get('contacted_at')))} ago)"
+                for r in owners
+            )
+        else:
+            who = "no runner carries these tags at all"
+
+        events.append({
+            "event": "runner_starved",
+            "payload": {"tags": tags, "pending": count, "owners": who},
+            "notify_title": f"{count} job(s) stuck on [{tags}]",
+            "notify_message": who,
+        })
+
+    for tags, before in previous.items():
+        if before and not current.get(tags):
+            events.append({
+                "event": "queue_cleared",
+                "payload": {"tags": tags, "was_pending": before},
+                "notify_title": f"[{tags}] queue cleared",
+                "notify_message": f"{before} job(s) drained",
+            })
+
+    return events
+
+
+def poll(state: dict, ctx: dict) -> tuple[list[dict], dict]:
+    fetched = _fetch_fleet()
+    if fetched is None:
+        return [], state  # transient — try again next tick
+
+    runners, pending, running = fetched
+    first_tick = not state
+
+    current_fleet = {str(r["id"]): _snapshot(r, pending or [], running)
+                     for r in runners}
+    previous_fleet = state.get("runners") or {}
+
+    events = _fleet_events(previous_fleet, current_fleet, first_tick,
+                           queue_known=pending is not None)
+
+    new_state: dict[str, Any] = {"runners": current_fleet}
+
+    if pending is None:
+        # Queue unknown this tick — carry the last reading forward untouched so
+        # an API blip cannot be read as either starvation or its resolution.
+        new_state["starved"] = state.get("starved") or {}
+        new_state["queue_known"] = False
+    else:
+        current_starved = runners_op.starved_tags(runners, pending)
+        events += _queue_events(state.get("starved") or {}, current_starved, runners)
+        new_state["starved"] = current_starved
+        new_state["queue_known"] = True
+        new_state["pending_total"] = len(pending)
+
+    silent = [s["description"] for s in current_fleet.values() if not s["responsive"]]
+    new_state["silent"] = silent
+    new_state["fleet_size"] = len(current_fleet)
+
+    return events, new_state
+
+
+def is_terminal(state: dict) -> bool:
+    """Never. A fleet has no end state — the watcher runs until unwatched."""
+    return False

--- a/tests/test_gl_runners.py
+++ b/tests/test_gl_runners.py
@@ -202,3 +202,99 @@ def test_waiting_for_counts_only_what_this_runner_may_take() -> None:
     runner = _runner(tag_list=["docker"])
     pending = [{"tag_list": ["docker"]}, {"tag_list": ["docker"]}, {"tag_list": ["other"]}]
     assert runners_op.waiting_for(runner, pending) == 2
+
+
+# ---------------------------------------------------------------------------
+# radar tier contract
+# ---------------------------------------------------------------------------
+
+def _api_stub(runners=None, pending=None, running=None, history=None, errors=None):
+    """Route the op's endpoints to canned payloads."""
+    errors = errors or {}
+
+    def fake_api(endpoint, paginate=False, timeout=20):
+        for key, err in errors.items():
+            if key in endpoint:
+                return (None, err)
+        if "runners?" in endpoint:
+            return (runners or [], None)
+        if "scope[]=pending" in endpoint:
+            return (pending or [], None)
+        if "scope[]=running" in endpoint:
+            return (running or [], None)
+        return (history or [], None)
+
+    return fake_api
+
+
+def test_the_tier_names_the_runner_holding_the_queue(monkeypatch) -> None:
+    dead = _runner(1, description="dptools-runner-2", tag_list=["runner-2"],
+                   contacted_at=_iso(7200))
+    monkeypatch.setattr(runners_op, "_api", _api_stub(
+        runners=[dead], pending=[{"tag_list": ["runner-2"], "created_at": _iso(1800)}]))
+    monkeypatch.setattr(runners_op, "_fetch_details", lambda listed: {})
+
+    lines, ok = runners_op.radar_report({})
+    joined = "\n".join(lines)
+    assert ok is False
+    assert "1 pending job(s) cannot start" in joined
+    assert "dptools-runner-2" in joined
+    assert "may be this, not your code" in joined
+
+
+def test_the_tier_is_healthy_when_a_live_runner_covers_the_queue(monkeypatch) -> None:
+    alive = _runner(1, tag_list=["docker"], contacted_at=_iso(10))
+    monkeypatch.setattr(runners_op, "_api", _api_stub(
+        runners=[alive], pending=[{"tag_list": ["docker"], "created_at": _iso(1800)}]))
+    monkeypatch.setattr(runners_op, "_fetch_details", lambda listed: {})
+
+    lines, ok = runners_op.radar_report({})
+    assert ok is True
+    assert "fleet ok" in "\n".join(lines)
+
+
+def test_a_403_tells_the_operator_what_to_do_about_it(monkeypatch) -> None:
+    """Most people who install this are not Maintainers on the project. A tier
+    they registered and cannot use must say so actionably, not cry wolf."""
+    monkeypatch.setattr(runners_op, "_api", _api_stub(
+        errors={"runners?": "ERROR: permission denied reading runners (403)"}))
+    lines, ok = runners_op.radar_report({})
+    joined = "\n".join(lines)
+    assert ok is False
+    assert "Maintainer" in joined
+    assert "radar_tiers" in joined
+
+
+def test_an_empty_queue_skips_the_history_scan(monkeypatch) -> None:
+    """With nothing queued there is no starvation question, so five pages of
+    job history answer nothing. A registered tier should stay cheap."""
+    calls: list[str] = []
+
+    def counting_api(endpoint, paginate=False, timeout=20):
+        calls.append(endpoint)
+        return _api_stub(runners=[_runner(1, contacted_at=_iso(10))])(endpoint, paginate, timeout)
+
+    monkeypatch.setattr(runners_op, "_api", counting_api)
+    monkeypatch.setattr(runners_op, "_fetch_details", lambda listed: {})
+    _lines, ok = runners_op.radar_report({})
+
+    assert ok is True
+    assert not any("&page=" in call for call in calls)
+
+
+def test_the_window_option_reaches_the_history_scan(monkeypatch) -> None:
+    seen: dict[str, int] = {}
+    monkeypatch.setattr(runners_op, "_api", _api_stub(
+        runners=[_runner(1, tag_list=["docker"], contacted_at=_iso(10))],
+        pending=[{"tag_list": ["docker"], "created_at": _iso(1800)}]))
+    monkeypatch.setattr(runners_op, "_fetch_details", lambda listed: {})
+    monkeypatch.setattr(runners_op, "fetch_recent_finished",
+                        lambda window=None: (seen.setdefault("window", window), [])[1:] or ([], False))
+    runners_op.radar_report({"window": 60})
+    assert seen["window"] == 60
+
+
+def test_the_tier_declares_the_options_it_understands() -> None:
+    """radar validates against this set, so an option added here without being
+    read, or read without being declared, is a silent no-op."""
+    assert runners_op.RADAR_OPTIONS == {"window", "quiet_when_healthy"}

--- a/tests/test_gl_runners.py
+++ b/tests/test_gl_runners.py
@@ -1,0 +1,204 @@
+"""Tests for the `gl-runners` op.
+
+The op exists because GitLab reports a wedged runner as `online` and `idle`,
+which is indistinguishable from a healthy runner between jobs. Everything here
+guards one of the two ways that judgement went wrong in practice: trusting a
+field GitLab throttles, and ordering job history by the wrong timestamp.
+"""
+from __future__ import annotations
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+OP_PATH = Path(__file__).parent.parent / "presets" / "gitlab" / "runners.py"
+
+_spec = importlib.util.spec_from_file_location("gl_runners_op", OP_PATH)
+assert _spec is not None and _spec.loader is not None
+runners_op = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(runners_op)
+
+
+def _iso(seconds_ago: float) -> str:
+    moment = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=seconds_ago)
+    return moment.isoformat().replace("+00:00", "Z")
+
+
+def _runner(rid: int = 1, **over) -> dict:
+    base = {
+        "id": rid, "description": f"runner-{rid}", "tag_list": ["docker"],
+        "run_untagged": False, "status": "online", "active": True,
+        "paused": False, "contacted_at": _iso(10), "job_execution_status": "idle",
+    }
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# liveness — the evidence ladder
+# ---------------------------------------------------------------------------
+
+def test_a_runner_that_finished_work_is_live_however_stale_its_heartbeat() -> None:
+    """Completed work outranks contacted_at, which GitLab throttles. This is the
+    case that made the first version fire on 6 of 6 healthy runners."""
+    runner = _runner(contacted_at=_iso(3600), _recent_jobs=4)
+    assert runners_op._is_responsive(runner) is True
+
+
+def test_a_runner_executing_right_now_is_live_however_stale_its_heartbeat() -> None:
+    runner = _runner(contacted_at=_iso(3600), job_execution_status="active")
+    assert runners_op._is_responsive(runner) is True
+
+
+def test_a_quiet_runner_inside_the_heartbeat_window_is_live() -> None:
+    assert runners_op._is_responsive(_runner(contacted_at=_iso(600))) is True
+
+
+def test_a_quiet_runner_past_the_heartbeat_window_with_no_work_is_not_live() -> None:
+    runner = _runner(contacted_at=_iso(runners_op._HEARTBEAT_WARN_SECONDS + 60))
+    assert runners_op._is_responsive(runner) is False
+
+
+def test_the_heartbeat_window_clears_gitlabs_measured_write_throttle() -> None:
+    """contacted_at was observed frozen for minutes on a runner that was working.
+    A window under that granularity measures GitLab's write policy, not health."""
+    assert runners_op._HEARTBEAT_WARN_SECONDS >= 1800
+
+
+@pytest.mark.parametrize("field,value", [
+    ("paused", True),
+    ("active", False),
+    ("status", "offline"),
+    ("status", "stale"),
+    ("status", "never_contacted"),
+])
+def test_an_explicitly_down_runner_is_never_rescued_by_recent_work(field, value) -> None:
+    """Ordering guard: the disqualifiers are checked before the proofs, so a
+    paused runner with recent history does not read as available."""
+    runner = _runner(_recent_jobs=9, job_execution_status="active", **{field: value})
+    assert runners_op._is_responsive(runner) is False
+
+
+# ---------------------------------------------------------------------------
+# throughput history
+# ---------------------------------------------------------------------------
+
+def test_history_counts_jobs_by_when_they_finished_not_when_they_started(monkeypatch) -> None:
+    """The regression this file was written for.
+
+    Job ids order by created_at, and finished_at is not monotonic with it: a
+    test job created hours ago finishes after jobs created since. Scanning by
+    created_at dropped exactly those, so busy runners reported zero throughput
+    while they were completing work.
+    """
+    old_job_just_finished = {
+        "id": 2, "created_at": _iso(4 * 3600), "finished_at": _iso(60),
+        "runner": {"id": 7},
+    }
+    recent_job_still_running = {
+        "id": 9, "created_at": _iso(120), "finished_at": None, "runner": {"id": 7},
+    }
+    pages = {1: [recent_job_still_running, old_job_just_finished], 2: []}
+
+    def fake_api(endpoint, paginate=False, timeout=20):
+        page = int(endpoint.split("&page=")[1])
+        return (pages.get(page, []), None)
+
+    monkeypatch.setattr(runners_op, "_api", fake_api)
+    finished, truncated = runners_op.fetch_recent_finished()
+
+    assert [job["id"] for job in finished] == [2]
+    assert truncated is False
+
+
+def test_history_ignores_jobs_that_finished_before_the_window(monkeypatch) -> None:
+    stale = {"id": 1, "created_at": _iso(9000), "finished_at": _iso(9000), "runner": {"id": 7}}
+    monkeypatch.setattr(runners_op, "_api",
+                        lambda endpoint, paginate=False, timeout=20:
+                        ([stale], None) if "page=1" in endpoint else ([], None))
+    finished, _truncated = runners_op.fetch_recent_finished()
+    assert finished == []
+
+
+def test_hitting_the_page_cap_is_reported_not_swallowed(monkeypatch) -> None:
+    """A truncated count that reads as a total is worse than no count."""
+    job = {"id": 1, "created_at": _iso(60), "finished_at": _iso(30), "runner": {"id": 7}}
+    monkeypatch.setattr(runners_op, "_api",
+                        lambda endpoint, paginate=False, timeout=20: ([job], None))
+    _finished, truncated = runners_op.fetch_recent_finished()
+    assert truncated is True
+
+
+def test_an_unreadable_history_costs_evidence_not_correctness(monkeypatch) -> None:
+    monkeypatch.setattr(runners_op, "_api",
+                        lambda endpoint, paginate=False, timeout=20: (None, "ERROR: 500"))
+    finished, truncated = runners_op.fetch_recent_finished()
+    assert (finished, truncated) == ([], False)
+
+
+def test_annotations_attribute_work_to_the_runner_that_did_it() -> None:
+    fleet = [_runner(7), _runner(8)]
+    runners_op.annotate_recent_work(fleet, [
+        {"runner": {"id": 7}}, {"runner": {"id": 7}}, {"runner": {"id": 8}},
+        {"runner": None},
+    ])
+    assert [r["_recent_jobs"] for r in fleet] == [2, 1]
+
+
+def test_a_runner_named_by_the_running_list_is_marked_active() -> None:
+    """Two independent reads: the runner record can be a moment staler than the
+    job list, and the job list naming it is proof enough."""
+    fleet = [_runner(7, job_execution_status="idle", contacted_at=_iso(9999))]
+    runners_op.annotate_live_jobs(fleet, [{"runner": {"id": 7}}])
+    assert runners_op._is_responsive(fleet[0]) is True
+
+
+# ---------------------------------------------------------------------------
+# tag routing and starvation
+# ---------------------------------------------------------------------------
+
+def test_a_runner_needs_every_tag_a_job_asks_for() -> None:
+    runner = _runner(tag_list=["docker"])
+    assert runners_op._can_serve(runner, ["docker"]) is True
+    assert runners_op._can_serve(runner, ["docker", "heavy"]) is False
+
+
+def test_untagged_jobs_only_go_to_runners_that_accept_them() -> None:
+    assert runners_op._can_serve(_runner(run_untagged=False), []) is False
+    assert runners_op._can_serve(_runner(run_untagged=True), []) is True
+
+
+def test_work_pinned_to_a_dead_runner_is_starved() -> None:
+    """The finding the op exists for: an exclusive tag means no fallback."""
+    dead = _runner(1, tag_list=["runner-2"], contacted_at=_iso(7200))
+    alive = _runner(2, tag_list=["docker"], contacted_at=_iso(10))
+    pending = [{"tag_list": ["runner-2"], "created_at": _iso(1800)}]
+    assert runners_op.starved_tags([dead, alive], pending) == {"runner-2": 1}
+
+
+def test_work_a_live_runner_can_take_is_never_starved() -> None:
+    alive = _runner(2, tag_list=["docker"], contacted_at=_iso(10))
+    pending = [{"tag_list": ["docker"], "created_at": _iso(1800)}]
+    assert runners_op.starved_tags([alive], pending) == {}
+
+
+def test_a_job_queued_a_moment_ago_is_scheduling_delay_not_starvation() -> None:
+    """Otherwise every pipeline reports starvation for its first seconds."""
+    dead = _runner(1, tag_list=["runner-2"], contacted_at=_iso(7200))
+    pending = [{"tag_list": ["runner-2"], "created_at": _iso(5)}]
+    assert runners_op.starved_tags([dead], pending) == {}
+
+
+def test_starvation_survives_a_job_with_no_creation_timestamp() -> None:
+    """Unknown age must not silently drop the job from the count — a missing
+    field is not evidence that the work is fine."""
+    dead = _runner(1, tag_list=["runner-2"], contacted_at=_iso(7200))
+    assert runners_op.starved_tags([dead], [{"tag_list": ["runner-2"]}]) == {"runner-2": 1}
+
+
+def test_waiting_for_counts_only_what_this_runner_may_take() -> None:
+    runner = _runner(tag_list=["docker"])
+    pending = [{"tag_list": ["docker"]}, {"tag_list": ["docker"]}, {"tag_list": ["other"]}]
+    assert runners_op.waiting_for(runner, pending) == 2

--- a/tests/test_watch_radar.py
+++ b/tests/test_watch_radar.py
@@ -8,6 +8,7 @@ believing `last_event` is the bug the op exists to prevent.
 """
 from __future__ import annotations
 
+import datetime
 import importlib.util
 import json
 import os
@@ -99,7 +100,16 @@ def env(tmp_path, monkeypatch):
         return os.getpid()
 
     monkeypatch.setattr(radar.dispatcher, "_spawn_poller", _fake_spawn)
-    return {"dir": tmp_path, "spawned": spawned, "monkeypatch": monkeypatch}
+    # The fleet tier reads live GitLab. Left unstubbed every test in this file
+    # would report the runner fleet as unreadable, which is correct behaviour
+    # and pure noise here — the fleet has its own tests at the bottom.
+    real_fleet_report = radar.fleet_report
+    monkeypatch.setattr(radar, "fleet_report", lambda: ([], True))
+    return {"dir": tmp_path, "spawned": spawned, "monkeypatch": monkeypatch,
+            # The unpatched function, for the tests that are about it. Calling
+            # radar.fleet_report() from one of those would reach the stub above
+            # and assert against the fixture instead of the code.
+            "fleet_report": real_fleet_report}
 
 
 def _mr_spawns(env) -> list[str]:
@@ -109,6 +119,10 @@ def _mr_spawns(env) -> list[str]:
 
 def _feed_spawns(env) -> list[tuple[str, str, list[str]]]:
     return [row for row in env["spawned"] if row[0] == radar.FEED_SOURCE]
+
+
+def _fleet_spawns(env) -> list[tuple[str, str, list[str]]]:
+    return [row for row in env["spawned"] if row[0] == radar.FLEET_SOURCE]
 
 
 def _live_feed(tmp_path: Path, scope: str = "") -> Path:
@@ -182,7 +196,11 @@ def test_open_mr_with_live_poller_is_not_respawned(env, capsys) -> None:
     _live_feed(env["dir"])
     _set_live(env, [_mr(33161, "running")])
     out = _run(env, capsys)
-    assert env["spawned"] == []
+    # Named per source rather than "nothing at all": radar legitimately spawns
+    # a fleet poller on every run, and an assertion that cannot tell the two
+    # apart would fail for the wrong reason the next time a tier is added.
+    assert _mr_spawns(env) == []
+    assert _feed_spawns(env) == []
     assert "[healed]" not in out
     assert "👁" in out
 
@@ -1194,3 +1212,151 @@ def test_an_empty_mr_is_still_a_standing_problem_under_its_own_name() -> None:
 
 def test_a_genuine_conflict_keeps_its_problem_label() -> None:
     assert radar._problem_label(_mr(6, has_conflicts=True, sha="a" * 40)) == "conflict"
+
+
+# ---------------------------------------------------------------------------
+# fleet tier
+# ---------------------------------------------------------------------------
+
+def _runner(rid: int, description: str, tags: list[str], contacted_at: str,
+            **over) -> dict:
+    base = {
+        "id": rid, "description": description, "tag_list": tags,
+        "run_untagged": False, "status": "online", "active": True,
+        "paused": False, "contacted_at": contacted_at,
+    }
+    base.update(over)
+    return base
+
+
+def _now_iso() -> str:
+    """The contacted_at of a runner that is heartbeating right now.
+
+    Computed rather than hardcoded: a fixed timestamp would age past the
+    responsiveness threshold and turn these into tests that pass until they
+    silently stop meaning anything.
+    """
+    return datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _stub_fleet(env, runners: list[dict], pending: list[dict]) -> None:
+    def fake_api(endpoint, paginate=False, timeout=20):
+        return (runners, None) if "runners" in endpoint else (pending, None)
+
+    env["monkeypatch"].setattr(radar.runners_op, "_api", fake_api)
+    env["monkeypatch"].setattr(radar.runners_op, "_fetch_details",
+                               lambda listed: {r["id"]: {} for r in listed})
+
+
+def test_a_silent_runner_holding_the_queue_is_named_with_its_last_contact(env) -> None:
+    """The whole point of the tier: GitLab reports this runner online and idle,
+    so nothing else in radar can explain why the jobs are not moving."""
+    _stub_fleet(
+        env,
+        [_runner(18, "dptools-runner-2", ["dptools-runner-2"], "2020-01-01T00:00:00Z")],
+        [{"tag_list": ["dptools-runner-2"]} for _ in range(3)],
+    )
+    lines, ok = env["fleet_report"]()
+    joined = "\n".join(lines)
+    assert ok is False
+    assert "3 pending job(s) cannot start" in joined
+    assert "dptools-runner-2" in joined
+    assert "seen" in joined
+
+
+def test_jobs_no_runner_carries_the_tags_for_are_reported_as_such(env) -> None:
+    """A typo'd tag in .gitlab-ci.yml queues forever behind a runner that does
+    not exist, which reads identically to a dead one until it is named."""
+    _stub_fleet(
+        env,
+        [_runner(26, "dptools-runner-4", ["docker"], _now_iso())],
+        [{"tag_list": ["dptols-runner-4"]}],
+    )
+    lines, ok = env["fleet_report"]()
+    assert ok is False
+    assert "NO runner carries these tags" in "\n".join(lines)
+
+
+def test_a_live_runner_covering_the_queue_is_healthy(env) -> None:
+    _stub_fleet(
+        env,
+        [_runner(26, "dptools-runner-4", ["docker"], _now_iso())],
+        [{"tag_list": ["docker"]}],
+    )
+    lines, ok = env["fleet_report"]()
+    assert ok is True
+    assert "fleet ok" in "\n".join(lines)
+    assert "none blocked" in "\n".join(lines)
+
+
+def test_a_silent_runner_with_nothing_queued_is_not_an_alarm(env) -> None:
+    """Five silent runners is the normal resting state of this fleet — retired,
+    paused, replaced. Silence only matters when work is stuck behind it."""
+    _stub_fleet(
+        env,
+        [_runner(23, "dptools-runner-3", ["old"], "2020-01-01T00:00:00Z", status="stale"),
+         _runner(26, "dptools-runner-4", ["docker"], _now_iso())],
+        [],
+    )
+    lines, ok = env["fleet_report"]()
+    assert ok is True
+    assert "1/2 runners live" in "\n".join(lines)
+
+
+def test_an_unreadable_fleet_is_unknown_never_green(env) -> None:
+    """The failure this tier exists to remove: answering "is the infrastructure
+    fine?" with silence when the question could not be asked."""
+    env["monkeypatch"].setattr(
+        radar.runners_op, "_api",
+        lambda endpoint, paginate=False, timeout=20: (None, "ERROR: glab not authenticated"))
+    lines, ok = env["fleet_report"]()
+    assert ok is False
+    assert "UNKNOWN, not green" in "\n".join(lines)
+
+
+def test_an_unreadable_queue_does_not_read_as_no_starvation(env) -> None:
+    def fake_api(endpoint, paginate=False, timeout=20):
+        if "runners" in endpoint:
+            return ([_runner(26, "dptools-runner-4", ["docker"], _now_iso())], None)
+        return (None, "ERROR: 500")
+
+    env["monkeypatch"].setattr(radar.runners_op, "_api", fake_api)
+    env["monkeypatch"].setattr(radar.runners_op, "_fetch_details", lambda listed: {})
+    lines, ok = env["fleet_report"]()
+    assert ok is False
+    assert "starvation is UNKNOWN" in "\n".join(lines)
+
+
+def test_a_blocked_fleet_is_reported_on_every_run_not_only_cold(env, capsys) -> None:
+    """Delta suppression is for transitions. Stuck jobs are a current fact, and
+    the second run is the one where a reader has stopped expecting bad news."""
+    _live_pid_file(env["dir"], "33172")
+    _live_feed(env["dir"])
+    _set_live(env, [_mr(33172, "success", "100")])
+    env["monkeypatch"].setattr(
+        radar, "fleet_report",
+        lambda: (["radar: FLEET — 14 pending job(s) cannot start"], False))
+    _run(env, capsys)
+    out = _run(env, capsys)
+    assert "FLEET — 14 pending job(s) cannot start" in out
+    assert "no change" in out
+
+
+def test_a_healthy_fleet_costs_one_line_per_session_not_per_run(env, capsys) -> None:
+    _live_pid_file(env["dir"], "33172")
+    _live_feed(env["dir"])
+    _set_live(env, [_mr(33172, "success", "100")])
+    env["monkeypatch"].setattr(
+        radar, "fleet_report", lambda: (["radar: fleet ok — 9/10 runners live"], True))
+    first = _run(env, capsys)
+    second = _run(env, capsys)
+    assert "fleet ok" in first
+    assert "fleet ok" not in second
+
+
+def test_radar_keeps_exactly_one_fleet_poller(env) -> None:
+    """Radar runs on a loop; n pollers over one fleet means n copies of every
+    runner_silent — the same defect ensure_feed was hardened against in #476."""
+    assert radar.ensure_fleet() == "spawned"
+    assert radar.ensure_fleet() == "alive"
+    assert len(_fleet_spawns(env)) == 1

--- a/tests/test_watch_radar.py
+++ b/tests/test_watch_radar.py
@@ -100,16 +100,11 @@ def env(tmp_path, monkeypatch):
         return os.getpid()
 
     monkeypatch.setattr(radar.dispatcher, "_spawn_poller", _fake_spawn)
-    # The fleet tier reads live GitLab. Left unstubbed every test in this file
-    # would report the runner fleet as unreadable, which is correct behaviour
-    # and pure noise here — the fleet has its own tests at the bottom.
-    real_fleet_report = radar.fleet_report
-    monkeypatch.setattr(radar, "fleet_report", lambda: ([], True))
-    return {"dir": tmp_path, "spawned": spawned, "monkeypatch": monkeypatch,
-            # The unpatched function, for the tests that are about it. Calling
-            # radar.fleet_report() from one of those would reach the stub above
-            # and assert against the fixture instead of the code.
-            "fleet_report": real_fleet_report}
+    # No tiers unless a test registers them. Left to the ambient environment,
+    # a shell that exported SUPERTOOL_RADAR_TIERS would make every test in this
+    # file reach live GitLab.
+    monkeypatch.delenv(radar.TIERS_ENV, raising=False)
+    return {"dir": tmp_path, "spawned": spawned, "monkeypatch": monkeypatch}
 
 
 def _mr_spawns(env) -> list[str]:
@@ -1214,149 +1209,132 @@ def test_a_genuine_conflict_keeps_its_problem_label() -> None:
     assert radar._problem_label(_mr(6, has_conflicts=True, sha="a" * 40)) == "conflict"
 
 
+
+
 # ---------------------------------------------------------------------------
-# fleet tier
+# tier registry
 # ---------------------------------------------------------------------------
 
-def _runner(rid: int, description: str, tags: list[str], contacted_at: str,
-            **over) -> dict:
-    base = {
-        "id": rid, "description": description, "tag_list": tags,
-        "run_untagged": False, "status": "online", "active": True,
-        "paused": False, "contacted_at": contacted_at,
-    }
-    base.update(over)
-    return base
+class _FakeTier:
+    RADAR_OPTIONS = {"window", "quiet_when_healthy"}
+
+    def __init__(self, lines, ok, boom=False):
+        self._lines, self._ok, self._boom = lines, ok, boom
+        self.seen_options = None
+
+    def radar_report(self, options=None):
+        self.seen_options = options
+        if self._boom:
+            raise RuntimeError("tier exploded")
+        return list(self._lines), self._ok
 
 
-def _now_iso() -> str:
-    """The contacted_at of a runner that is heartbeating right now.
-
-    Computed rather than hardcoded: a fixed timestamp would age past the
-    responsiveness threshold and turn these into tests that pass until they
-    silently stop meaning anything.
-    """
-    return datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+def _register(env, name, tier):
+    env["monkeypatch"].setenv(radar.TIERS_ENV, json.dumps({name: {}}))
+    env["monkeypatch"].setattr(radar, "_tier_module", lambda n: tier if n == name else None)
 
 
-def _stub_fleet(env, runners: list[dict], pending: list[dict]) -> None:
-    def fake_api(endpoint, paginate=False, timeout=20):
-        return (runners, None) if "runners" in endpoint else (pending, None)
-
-    env["monkeypatch"].setattr(radar.runners_op, "_api", fake_api)
-    env["monkeypatch"].setattr(radar.runners_op, "_fetch_details",
-                               lambda listed: {r["id"]: {} for r in listed})
+def test_no_registered_tiers_means_no_tier_output_at_all(env) -> None:
+    """The default every stranger who installs this gets. Radar stays an MR
+    reconcile tool until someone asks for more."""
+    assert radar.read_tiers("") == ({}, [])
+    assert radar.tier_reports() == ([], True)
 
 
-def test_a_silent_runner_holding_the_queue_is_named_with_its_last_contact(env) -> None:
-    """The whole point of the tier: GitLab reports this runner online and idle,
-    so nothing else in radar can explain why the jobs are not moving."""
-    _stub_fleet(
-        env,
-        [_runner(18, "dptools-runner-2", ["dptools-runner-2"], "2020-01-01T00:00:00Z")],
-        [{"tag_list": ["dptools-runner-2"]} for _ in range(3)],
-    )
-    lines, ok = env["fleet_report"]()
-    joined = "\n".join(lines)
+def test_a_healthy_tier_is_silent_by_default(env) -> None:
+    tier = _FakeTier(["all good"], True)
+    _register(env, "gl-runners", tier)
+    assert radar.tier_reports() == ([], True)
+
+
+def test_a_healthy_tier_speaks_when_asked_to(env) -> None:
+    tier = _FakeTier(["all good"], True)
+    env["monkeypatch"].setenv(radar.TIERS_ENV,
+                              json.dumps({"gl-runners": {"quiet_when_healthy": False}}))
+    env["monkeypatch"].setattr(radar, "_tier_module", lambda n: tier)
+    assert radar.tier_reports() == (["all good"], True)
+
+
+def test_an_unhealthy_tier_always_speaks(env) -> None:
+    tier = _FakeTier(["FLEET — 14 stuck"], False)
+    _register(env, "gl-runners", tier)
+    lines, ok = radar.tier_reports()
+    assert lines == ["FLEET — 14 stuck"]
     assert ok is False
-    assert "3 pending job(s) cannot start" in joined
-    assert "dptools-runner-2" in joined
-    assert "seen" in joined
 
 
-def test_jobs_no_runner_carries_the_tags_for_are_reported_as_such(env) -> None:
-    """A typo'd tag in .gitlab-ci.yml queues forever behind a runner that does
-    not exist, which reads identically to a dead one until it is named."""
-    _stub_fleet(
-        env,
-        [_runner(26, "dptools-runner-4", ["docker"], _now_iso())],
-        [{"tag_list": ["dptols-runner-4"]}],
-    )
-    lines, ok = env["fleet_report"]()
+def test_tier_options_reach_the_tier(env) -> None:
+    tier = _FakeTier([], True)
+    env["monkeypatch"].setenv(radar.TIERS_ENV, json.dumps({"gl-runners": {"window": 60}}))
+    env["monkeypatch"].setattr(radar, "_tier_module", lambda n: tier)
+    radar.tier_reports()
+    assert tier.seen_options == {"window": 60}
+
+
+def test_an_unknown_option_is_named_not_silently_ignored(env) -> None:
+    """A silently-dropped option is how someone believes they configured a
+    threshold they did not."""
+    tier = _FakeTier([], True)
+    env["monkeypatch"].setenv(radar.TIERS_ENV, json.dumps({"gl-runners": {"windoww": 60}}))
+    env["monkeypatch"].setattr(radar, "_tier_module", lambda n: tier)
+    lines, _ok = radar.tier_reports()
+    assert any("unknown option" in line and "windoww" in line for line in lines)
+
+
+def test_an_unresolvable_tier_name_is_reported(env) -> None:
+    env["monkeypatch"].setenv(radar.TIERS_ENV, json.dumps({"gl-runnerz": {}}))
+    env["monkeypatch"].setattr(radar, "_tier_module", lambda n: None)
+    lines, ok = radar.tier_reports()
+    assert any("gl-runnerz" in line and "radar_report" in line for line in lines)
     assert ok is False
-    assert "NO runner carries these tags" in "\n".join(lines)
 
 
-def test_a_live_runner_covering_the_queue_is_healthy(env) -> None:
-    _stub_fleet(
-        env,
-        [_runner(26, "dptools-runner-4", ["docker"], _now_iso())],
-        [{"tag_list": ["docker"]}],
-    )
-    lines, ok = env["fleet_report"]()
-    assert ok is True
-    assert "fleet ok" in "\n".join(lines)
-    assert "none blocked" in "\n".join(lines)
+def test_a_tier_that_raises_cannot_take_the_board_down(env) -> None:
+    """The MR board is the thing radar exists for; an optional tier must never
+    be able to cost the reader their board."""
+    _register(env, "gl-runners", _FakeTier([], True, boom=True))
+    lines, ok = radar.tier_reports()
+    assert any("tier exploded" in line for line in lines)
+    assert ok is False
 
 
-def test_a_silent_runner_with_nothing_queued_is_not_an_alarm(env) -> None:
-    """Five silent runners is the normal resting state of this fleet — retired,
-    paused, replaced. Silence only matters when work is stuck behind it."""
-    _stub_fleet(
-        env,
-        [_runner(23, "dptools-runner-3", ["old"], "2020-01-01T00:00:00Z", status="stale"),
-         _runner(26, "dptools-runner-4", ["docker"], _now_iso())],
-        [],
-    )
-    lines, ok = env["fleet_report"]()
-    assert ok is True
-    assert "1/2 runners live" in "\n".join(lines)
+def test_unparseable_tier_config_yields_the_ordinary_board_plus_a_complaint() -> None:
+    tiers, complaints = radar.read_tiers("{not json")
+    assert tiers == {}
+    assert complaints and "not valid JSON" in complaints[0]
 
 
-def test_an_unreadable_fleet_is_unknown_never_green(env) -> None:
-    """The failure this tier exists to remove: answering "is the infrastructure
-    fine?" with silence when the question could not be asked."""
+def test_tier_options_that_are_not_an_object_are_skipped_loudly() -> None:
+    tiers, complaints = radar.read_tiers(json.dumps({"gl-runners": "yes"}))
+    assert tiers == {}
+    assert complaints and "must be an object" in complaints[0]
+
+
+def test_a_tier_with_null_options_is_accepted_as_defaults() -> None:
+    tiers, complaints = radar.read_tiers(json.dumps({"gl-runners": None}))
+    assert tiers == {"gl-runners": {}}
+    assert complaints == []
+
+
+# ---------------------------------------------------------------------------
+# respawn cap (#513) applies to every spawner, not only the per-MR heal
+# ---------------------------------------------------------------------------
+
+def test_a_slot_past_the_death_cap_is_not_respawned(env) -> None:
     env["monkeypatch"].setattr(
-        radar.runners_op, "_api",
-        lambda endpoint, paginate=False, timeout=20: (None, "ERROR: glab not authenticated"))
-    lines, ok = env["fleet_report"]()
-    assert ok is False
-    assert "UNKNOWN, not green" in "\n".join(lines)
+        radar.transport, "deaths",
+        lambda source, scope: [{}] * radar.transport.DEATH_RESPAWN_LIMIT)
+    assert radar.ensure_watcher("gitlab-mr-feed", "@me") == "capped"
+    assert env["spawned"] == []
 
 
-def test_an_unreadable_queue_does_not_read_as_no_starvation(env) -> None:
-    def fake_api(endpoint, paginate=False, timeout=20):
-        if "runners" in endpoint:
-            return ([_runner(26, "dptools-runner-4", ["docker"], _now_iso())], None)
-        return (None, "ERROR: 500")
-
-    env["monkeypatch"].setattr(radar.runners_op, "_api", fake_api)
-    env["monkeypatch"].setattr(radar.runners_op, "_fetch_details", lambda listed: {})
-    lines, ok = env["fleet_report"]()
-    assert ok is False
-    assert "starvation is UNKNOWN" in "\n".join(lines)
+def test_a_capped_slot_is_named_loudly_rather_than_going_quiet(env) -> None:
+    """A capped slot is unwatched, and an unwatched slot that says nothing is
+    the exact failure #513 was about."""
+    warnings = radar.watcher_cap_warnings({"gl-runners:fleet": "capped"})
+    assert warnings and "stopped respawning gl-runners:fleet" in warnings[0]
+    assert "re-arm" in warnings[0]
 
 
-def test_a_blocked_fleet_is_reported_on_every_run_not_only_cold(env, capsys) -> None:
-    """Delta suppression is for transitions. Stuck jobs are a current fact, and
-    the second run is the one where a reader has stopped expecting bad news."""
-    _live_pid_file(env["dir"], "33172")
-    _live_feed(env["dir"])
-    _set_live(env, [_mr(33172, "success", "100")])
-    env["monkeypatch"].setattr(
-        radar, "fleet_report",
-        lambda: (["radar: FLEET — 14 pending job(s) cannot start"], False))
-    _run(env, capsys)
-    out = _run(env, capsys)
-    assert "FLEET — 14 pending job(s) cannot start" in out
-    assert "no change" in out
-
-
-def test_a_healthy_fleet_costs_one_line_per_session_not_per_run(env, capsys) -> None:
-    _live_pid_file(env["dir"], "33172")
-    _live_feed(env["dir"])
-    _set_live(env, [_mr(33172, "success", "100")])
-    env["monkeypatch"].setattr(
-        radar, "fleet_report", lambda: (["radar: fleet ok — 9/10 runners live"], True))
-    first = _run(env, capsys)
-    second = _run(env, capsys)
-    assert "fleet ok" in first
-    assert "fleet ok" not in second
-
-
-def test_radar_keeps_exactly_one_fleet_poller(env) -> None:
-    """Radar runs on a loop; n pollers over one fleet means n copies of every
-    runner_silent — the same defect ensure_feed was hardened against in #476."""
-    assert radar.ensure_fleet() == "spawned"
-    assert radar.ensure_fleet() == "alive"
-    assert len(_fleet_spawns(env)) == 1
+def test_a_healthy_slot_produces_no_cap_warning() -> None:
+    assert radar.watcher_cap_warnings({"gl-runners:fleet": "spawned"}) == []


### PR DESCRIPTION
## Why

GitLab reports a wedged runner as `status: online, job_execution_status: idle` — byte-identical to a healthy runner between jobs. Work pinned to its exclusive tag queues behind it, no other runner is permitted to take it, and nothing turns red.

Found one on the first run: **14 jobs stuck behind a runner GitLab had advertised as online for an hour.**

## What

- **`gl-runners` op** — fleet table with type, status, heartbeat age, live/queued/completed counts per runner, sorted worst-health first. `:full` adds project scope and versions, `:queue` groups jobs by the runners allowed to take them.
- **`gl-runners` watch source** — `runner_silent`, `runner_starved`, `runner_recovered`, `queue_cleared`, `runner_paused`, `runner_added`, `runner_vanished`.
- **Radar tier registry** (`ops.radar.radar_tiers`) — radar stops having hardcoded tiers.
- **The #513 respawn cap now applies to every spawner**, not only the per-MR heal.

## The part worth reviewing

**Liveness is judged on evidence in descending strength, and the order is load-bearing:**

1. jobs completed in the throughput window
2. `job_execution_status == "active"`, or owning a job in `scope[]=running`
3. `contacted_at` age — last, at 30 minutes

Step 3 is last because **GitLab throttles that write**. Measured on a live fleet: `contacted_at` frozen at the same millisecond across 7 samples spanning 2 minutes, drifting to ~10 minutes of apparent staleness while the fleet completed jobs throughout. Healthy runners routinely read 11–27m stale.

An earlier version keyed on it alone at 300s and fired `runner_silent` on **6 of 6 online runners** within the hour. A signal that fires on the whole healthy fleet does not merely fail to inform — it buries the one event that was real. So silence is also gated on consequence: a quiet runner with an empty queue has nothing to do, which is not a fault.

**Job history filters on `finished_at`, never `created_at`.** Ids order by creation and the two are not monotonic — a test job created hours ago finishes after jobs created since, so scanning by creation dropped exactly the long jobs whose completion is the best evidence.

## Why the tier registry is empty by default

Radar is an MR reconcile tool for most people who install this. Plenty sit below Maintainer or on shared runners, where reading `projects/:id/runners` is a **403** — shipping this tier on by default would hand every one of them a standing WARNING about infrastructure they neither own nor can read. That is a regression delivered as a feature.

Tiers resolve through the preset that declares the op, so any op joins by exposing `radar_report(options)`. Unknown names and unknown options are reported on the board, never silently ignored.

## Follow-ups

Watcher sources this makes obvious: #524 (`gh-run`), #525 (`gl-issue`/`gh-issue`), #526 (engagement).

## Tests

4510 passed, 36 skipped. 35 net new, including regression tests for both bugs above.
