### PR TITLE
docs(watch): document the unsendable disclosure alongside clamped and collided (#612)

### DIFF
--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -787,7 +787,7 @@ the consumer's reasoning is in
 
 **Payload keys are also name-capped**: `payload` may not carry a key named
 `watcher_source`, `id`, `event`, `ts`, `first_tick`, `source`, `clamped`,
-`collided` or `__proto__`, because the consumer writes those itself
+`collided`, `unsendable` or `__proto__`, because the consumer writes those itself
 ([#609](https://github.com/Digital-Process-Tools/claude-supertool/issues/609)).
 Until #609 the payload was merged *over* them, so a `payload.id` silently
 re-aimed the event — an event announced as `gitlab-mr 33173: pipeline_failed` was
@@ -795,6 +795,25 @@ delivered as `not-gitlab 11111: pipeline_succeeded`, every surface agreeing.
 Such a key is now ignored and disclosed in a `collided` attribute and in the
 body, naming the key and the reserved set. Rename the field at the source
 (`mr_id`, `event_kind`) rather than relying on it arriving.
+
+**A payload value the bridge will not coerce is disclosed too**, in an
+`unsendable` attribute
+([#612](https://github.com/Digital-Process-Tools/claude-supertool/issues/612)).
+`_meta` is a string map the receiver enforces with a schema, so only strings,
+booleans and finite numbers can be sent; an object, array, `null`, `undefined`,
+`NaN` or an infinity is refused rather than stringified — `String({})` is
+`"[object Object]"`, which reads downstream as data somebody meant to send.
+Until #612 that refusal was silent, so a producer whose key was dropped for
+*size* was told, one dropped for *colliding* was told, and one dropped for
+*being an object* was not. The disclosure names the key and the value's
+**shape** (`object`, `array`, `null`, …), never its contents — quoting is
+precisely what the refusal exists to avoid. Send a pre-serialised string
+(`tags: sorted(...)` → `tags: ",".join(...)`) rather than relying on the
+structure arriving.
+
+The three disclosures share one vocabulary and one bound: each names up to five
+keys and then `+N more`, and each is applied *after* the size clamp, so a clamp
+can never withhold the disclosure about itself.
 
 Consumers can rely on `ts/source/id/event/payload/first_tick` always being present. Extra fields inside `payload` vary by source — see each source's `events.json` and `poller.py`. `gitlab-mr` payloads additionally carry an [`observed_*` snapshot](#gitlab-mr-events-carry-the-state-that-produced-them-435) of the state that produced the event, timestamped so its age is readable without a call back.
 


### PR DESCRIPTION
## What

`docs/presets/watch.md` documented two of the channel's three disclosures. `clamped` (#605) and `collided` (#609) were both described; `unsendable` (#612, merged tonight in #618) was not — not in the reserved-key list, and not in the prose that explains why a key a producer sent might not arrive.

A reader of that page would reasonably conclude there are exactly two ways a payload key fails to reach the session. There are three.

## Why it was invisible

Nothing was missing in the way a missing thing usually looks. #618 documented `unsendable` in `notifiers/claude-channel/README.md` and `presets/watch/README.md` — both correct, both consumer-side. The user-facing preset doc, which is where the other two live, did not get it.

The gap only surfaced by comparison: `grep -rl` for `collided` returns `docs/presets/watch.md`; the same grep for `unsendable` does not. Undocumented work looks identical to documented work from the inside, and only fails later, for someone else.

## Changes

- `unsendable` added to the reserved payload-key list. It **is** reserved in the code (`RESERVED_KEYS` in `channel.ts`), so its absence from that list was factually wrong, not merely incomplete — a producer reading it would think `payload.unsendable` was safe to send.
- A paragraph describing the disclosure: why non-scalars are refused rather than stringified (`String({})` is `"[object Object]"`, which reads downstream as data somebody meant to send), that the disclosure names the value's **shape** and never its contents, and what a producer should do instead — with the real example, since `gl-runners` sends `payload.tags` as a list and is the live case that made #612 worth building rather than documenting away.
- One sentence tying the three together: each names up to five keys then `+N more`, and each is applied *after* the size clamp so a clamp cannot withhold the disclosure about itself.

Verified rather than asserted: `WITHHELD_NAMED_MAX = 5` has exactly three call sites in `channel.ts` (lines 331, 369, 386), one per disclosure, so the shared-bound claim is true of all three and not just the one I read the diff for.

## No CHANGELOG entry — deliberate

`## Unreleased` already carries #612's entry describing this behaviour, and it has not shipped yet. A second entry saying "documented the thing the entry above shipped" adds noise to a release note that is already 57 items long and getting harder to review with every merge. The behaviour is discoverable; this completes its documentation rather than changing anything.

Flagging the judgment because "CHANGELOG always" is the standing rule and this is a deliberate exception, not an oversight.

## Test plan

Docs only, no code paths touched. `git-status` validator clean on both edits.
