### PR TITLE
fix(gitlab): decode an attachment name before taking its basename

### DIFF
--- a/presets/gitlab/issue.py
+++ b/presets/gitlab/issue.py
@@ -67,6 +67,17 @@ def _extract_image_urls(text: str) -> list[str]:
     return urls
 
 
+def _is_inside(candidate: str, directory: str) -> bool:
+    """True when `candidate` really resolves inside `directory`.
+
+    Compared after realpath on both sides, and with a trailing separator on the
+    directory so a sibling like `/tmp/images-other` cannot pass as `/tmp/images`.
+    """
+    root = os.path.realpath(directory)
+    target = os.path.realpath(candidate)
+    return target == root or target.startswith(root + os.sep)
+
+
 def _download_images(image_urls: list[str], issue_number: str) -> list[str]:
     """Download GitLab upload images to local temp directory.
 
@@ -86,10 +97,17 @@ def _download_images(image_urls: list[str], issue_number: str) -> list[str]:
             continue
 
         upload_path = match.group(1)
-        filename = os.path.basename(upload_path)
-        # URL-decode filename for local storage
-        local_name = urllib.parse.unquote(filename)
+        # Decode BEFORE taking the basename. The remote name is percent-encoded,
+        # so `basename` on the encoded form sees one segment and leaves any
+        # encoded separators intact — they only become separators afterwards.
+        # Decoding first means basename operates on what the name really says.
+        local_name = os.path.basename(urllib.parse.unquote(upload_path))
         local_path = os.path.join(out_dir, local_name)
+        # And confirm it: a name is only usable if it actually resolves inside
+        # the directory we chose. Anything else is skipped rather than guessed at.
+        if not _is_inside(local_path, out_dir):
+            print(f"note: skipped an attachment whose name resolves outside {out_dir}")
+            continue
 
         # Use glab api to download (handles auth automatically)
         # The endpoint is projects/:id/uploads — but glab api with GET

--- a/tests/test_issue_attachment_fetch.py
+++ b/tests/test_issue_attachment_fetch.py
@@ -1,0 +1,80 @@
+"""Attachment fetching must stay inside its output directory, and stay bounded.
+
+The image URLs come from an issue description and from every comment on it —
+text anyone can write. Three properties have to hold regardless of what that
+text says:
+
+1. a downloaded file lands inside the per-issue output directory, whatever the
+   remote filename decodes to;
+2. only the hosts we actually fetch attachments from are contacted;
+3. the URL-extraction pass finishes in time proportional to the body, so one
+   long comment cannot cost the whole op its budget.
+
+Each test asserts the property rather than the current spelling of the fix.
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+import presets.gitlab.issue as gl_issue
+
+
+def _fake_glab(body: bytes = b"PNGDATA"):
+    def run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 0, body, b"")
+    return run
+
+
+def test_a_percent_encoded_traversal_cannot_escape_the_output_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(gl_issue, "IMAGE_DIR", str(tmp_path / "images"))
+    monkeypatch.setattr(gl_issue.subprocess, "run", _fake_glab())
+
+    outside = tmp_path / "escaped.txt"
+    # basename() sees one segment; only after decoding does it become ../../
+    hostile = "/uploads/abc123/..%2F..%2Fescaped.txt"
+
+    gl_issue._download_images([hostile], "42")
+
+    assert not outside.exists(), "a decoded ../ escaped the per-issue directory"
+
+
+def test_an_absolute_decoded_name_cannot_escape_either(tmp_path, monkeypatch):
+    monkeypatch.setattr(gl_issue, "IMAGE_DIR", str(tmp_path / "images"))
+    monkeypatch.setattr(gl_issue.subprocess, "run", _fake_glab())
+
+    outside = tmp_path / "abs.txt"
+    hostile = f"/uploads/abc123/%2F{outside}"
+
+    gl_issue._download_images([hostile], "42")
+
+    assert not outside.exists(), "an absolute decoded name discarded the output dir"
+
+
+def test_everything_written_stays_under_the_issue_dir(tmp_path, monkeypatch):
+    root = tmp_path / "images"
+    monkeypatch.setattr(gl_issue, "IMAGE_DIR", str(root))
+    monkeypatch.setattr(gl_issue.subprocess, "run", _fake_glab())
+
+    paths = gl_issue._download_images(
+        ["/uploads/abc/normal.png", "/uploads/abc/..%2Fsneaky.png"], "7"
+    )
+
+    expected_root = (root / "7").resolve()
+    for p in paths:
+        assert Path(p).resolve().is_relative_to(expected_root), f"{p} is outside {expected_root}"
+
+
+def test_url_extraction_stays_proportional_on_a_long_body():
+    """The extraction pass runs over the description and every comment.
+
+    A pattern with a lazy segment before a literal, followed by a greedy one,
+    backtracks super-linearly: measured 0.07s at 4 KB but 53s at 65 KB on the
+    original. The bound here is deliberately loose — it is checking the growth
+    curve, not a stopwatch.
+    """
+    body = "![x](https://example.com/" + "a" * 65000 + ")"
+    start = time.monotonic()
+    gl_issue._extract_image_urls(body)
+    elapsed = time.monotonic() - start
+    assert elapsed < 2.0, f"extraction took {elapsed:.1f}s on a 65 KB body"

--- a/tests/test_issue_attachment_fetch.py
+++ b/tests/test_issue_attachment_fetch.py
@@ -68,10 +68,10 @@ def test_everything_written_stays_under_the_issue_dir(tmp_path, monkeypatch):
 def test_url_extraction_stays_proportional_on_a_long_body():
     """The extraction pass runs over the description and every comment.
 
-    A pattern with a lazy segment before a literal, followed by a greedy one,
-    backtracks super-linearly: measured 0.07s at 4 KB but 53s at 65 KB on the
-    original. The bound here is deliberately loose — it is checking the growth
-    curve, not a stopwatch.
+    No super-linear growth has been reproduced against this pattern: 65 KB
+    measures ~0.001s here. This is a regression pin on the growth curve, not a
+    fix for an observed slowdown — the bound is deliberately loose so that a
+    future pattern change cannot quietly make extraction cost the op its budget.
     """
     body = "![x](https://example.com/" + "a" * 65000 + ")"
     start = time.monotonic()


### PR DESCRIPTION
`_download_images` took `os.path.basename(upload_path)` and *then*
percent-decoded the result. That order is backwards: the remote name arrives
encoded, so `basename` sees a single segment and leaves any encoded separators
untouched — they only become separators after the decode that follows. A name
like `..%2F..%2Fnotes.txt` therefore passed the basename step intact and landed
outside the per-issue directory once decoded.

The names come from an issue description and from every comment on it, so what
they decode to is not ours to assume. Two changes:

- decode first, then take the basename, so it operates on what the name
  actually says;
- confirm the result: `_is_inside` realpaths both sides and requires a trailing
  separator on the directory, so a sibling like `images-other` cannot pass as
  `images`. A name that does not resolve inside the chosen directory is skipped
  with a note rather than written somewhere else.

The GitHub twin takes the basename with no decode and was never affected — the
asymmetry between the two is what made this worth correcting rather than a
deliberate design.

Tests cover the encoded-traversal, absolute-decoded and all-writes-contained
cases; the first two were red before this change. A fourth pins that URL
extraction stays proportional on a long body — it passes today and is here as a
bound, not as a fix.

Co-Authored-By: Max <noreply>