### PR TITLE
test(secrets): assemble the Google-key prop at runtime, like the GitLab one

### DIFF
--- a/tests/test_secret_redaction_760.py
+++ b/tests/test_secret_redaction_760.py
@@ -42,6 +42,14 @@ import _secrets  # noqa: E402
 # Do not tidy this back into a single literal.
 FAKE_GITLAB_PAT = "glpat" + "-AbCdEf1234567890XyZq"
 
+# Same treatment, arrived at the other way round: this one was written as a
+# single literal and pushed fine, because scanning alerted after the fact
+# instead of blocking (alert #1, "Google API Key"). Nothing leaked — the value
+# is a prop, and a shape-matching detector cannot be tested without one that
+# looks real. A known-false entry left sitting in the alert list is how a real
+# alert later goes unread, so the literal is split here too.
+FAKE_GOOGLE_API_KEY = "AIza" + "Sy" + "A1234567890" + "abcdefghijklmnopqrstuv"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -152,9 +160,9 @@ class TestDetectorMatches:
         assert "xoxb-1234567890" not in out
 
     def test_google_api_key(self) -> None:
-        out, n = _secrets.redact("key=AIzaSyA1234567890abcdefghijklmnopqrstuv")
+        out, n = _secrets.redact(f"key={FAKE_GOOGLE_API_KEY}")
         assert n >= 1
-        assert "AIzaSyA1234567890abcdefghijklmnopqrstuv" not in out
+        assert FAKE_GOOGLE_API_KEY not in out
 
     def test_url_basic_auth_password(self) -> None:
         out, n = _secrets.redact("git clone https://user:hunter2secret@example.com/repo.git")


### PR DESCRIPTION
GitHub secret scanning opened alert #1, "Google API Key", against `tests/test_secret_redaction_760.py:155`.

**Nothing leaked.** The value is `AIzaSy` followed by `A1234567890` and then the alphabet — a prop, written to be shaped like a Google API key so the redaction test can prove `_secrets.redact` catches that shape. The detector under test matches on shape; so does GitHub's scanner; both were right about the shape and there is no key behind it. No rotation, no revocation, no log review.

## Why change anything then

Because a known-false entry that sits in the alert list forever is how a real alert later goes unread. The alert list is a surface, and a surface nobody trusts is worse than no surface.

## The fix is the pattern already in this file

`FAKE_GITLAB_PAT` (line 43) had the identical problem and was already solved by assembling the value from parts, with a note saying not to tidy it back. That one was *blocked at push time* by push protection (GH013), so it got fixed immediately. The Google literal survived only because scanning alerted after the fact instead of blocking — same defect, quieter failure mode, so it shipped.

So this adds `FAKE_GOOGLE_API_KEY` beside it, same treatment, same warning against folding it back into one literal.

Verified byte-identical: `("AIza" + "Sy" + "A1234567890" + "abcdefghijklmnopqrstuv") == "AIzaSyA1234567890abcdefghijklmnopqrstuv"` → `True`, so the string the detector receives is unchanged and coverage is unaffected. `tests/test_secret_redaction_760.py`: 34 passed. Zero occurrences of the literal remain in the file.

## What this does not do

The literal is still in git history, in commit `1e05b9b`. Purging it would mean rewriting published history for a value that was never a credential, which is not worth it. So alert #1 wants resolving as a false positive by hand — that is a security-record decision and deliberately not automated here.
