### PR TITLE
feat(read): abstract read for every tree-sitter language, not just PHP (#670)

### DIFF
--- a/.supertool.example.json
+++ b/.supertool.example.json
@@ -65,10 +65,11 @@
   "builtin-ops": {
     "read": {
       "syntax": "read:PATH[:OFFSET:LIMIT|:START-END|:full]",
-      "description": "Read file (300 lines, 20KB cap). Set php_abstract:1 to return tree-sitter symbol maps for PHP files larger than max_bytes \u2014 saves tokens on big classes. Use :full to force raw. Threshold override: SUPERTOOL_READ_ABSTRACT_THRESHOLD_BYTES=N Inline grep= filter contains ':'? Use read:@payload.toml or read:@- (fields: path, offset, limit, grep, full).",
+      "description": "Read file (300 lines, 20KB cap). Set abstract:1 to return a tree-sitter symbol map instead of raw source for any file over abstract_threshold_bytes (php, python, js/jsx, ts/tsx, go, rust, java, ruby, c, cpp, swift, kotlin, scala, lua, bash), median 5% of the source bytes; falls back to raw source and names the reason when the map would be empty or no smaller. php_abstract is the former name and still enables it \u2014 saves tokens on big files. Use :full to force raw. Threshold override: SUPERTOOL_READ_ABSTRACT_THRESHOLD_BYTES=N Inline grep= filter contains ':'? Use read:@payload.toml or read:@- (fields: path, offset, limit, grep, full).",
       "example": "read:src/app/Module.py:full",
       "max_lines": 300,
       "max_bytes": 20000,
+      "abstract": 0,
       "php_abstract": 0
     },
     "read-grep": {

--- a/.supertool.json
+++ b/.supertool.json
@@ -31,7 +31,7 @@
   "builtin-ops": {
     "read": {
       "syntax": "read:PATH[:OFFSET:LIMIT|:START-END|:full]",
-      "description": "Read file (300 lines, 20KB cap) Inline grep= filter contains ':'? Use read:@payload.toml or read:@- (fields: path, offset, limit, grep, full).",
+      "description": "Read file (300 lines, 20KB cap). abstract:1 → tree-sitter symbol map instead of source for big files, any supported language; falls back to raw and says why. Inline grep= filter contains ':'? Use read:@payload.toml or read:@- (fields: path, offset, limit, grep, full).",
       "example": "read:supertool.py:1:50"
     },
     "read-grep": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The abstract read is a tree-sitter capability now, not a PHP capability** ([#670](https://github.com/Digital-Process-Tools/claude-supertool/issues/670)). `read` on a file over the threshold returns the file's symbol map instead of the first 300 lines of source — the one thing that makes `read` better than an ordinary file read on a big file. It was gated on `path.endswith(".php")`, three hundred lines above a `_TS_LANG_MAP` that already covered eighteen extensions and a `_TS_DEF_NODES` the `between:` op already exercised for eight languages. Someone installing this plugin into a TypeScript repo — which is most of the Claude Code population — opened a 2,000-line component and got the file back. The gate is now membership of that table.
+
+  **Measured, not assumed, because `abstract_threshold_bytes` was tuned on PHP.** 263 real files over the 20 KB threshold, from Hugo, cobra, ripgrep, pdf.js, lodash, Vue core, React Router, gson, RuboCop, Sinatra, curl, nlohmann/json, Alamofire, OkHttp, os-lib, plenary.nvim, nvm and CPython's `site-packages`. Median map/source: TypeScript 2.3%, cpp 2.5%, tsx and lua 2.6%, c 2.7%, bash 3.1%, python 4.3%, java 4.7%, go 4.8%, php 5.4%, swift 5.4%, javascript 5.7%, rust 6.0%, kotlin 6.8%, ruby 10.7%, scala 17.5%. Every language wins, so none is excluded; scala, lua and bash have thin samples and lean on the per-file guard rather than the median. The full table is in `docs/operations/reads.md`.
+
+  **The threshold does not travel, so the decision moved per-file.** A language-level allowlist tuned on medians still hands you a bad answer for the file in front of you: the worst cpp map measured is 187% of the bytes the raw read would have emitted, and three of twenty javascript files parse to no definitions at all. So the map has to earn the substitution each time — non-empty, and smaller than the read it replaces — and when it does not, the read returns source **and says which of the two happened**, never a silent partial map:
+
+  ```
+  [abstract read skipped — no symbols found in src/rows.ts (typescript); showing raw source]
+  [abstract read skipped — symbol map for gen.cpp (cpp) is 37412 bytes, not smaller than the 20000 bytes this read emits; showing raw source]
+  ```
+
+  When tree-sitter is not installed at all the reason says so rather than blaming the file (`docs/validators.md` §"Declining instead of guessing"). 29 of the 263 files declined, 20 of them C# — see below. A `.txt` gets no note, because the feature never claimed to apply there and a skip line that fires everywhere means nothing.
+
+  **One switch, not a per-language map.** A per-language config would let a project turn it on for TS and off for Python, but the question it answers — "is a map worth it for this file" — is now answered per file by the guard, from measurement rather than from the user's guess. A per-language table would be a second, staler copy of that judgement, and it would need an entry for every new grammar.
+
+  **`read.php_abstract` still works.** It is documented in `.supertool.example.json` and listed by `ops`, so it is public API and a hard rename is not an auto-merge. The canonical key is now `read.abstract` — which also makes it consistent with `abstract_threshold_bytes`, already language-neutral next to it — and either key set to `1` enables the feature. `SUPERTOOL_READ_PHP_ABSTRACT` keeps working alongside `SUPERTOOL_READ_ABSTRACT`.
+
+  **The banner changed, and that is user-visible.** `[php abstract — …]` is now `[abstract read — <language>, …]`; it said "php" over a TypeScript map otherwise.
+
+  **Found on the way, filed separately: C# produces no symbols anywhere.** `_TS_LANG_MAP` maps `.cs` to `c_sharp`, the name the older `tree-sitter-languages` package used; `tree-sitter-language-pack` calls it `csharp` and raises `LookupError`, which `_ts_extract` swallows. All 20 sampled C# files yield zero symbols — in `map` and `between:` as well as in the abstract read. The guard means a `.cs` read degrades to source with a stated reason rather than to an empty map, but `map:` on a C# project still quietly returns nothing.
+
+  11 new tests in `tests/test_read_abstract_languages_670.py`, red before the change: the gate, the legacy key, the banner naming its language, both decline paths, the tree-sitter-missing reason, and two negative controls that must stay silent (`:full`, and an extension the feature never applied to).
+
 ### Added
 
 - **`gh-issues` — an issue board that ranks the queue and flags a body its comments have overtaken** ([#769](https://github.com/Digital-Process-Tools/claude-supertool/issues/769)). Both trackers could read an issue whose number you already knew and file a new one, and neither could tell you which numbers existed. Every triage tick fell back to a hand-written `gh issue list --json … -q …`, where the jq template decides what triage sees and silently omits whatever the caller forgot to ask for — the same shape as [#454](https://github.com/Digital-Process-Tools/claude-supertool/issues/454), where hand-summing CI legs turned `CANCELLED` into "pending". The shape now lives in the op.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,26 @@ Quick examples:
 ./supertool 'read:src/Foo.py' 'grep:TODO:src/' 'map:src/'
 ```
 
+### Abstract read — a big file comes back as its symbol map
+
+Off by default. Turn it on once, per project:
+
+```json
+{ "builtin-ops": { "read": { "abstract": 1 } } }
+```
+
+After that, `read:PATH` on a file over `abstract_threshold_bytes` (default: the 20 KB read cap) returns that file's **symbol map** — classes, functions, methods, with line numbers, for the whole file — instead of the first 300 lines of its source. `read:PATH:full` still gives you the source, `read:PATH:::grep=…` still filters it, and an explicit offset or limit is left alone.
+
+Every language supertool has a grammar for, not just PHP: `.php .py .js .jsx .ts .tsx .go .rs .java .rb .c .h .cpp .hpp .swift .kt .scala .lua .sh .bash`. Measured over 263 real files above the threshold — Hugo, ripgrep, pdf.js, Vue, React Router, gson, RuboCop, curl, Alamofire, OkHttp, nlohmann/json, CPython's site-packages — the map costs a **median 5% of the source bytes**, 2.3% at best (TypeScript) and 17.5% at worst (Scala). Per-language table: [docs/operations/reads.md](docs/operations/reads.md#abstract-read).
+
+**It declines rather than guess.** A map that comes back empty — a data-only module, an extension whose grammar is not installed — or one that is no smaller than the read it would replace is a worse answer than the source. In both cases the read returns the source and names which happened:
+
+```
+[abstract read skipped — no symbols found in src/rows.ts (typescript); showing raw source]
+```
+
+On the corpus above that fires on about 4% of files. `read.php_abstract` — the option's former name, from when the gate really was `.php` — still switches it on.
+
 ---
 
 ## Input forms

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,10 @@ Entries document built-in operations (`syntax`, `description`, `example`). Set `
 | Op     | Key           | Default          | Effect                                                                                   |
 | ------ | ------------- | ---------------- | ---------------------------------------------------------------------------------------- |
 | `read` | `max_lines`   | 300              | Max lines per read                                                                       |
-| `read` | `max_bytes`   | 20000            | Max bytes per read (truncates at cap)                                                    |
+| `read` | `max_bytes`   | 20000            | Max bytes per read (truncates at cap). Also the yardstick the abstract read has to beat  |
+| `read` | `abstract`    | 0                | `1` → a read of a file over the threshold returns its tree-sitter symbol map instead of source, for every language in supertool's table. Falls back to source, with the reason, when the map is empty or no smaller. See [operations/reads.md](operations/reads.md#abstract-read) |
+| `read` | `php_abstract` | 0               | Former name of `abstract`, from when the gate was `.php`. Still enables it; either key set to `1` is enough |
+| `read` | `abstract_threshold_bytes` | `max_bytes` | File size above which the abstract read applies. Env: `SUPERTOOL_READ_ABSTRACT_THRESHOLD_BYTES` |
 | `grep` | `max_results` | 10               | Default result limit when not specified in the op                                        |
 | `grep` | `max_line_chars` | 500           | Max chars per output line (match or context); remainder shown as `… (+N chars)`           |
 | `grep` | `extensions`  | `[]` (all files) | Restrict grep to these file patterns (e.g. `["*.py", "*.js"]`). Empty = search all files |

--- a/docs/operations/reads.md
+++ b/docs/operations/reads.md
@@ -6,7 +6,7 @@ File reading and directory listing ops. Reach for these when you know the path a
 
 | Op | Syntax | What it does |
 |----|--------|--------------|
-| `read` | `read:PATH` or `read:PATH:OFFSET:LIMIT` | 300 lines / 20KB cap |
+| `read` | `read:PATH` or `read:PATH:OFFSET:LIMIT` | 300 lines / 20KB cap. With `read.abstract` on, a file over the threshold comes back as its symbol map instead — see [Abstract read](#abstract-read) |
 | `read` (range) | `read:PATH:START-END` | Explicit inclusive line range. Prefer over `:OFFSET:LIMIT` when you know the lines — the offset form reads like a range but is not. Composes with `:full` and `:grep=PATTERN`. |
 | `read` (filter) | `read:PATH:OFFSET:LIMIT:grep=PATTERN` | Only show lines matching PATTERN (original line numbers preserved). Use `read:PATH:::grep=PATTERN` for defaults. |
 | `head` | `head:PATH:N` | First N lines (default 20). Minified single-line files return a char-window peek instead of the whole giant line; window size via `builtin-ops.head.char_window` (default 1000, or env `SUPERTOOL_HEAD_CHAR_WINDOW`). |
@@ -17,6 +17,59 @@ File reading and directory listing ops. Reach for these when you know the path a
 | `glob` | `glob:PATTERN` | `**` supported. Patterns resolve from the repo root; an unanchored pattern that matches nothing is retried once as `**/PATTERN`, so `glob:SiBrief/**/*.php` also finds a `SiBrief/` nested deeper (the retry prints a `[mid-path retry: …]` line — a genuine zero stays zero). **Auto-reads** if PATTERN is a concrete file path (no wildcards). |
 | `tree` | `tree:PATH` or `tree:PATH:DEPTH` | Directory structure with depth limit (default 3). Hides dotfiles. Files listed before subdirectories. |
 | `diff` | `diff:PATH1:PATH2` | Unified diff between two files. |
+
+## Abstract read
+
+`read` on a large file can return the file's **symbol map** instead of its source: every class, function and method with its line number, for the whole file, rather than the first 300 lines of text. Off by default; enable per project in `.supertool.json`:
+
+```json
+{ "builtin-ops": { "read": { "abstract": 1, "abstract_threshold_bytes": 20000 } } }
+```
+
+`abstract_threshold_bytes` defaults to `read.max_bytes` (20 KB) and can be overridden for one call with `SUPERTOOL_READ_ABSTRACT_THRESHOLD_BYTES=N`. `read.php_abstract` is the former name of the switch — from when it only applied to `.php` — and still enables it.
+
+**What it applies to.** Any extension in supertool's language table: `.php .py .js .jsx .ts .tsx .go .rs .java .rb .c .h .cpp .hpp .swift .kt .scala .lua .sh .bash`. It never applies to `read:PATH:full`, to a read with an explicit offset/limit or `grep=` filter, or to a file at or below the threshold.
+
+**What it costs.** Measured on 263 real files over the 20 KB threshold, sampled from Hugo, cobra, ripgrep, pdf.js, lodash, Vue core, React Router, gson, RuboCop, Sinatra, curl, nlohmann/json, Alamofire, OkHttp, os-lib, plenary.nvim, nvm and CPython's `site-packages`, plus a PHP codebase:
+
+| language | files | median source | median map | median map/source | worst |
+|----------|------:|--------------:|-----------:|------------------:|------:|
+| typescript | 20 | 43.0 KB | 1.0 KB | 2.3% | 16% |
+| ruby | 7 | 22.7 KB | 2.6 KB | 10.7% | 15% |
+| tsx | 20 | 37.0 KB | 1.1 KB | 2.6% | 6% |
+| lua | 3 | 23.6 KB | 1.0 KB | 2.6% | 10% |
+| cpp | 16 | 41.8 KB | 1.6 KB | 2.5% | 7% |
+| c | 20 | 36.3 KB | 1.0 KB | 2.7% | 8% |
+| bash | 1 | 168.7 KB | 5.3 KB | 3.1% | 3% |
+| python | 20 | 38.8 KB | 1.4 KB | 4.3% | 11% |
+| java | 8 | 33.5 KB | 1.5 KB | 4.7% | 8% |
+| go | 20 | 26.9 KB | 1.4 KB | 4.8% | 13% |
+| php | 20 | 24.4 KB | 1.4 KB | 5.4% | 25% |
+| swift | 20 | 37.6 KB | 2.4 KB | 5.4% | 19% |
+| javascript | 20 | 40.2 KB | 2.8 KB | 5.7% | 38% |
+| rust | 20 | 37.9 KB | 2.0 KB | 6.0% | 9% |
+| kotlin | 20 | 32.9 KB | 2.8 KB | 6.8% | 13% |
+| scala | 3 | 24.0 KB | 3.7 KB | 17.5% | 19% |
+
+Scala, lua and bash are thin samples — the per-file guard below is what protects them, not the median.
+
+**C# is in the language table and does not currently produce a map.** `.cs` maps to the grammar name `c_sharp`, which `tree-sitter-language-pack` does not answer to (it calls it `csharp`), so every `.cs` file yields zero symbols — in `map` and `between:` as well as here. The guard below catches it: a `.cs` read falls back to source with the reason stated, rather than returning an empty map.
+
+**Two ways it declines.** A symbol map that is empty, or one that is no smaller than the bytes this read would otherwise emit, is a worse answer than the source. Either way the read returns the source and prints which happened — an absence produced by the tool must never read as an absence in the world (see [validators.md](../validators.md#declining-instead-of-guessing)):
+
+```
+[abstract read skipped — no symbols found in src/rows.ts (typescript); showing raw source]
+[abstract read skipped — no symbols found in app.swift (swift) — tree-sitter is not installed, so only the regex tier ran; showing raw source]
+[abstract read skipped — symbol map for gen.cpp (cpp) is 37412 bytes, not smaller than the 20000 bytes this read emits; showing raw source]
+```
+
+Across the corpus above, 29 of 263 files declined — 20 of them C#.
+
+A successful abstract read is labelled, and says how to get the source anyway:
+
+```
+[abstract read — typescript, 1204 lines, 43001 bytes raw — use read:src/Big.ts:full for content or read:src/Big.ts:::grep=PATTERN to filter]
+```
 
 ## Common patterns
 

--- a/supertool.py
+++ b/supertool.py
@@ -2321,40 +2321,90 @@ def _read_range_note(path: str, offset: int, limit: int, body: str) -> str:
     )
 
 
+def _abstract_lang(path: str) -> str:
+    """tree-sitter language name for PATH's extension, or "" when the abstract
+    read has no language table for it.
+
+    The gate used to be `path.endswith(".php")` while `_TS_LANG_MAP` already
+    covered eighteen extensions (#670) — so a TypeScript or Python user got the
+    raw file, which is the thing they already had."""
+    return _TS_LANG_MAP.get(os.path.splitext(path)[1].lower(), "")
+
+
+def _abstract_map(path: str, lang: str, size_bytes: int) -> Tuple[str, str]:
+    """Symbol map for PATH, or the reason there isn't a usable one.
+
+    Returns `(map, "")` on success and `("", reason)` when the caller should
+    fall back to raw source. Two ways to fail, and the caller states which:
+
+    - **No symbols.** The parser ran and found no definitions (a data-only
+      module), or no parser matched at all. Returning that empty map would
+      read as "this file has no code" — the absence of an answer wearing the
+      shape of one. See docs/validators.md, "Declining instead of guessing".
+    - **No saving.** A map that is not smaller than the bytes this read would
+      otherwise emit is a worse answer than the source. Measured on 263 real
+      files across 16 languages this fires on ~4% of them, so it is rare but
+      not theoretical.
+    """
+    body = op_map(path)
+    if (body.startswith("ERROR:") or "(no symbols)" in body
+            or "no supported files" in body):
+        reason = f"no symbols found in {path} ({lang})"
+        if not _has_tree_sitter():
+            reason += " — tree-sitter is not installed, so only the regex tier ran"
+        return "", reason
+    map_bytes = len(body.encode("utf-8", errors="replace"))
+    budget = min(size_bytes, _get_op_int("read", "max_bytes", MAX_READ_BYTES))
+    if map_bytes >= budget:
+        return "", (f"symbol map for {path} ({lang}) is {map_bytes} bytes, "
+                    f"not smaller than the {budget} bytes this read emits")
+    return body, ""
+
+
 def op_read(path: str, offset: int = 0, limit: int = 0,
             grep_filter: str = "", force_full: bool = False) -> str:
-    # PHP abstract mode — when enabled, read:PATH on a PHP file with no
-    # offset/limit/grep returns the symbol map (~10x smaller). Skipped when:
+    # Abstract mode — when enabled, read:PATH on a file in a language
+    # tree-sitter knows, with no offset/limit/grep, returns the symbol map
+    # (measured 3-18% of the source bytes, median ~5%). Skipped when:
+    #   - the extension is not in _TS_LANG_MAP (no map to build)
     #   - file size <= threshold (small files fit raw in the cap, abstract
     #     buys nothing)
     #   - caller passes :full / :raw (force_full)
     #   - explicit offset/limit/grep
-    if (offset == 0 and limit == 0 and not grep_filter
-            and not force_full
-            and path.endswith(".php")
-            and _get_op_int("read", "php_abstract", 0)):
+    #   - the map would be empty or no smaller than the raw read — those two
+    #     fall back to source *and say so*, never silently
+    skip_note = ""
+    if (offset == 0 and limit == 0 and not grep_filter and not force_full
+            and (_get_op_int("read", "abstract", 0)
+                 or _get_op_int("read", "php_abstract", 0))):
+        lang = _abstract_lang(path)
         threshold = _get_op_int("read", "abstract_threshold_bytes",
                                 _get_op_int("read", "max_bytes", MAX_READ_BYTES))
         try:
             size_bytes = os.path.getsize(path)
         except OSError:
             size_bytes = 0
-        if size_bytes > threshold:
-            line_count = 0
-            try:
-                with open(path, "rb") as f:
-                    for line_count, _ in enumerate(f, 1):
-                        pass
-            except OSError:
-                pass
-            return (op_map(path)
-                    + f"\n[php abstract — {line_count} lines, {size_bytes} bytes raw — "
-                      f"use read:{path}:full for content "
-                      f"or read:{path}:::grep=PATTERN to filter]\n")
+        if lang and size_bytes > threshold:
+            body, reason = _abstract_map(path, lang, size_bytes)
+            if body:
+                line_count = 0
+                try:
+                    with open(path, "rb") as f:
+                        for line_count, _ in enumerate(f, 1):
+                            pass
+                except OSError:
+                    pass
+                return (body
+                        + f"\n[abstract read — {lang}, {line_count} lines, "
+                          f"{size_bytes} bytes raw — "
+                          f"use read:{path}:full for content "
+                          f"or read:{path}:::grep=PATTERN to filter]\n")
+            skip_note = (f"[abstract read skipped — {reason}; "
+                         f"showing raw source]\n")
     if limit <= 0:
         limit = _get_op_int("read", "max_lines", MAX_READ_LINES)
     body = render_file(path, offset, limit, grep_filter, force_full)
-    return body + _read_edit_hint(path, body)
+    return skip_note + body + _read_edit_hint(path, body)
 
 
 def _read_edit_hint(path: str, body: str) -> str:

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -127,13 +127,20 @@ def test_render_file_handles_empty_file(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# PHP abstract mode — size threshold, :full bypass, env var override
+# Abstract mode — size threshold, :full bypass, env var override
+#
+# Enabled here through the legacy `php_abstract` key on purpose: it is public
+# API (#670) and these tests are what keeps it honoured. The threshold is set
+# directly rather than through `max_bytes`, because since #670 `max_bytes` is
+# also the yardstick the map has to beat — driving both from one knob made a
+# 100-byte cap mean "abstract everything, then reject every map".
 # ---------------------------------------------------------------------------
 
-def _enable_abstract(monkeypatch, max_bytes: int = 100) -> None:
+def _enable_abstract(monkeypatch, threshold: int = 100) -> None:
     monkeypatch.setattr(
         supertool, "_CONFIG",
-        {"builtin-ops": {"read": {"php_abstract": 1, "max_bytes": max_bytes}}},
+        {"builtin-ops": {"read": {"php_abstract": 1,
+                                  "abstract_threshold_bytes": threshold}}},
     )
 
 
@@ -141,29 +148,29 @@ def test_read_php_abstract_off_by_default(tmp_path: Path) -> None:
     f = tmp_path / "x.php"
     f.write_text("<?php\n" + "// x\n" * 200)
     out = supertool.op_read(str(f))
-    assert "[php abstract" not in out
+    assert "[abstract read" not in out
     assert "<?php" in out
 
 
 def test_read_php_abstract_skipped_below_threshold(
     tmp_path: Path, monkeypatch
 ) -> None:
-    _enable_abstract(monkeypatch, max_bytes=100000)
+    _enable_abstract(monkeypatch, threshold=100000)
     f = tmp_path / "x.php"
     f.write_text("<?php\necho 'hi';\n")
     out = supertool.op_read(str(f))
-    assert "[php abstract" not in out
+    assert "[abstract read" not in out
     assert "echo" in out
 
 
 def test_read_php_abstract_triggers_above_threshold(
     tmp_path: Path, monkeypatch
 ) -> None:
-    _enable_abstract(monkeypatch, max_bytes=100)
+    _enable_abstract(monkeypatch, threshold=100)
     f = tmp_path / "x.php"
     f.write_text("<?php\nclass Foo {}\n" + "// pad\n" * 200)
     out = supertool.op_read(str(f))
-    assert "[php abstract" in out
+    assert "[abstract read — php" in out
     assert "bytes raw" in out
     assert ":full for content" in out
 
@@ -171,31 +178,31 @@ def test_read_php_abstract_triggers_above_threshold(
 def test_read_force_full_bypasses_abstract(
     tmp_path: Path, monkeypatch
 ) -> None:
-    _enable_abstract(monkeypatch, max_bytes=100)
+    _enable_abstract(monkeypatch, threshold=100)
     f = tmp_path / "x.php"
     f.write_text("<?php\nclass Foo {}\n" + "// pad\n" * 200)
     out = supertool.op_read(str(f), force_full=True)
-    assert "[php abstract" not in out
+    assert "[abstract read" not in out
     assert "<?php" in out
 
 
 def test_read_env_var_overrides_threshold(
     tmp_path: Path, monkeypatch
 ) -> None:
-    _enable_abstract(monkeypatch, max_bytes=100000)
+    _enable_abstract(monkeypatch, threshold=100000)
     monkeypatch.setenv("SUPERTOOL_READ_ABSTRACT_THRESHOLD_BYTES", "100")
     f = tmp_path / "x.php"
     f.write_text("<?php\nclass Foo {}\n" + "// pad\n" * 200)
     out = supertool.op_read(str(f))
-    assert "[php abstract" in out
+    assert "[abstract read — php" in out
 
 
 def test_dispatch_read_full_keyword(tmp_path: Path, monkeypatch) -> None:
-    _enable_abstract(monkeypatch, max_bytes=100)
+    _enable_abstract(monkeypatch, threshold=100)
     f = tmp_path / "x.php"
     f.write_text("<?php\nclass Foo {}\n" + "// pad\n" * 200)
     out = supertool.dispatch(f"read:{f}:full")
-    assert "[php abstract" not in out
+    assert "[abstract read" not in out
     assert "<?php" in out
 
 

--- a/tests/test_read_abstract_languages_670.py
+++ b/tests/test_read_abstract_languages_670.py
@@ -1,0 +1,197 @@
+"""Abstract read is a tree-sitter capability, not a PHP capability (#670).
+
+`read` on a file over the threshold returns a symbol map instead of raw source,
+at roughly a twentieth of the bytes. That was gated on `path.endswith(".php")`
+while the language tables next to it already covered eighteen extensions.
+
+These tests pin three things:
+  - the gate is language-table membership, not a `.php` suffix
+  - the legacy `read.php_abstract` config key keeps enabling it
+  - when the map cannot beat the raw source, the read says so rather than
+    returning a map that is empty or larger (docs/validators.md
+    "Declining instead of guessing" — an absence has to be stated)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import supertool
+
+
+def _enable(monkeypatch, key: str = "abstract", threshold: int = 400) -> None:
+    monkeypatch.setattr(
+        supertool, "_CONFIG",
+        {"builtin-ops": {"read": {key: 1, "abstract_threshold_bytes": threshold}}},
+    )
+
+
+def _big_ts(path: Path) -> Path:
+    body = ["export interface Shape { kind: string; }"]
+    for i in range(60):
+        body.append(f"export class Widget{i} {{")
+        body.append(f"  render{i}(): string {{")
+        body.append(f"    // {'pad ' * 12}")
+        body.append(f"    return 'widget-{i}';")
+        body.append("  }")
+        body.append("}")
+    path.write_text("\n".join(body) + "\n")
+    return path
+
+
+def _big_py(path: Path) -> Path:
+    body = []
+    for i in range(60):
+        body.append(f"class Handler{i}:")
+        body.append(f"    def handle{i}(self):")
+        body.append(f"        # {'pad ' * 12}")
+        body.append(f"        return {i}")
+        body.append("")
+    path.write_text("\n".join(body) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The gate: any language in the table, not just PHP
+# ---------------------------------------------------------------------------
+
+def test_abstract_read_applies_to_typescript(tmp_path: Path, monkeypatch) -> None:
+    _enable(monkeypatch)
+    f = _big_ts(tmp_path / "widgets.ts")
+    out = supertool.op_read(str(f))
+    assert "[abstract read" in out
+    assert "Widget7" in out
+    assert "return 'widget-7'" not in out, "raw source leaked — this is not a map"
+
+
+def test_abstract_read_applies_to_python(tmp_path: Path, monkeypatch) -> None:
+    _enable(monkeypatch)
+    f = _big_py(tmp_path / "handlers.py")
+    out = supertool.op_read(str(f))
+    assert "[abstract read" in out
+    assert "Handler7" in out
+    assert "return 7" not in out
+
+
+def test_abstract_banner_names_the_language(tmp_path: Path, monkeypatch) -> None:
+    _enable(monkeypatch)
+    f = _big_py(tmp_path / "handlers.py")
+    out = supertool.op_read(str(f))
+    assert "python" in out.split("[abstract read", 1)[1].split("]", 1)[0]
+
+
+def test_abstract_read_still_applies_to_php(tmp_path: Path, monkeypatch) -> None:
+    _enable(monkeypatch)
+    f = tmp_path / "Foo.php"
+    f.write_text("<?php\nclass Foo { public function bar() {} }\n" + "// pad\n" * 200)
+    out = supertool.op_read(str(f))
+    assert "[abstract read" in out
+    assert "Foo" in out
+
+
+def test_abstract_read_off_by_default(tmp_path: Path) -> None:
+    f = _big_ts(tmp_path / "widgets.ts")
+    out = supertool.op_read(str(f))
+    assert "[abstract read" not in out
+    assert "return 'widget-0'" in out
+
+
+def test_abstract_read_full_bypasses_for_typescript(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _enable(monkeypatch)
+    f = _big_ts(tmp_path / "widgets.ts")
+    out = supertool.op_read(str(f), force_full=True)
+    assert "[abstract read" not in out
+    assert "return 'widget-0'" in out
+
+
+# ---------------------------------------------------------------------------
+# The legacy key stays public API
+# ---------------------------------------------------------------------------
+
+def test_legacy_php_abstract_key_enables_every_language(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`read.php_abstract` is documented in .supertool.example.json and listed
+    by `ops`. A project that set it keeps the feature — now for all languages,
+    which is what the key meant to ask for."""
+    _enable(monkeypatch, key="php_abstract")
+    f = _big_ts(tmp_path / "widgets.ts")
+    out = supertool.op_read(str(f))
+    assert "[abstract read" in out
+
+
+# ---------------------------------------------------------------------------
+# Silence has to be stated (docs/validators.md — declining instead of guessing)
+# ---------------------------------------------------------------------------
+
+def test_no_symbols_falls_back_to_raw_and_says_so(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A big data-only module parses fine and yields no definitions. Returning
+    that empty map would read as 'this file has no code'."""
+    _enable(monkeypatch)
+    f = tmp_path / "data.ts"
+    rows = ",\n".join(f'  {{ id: {i}, name: "row-{i}" }}' for i in range(120))
+    f.write_text("export const ROWS = [\n" + rows + "\n];\n")
+    out = supertool.op_read(str(f))
+    assert "[abstract read skipped" in out
+    assert "no symbols" in out
+    assert "data.ts" in out
+    assert '"row-3"' in out, "must fall back to the actual source"
+
+
+def test_map_no_smaller_than_source_falls_back_and_reports_sizes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A symbol map that is not smaller than what a raw read would emit is a
+    worse answer than the source. Long names, no bodies — the map restates the
+    file."""
+    _enable(monkeypatch, threshold=200)
+    monkeypatch.setattr(
+        supertool, "_CONFIG",
+        {"builtin-ops": {"read": {"abstract": 1, "abstract_threshold_bytes": 200,
+                                  "max_bytes": 400}}},
+    )
+    f = tmp_path / "many.py"
+    f.write_text("\n".join(
+        f"def function_with_a_very_long_and_descriptive_name_number_{i}(): pass"
+        for i in range(40)) + "\n")
+    out = supertool.op_read(str(f))
+    assert "[abstract read skipped" in out
+    assert "not smaller" in out
+    assert "def function_with_a_very_long_and_descriptive_name_number_0" in out
+
+
+def test_skip_note_names_tree_sitter_when_it_is_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """No tree-sitter and no regex tier for this extension means no map. The
+    reader has to be able to tell that from 'this file has no symbols'."""
+    _enable(monkeypatch)
+    monkeypatch.setattr(supertool, "_TS_AVAILABLE", False)
+    monkeypatch.setattr(supertool, "_TS_CHECKED", True)
+    monkeypatch.setattr(supertool, "_CTAGS_PATH", None)
+    monkeypatch.setattr(supertool, "_CTAGS_CHECKED", True)
+    f = tmp_path / "app.swift"
+    f.write_text("\n".join(f"class Screen{i} {{ func draw{i}() {{}} }}"
+                           for i in range(60)) + "\n")
+    out = supertool.op_read(str(f))
+    assert "[abstract read skipped" in out
+    assert "tree-sitter" in out
+    assert "class Screen0" in out
+
+
+def test_unknown_extension_is_untouched_and_unannounced(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A .txt file was never a candidate. It gets raw source and no note —
+    the skip note means 'this could have been a map and was not', so it must
+    not fire where the feature never applied."""
+    _enable(monkeypatch)
+    f = tmp_path / "notes.txt"
+    f.write_text("word " * 4000)
+    out = supertool.op_read(str(f))
+    assert "[abstract read" not in out
+    assert "word word" in out


### PR DESCRIPTION
Closes #670

`read` returns a tree-sitter symbol map instead of raw source for a large file, at a fraction of the tokens — the feature that makes it meaningfully better than an ordinary file read. It was gated on `path.endswith(".php")` while `_TS_LANG_MAP` and `_TS_DEF_NODES` already carried the machinery for every language the tool parses. Someone opening a 2,000-line TypeScript component got the raw file, with no way to know the capability existed and was wired for their language.

## Measured, not assumed

263 real files over the 20 KB threshold, from Hugo, cobra, ripgrep, pdf.js, lodash, Vue core, React Router, gson, RuboCop, Sinatra, curl, nlohmann/json, Alamofire, OkHttp, os-lib, plenary.nvim, nvm, CPython site-packages, and DVSI for PHP.

| lang | n | med src | med map | med map/src |
|---|---:|---:|---:|---:|
| typescript | 20 | 43.0 KB | 1.0 KB | 2.3% |
| cpp | 16 | 41.8 KB | 1.6 KB | 2.5% |
| tsx | 20 | 37.0 KB | 1.1 KB | 2.6% |
| c | 20 | 36.3 KB | 1.0 KB | 2.7% |
| python | 20 | 38.8 KB | 1.4 KB | 4.3% |
| java | 8 | 33.5 KB | 1.5 KB | 4.7% |
| go | 20 | 26.9 KB | 1.4 KB | 4.8% |
| php | 20 | 24.4 KB | 1.4 KB | 5.4% |
| swift | 20 | 37.6 KB | 2.4 KB | 5.4% |
| javascript | 20 | 40.2 KB | 2.8 KB | 5.7% |
| rust | 20 | 37.9 KB | 2.0 KB | 6.0% |
| kotlin | 20 | 32.9 KB | 2.8 KB | 6.8% |
| ruby | 7 | 22.7 KB | 2.6 KB | 10.7% |
| scala | 3 | 24.0 KB | 3.7 KB | 17.5% |
| lua / bash | 3 / 1 | — | — | 2.6% / 3.1% |

Every language wins on the median, so none is excluded by name. Scala, lua and bash are thin samples (3/3/1) and the docs say so — they lean on the per-file guard rather than on the median.

## The per-file guard is what makes a single switch safe

Medians do not decide anything at read time; the guard does, per file, from the actual bytes. It compares the map against `min(source, read.max_bytes)` — **the bytes the read would actually emit**, not the whole source, because the raw read is capped. That is what catches a `cpp` file whose map is 187% of the excerpt it would have replaced. It fires on 29 of 263 files.

Which is also why this is one switch rather than a per-language map: a static table answers "is a map worth it here?" with the user's guess, staler than the file in front of you, plus an entry to maintain per grammar.

Both fallbacks state which arm fired, and a file the feature never applied to gets no note at all:

```
[abstract read skipped — no symbols found in src/rows.ts (typescript); showing raw source]
[abstract read skipped — no symbols found in app.swift (swift) — tree-sitter is not installed, so only the regex tier ran; showing raw source]
[abstract read skipped — symbol map for gen.cpp (cpp) is 37412 bytes, not smaller than the 20000 bytes this read emits; showing raw source]
```

## Option name

`read.abstract` is canonical; `read.php_abstract` and `SUPERTOOL_READ_PHP_ABSTRACT` keep working, so this is not a public API rename. A test pins the legacy key enabling TypeScript. Beyond brevity: the sibling `abstract_threshold_bytes` was already language-neutral, so `php_abstract` was the odd one out inside its own config block.

**One user-visible string change:** the banner `[php abstract — …]` becomes `[abstract read — <language>, …]`. It said "php" above a TypeScript map otherwise. Called out in the CHANGELOG.

## Test-helper change worth flagging

`_enable_abstract(monkeypatch, max_bytes=100)` in `tests/test_read.py` drove the threshold *through* `max_bytes`, which now also serves as the yardstick the map must beat — so a 100-byte cap would have meant "abstract everything, then reject every map". It now sets `abstract_threshold_bytes` directly, with the parameter renamed to `threshold`. The two knobs were only coincidentally the same before this change.

## Found on the way, filed separately as #790

C# returns **0 symbols on 20 of 20 files**, and not because of def-nodes: `.cs` maps to `"c_sharp"`, the old `tree-sitter-languages` name, while the installed `tree-sitter-language-pack` calls it `"csharp"` and raises `LookupError` — swallowed by a bare except. So `map:` and `between:` on a C# file return nothing and say nothing today. Not folded in here: it predates this change and has its own blast radius. A uniform zero across an entire language was the only tell.

## Tests

TDD. RED: 8 failed, 3 passed — the 3 are negative controls (off by default, `:full` bypass, unknown extension untouched) that pass before and after by design, present to catch the change over-reaching. GREEN: 11 passed in the new file; full suite 6335 passed, 63 skipped, coverage 89.41% against an 86% gate.

Docs: `README.md` gains an "Abstract read" section — it was not PHP-only in the README, it was **absent**, zero occurrences of "abstract" in the whole file. Plus `docs/operations/reads.md` (measured table, both decline paths, the C# note), `docs/configuration.md`, `.supertool.json`, `.supertool.example.json`, `CHANGELOG.md`.
