### PR TITLE
chore(hooks): gate the pre-push suite on the destination ref, not on every push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -79,6 +79,39 @@ if [ -z "${PYTHON:-}" ]; then
     exit 1
 fi
 
+# Which refs is this push updating? A pre-push hook is handed one line per ref
+# on stdin: `<local ref> <local sha> <remote ref> <remote sha>`. The suite is a
+# gate worth three minutes when the destination is `master`, where a red default
+# branch is a shared cost nobody opted into. Pushing a feature branch is the
+# opposite trade: the PR runs 19 checks in parallel on somebody else's machine
+# while the author keeps working, so running them here first buys nothing except
+# a serial wait. CI being slower in wall-clock does not matter when it costs the
+# author no waiting at all.
+#
+# The skip is disclosed rather than silent, and it names the way to override it —
+# a gate that quietly stops gating is worse than one that was never there.
+target_protected=0
+saw_ref=0
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+    saw_ref=1
+    case "$remote_ref" in
+        refs/heads/master|refs/heads/main) target_protected=1 ;;
+    esac
+done
+
+# Three states, not two. No refs on stdin means the question was never answered
+# — some callers invoke the hook with stdin closed — and an unanswered question
+# must not read as "feature branch, skip it". Say so, then run the suite: the
+# cost of being wrong that way is three minutes, and the other way is master.
+if [ "$saw_ref" -eq 0 ]; then
+    echo "── pre-push: could not read the push refs from stdin — running the suite ──"
+elif [ "$target_protected" -eq 0 ] && [ -z "${PREPUSH_FULL:-}" ]; then
+    echo "── pre-push: feature branch — suite NOT run here ──"
+    echo "   The PR's checks are the gate, and they run in parallel while you work."
+    echo "   Force it locally with: PREPUSH_FULL=1 git push"
+    exit 0
+fi
+
 echo "── pre-push: running full test suite (mirrors CI) ──"
 # Mirror the CI gate (.github/workflows/tests.yml): run slow tests too, and do
 # NOT gate coverage (--no-cov). CI is the authority on what's mergeable; gating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The pre-push hook runs the suite for `master`, not for feature branches** ([#893](https://github.com/Digital-Process-Tools/claude-supertool/issues/893)). It ran the full suite on every push — measured at **176.66s** on a real push — and that cost is serial and blocking, while the PR's 19 checks run in parallel on somebody else's machine and cost the author no waiting at all. CI being slower in wall-clock is not the comparison that matters. The hook now reads the refs git hands it on stdin and gates on the destination: `master`/`main` still pay for the suite, where a red default branch is a shared cost nobody opted into; a feature branch does not, because a red PR branch is what PRs are for. `PREPUSH_FULL=1 git push` forces it.
+
+  **The skip is announced, and an unreadable stdin runs the suite rather than skipping it.** Three states, not two: some callers invoke a hook with stdin closed, and "the question was never answered" must not render as "feature branch, skip it" — the cost of being wrong that way is three minutes, and the other way is master. Both paths say which one they took.
+
+  **What was rejected, and why it is written down.** Dropping the hook's `-m 'not benchmark'` override was considered and refused: the comment above it argues that the default `not slow` filter lets a slow test CI runs slip through, and that reasoning holds. It would also have bought nothing today — only 7 tests carry `@pytest.mark.slow` and none of them are the four that own the suite's cost ([#891](https://github.com/Digital-Process-Tools/claude-supertool/issues/891)). `-x` was refused too: on a three-minute suite it converts one run showing every failure into one run per failure, which is why `--tb=short` is there.
+
 ### Added
 
 - **`validate:@payload` — the file list travels in a field nothing re-splits** ([#878](https://github.com/Digital-Process-Tools/claude-supertool/issues/878)). `validate:@-` / `validate:@file.toml` take `path` **or** `paths` (a list), plus `tools` and `verbose`. The colon list form `validate:f1,f2,…:FILTER` joins on `:` and `,` and has no escape for either. `_split_arg` rescues the common case — a Windows drive letter, per comma-segment — but not a `:` that is not followed by a separator (`x:ruff` re-points the filter) and not a `,` in a filename (`a,b.py` re-parses into two paths, neither real). Same `@file`/`@-` shape the read and mutating ops already use, dispatched straight to the op so the payload is never rebuilt into a colon string. Documented in `docs/input-forms.md`.


### PR DESCRIPTION

Closes #893

The hook ran the full suite on every push — **176.66s measured** on a real push of `fix/885-886`. That cost is serial and blocking. The PR's 19 checks run in parallel on somebody else's machine and cost the author no waiting at all, so CI being slower in wall-clock is not the comparison that matters.

It now reads the refs git hands it on stdin and gates on destination:

| pushing to | suite runs? | why |
| --- | --- | --- |
| `master` / `main` | yes | a red default branch is a shared cost nobody opted into |
| a feature branch | no | a red PR branch is what PRs are for; 19 checks are already the gate |
| stdin unreadable | **yes**, and says so | the question was never answered, and that must not read as "feature branch, skip it" |

`PREPUSH_FULL=1 git push` forces it.

Measured on this branch's own push: **6.18s**, verified against the remote.

## Rejected, and recorded in the CHANGELOG rather than silently dropped

Both were in my own first recommendation, and the code argued me out of them:

- **Dropping the `-m 'not benchmark'` override.** The comment above it says the default `not slow` filter would let a slow test CI runs slip through — that reasoning holds. It would also buy nothing today: only 7 tests carry `@pytest.mark.slow`, and none of them are the four that own the suite's cost (#891).
- **Adding `-x`.** On a three-minute suite it converts one run showing every failure into one run per failure, which is exactly what `--tb=short` is there to avoid.

## Verified

All three gate states exercised directly against the hook with synthetic stdin — feature branch skips (exit 0), `master` reaches the suite, empty stdin discloses and reaches the suite.