### PR TITLE
Potential fix for code scanning alert no. 5: Bad HTML filtering regexp

### DIFF
--- a/supertool.py
+++ b/supertool.py
@@ -407,7 +407,7 @@ _COMPACT_SKIP = re.compile(
     r"|^\s*/\*"        # block comment open
     r"|^\s*\*/"        # block comment close
     r"|^\s*<!--"       # XML/HTML comment open
-    r"|^\s*-->"        # XML/HTML comment close
+    r"|^\s*--!?>"      # XML/HTML comment close (--> or --!>)
 )
 
 # Config file — .supertool.json in project root (or parent dirs)


### PR DESCRIPTION
Potential fix for [https://github.com/Digital-Process-Tools/claude-supertool/security/code-scanning/5](https://github.com/Digital-Process-Tools/claude-supertool/security/code-scanning/5)

The best fix is to broaden the HTML comment-close branch in `_COMPACT_SKIP` so it matches both `-->` and `--!>` forms, while keeping existing behavior unchanged for all other branches.

In `supertool.py`, in the `_COMPACT_SKIP = re.compile(...)` block (around lines 402–411), replace the current HTML close-tag branch:

- `r"|^\s*-->"       # XML/HTML comment close`

with a regex that accepts optional `!` before `>`:

- `r"|^\s*--!?>"     # XML/HTML comment close (--> or --!>)`

No new imports or helper methods are needed. This is a minimal, targeted change that addresses CodeQL’s finding without changing surrounding functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
