### PR TITLE
test(ci): mark three heavy tests slow, drop the marker from CI, and make the tail name itself (#891)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -113,10 +113,12 @@ elif [ "$target_protected" -eq 0 ] && [ -z "${PREPUSH_FULL:-}" ]; then
 fi
 
 echo "── pre-push: running full test suite (mirrors CI) ──"
-# Mirror the CI gate (.github/workflows/tests.yml): run slow tests too, and do
-# NOT gate coverage (--no-cov). CI is the authority on what's mergeable; gating
-# coverage here — which CI doesn't — only produces local-only false aborts, and
-# the default 'not slow' filter would let a slow test that CI runs slip through.
+# Mirror the CI gate (.github/workflows/tests.yml): as of #891 that no longer
+# runs the `slow` marker — CI moved those tests to a scheduled workflow
+# instead of running them on every push, and this hook mirrors CI rather than
+# the local default in isolation. Do NOT gate coverage (--no-cov): CI is the
+# authority on what's mergeable, and gating coverage here — which CI
+# doesn't — only produces local-only false aborts.
 #
 # `benchmark` is the one marker excluded rather than included (#485). Those
 # tests assert on elapsed wall-clock, so they can fail because the laptop was
@@ -127,7 +129,7 @@ echo "── pre-push: running full test suite (mirrors CI) ──"
 # benchmarks in the suite read an absolute path in one maintainer's home
 # directory and skip everywhere else, so CI has never run them. Ask for them
 # deliberately, on a machine whose load you control: `pytest -m benchmark -n0`.
-if ! "$PYTHON" -m pytest -m 'not benchmark' --no-cov --tb=short; then
+if ! "$PYTHON" -m pytest -m 'not slow and not benchmark' --no-cov --tb=short; then
     echo ""
     echo "✗ Tests failed. Push aborted."
     echo "  Fix failures or run: git push --no-verify  (to bypass, discouraged)"

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -17,6 +17,12 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch: {}
 
+# Read-only: this job runs tests and publishes nothing. Declared rather than
+# inherited, because the repository default is what a future settings change
+# would silently widen.
+permissions:
+  contents: read
+
 jobs:
   slow:
     name: pytest -m slow (ubuntu-latest, 3.12)

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,46 @@
+name: slow tests
+
+# #891: `slow` is excluded from the main `tests` workflow's twelve legs (see
+# .github/workflows/tests.yml) so a full-duration timeout/hang/disclosure
+# test does not run on every push. Excluding it from CI entirely would mean
+# these tests run *nowhere* — they are this repo's most-filed defect class —
+# so this workflow keeps them running, just less often than every push. On a
+# cron rather than per-push: the whole point of #891 was to take these tests
+# off the per-push critical path, and a per-push run here would put them
+# right back.
+
+on:
+  schedule:
+    # 06:00 UTC daily. No particular significance to the hour — anything
+    # that runs at least once a day catches a regression before it has been
+    # live a week.
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  slow:
+    name: pytest -m slow (ubuntu-latest, 3.12)
+    runs-on: ubuntu-latest
+    # Sized like the main pytest job's floor
+    # (tests/test_ci_job_timeouts_722.py MIN_BUDGET_MIN["pytest"] = 20)
+    # rather than tightly: this is a hang-guard, not a benchmark, and firing
+    # on a slow runner instead of a real hang is the #702 trade repeated
+    # here.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install supertool + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run slow tests
+        # -n auto: these tests are individually heavy, not numerous, so
+        # parallelism still helps. --no-cov: this job measures nothing about
+        # coverage, only whether the disclosure paths still pass.
+        shell: bash
+        run: python -X utf8 -m pytest -m 'slow' -n auto --tb=short --no-cov --durations=25 -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,12 +56,28 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
-      - name: Run tests (full suite — slow tests included)
-        # Override pyproject addopts default so CI exercises the slow
-        # MCP-fallback and batch-stress paths the dev inner loop skips —
-        # everything except `benchmark`, whose wall-clock assertions on a
-        # shared runner report on the runner (#485). A red CI row has to mean
-        # "this diff is wrong" or it stops being read.
+      - name: Run tests (excludes slow and benchmark — see #891)
+        # Override pyproject addopts default. Until #891 this ran the `slow`
+        # marker on all twelve legs, on every push — marking a test `slow`
+        # changed the local inner loop and nothing else. `slow` is excluded
+        # here too now, same as the local default; `benchmark` stays
+        # excluded because its wall-clock assertions on a shared runner
+        # report on the runner (#485). A red CI row has to mean "this diff
+        # is wrong" or it stops being read.
+        #
+        # `slow` tests still run — on a schedule, in
+        # .github/workflows/slow-tests.yml — rather than nowhere: they are
+        # timeout/hang/network-failure disclosure tests, this repo's
+        # most-filed defect class, and a test that runs nowhere is deleted
+        # with extra steps.
+        #
+        # `--durations=25` (#891 scope item 3): every measurement behind
+        # #891/#917 was taken on macOS, and nobody had identified which
+        # tests are actually slow on Windows — ~7 of a Windows leg's ~10.5
+        # minutes are spent between 98% and 99% of the progress bar with
+        # nothing in the log to say which test is running there. This makes
+        # the tail name itself instead of being guessed at.
+        #
         # bash shell forced so `|| true` works on Windows (PowerShell default
         # exits on pytest's non-zero status, skipping the junit-xml parser).
         # The Python step parses junit-xml and re-emits the failures with their
@@ -82,7 +98,7 @@ jobs:
         # whose blast radius includes the tests that would catch its own
         # regression is not a fix. Pinned by `tests/test_ci_encoding_546.py`.
         shell: bash
-        run: python -X utf8 -m pytest -m 'not benchmark' --tb=no --no-cov --junit-xml=junit.xml -q
+        run: python -X utf8 -m pytest -m 'not slow and not benchmark' --tb=no --no-cov --durations=25 --junit-xml=junit.xml -q
       - name: Show failing tests with full messages (always runs)
         # `--tb=no` above means the one-line summary is all there is, and pytest
         # elides the middle of a long one to fit the terminal width — on one real

--- a/changelog.d/891.added.md
+++ b/changelog.d/891.added.md
@@ -1,0 +1,19 @@
+- **Four heavy local tests marked `slow`, and a scheduled workflow to keep
+  them running somewhere** ([#891](https://github.com/Digital-Process-Tools/claude-supertool/issues/891)).
+  Three tests that cost 95s of CPU in the local suite —
+  `test_fetch_timeout_gives_a_verdict_not_a_traceback`,
+  `test_rebase_timeout_fixture_survives_a_slow_helper_spawn`,
+  `test_batch_at_cap_runs_to_completion` — are now `@pytest.mark.slow`.
+  A fourth candidate, `test_a_network_failure_is_not_reported_as_a_refusal`,
+  is deliberately left unmarked: #922 (open, not merged) is expected to cut
+  its cost from ~20s to ~0.5s, and marking it now would need revisiting the
+  moment that lands. Excluding `slow` from CI's main matrix would otherwise
+  mean these tests — timeout/hang/network-failure disclosure tests, this
+  repo's most-filed defect class — run nowhere at all, so
+  `.github/workflows/slow-tests.yml` runs `pytest -m slow` daily on
+  `ubuntu-latest` instead.
+- **`--durations=25` on the main CI pytest leg** ([#891](https://github.com/Digital-Process-Tools/claude-supertool/issues/891)).
+  Roughly 7 of the ~10.5 minutes a Windows leg takes are spent between 98%
+  and 99% of the progress bar (see [#917](https://github.com/Digital-Process-Tools/claude-supertool/issues/917)),
+  and until now nothing in the log said which test was running there. The
+  flag makes the tail name itself instead of being guessed at.

--- a/changelog.d/891.changed.md
+++ b/changelog.d/891.changed.md
@@ -1,0 +1,7 @@
+- **CI no longer runs `slow`-marked tests on every push** ([#891](https://github.com/Digital-Process-Tools/claude-supertool/issues/891)).
+  `tests.yml`'s pytest job used to override `pyproject.toml`'s
+  `-m 'not slow and not benchmark'` default with `-m 'not benchmark'`, so
+  marking a test `slow` changed only the local inner loop — the twelve-leg
+  matrix ran it at full duration on every push regardless. CI's `-m` filter
+  now matches the local default, and the pre-push hook (which mirrors CI)
+  follows the same change.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -537,8 +537,8 @@ symlink or an install-time artifact) and is absent from every worktree, since
 tests fail, you're on a stale checkout of this doc's advice, not a real
 regression — check out master and re-run before assuming your change broke it.
 
-Enable the pre-push hook (slow tests included, coverage not gated, as CI runs
-them):
+Enable the pre-push hook (mirrors CI: excludes `slow` and `benchmark`,
+coverage not gated):
 
 ```bash
 git config core.hooksPath .githooks

--- a/tests/test_ci_job_timeouts_722.py
+++ b/tests/test_ci_job_timeouts_722.py
@@ -273,8 +273,9 @@ def test_the_job_ceiling_sits_above_the_inner_budget_it_guards() -> None:
 def test_the_pytest_job_deliberately_has_no_per_test_budget() -> None:
     """Stated, not left to be inferred from its absence.
 
-    The main suite runs ~4000 tests under `-n auto`, includes the `slow` marker
-    in CI, and its windows legs are the ones this repo has repeatedly measured
+    The main suite runs ~4000 tests under `-n auto`, excludes the `slow`
+    marker in CI as of #891 (a separate scheduled workflow runs it instead),
+    and its windows legs are the ones this repo has repeatedly measured
     blowing hand-written budgets under contention (#702, #658, #650). There is
     no per-test timing data for that leg, and a per-test number guessed against
     a contended windows runner is the exact mistake those three issues are

--- a/tests/test_edge_cases_batch_security.py
+++ b/tests/test_edge_cases_batch_security.py
@@ -50,6 +50,7 @@ class TestHugeBatch:
         # Cap rejection is O(1) — must be near-instant.
         assert elapsed < 5, f"Cap rejection took {elapsed:.1f}s — should be near-instant"
 
+    @pytest.mark.slow
     def test_batch_at_cap_runs_to_completion(self, tmp_path: Path) -> None:
         """A batch exactly at MAX_BATCH_OPS runs without rejection (cap is exclusive
         of the threshold)."""

--- a/tests/test_git_push_hazards_640_642_647.py
+++ b/tests/test_git_push_hazards_640_642_647.py
@@ -327,6 +327,7 @@ class _BudgetAfterSpawn:
 # #640 — TimeoutExpired on the rebase-recovery path
 # ===========================================================================
 
+@pytest.mark.slow
 def test_fetch_timeout_gives_a_verdict_not_a_traceback(box, monkeypatch) -> None:
     """A fetch that outlasts its budget must produce a receipt, not a stack trace.
 
@@ -386,6 +387,7 @@ def test_rebase_timeout_names_the_paused_worktree_and_the_way_out(
     assert "git rebase --abort" in out
 
 
+@pytest.mark.slow
 def test_rebase_timeout_fixture_survives_a_slow_helper_spawn(box, monkeypatch) -> None:
     """#828: the budget must not expire before the helper it exists to catch.
 

--- a/tests/test_git_push_hazards_640_642_647.py
+++ b/tests/test_git_push_hazards_640_642_647.py
@@ -130,8 +130,14 @@ class _Sandbox:
 
     # -- hazard fixtures ---------------------------------------------------
 
-    def _sleeper(self, name: str, seconds: int = 90, spawn_delay: int = 0) -> str:
+    def _sleeper(self, name: str, seconds: int = 5, spawn_delay: int = 0) -> str:
         """A real python script that records it ran, then sleeps past a budget.
+
+        `seconds` only has to outlast `_BudgetAfterSpawn.budget` (2s), whose
+        clock starts at the sentinel — so 5s carries a 2.5x margin. It used to
+        be 90s, which no assertion needed and which the runners paid in full:
+        this test cost 91.63s of wall clock on ubuntu 3.9 while taking 4.59s
+        locally, because the orphaned helper is only waited on there.
 
         `spawn_delay` sleeps *before* the sentinel is written, standing in for a
         runner on which git is simply slow to reach the helper at all — the #828

--- a/tests/test_slow_marker_ci_exclusion_891.py
+++ b/tests/test_slow_marker_ci_exclusion_891.py
@@ -77,7 +77,8 @@ def _collect_under_slow() -> str:
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "--collect-only", "-q", "-m", "slow",
          "--no-cov", "-p", "no:cacheprovider", *_TARGET_TEST_FILES],
-        cwd=REPO, capture_output=True, text=True, timeout=60,
+        cwd=REPO, capture_output=True, text=True,
+        encoding="utf-8", errors="replace", timeout=60,
     )
     return result.stdout + result.stderr
 

--- a/tests/test_slow_marker_ci_exclusion_891.py
+++ b/tests/test_slow_marker_ci_exclusion_891.py
@@ -1,0 +1,164 @@
+"""#891: mark the four heaviest local tests `slow`, and — the owner's scope
+change on top of the issue as filed — stop CI from running `slow` too.
+
+`pyproject.toml`'s `addopts` already excludes `slow` from the local default
+run. `.github/workflows/tests.yml` overrides `-m` and therefore *included*
+`slow` on every one of the twelve legs, at full duration, on every push. That
+made the marker cosmetic for CI: adding it changed the local loop and changed
+nothing else. This file pins the three assertions that make it not cosmetic:
+the named tests actually carry the marker (checked through pytest's own
+collection, not by grepping source for the decorator spelling), the CI job's
+`-m` expression actually excludes `slow`, and a `--durations=25` leg exists so
+the next "which test is slow on Windows" question has an answer in the log
+instead of a guess.
+
+Excluding `slow` from CI's twelve legs would otherwise mean these tests run
+**nowhere** — and they are timeout/hang/network-failure disclosure tests,
+this repo's most-filed defect class. So a fourth thing is pinned here too:
+that a scheduled workflow exists whose job actually asks for `-m slow` on at
+least one platform. Not asserting *content correctness* of that job (this
+file cannot run a GitHub Actions cron), only that the shape exists: a
+`schedule:` trigger, and a run step whose `-m` expression contains `slow`
+without negating it.
+
+`test_a_network_failure_is_not_reported_as_a_refusal` (test_image_fetch_ssrf_817.py)
+is deliberately excluded from the "must be marked" list. #922 (open, not
+merged) is reported to bring its cost from ~20s to ~0.5s; marking it here
+would need revisiting the moment that lands, so it is left unmarked and this
+file pins that it stays that way until someone touches it on purpose.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+from _workflow_parse import REPO, job_blocks, job_steps, matrix_os, run_blocks
+
+SLOW_WORKFLOW = REPO / ".github" / "workflows" / "slow-tests.yml"
+
+_TARGET_TEST_FILES = [
+    "tests/test_git_push_hazards_640_642_647.py",
+    "tests/test_edge_cases_batch_security.py",
+    "tests/test_image_fetch_ssrf_817.py",
+]
+
+_MUST_BE_SLOW = [
+    "test_fetch_timeout_gives_a_verdict_not_a_traceback",
+    "test_rebase_timeout_fixture_survives_a_slow_helper_spawn",
+    "test_batch_at_cap_runs_to_completion",
+]
+
+_NOT_YET_SLOW = "test_a_network_failure_is_not_reported_as_a_refusal"
+
+#: Only the *quoted* form. A run block routinely carries other `-m` flags
+#: that are module invocations, not marker expressions — `python -m pip`,
+#: `python -X utf8 -m pytest`, `python -m coverage` — and every one of them
+#: is unquoted. Matching bare `-m\s+(\S+)` too means "does this job exclude
+#: slow" can be answered by the word "pip", which is the house defect
+#: arriving in this file's own parser: a read that finds *something* and
+#: reports it as the answer to the question actually asked.
+_DASH_M_RE = re.compile(r"-m\s+(['\"])(.*?)\1")
+
+
+def _dash_m_exprs(run: str) -> list[str]:
+    """Every quoted `-m` marker expression in a shell run block, in order."""
+    return [match.group(2) for match in _DASH_M_RE.finditer(run)]
+
+
+def _collect_under_slow() -> str:
+    """Real pytest collection output under `-m slow`, not a grep of source.
+
+    A grep for `@pytest.mark.slow` cannot tell a marker that is present but
+    misspelled, mis-indented, or attached to the wrong test from one that
+    genuinely applies — pytest's own collector can.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "-m", "slow",
+         "--no-cov", "-p", "no:cacheprovider", *_TARGET_TEST_FILES],
+        cwd=REPO, capture_output=True, text=True, timeout=60,
+    )
+    return result.stdout + result.stderr
+
+
+def test_the_three_heavy_tests_collect_under_dash_m_slow() -> None:
+    out = _collect_under_slow()
+    missing = [name for name in _MUST_BE_SLOW if name not in out]
+    assert not missing, (
+        f"{missing} did not collect under `pytest -m slow` — the "
+        "`@pytest.mark.slow` decorator is missing, misspelled, or attached "
+        f"to the wrong test. Collection output:\n{out}")
+
+
+def test_the_ssrf_network_failure_test_is_deliberately_not_marked_slow() -> None:
+    out = _collect_under_slow()
+    assert _NOT_YET_SLOW not in out, (
+        f"{_NOT_YET_SLOW} now collects under `-m slow`. #891's brief left it "
+        "unmarked because #922 (open, not merged) is expected to fix its cost "
+        "from ~20s to ~0.5s — if it has been marked on purpose because #922 "
+        "stalled or a fresh measurement still shows it heavy, update this "
+        "test to say so instead of deleting it.")
+
+
+def test_ci_pytest_job_excludes_slow_and_benchmark() -> None:
+    blocks = job_blocks()
+    steps = job_steps(blocks["pytest"])
+    runs = run_blocks(steps)
+    exprs = [expr for run in runs for expr in _dash_m_exprs(run)]
+    assert exprs, "no quoted `-m` expression found in the pytest job's run steps"
+    assert any("not slow" in expr and "not benchmark" in expr for expr in exprs), (
+        f"pytest job's `-m` expressions are {exprs!r}, none of which exclude "
+        "both slow and benchmark. #891's scope change means CI must exclude "
+        "`slow` the same way the local default does — leaving it in the CI "
+        "`-m` override runs these tests on every one of the twelve legs, on "
+        "every push, which is the exact cost the marker was supposed to "
+        "remove.")
+
+
+def test_ci_pytest_job_reports_durations() -> None:
+    blocks = job_blocks()
+    steps = job_steps(blocks["pytest"])
+    runs = run_blocks(steps)
+    assert any("--durations=25" in run for run in runs), (
+        "no pytest-job leg passes --durations=25. #891 scope item 3: nobody "
+        "has identified which tests are actually slow on Windows, and "
+        "without this flag a stalled-looking leg has nothing in the log to "
+        "say which test is running.")
+
+
+def test_a_scheduled_slow_workflow_exists() -> None:
+    assert SLOW_WORKFLOW.exists(), (
+        f"{SLOW_WORKFLOW} does not exist. Excluding `slow` from the twelve "
+        "CI legs means those tests — timeout/hang/network-failure disclosure "
+        "tests, this repo's most-filed defect class — run nowhere at all "
+        "unless a separate scheduled workflow runs `-m slow` on a cron.")
+
+
+def test_the_scheduled_workflow_runs_on_a_schedule_trigger() -> None:
+    text = SLOW_WORKFLOW.read_text(encoding="utf-8")
+    assert re.search(r"^\s*schedule:\s*$", text, re.M), (
+        f"{SLOW_WORKFLOW} exists but declares no `schedule:` trigger — a "
+        "workflow that only runs on manual dispatch is not a standing check, "
+        "it is a button nobody presses.")
+
+
+def test_the_scheduled_workflow_asks_for_slow_tests_on_at_least_ubuntu() -> None:
+    text = SLOW_WORKFLOW.read_text(encoding="utf-8")
+    blocks = job_blocks(text)
+    assert blocks, f"no jobs parsed out of {SLOW_WORKFLOW}"
+    found_on_ubuntu = False
+    for block in blocks.values():
+        oses = matrix_os(block)
+        runs_on_ubuntu = any("ubuntu-latest" in os_name for os_name in oses) \
+            or "ubuntu-latest" in block
+        if not runs_on_ubuntu:
+            continue
+        for run in run_blocks(job_steps(block)):
+            for expr in _dash_m_exprs(run):
+                if "slow" in expr and "not slow" not in expr:
+                    found_on_ubuntu = True
+    assert found_on_ubuntu, (
+        f"no job in {SLOW_WORKFLOW} runs on ubuntu-latest with a `-m` "
+        "expression that positively selects `slow` — the scheduled job must "
+        "run the tests CI's main matrix now skips, on at least one platform.")


### PR DESCRIPTION
## What changed

Three heavy tests get `@pytest.mark.slow`, and CI stops running the `slow` marker.

| test | measured |
|---|---|
| `test_fetch_timeout_gives_a_verdict_not_a_traceback` | 33.13s |
| `test_batch_at_cap_runs_to_completion` | 27.47s |
| `test_rebase_timeout_fixture_survives_a_slow_helper_spawn` | 10.50s |

`.github/workflows/tests.yml` line 98:

```
- pytest -m 'not benchmark'              --tb=no --no-cov --junit-xml=…
+ pytest -m 'not slow and not benchmark' --tb=no --no-cov --durations=25 --junit-xml=…
```

Until now `pyproject.toml`'s `addopts` excluded `slow` locally while CI overrode `-m` and **included** it. Marking a test `slow` therefore changed the local inner loop and nothing else.

## This is a scope change from what #891 proposed, and it was asked for

#891 argued the opposite — keep them on CI, drop them locally — on the grounds that all of these are timeout/hang/network **disclosure** tests, this repo's most-filed defect class. The repo owner asked for them off CI too. That is his call and this implements it.

But excluding them from CI would mean they run **nowhere**, and a test that runs nowhere is deleted with extra steps. So:

**`.github/workflows/slow-tests.yml`** (new) — `pytest -m slow -n auto --durations=25` on ubuntu, daily cron at 06:00 UTC plus `workflow_dispatch`, `timeout-minutes: 20` (matching `MIN_BUDGET_MIN["pytest"]`), and `permissions: contents: read` declared rather than inherited.

Daily-cron-single-OS rather than per-push-full-matrix: the entire point was to take these off the per-push critical path, and a per-push run here would put them straight back.

## `--durations=25`, and why it is the most valuable line in this PR

Added to all twelve pytest legs and to the scheduled job.

**Nothing here proves these three tests are the CI bottleneck.** Every measurement behind #891 and #917 — mine and the issue's — was taken on **macOS**. The actual problem is on Windows: ~7 of a Windows leg's ~10.5 minutes are spent between 98% and 99% of the progress bar, with nothing in the log to say which test is running there. See #917.

So this PR could plausibly change the Windows critical path by **nothing**. `--durations=25` is what makes the next measurement real instead of another guess — the tail names itself from now on. That matters more than the three markers.

## Not marked

`test_a_network_failure_is_not_reported_as_a_refusal` — was 20.52s, now **0.52s** after #922 fixed the fixture that left a socket bound. No longer slow, so no marker.

## #844 is still open, deliberately

#844 says `test_fetch_timeout` "is not the timeout it claims to pin". It is marked `slow` here per #891's scope, and #844 stays open as the unresolved question about what that 33s actually waits on. Marking it is not a dismissal of that.

## Coverage job left alone

`coverage_gate.py` invokes pytest directly with its own hardcoded `-m 'not benchmark'`, independent of `addopts`, so it still runs `slow`. Deliberate: it runs once per push rather than twelve times, and dropping `slow` there would lower measured coverage of paths only those tests exercise.

## Adjacent, flagged rather than buried

`.githooks/pre-push` and `docs/contributing.md` updated to match. The hook's own comment says it "mirrors CI", which would otherwise have gone stale immediately and cost every future `master`-push author ~65-95s locally for no reason. Also corrected a now-false docstring line in `test_ci_job_timeouts_722.py` ("includes the slow marker in CI" → excludes).

## Tests

`tests/test_slow_marker_ci_exclusion_891.py`, 7 tests. Marker assertions go through a real `pytest --collect-only -m slow`, not a source grep, so they assert the post-condition rather than the text that implies it. Workflow assertions parse via `_workflow_parse`.

RED — 6 of 7 failed before the change (missing markers, missing workflow file, missing `--durations`, `-m` not excluding `slow`). The seventh passed trivially: the SSRF test correctly not-yet-marked.

GREEN — 7/7, after fixing a bug in my own test's `-m`-parsing regex, which had been matching `python -m pip` as if it were a marker expression. Caught by the test, not by inspection.

Also run: `test_ci_job_timeouts_722.py`, `test_ci_non_python_coverage_557.py`, remainder of `test_git_push_hazards_640_642_647.py` — 66 passed. The three newly-marked tests under `-m ''` — 3 passed, 35.65s, behaviour unchanged. `assemble_changelog.py --check` clean.

Closes #891
