### PR TITLE
fix(tests): a stale sentinel, a zero-tolerance clock bracket, and a fixture that wrote CRLF (#844, #909, #777)

### DIFF
--- a/changelog.d/777.fixed.md
+++ b/changelog.d/777.fixed.md
@@ -1,0 +1,25 @@
+- **The `gofmt` validator's Windows skip was hiding a defect in the test, not in the adapter** ([#777](https://github.com/Digital-Process-Tools/claude-supertool/issues/777)).
+  `test_gofmt_check_valid_formatted_file` skipped `win32` with
+  `reason="gofmt adapter has encoding issues on Windows"`, and that phrase was
+  the entire diagnosis on file — cited three times, never reproduced. The
+  fixture was written with `Path.write_text`, which translates newlines to
+  `os.linesep`, so on Windows a deliberately gofmt-clean file arrived at gofmt
+  as CRLF; `gofmt -l` prints the filename of a CRLF file whatever else is in
+  it, so the clean fixture was reported as needing formatting. The bytes now go
+  to disk unmodified through `write_go`, the skip is gone, and Windows has back
+  the only test it had that a clean Go file is reported clean. The mechanism is
+  pinned on every platform by
+  `test_gofmt_reads_a_crlf_file_as_needing_formatting`, since the platform this
+  appears on is the one no local check can see.
+
+  The separate `adapter` decline that reddened master twice is still
+  undiagnosed, and this does not close it. What changed is that it can now be
+  diagnosed: the decline is a legitimate third answer and stays visible as an
+  xfail rather than a skip, but the reason it prints carries what gofmt-check
+  actually said. `tool_fault` had put gofmt's exit code and output into the
+  message all along, and the branch meeting it printed a fixed sentence and
+  dropped them — so three occurrences produced no information beyond having
+  happened. The next one names its own cause.
+
+  `test_a_windows_gofmt_decline_reports_what_gofmt_said` holds that, on every
+  platform, and fails against the sentence it replaced.

--- a/changelog.d/844.fixed.md
+++ b/changelog.d/844.fixed.md
@@ -1,0 +1,26 @@
+- **The fetch-timeout test's spawn barrier armed on the wrong spawn** ([#844](https://github.com/Digital-Process-Tools/claude-supertool/issues/844)).
+  `_BudgetAfterSpawn` exists so a recovery-budget test measures a real stall
+  rather than how fast the runner reaches the helper it stalls on, and on the
+  fetch path it was not doing that. `make_fetch_hang` stalls the whole
+  `remote.<name>.url`, and the recovery fetch is not the first git call to read
+  it — the rejected push is verified with `git ls-remote` first, through the
+  same sleeping `ext::` helper. That preflight announced itself, so the barrier
+  found the sentinel already on disk and returned in 62us: a wall-clock budget
+  again, on the one path it was written to take a wall clock off. The sentinel
+  now records every announcement and the barrier waits for the one belonging to
+  the call it guards.
+
+  `assert box.fixture_ran` was satisfied by the same stale file, so the guard
+  reading "this test would prove nothing" could not detect the case it names —
+  the test would have passed with the fetch's transport never spawned at all.
+  `test_fetch_timeout_fixture_survives_a_slow_helper_spawn` now covers the fetch
+  side of the same hazard its rebase sibling has covered since #828, and fails
+  by 1-of-2 announcements without the barrier fix.
+
+  The issue's headline numbers no longer hold and are not reproduced here. The
+  33s is 8.2s measured on this branch, and the cost is not paid per leg: #843
+  cut the helper's sleep from 90s to 5s, and #891 dropped the `slow` marker from
+  all twelve `tests` legs, so this test runs once on a scheduled job rather than
+  eighteen times per push. Of the original 34.02s, 30 were our own
+  `_CHECK_TIMEOUT` expiring on that preflight `ls-remote` — not, as the issue
+  hypothesised, a default of git's.

--- a/changelog.d/909.fixed.md
+++ b/changelog.d/909.fixed.md
@@ -1,0 +1,25 @@
+- **A poller test bracketed one clock with another and allowed no tolerance** ([#909](https://github.com/Digital-Process-Tools/claude-supertool/issues/909)).
+  `test_the_snapshot_says_when_it_was_read` sandwiched `observed_at` between two
+  `datetime.now(timezone.utc)` reads with nothing to spare, and reported a value
+  a whole second *earlier* than a bound taken before it — an ordering the
+  process cannot produce, so what it detected was the runner stepping its wall
+  clock backwards. It reddened two legs of a pull request whose entire diff was
+  one character of regex.
+
+  The bracket now carries two minutes of slack and reads `time.time()`, the same
+  clock family the product reads. Widening it is not the assertion being
+  weakened to stop a red: everything the field is defended against is wrong by
+  an epoch rather than by a minute, so an age, a hardcoded string, a wrong
+  epoch, milliseconds read as seconds and a value minutes stale all still fail.
+
+  Reading the same API would not have prevented the failure on its own, which is
+  worth stating because it was the obvious fix: `datetime.now(timezone.utc)` and
+  `time.gmtime()` are both `CLOCK_REALTIME`, and a step moves them together.
+
+  The part slack would have blurred is now pinned exactly, by
+  `test_the_snapshot_is_read_off_the_utc_clock`: it freezes `time.gmtime` and
+  `time.localtime` to distinguishable instants and asserts the emitted string.
+  The `Z` suffix is a claim about which clock was read, and a bracket around a
+  real clock cannot check it at all on a runner whose local zone is already
+  UTC — which is every leg here. Swapping the product to `time.localtime()`
+  leaves the old assertion green and this one red.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -824,6 +824,56 @@ assert "I-AM-THE-FAKE" in json.dumps(data), describe(data)
 Worked examples: `tests/test_phplint_tool_vs_file_745.py` (one adapter) and
 `tests/test_adapter_tool_vs_file_753.py` (seven, parametrised).
 
+### Never write a formatter's fixture with `write_text`
+
+A fixture for a formatting check goes to disk as bytes:
+
+```python
+path.write_bytes(text.encode("utf-8"))
+```
+
+`Path.write_text` translates every newline to `os.linesep`, so on Windows the
+fixture arrives at the tool as CRLF — and a formatter rewrites CRLF. `gofmt -l`
+prints the filename of a CRLF file whatever else is in it, so the *correctly
+formatted* fixture is reported as needing formatting, on Windows only.
+
+This is worth a rule because of how it was read the first time. The failure was
+recorded as `reason="gofmt adapter has encoding issues on Windows"` and the test
+was skipped there — so the adapter carried the blame for three occurrences, the
+phrase in that skip reason was the entire diagnosis on file, and Windows lost
+its only check that a clean Go file is reported clean
+([#777](https://github.com/Digital-Process-Tools/claude-supertool/issues/777)).
+The mechanism is pinned on every platform by
+`test_gofmt_reads_a_crlf_file_as_needing_formatting`, because the platform a
+newline defect appears on is the one nobody here can run a local check against.
+
+The terraform and cargo fixtures in `tests/test_validators_tier2.py` still use
+`write_text`; they are guarded by a `which()` skip that keeps them off the
+Windows legs today, which is luck rather than design.
+
+### Never bracket a timestamp with zero tolerance
+
+A test that reads a clock before and after a call and demands the emitted value
+land between them is asserting that the host does not adjust its wall clock. It
+does: `test_the_snapshot_says_when_it_was_read` reported a value a full second
+*earlier* than a bound read before it, which program order cannot produce, and
+reddened two legs of a pull request whose diff was one character of regex
+([#909](https://github.com/Digital-Process-Tools/claude-supertool/issues/909)).
+
+Reading the same clock API the product reads does not fix it — `datetime.now(
+timezone.utc)` and `time.gmtime()` are both `CLOCK_REALTIME`, and a step moves
+them together. Two things do, and the split is the point:
+
+1. **Slack on the bracket**, sized so that everything the assertion exists to
+   catch is still caught. An age, a hardcoded string, a wrong epoch and
+   milliseconds-read-as-seconds are all wrong by an epoch, not by a minute, so
+   two minutes of tolerance costs the test nothing.
+2. **A second test with the clock frozen**, for the part slack would blur.
+   Patch both `time.gmtime` and `time.localtime` to distinguishable values and
+   assert the exact string: that is what pins a `Z` suffix as a claim about
+   *which* clock was read, and a real-clock bracket cannot see a local-time
+   swap at all on a runner whose zone is already UTC.
+
 ### Never write a subprocess timeout by hand
 
 If a test spawns a validator adapter, its budget comes from

--- a/tests/test_git_push_hazards_640_642_647.py
+++ b/tests/test_git_push_hazards_640_642_647.py
@@ -145,21 +145,23 @@ class _Sandbox:
         """
         script = os.path.join(self.tmp, name)
         Path(script).write_text(
-            "import pathlib, time" + NL +
+            "import io, time" + NL +
             "time.sleep(%d)" % spawn_delay + NL +
-            "pathlib.Path(%r).write_text('ran')" % self.sentinel + NL +
+            "fh = io.open(%r, 'a', encoding='utf-8')" % self.sentinel + NL +
+            "fh.write(%r + chr(10))" % name + NL +
+            "fh.close()" + NL +
             "time.sleep(%d)" % seconds + NL,
             encoding="utf-8")
         return script
 
-    def make_fetch_hang(self) -> None:
+    def make_fetch_hang(self, spawn_delay: int = 0) -> None:
         """Route *fetch* through a sleeping `ext::` helper; push stays real.
 
         `remote.<name>.pushurl` keeps `git push` on the real bare repo, so the
         non-fast-forward rejection that opens the recovery path is genuine.
         Only the fetch inside `_recover_by_rebase` hits the stalling transport.
         """
-        script = self._sleeper("slow_transport.py")
+        script = self._sleeper("slow_transport.py", spawn_delay=spawn_delay)
         assert _run(["config", f"remote.{self.remote_name}.pushurl",
                      Path(self.remote).as_posix()], self.mine).returncode == 0
         assert _run(["config", f"remote.{self.remote_name}.url",
@@ -201,6 +203,22 @@ class _Sandbox:
     @property
     def fixture_ran(self) -> bool:
         return os.path.exists(self.sentinel)
+
+    def spawn_count(self) -> int:
+        """How many times a fixture helper has announced itself.
+
+        `fixture_ran` cannot answer the question the timeout tests actually
+        ask — did *this* git call reach *its* helper. `make_fetch_hang` stalls
+        the whole `remote.<name>.url`, and `_push_op` reads that URL with
+        `git ls-remote` (push.py:1580) before the recovery fetch is issued, so
+        on the fetch path the first announcement on record belongs to a call no
+        assertion is about (#844). A count distinguishes them; an existence
+        check cannot, and read the preflight's spawn as the fetch's.
+        """
+        if not os.path.exists(self.sentinel):
+            return 0
+        lines = Path(self.sentinel).read_text(encoding="utf-8").splitlines()
+        return len([ln for ln in lines if ln.strip()])
 
     def rebase_in_progress(self) -> bool:
         g = Path(self.mine, ".git")
@@ -301,27 +319,49 @@ class _BudgetAfterSpawn:
     announces itself the wait gives up after `cap` and the test fails on its own
     precondition exactly as it does today: this removes the race, not the
     assertion.
+
+    `spawns` is how many announcements have to be on record before the clock
+    may start, and it exists because "the sentinel is there" and "the call I am
+    guarding reached its helper" are not the same statement (#844). On the fetch
+    path they came apart: `make_fetch_hang` stalls the whole
+    `remote.<name>.url`, and `_push_op` reads that URL with `git ls-remote`
+    (push.py:1580) before it ever issues the recovery fetch. The preflight's
+    helper announced first, so the barrier saw an existing sentinel and returned
+    in ~60us — a wall-clock budget again, on the one path #828 was written to
+    take a wall clock off. Counting the announcements is what tells the fetch's
+    spawn from somebody else's; an existence check cannot, and silently read the
+    preflight's as the fetch's.
     """
 
     def __init__(self, sentinel: str, stage: int, budget: int = 2,
-                 lead: int = 60, cap: float = 30.0) -> None:
+                 lead: int = 60, cap: float = 30.0, spawns: int = 1) -> None:
         self.sentinel = sentinel
         self.stage = stage
         self.budget = budget
         self.lead = lead
         self.cap = cap
+        self.spawns = spawns
         self.uses = 0
         self.waited = 0.0
+        self.observed = 0
+
+    def _announced(self) -> int:
+        try:
+            lines = Path(self.sentinel).read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return 0
+        return len([ln for ln in lines if ln.strip()])
 
     def __radd__(self, started: float) -> float:
         self.uses += 1
         if self.uses < self.stage:
             return started + self.lead
         begin = time.monotonic()
-        while not os.path.exists(self.sentinel):
+        while self._announced() < self.spawns:
             if time.monotonic() - begin >= self.cap:
                 break
             time.sleep(0.01)
+        self.observed = self._announced()
         self.waited = time.monotonic() - begin
         return started + self.waited + self.budget
 
@@ -342,7 +382,7 @@ def test_fetch_timeout_gives_a_verdict_not_a_traceback(box, monkeypatch) -> None
     """
     box.advance_remote_feature()
     box.make_fetch_hang()
-    budget = _BudgetAfterSpawn(box.sentinel, stage=1)
+    budget = _BudgetAfterSpawn(box.sentinel, stage=1, spawns=2)
     monkeypatch.setattr(push, "_RECOVER_TIMEOUT", budget, raising=False)
     before = box.head()
 
@@ -352,8 +392,10 @@ def test_fetch_timeout_gives_a_verdict_not_a_traceback(box, monkeypatch) -> None
     assert budget.uses == budget.stage, (
         "the recovery budget was consumed at a different git call than the "
         "barrier arms on — the wait is guarding the wrong stage")
-    assert box.fixture_ran, (
-        "the ext:: transport helper never spawned — this test would prove nothing")
+    assert box.spawn_count() >= 2, (
+        "the *fetch's* ext:: transport helper never spawned — only the "
+        "preflight `ls-remote` did, and `fixture_ran` cannot tell them apart, "
+        "so this test would prove nothing (#844)")
     assert rc != 0
     assert not box.rebase_in_progress()
     assert box.head() == before
@@ -362,6 +404,46 @@ def test_fetch_timeout_gives_a_verdict_not_a_traceback(box, monkeypatch) -> None
     assert "fetch" in verdict.lower()
     # The one thing the caller needs: is my worktree ok?
     assert "not started" in verdict.lower() or "unchanged" in verdict.lower(), verdict
+
+
+@pytest.mark.slow
+def test_fetch_timeout_fixture_survives_a_slow_helper_spawn(
+        box, monkeypatch) -> None:
+    """#844: the fetch side of #828, which the fetch side never got.
+
+    `make_fetch_hang` stalls the whole `remote.<name>.url`, and the recovery
+    fetch is not the first git call to read it — `_push_op` verifies the
+    rejected push with `git ls-remote` first (push.py:1580), through the same
+    sleeping helper. That preflight announces itself, so the sentinel already
+    exists when the fetch arms its budget and the barrier returns in ~60us:
+    the #828 guarantee that the clock starts when *this* call reaches *its*
+    helper is not in force on this path, and `fixture_ran` is satisfied by a
+    spawn the assertion is not about.
+
+    `spawn_delay` makes git slow to reach the *fetch's* helper, which is the
+    #828 shape. With a barrier armed by mere existence the budget expires
+    before that helper announces, the fetch never stalls at the hazard, and the
+    test passes anyway — a red turned quiet, which is worse than the red.
+    """
+    delay = 6
+    box.advance_remote_feature()
+    box.make_fetch_hang(spawn_delay=delay)
+    budget = _BudgetAfterSpawn(box.sentinel, stage=1, spawns=2)
+    monkeypatch.setattr(push, "_RECOVER_TIMEOUT", budget, raising=False)
+
+    with _no_mr():
+        rc, out = box.drive_push()
+
+    assert box.spawn_count() >= 2, (
+        "only the preflight `ls-remote` reached the helper: the recovery fetch "
+        "was cut off before its own transport announced itself, so the hazard "
+        "this test exists for never happened and `fixture_ran` said yes anyway "
+        "(#844)")
+    assert budget.waited >= delay, (
+        f"the barrier waited {budget.waited:.2f}s for a helper that needs "
+        f"{delay}s to spawn — it armed on somebody else's spawn (#844)")
+    assert rc != 0
+    assert "TIMED OUT" in _last_result(out)
 
 
 def test_rebase_timeout_names_the_paused_worktree_and_the_way_out(

--- a/tests/test_validators_tier2.py
+++ b/tests/test_validators_tier2.py
@@ -37,9 +37,77 @@ def run_adapter_proc(adapter: Path, file: str, timeout: int | None = None) -> su
                           timeout=adapter_budget(adapter) if timeout is None else timeout, encoding="utf-8", errors="replace")
 
 
+# The two Go fixtures, kept side by side so the difference is legible: a tab is
+# what gofmt wants, the four spaces are what it rewrites.
+GO_FORMATTED = 'package main\n\nfunc main() {\n\t_ = 1\n}\n'
+GO_UNFORMATTED = 'package main\n\nfunc main() {\n    _ = 1\n}\n'
+
+
+def write_go(path: Path, text: str) -> Path:
+    """Write a Go fixture with the newlines gofmt is being asked about (#777).
+
+    `Path.write_text` translates every newline to `os.linesep`, so on Windows
+    each of these fixtures reached gofmt as CRLF. gofmt rewrites CRLF — `gofmt
+    -l` prints the filename of a CRLF file whatever else is in it — so the
+    *formatted* fixture is reported as needing formatting there, and the test
+    asserting it is clean fails on every Windows leg.
+
+    That is what `skipif(sys.platform == "win32", reason="gofmt adapter has
+    encoding issues on Windows")` was suppressing: a defect in how this file
+    wrote its fixture, recorded as a defect in the code under test, and left in
+    prose long enough to be cited three times. The bytes go to disk unmodified
+    now, so the assertion is about gofmt again and the skip goes with it.
+    """
+    path.write_bytes(text.encode("utf-8"))
+    return path
+
+
+def _windows_decline_reason(data: dict) -> str:
+    """The xfail reason for a `gofmt-check` decline on Windows (#777).
+
+    A decline is a legitimate third answer and this treats it as one. What it
+    must not do is discard the evidence: `tool_fault` has already put gofmt's
+    exit code and gofmt's own output into the message, and the branch that met
+    that decline printed a fixed sentence instead. After three Windows
+    occurrences the entire record of the defect was still the phrase "encoding
+    issues on Windows" in a skip reason — an absence this suite produced and
+    then read as an absence in the world.
+    """
+    errors = data.get("errors") or [{}]
+    said = errors[0].get("msg") or "(the adapter recorded no message)"
+    return ("gofmt-check declined with 'adapter' on Windows — known flake, see "
+            "#777. The adapter, not this test, is what needs fixing. "
+            "gofmt-check said: " + said)
+
+
 # ---------------------------------------------------------------------------
 # gofmt-check
 # ---------------------------------------------------------------------------
+
+
+def test_a_windows_gofmt_decline_reports_what_gofmt_said() -> None:
+    """#777: a decline is an answer, and an answer has to say something.
+
+    `tool_fault` already puts gofmt's exit code and gofmt's own output into the
+    message — the adapter knows exactly what happened. The branch that meets
+    that decline printed a fixed sentence instead and dropped the message, so
+    after three Windows occurrences the whole record of the defect is still the
+    phrase "encoding issues on Windows" in a sibling test's skip reason. A
+    decline that does not carry what the tool said makes every future
+    occurrence another log read that produces nothing new, which is this
+    repository's own defect class pointed at its own test suite.
+    """
+    said = "`gofmt -l` exited 2 — subject.go: The process cannot access the file"
+    data = {"tool": "gofmt-check", "ok": False, "count": 1,
+            "errors": [{"line": None, "col": None, "severity": "error",
+                        "code": "adapter", "msg": said}]}
+
+    reason = _windows_decline_reason(data)
+
+    assert "#777" in reason
+    assert said in reason, (
+        "the decline was reported without the one thing only that run knows — "
+        "what gofmt actually said (#777)")
 
 def test_gofmt_check_no_arg_returns_schema_error() -> None:
     r = subprocess.run([sys.executable, str(GOFMT_CHECK)],
@@ -51,22 +119,49 @@ def test_gofmt_check_no_arg_returns_schema_error() -> None:
 
 
 @pytest.mark.skipif(not shutil.which("gofmt"), reason="gofmt not installed")
-@pytest.mark.skipif(sys.platform == "win32", reason="gofmt adapter has encoding issues on Windows")
 def test_gofmt_check_valid_formatted_file(tmp_path: Path) -> None:
-    f = tmp_path / "ok.go"
-    # gofmt-formatted Go: tabs for indentation, correct spacing
-    f.write_text('package main\n\nfunc main() {\n\t_ = 1\n}\n')
+    """Runs on Windows again (#777).
+
+    It used to skip win32 outright, on the stated grounds that the adapter has
+    "encoding issues" there. It does not: the fixture went through
+    `Path.write_text`, which made it CRLF on Windows, and gofmt reports a CRLF
+    file as needing formatting. `write_go` puts the bytes down unmodified,
+    which is the whole of that fix — and the skip was the more expensive
+    answer, because it left Windows with no test at all that a clean Go file is
+    reported clean.
+    """
+    f = write_go(tmp_path / "ok.go", GO_FORMATTED)
     data = run_adapter(GOFMT_CHECK, str(f))
     assert data["tool"] == "gofmt-check"
+    if sys.platform == "win32" and not data["ok"] and (
+            data["errors"] or [{}])[0].get("code") == "adapter":
+        # The `adapter` decline of #777 is still undiagnosed and is not this
+        # test's subject. Tolerated exactly as its sibling tolerates it —
+        # visibly, with the evidence attached, and never as a skip.
+        pytest.xfail(_windows_decline_reason(data))
     assert_ok(data)
     assert data["count"] == 0
 
 
 @pytest.mark.skipif(not shutil.which("gofmt"), reason="gofmt not installed")
+def test_gofmt_reads_a_crlf_file_as_needing_formatting(tmp_path: Path) -> None:
+    """The mechanism behind the win32 skip, which was never diagnosed (#777).
+
+    Pinned on every platform, because the platform it was misdiagnosed on is
+    the one nobody here can run a local check against. If this ever stops being
+    true, `write_go` stops being necessary — and the reader finds that out
+    here rather than from a red Windows leg.
+    """
+    f = tmp_path / "crlf.go"
+    f.write_bytes(GO_FORMATTED.replace(chr(10), chr(13) + chr(10)).encode("utf-8"))
+    data = run_adapter(GOFMT_CHECK, str(f))
+    assert_declined(data)
+    assert data["errors"][0]["code"] == "formatting", data["errors"][0]
+
+
+@pytest.mark.skipif(not shutil.which("gofmt"), reason="gofmt not installed")
 def test_gofmt_check_unformatted_file_is_hard_error(tmp_path: Path) -> None:
-    f = tmp_path / "bad.go"
-    # spaces instead of tabs — gofmt will flag this
-    f.write_text('package main\n\nfunc main() {\n    _ = 1\n}\n')
+    f = write_go(tmp_path / "bad.go", GO_UNFORMATTED)
     data = run_adapter(GOFMT_CHECK, str(f))
     assert data["tool"] == "gofmt-check"
     assert_declined(data)
@@ -87,10 +182,9 @@ def test_gofmt_check_unformatted_file_is_hard_error(tmp_path: Path) -> None:
         # loudly while a red master stops training everyone to ignore this
         # file. It deliberately does NOT skip: skipping hides that Windows
         # users have a broken validator, which is the thing #777 is about.
-        pytest.xfail(
-            "gofmt-check declined with 'adapter' on Windows — known "
-            "flake, see #777. The adapter, not this test, is what needs fixing."
-        )
+        # The reason carries what gofmt-check actually said, because until it
+        # did, three occurrences produced no information beyond having happened.
+        pytest.xfail(_windows_decline_reason(data))
 
     assert code == "formatting"
     assert "gofmt" in data["errors"][0]["msg"]

--- a/tests/test_watch_gitlab_mr_poller.py
+++ b/tests/test_watch_gitlab_mr_poller.py
@@ -1,9 +1,10 @@
 """Unit tests for the gitlab-mr poller source — state diff logic."""
 from __future__ import annotations
 
+import calendar
 import importlib.util
 import sys
-from datetime import datetime, timezone
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -449,6 +450,13 @@ SNAPSHOT_KEYS = {
 }
 
 
+# How far the emitted instant may sit outside a bracket read around the poll.
+# It is sized to swallow a wall-clock adjustment on a shared runner and nothing
+# else: every wrong value this test exists to catch is wrong by an epoch, not by
+# a minute (#909).
+_CLOCK_SLACK = 120.0
+
+
 def _branched(**kw):
     """An MR body carrying the branch pair and head sha a real API returns."""
     body = _mr(**kw)
@@ -476,15 +484,64 @@ def test_the_snapshot_says_when_it_was_read() -> None:
     An absolute instant, not an age: an age is computed once and is wrong from
     the next second onward, which is the exact defect this field exists to
     prevent. The consumer subtracts.
+
+    The bracket carries `_CLOCK_SLACK` and this is not the assertion being
+    weakened to stop a red (#909). It used to be a strict sandwich with no
+    tolerance at all, and on PR #908 it reported `parsed` landing a whole
+    second *before* a `before` that program order reads first — an ordering the
+    process cannot produce, so what it detected was the host stepping its wall
+    clock backwards, on two legs of a PR whose diff is one character of regex.
+    Note what that rules out: reading the same clock API the product reads
+    would not have prevented it either, because `datetime.now(timezone.utc)`
+    and `time.gmtime()` are both `CLOCK_REALTIME` and a step moves them
+    together. Only slack does.
+
+    Two minutes of it still fails everything the field is defended against — an
+    age (seconds-since-epoch parses to 1970), a hardcoded string, a wrong
+    epoch, milliseconds read as seconds, a value minutes stale. It only stops
+    failing on the second boundary and the NTP step, neither of which is a
+    statement about this code. *Which* clock is read is pinned exactly, and
+    without any tolerance, by `test_the_snapshot_is_read_off_the_utc_clock`.
+
+    It reads `time.time()` rather than `datetime.now()` for the smaller reason
+    that the product reads `time.gmtime()`: a test and the code it guards
+    disagreeing about which API they mean is one thing less to reason about
+    when this next goes red.
     """
-    before = datetime.now(timezone.utc).replace(microsecond=0)
+    before = time.time()
     with mock.patch.object(poller, "_fetch", return_value=_ok(_branched(pipeline_status="failed"))):
         events, _ = poller.poll({"pipeline_status": "running"}, {"id": "21803"})
-    after = datetime.now(timezone.utc)
+    after = time.time()
     observed_at = events[0]["payload"]["observed_at"]
     assert observed_at.endswith("Z"), observed_at
-    parsed = datetime.strptime(observed_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-    assert before <= parsed <= after, f"{observed_at} not within [{before}, {after}]"
+    parsed = calendar.timegm(time.strptime(observed_at, "%Y-%m-%dT%H:%M:%SZ"))
+    assert before - _CLOCK_SLACK <= parsed <= after + _CLOCK_SLACK, (
+        f"{observed_at} ({parsed}) is not within {_CLOCK_SLACK:.0f}s of "
+        f"[{before}, {after}]")
+
+
+def test_the_snapshot_is_read_off_the_utc_clock() -> None:
+    """The `Z` has to be earned, and only a frozen clock can prove it (#909).
+
+    `observed_at` is published as `...Z`, so a swap of `time.gmtime()` for a
+    local-time call would label an offset instant as UTC and every consumer's
+    subtraction would be wrong by the runner's zone. A bracket around the real
+    clock cannot see that at all on a host whose local zone *is* UTC, which is
+    every CI leg this repo has. Two distinguishable frozen clocks can, on every
+    host, and without a second of tolerance.
+    """
+    utc = time.struct_time((2026, 8, 7, 4, 50, 33, 4, 219, 0))
+    local = time.struct_time((2026, 8, 7, 23, 15, 7, 4, 219, 0))
+    with mock.patch("time.gmtime", return_value=utc):
+        with mock.patch("time.localtime", return_value=local):
+            with mock.patch.object(
+                    poller, "_fetch",
+                    return_value=_ok(_branched(pipeline_status="failed"))):
+                events, _ = poller.poll({"pipeline_status": "running"},
+                                        {"id": "21803"})
+    assert events[0]["payload"]["observed_at"] == "2026-08-07T04:50:33Z", (
+        "the snapshot was stamped from a clock that is not UTC — the `Z` is a "
+        "claim about which clock was read, and it is now false (#909)")
 
 
 def test_a_merge_is_tied_to_the_pipeline_that_permitted_it() -> None:


### PR DESCRIPTION
Closes #844
Closes #909
Closes #777

Three test-side defects. Each issue's headline turned out to be wrong, and in all three cases the thing underneath was worth more than the thing filed.

## #844 — the premise is stale; the bug it was shadowing is real

Re-derived rather than quoted:

| Claim in #844 | Measured on this branch's base |
| --- | --- |
| ~33s (34.02s on unmodified master) | **8.24s** call, macOS/py3.14 |
| "per leg, on an 18-leg matrix, on every push" | the matrix is **12** legs, and the test is `@pytest.mark.slow`, which **#891 already excluded from all twelve**. It runs once, on a scheduled job, under `-n auto`. |
| "sits there until **git's own** default timeout" | it is **our** `_CHECK_TIMEOUT = 30` on `git ls-remote`. #843 cut the fixture's sleeper 90s→5s, so that call now costs 5.12s. The hypothesis was right about the shape and wrong about whose timeout. |

**What the 33s was hiding.** `make_fetch_hang` stalls the whole `remote.<name>.url`, and the recovery fetch is not the first git call to read it — `_push_op` verifies the rejected push with `ls-remote` first, through the same sleeping helper. That preflight writes the sentinel. So `_BudgetAfterSpawn` — added by #828 precisely so the clock starts when *this* call reaches *its* helper — found the file already there:

```
waited=0.000062 uses=1 fixture_ran=True
```

62 microseconds. On the fetch path #828's guarantee was not in force, and `assert box.fixture_ran` — the assertion whose whole job is "this test would otherwise prove nothing" — was satisfied by a stale file. **The test would have passed with the fetch's transport never spawned.**

```
RED:
E   AssertionError: only the preflight `ls-remote` reached the helper: the recovery fetch was
E   cut off before its own transport announced itself, so the hazard this test exists for never
E   happened and `fixture_ran` said yes anyway (#844)
E   assert 1 >= 2
```

`_BudgetAfterSpawn(..., spawns=N)` now waits for the announcement belonging to the call it guards.

**Judgment call: it is not faster, deliberately.** Speed was the premise and the premise is gone — this costs nothing per push. Buying 4s by shrinking the sleeper would trade fixture margin for a number nobody pays. Deleting it was on the table and is wrong; it pins a real receipt (#640/#642/#647). Net wall clock on the scheduled `slow` leg goes **up ~21s**, which is the price of coverage that did not previously exist.

## #909 — the issue's own suggested fix would not have worked

Direction 2 ("read the same clock the product reads") does not prevent the observed failure: `datetime.now(timezone.utc)` and `time.gmtime()` both resolve `CLOCK_REALTIME`, so a backward NTP step moves them together. Truncation cannot produce `parsed < before` either — `.replace(microsecond=0)` only moves `before` earlier. Only slack helps.

But slack alone loses what the `Z` is for, so it is split in two:

- **Bracket with 120s slack on `time.time()`.** Everything it defends against is wrong by an epoch, not a minute — age, hardcoded string, wrong epoch, ms-as-seconds, minutes-stale all still fail.
- **A frozen-clock test** for the part slack blurs: patch `time.gmtime` *and* `time.localtime` to distinguishable instants and assert the exact string.

```
RED — product mutated gmtime() -> localtime(), run under TZ=UTC (i.e. a CI leg):
E  AssertionError: the snapshot was stamped from a clock that is not UTC — the `Z` is a claim
E  about which clock was read, and it is now false (#909)
E  assert '2026-08-07T23:15:07Z' == '2026-08-07T04:50:33Z'
1 failed, 1 passed
```

The `1 passed` is `test_the_snapshot_says_when_it_was_read` — **green on the exact regression its `Z` exists to catch.** That is what a real-clock bracket can never see.

## #777 — the skip reason was wrong and blamed the wrong component

Two things the issue does not have. First, PR #783 already landed the xfail branch, so "reddened master" is closed. Second, **the sibling's skip is not correct and copying it would have been wrong.** Its entire diagnosis on file is `reason="gofmt adapter has encoding issues on Windows"`, cited three times. Measured with the real tool:

```
$ printf 'package main\r\n\r\nfunc main() {\r\n\t_ = 1\r\n}\r\n' > crlf.go
$ gofmt -l crlf.go
crlf.go
$ gofmt -l lf.go        # same bytes, LF
(nothing)
```

`Path.write_text` translates newlines to `os.linesep`. On Windows the deliberately gofmt-clean fixture reached gofmt as CRLF, and gofmt rewrites CRLF — so it was reported as needing formatting. **A defect in how the test wrote the file, recorded as a defect in the code under test, and paid for by deleting Windows' only check that a clean Go file is reported clean.**

Fixed with `write_go` (bytes, unmodified); skip removed; the mechanism pinned by `test_gofmt_reads_a_crlf_file_as_needing_formatting` on every platform — because the one it appears on is the one that cannot be checked locally.

This does **not** close the `adapter` decline (non-zero exit, different symptom, still undiagnosed). What changes is that it becomes diagnosable: `tool_fault` carried gofmt's exit code and output in the message all along, and the xfail branch printed a fixed sentence instead — so three occurrences produced no information beyond having happened.

**No win32 skip was added anywhere.** A local green proves nothing about the remaining Windows flake.

## Suite

```
7389 passed, 70 skipped in 325.14s     -m 'not slow and not benchmark'
11 passed in 44.69s                    -m slow
assemble_changelog.py --check          ok (12 fragments)
```

## Also

`docs/contributing.md` gains two conventions earned here: *never write a formatter's fixture with `write_text`*, and *never bracket a timestamp with zero tolerance*.

## Follow-ups, not in this PR

- `_live_remote_sha` blocks up to `_CHECK_TIMEOUT` (30s) verifying a post-push against an unreachable remote, *before* the recovery path starts. Bounded and three-state-reported, so not a defect — but it is 30s of `git-push` nobody has budgeted as such.
- The terraform and cargo fixtures in `tests/test_validators_tier2.py` have the same `write_text` CRLF exposure. They are off the Windows legs only because a `which()` skip happens to hide them — luck, not design.

**No collision with #942 / `fix/931`:** nothing in this diff names the module — no imports, no `--cov` targets, no source-reading tests, no path regexes. All three fixes are test-side plus docs. Sequence freely.
