### PR TITLE
fix(radar): a delta board accounts for the rows it did not print (#1022)

### DIFF
--- a/changelog.d/1022.fixed.md
+++ b/changelog.d/1022.fixed.md
@@ -1,0 +1,17 @@
+- **`radar` printed 3 PR rows under a footer reading `6 open | 2 failing | 4 running`, and nothing said the other three had been elided** ([#1022](https://github.com/Digital-Process-Tools/claude-supertool/issues/1022)). `gh-prs`, run from the same directory seconds later, returned all six. Nothing was lost in the fetch: both tiers render a *delta* board after the first tick — rows that moved since the previous snapshot, plus standing problems — while the footer tallies the whole open population. `running` is not a standing problem, so three ordinary open PRs that had simply not changed since the previous tick dropped off a board that still counted them. A partial board is strictly harder to notice than an empty one, because it looks like a working board.
+
+  **Rendered rows plus elided rows now equal the population the footer prints.** Every open PR or MR lands in exactly one of `shown` and `elided`; the footer carries an `N unchanged not shown` token so the arithmetic can be checked against the rows above it, and a partial board names the rows it held back:
+
+  ```
+  radar: NOTE — 3 of 6 open PRs are not on the board: unchanged since the previous
+  run and not a standing problem (#1004, #956, #1018). The footer counts all 6, so
+  rows plus 'unchanged not shown' is the whole population; `gh-prs` prints every row.
+  ```
+
+  A count a reader cannot resolve back to a PR is not a disclosure, so the identifiers are named and not merely tallied — capped at twelve, with the remainder counted.
+
+  **The elision itself is kept.** A running PR that has not moved since the last tick is genuinely no news, and re-printing it every tick is how a board trains its reader to skim — which is the failure mode standing exclusions already exist to prevent. What was wrong was the silence, not the choice.
+
+  **Both tiers had it, so both are fixed.** `gl-mrs` carries the identical construct and elided identically; the disclosure lives once, in `tiers/_snapshot.py`, next to the delta store whose consequence it is. The `gl-mrs` footer gained the same token, which changes one exact-match line: `radar: no change | … | 1 watched | 1 unchanged not shown | feed ok`.
+
+  **Three existing tests asserted the defect.** They checked that a suppressed row's identifier appeared nowhere in the output at all, which makes "this row was suppressed" and "this row was suppressed silently" the same assertion. They now assert the row is absent from the printed rows *and* named in the disclosure.

--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -217,10 +217,38 @@ A blocked MR is now labelled by *what* blocks it:
 **"Nothing moved"** means the set of open MRs is unchanged, no MR changed pipeline status / pipeline id / draft / conflict flag, and radar took no action. Then radar prints one summary line — not nothing:
 
 ```
-radar: no change | scope author=@me,state=opened (default) | 7 open | 7 watched
+radar: no change | scope author=@me,state=opened (default) | 7 open | 7 watched | 7 unchanged not shown | feed ok
 ```
 
 Total silence would be indistinguishable from a radar that failed to run, which is the failure this op exists to remove. For the same reason an unreachable GitLab is a hard error (exit 1, no board, nothing pruned or healed) rather than an empty green board. Standing failures and conflicts are re-printed even when unchanged — an unfixed red is a current fact, not history.
+
+### A delta board accounts for the rows it did not print ([#1022](https://github.com/Digital-Process-Tools/claude-supertool/issues/1022))
+
+The line above is the *easy* case: everything was elided, and `radar: no change` says so plainly. The dangerous case is the partial board, and it is why every count in the footer describes the whole open population while the rows above it are a subset.
+
+Observed live on the GitHub tier: three rendered rows under `6 open | 2 failing | 4 running`. Nothing was lost in the fetch — `gh-prs`, seconds later, returned all six. Two of the three failing PRs were standing problems and a third had just picked up a conflict; the other three were ordinary running PRs that had not changed since the previous tick, so the delta dropped them. A partial board is strictly harder to notice than an empty one, because it looks like a working board, and a maintainer who reads three rows merges as though three were all there was.
+
+**Rendered rows plus elided rows equal the population the footer prints.** The footer carries the missing token, so the arithmetic is checkable on the board itself:
+
+```
+scope author=@me (default) on Digital-Process-Tools/claude-supertool | 6 open |
+3 unchanged not shown | 2 failing | 4 running | 6 watched | 2 no longer open |
+discovery: radar ticks only
+```
+
+and a partial board names what it held back, because a count a reader cannot resolve back to a row is not a disclosure:
+
+```
+radar: NOTE — 3 of 6 open PRs are not on the board: unchanged since the previous
+run and not a standing problem (#1004, #956, #1018). The footer counts all 6, so
+rows plus 'unchanged not shown' is the whole population; `gh-prs` prints every row.
+```
+
+Capped at twelve identifiers, with the remainder counted. Both tiers do this and the sentence lives once, in `presets/watch/tiers/_snapshot.py`.
+
+**On a board where nothing was elided the line is absent, and the absence is the claim.** A disclosure printed unconditionally is one the reader learns to skip, which is the same failure one level up — the reason `_unchecked_warning` returns `[]` on a fully-checked board.
+
+**The elision is kept.** A running MR or PR that has not moved since the last tick is genuinely no news, and re-printing it every tick trains a reader to skim the board — exactly what [standing exclusions](#standing-exclusions) exist to prevent. What was wrong was the silence, not the choice.
 
 ### Standing exclusions
 
@@ -433,6 +461,7 @@ Rendering that as `0 watched` would be a number a reader acts on, and healing on
 | the filter matched nothing | reported *with its scope*: `No PRs matched — scope label=bug on owner/repo.` "No open PRs" is a claim about the world; this is a claim about a query |
 | a PR with an empty check rollup | counted `unchecked`, never green — the run may not exist yet, and "not yet" has rendered as "fine" on this board's GitLab twin before ([#659](https://github.com/Digital-Process-Tools/claude-supertool/issues/659)) |
 | a green whose legs do not reconcile | `[legs UNVERIFIED]`, counted `unchecked`, `healthy=False` |
+| a row the delta elided as unchanged | counted in the footer as `N unchanged not shown` and named on a `radar: NOTE` line ([#1022](https://github.com/Digital-Process-Tools/claude-supertool/issues/1022)) — see [A delta board accounts for the rows it did not print](#a-delta-board-accounts-for-the-rows-it-did-not-print-1022) |
 
 **Only the greens are reconciled, and that is the economy.** A red row is already a finding and a running row is already unknown — a doubt attached to either changes no action. A green is the one claim that can be wrong in the expensive direction, so green rows go through `gh-pr`'s own `_reconcile_checks` ([#724](https://github.com/Digital-Process-Tools/claude-supertool/issues/724)/[#804](https://github.com/Digital-Process-Tools/claude-supertool/issues/804)/[#837](https://github.com/Digital-Process-Tools/claude-supertool/issues/837)) — consumed, never re-implemented. The tier prints no leg count of its own; a tally that looks reconciled and is not is the defect those three PRs closed. The budget is `reconcile_cap` (6), and when it cuts it says so and marks the rest unchecked rather than going quiet.
 

--- a/presets/watch/tiers/_snapshot.py
+++ b/presets/watch/tiers/_snapshot.py
@@ -13,6 +13,11 @@ What is deliberately *not* here: what a member is, what counts as moved, and
 what the key is made of. Those are the tier's semantics — a GitLab MR is keyed
 by pipeline id and a GitHub PR by head SHA, and forcing one shape on both is the
 bend this module exists to avoid.
+
+What *is* here, besides the store, is `elided_note`: the disclosure a delta
+board owes for the rows it did not print (#1022). Both tiers elide identically
+and both used to elide silently, so the sentence lives once, next to the delta
+whose consequence it is.
 """
 from __future__ import annotations
 
@@ -60,6 +65,40 @@ def read(prefix: str, digest: str, member: str) -> dict[str, Any] | None:
     if not isinstance(loaded, dict) or not isinstance(loaded.get(member), dict):
         return None
     return loaded
+
+
+def elided_note(elided: list[str], total: int, noun: str, sigil: str,
+                wider: str) -> list[str]:
+    """Name the rows a delta board kept off itself. `[]` when it kept none.
+
+    A delta board prints the rows that moved and the rows that are standing
+    problems; everything else it drops. That is the point of a delta — but the
+    footer counts the whole population, so the two disagree by construction and
+    nothing used to say which to believe. Live (#1022): three rendered rows
+    under `6 open | 2 failing | 4 running`, and the three that vanished were
+    ordinary running PRs that simply had not changed since the previous tick.
+
+    A partial board is strictly harder to notice than an empty one, because it
+    looks like a working board — a maintainer reads three rows and merges as
+    though three were all there was. So the count goes in the footer, where the
+    arithmetic can be checked, and the identifiers go here, because a number a
+    reader cannot resolve back to a row is not a disclosure.
+
+    The empty return is load-bearing the same way `_unchecked_warning`'s is: on
+    a board that printed everything, the *absence* of this line is the positive
+    claim that nothing was held back. A line printed unconditionally is one the
+    reader learns to skip.
+    """
+    if not elided:
+        return []
+    named = ", ".join(f"{sigil}{n}" for n in elided[:12])
+    if len(elided) > 12:
+        named += f", +{len(elided) - 12} more"
+    return [f"radar: NOTE — {len(elided)} of {total} open {noun} are not on the "
+            f"board: unchanged since the previous run and not a standing "
+            f"problem ({named}). The footer counts all {total}, so rows plus "
+            f"'unchanged not shown' is the whole population; `{wider}` prints "
+            f"every row."]
 
 
 def write(prefix: str, digest: str, entries: dict[str, Any], member: str) -> None:

--- a/presets/watch/tiers/gh_prs.py
+++ b/presets/watch/tiers/gh_prs.py
@@ -497,12 +497,22 @@ def _is_standing_problem(p: dict) -> bool:
 
 def _footer(open_prs: list[dict], covered: set[str] | None, healed: list[str],
             uncovered: list[str], gone: int, label: str,
-            unchecked_n: int) -> str:
+            unchecked_n: int, elided_n: int = 0) -> str:
+    """Tallies over the whole open population, plus what the delta held back.
+
+    `elided_n` is the token that makes the footer checkable against the rows
+    above it (#1022): every other count here describes all `len(open_prs)` PRs
+    while the board prints only those that moved, so without it a reader has
+    `6 open | 4 running` over three rows and no way to tell a suppressed row
+    from a merged one.
+    """
     counts: dict[str, int] = {}
     for p in open_prs:
         key = str(p.get("_checks") or "none")
         counts[key] = counts.get(key, 0) + 1
     parts = [label, f"{len(open_prs)} open"]
+    if elided_n:
+        parts.append(f"{elided_n} unchanged not shown")
     if counts.get("failed"):
         parts.append(f"{counts['failed']} failing")
     if counts.get("running"):
@@ -556,7 +566,18 @@ def _unchecked_warning(numbers: list[str], total: int) -> list[str]:
 def render(open_prs: list[dict], covered: set[str] | None, healed: list[str],
            uncovered: list[str], previous: dict | None, label: str,
            notes: list[str] | None = None) -> list[str]:
-    """Full board on cold start; changed + standing-problem rows afterwards."""
+    """Full board on cold start; changed + standing-problem rows afterwards.
+
+    Every open PR lands in exactly one of `shown` and `elided`, and both are
+    reported (#1022). The partition is the fix: the footer counts the whole
+    population and the loop prints a subset, so the two were free to disagree,
+    and a board that quietly prints three of six rows is byte-identical to a
+    board with three PRs on it.
+
+    The elision itself is kept. A running PR that has not moved since the last
+    tick is genuinely no news, and re-printing it every tick is how a board
+    trains its reader to skim. What was wrong was the silence, not the choice.
+    """
     cold = previous is None
     prev_entries: dict[str, Any] = (previous or {}).get("prs", {}) or {}
     healed_set, uncovered_set = set(healed), set(uncovered)
@@ -564,6 +585,7 @@ def render(open_prs: list[dict], covered: set[str] | None, healed: list[str],
     unchecked_numbers = unchecked(open_prs)
 
     shown = []
+    elided: list[str] = []
     for p in sorted(open_prs, key=prs._sort_key):
         number = str(p.get("number", "?"))
         moved = prev_entries.get(number) != snap_entry(p)
@@ -572,14 +594,25 @@ def render(open_prs: list[dict], covered: set[str] | None, healed: list[str],
             shown.append(prs._row(p, covered,
                                   _marks(p, healed_set, uncovered_set,
                                          coverage_known)))
+        else:
+            elided.append(number)
 
     live = {str(p.get("number")) for p in open_prs}
     gone = len([n for n in prev_entries if n not in live])
     footer = _footer(open_prs, covered, healed, uncovered, gone, label,
-                     len(unchecked_numbers))
+                     len(unchecked_numbers), len(elided))
+
+    # Named only when the board is *partial*. A board where everything was
+    # elided already says so unambiguously on its `radar: no change` line, and
+    # the footer token still carries the arithmetic; listing every number there
+    # would print the whole population back on a board whose entire claim is
+    # that there is nothing to look at.
+    elision = (snapshot.elided_note(elided, len(open_prs), "PRs", "#", "gh-prs")
+               if shown else [])
 
     lines = (_coverage_warning(covered)
              + _unchecked_warning(unchecked_numbers, len(open_prs))
+             + elision
              + list(notes or []))
     if cold:
         lines.append("radar: cold start — no prior snapshot, full board")

--- a/presets/watch/tiers/gl_mrs.py
+++ b/presets/watch/tiers/gl_mrs.py
@@ -775,8 +775,13 @@ def resolve_exclusions(open_mrs: list[dict], exclusions: dict[str, dict[str, str
 def _footer(open_mrs: list[dict], covered: set[str], healed: list[str],
             drifted: dict[str, tuple[str, str]], pruned: list[str],
             uncovered: list[str], gone: int, feed: str, label: str = "",
-            excluded: int = 0) -> str:
+            excluded: int = 0, elided: int = 0) -> str:
     """Tallies over the board that was printed, plus what was kept off it.
+
+    `elided` is the delta's own withholding, disclosed for the same reason the
+    exclusion total is (#1022). Every count below describes all `open_mrs`
+    while `render` prints only the rows that moved, so without this token the
+    footer and the rows disagree by construction and nothing says so.
 
     `open_mrs` here is the *shown* population. A footer counting the full one
     would report a failure with no row behind it, which sends the reader
@@ -819,6 +824,8 @@ def _footer(open_mrs: list[dict], covered: set[str], healed: list[str],
         parts.append(f"{gone} no longer open")
     if excluded:
         parts.append(f"{excluded} excluded")
+    if elided:
+        parts.append(f"{elided} unchanged not shown")
     parts.append(FEED_LABEL.get(feed, feed))
     return " | ".join(parts)
 
@@ -915,6 +922,7 @@ def render(open_mrs: list[dict], covered: set[str], healed: list[str],
     board_mrs = [m for m in open_mrs if str(m.get("iid", "?")) not in excluded]
 
     shown = []
+    elided: list[str] = []
     for m in sorted(board_mrs, key=mrs._sort_key):
         iid = str(m.get("iid", "?"))
         moved = prev_entries.get(iid) != _snap_entry(m)
@@ -922,13 +930,23 @@ def render(open_mrs: list[dict], covered: set[str], healed: list[str],
         if cold or moved or notable or _is_standing_problem(m):
             marks = _marks(iid, drifted, healed_set, uncovered_set)
             shown.append(mrs._row(m, covered, True, marks))
+        else:
+            elided.append(iid)
 
     gone = len([i for i in prev_entries if i not in {str(m.get("iid")) for m in open_mrs}])
     footer = _footer(board_mrs, covered, healed, drifted, pruned, uncovered, gone,
-                     feed, label, len(excluded))
+                     feed, label, len(excluded), len(elided))
+
+    # Partial boards only — see the same call in `gh_prs.render`. `excluded` is
+    # a different withholding with its own `notes`, and the two are counted
+    # separately because one is the operator's standing decision and this one
+    # is this tick's delta.
+    elision = (snapshot.elided_note(elided, len(board_mrs), "MRs", "!", "gl-mrs")
+               if shown else [])
 
     lines = (_feed_warnings(feed, feed_err, other_scopes)
              + _unchecked_warning(mrs._unchecked_count(open_mrs), len(open_mrs))
+             + elision
              + list(losses or []))
     if cold:
         lines.append("radar: cold start — no prior snapshot, full board")

--- a/tests/test_radar_delta_elision_1022.py
+++ b/tests/test_radar_delta_elision_1022.py
@@ -1,0 +1,260 @@
+"""A delta board must account for every row it did not print (#1022).
+
+Observed live: `radar` printed three PR rows under a footer reading
+`6 open | 2 failing | 4 running`, and `gh-prs` seconds later returned all six.
+Nothing was lost in the fetch — the footer and the rows are computed from the
+same population. `render` deliberately elides a row that is unchanged since the
+previous snapshot and is not a standing problem, and `running` is not a standing
+problem. The elision is defensible; its silence is not.
+
+A partial board is strictly harder to notice than an empty one, because it looks
+like a working board — a maintainer reads three rows and merges as though three
+were all there was. So the invariant pinned here is arithmetic:
+
+    rendered rows + rows the board says it elided == the population the footer
+    counts
+
+and the elided rows are named, because a number a reader cannot resolve back to
+a PR is not a disclosure.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+WATCH_DIR = ROOT / "presets" / "watch"
+
+
+def _module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+tier = _module("radar_gh_prs_1022", WATCH_DIR / "tiers" / "gh_prs.py")
+gl_tier = _module("radar_gl_mrs_1022", WATCH_DIR / "tiers" / "gl_mrs.py")
+
+
+# ---------------------------------------------------------------------------
+# fixtures — the same two real boundaries the #859 file drives
+# ---------------------------------------------------------------------------
+
+RUN_LEG = {"name": "pytest", "status": "IN_PROGRESS", "conclusion": None,
+           "detailsUrl": "https://github.com/o/r/actions/runs/1/job/9"}
+RED_LEG = {"name": "pytest (windows-latest, 3.12)", "status": "COMPLETED",
+           "conclusion": "FAILURE",
+           "detailsUrl": "https://github.com/o/r/actions/runs/1/job/9"}
+
+
+def _pr(number: int, rollup, sha: str = "a" * 40, **kw) -> dict:
+    row = {
+        "number": number, "title": f"pr {number}", "state": "OPEN",
+        "author": {"login": "me"}, "headRefName": f"fix/{number}",
+        "baseRefName": "master", "headRefOid": sha, "labels": [],
+        "isDraft": False, "mergeable": "MERGEABLE", "reviewDecision": "",
+        "statusCheckRollup": rollup, "additions": 1, "deletions": 1,
+        "changedFiles": 1, "updatedAt": "2026-08-07T10:00:00Z",
+        "createdAt": "2026-08-07T09:00:00Z", "assignees": [],
+        "url": f"https://github.com/o/r/pull/{number}",
+    }
+    row.update(kw)
+    return row
+
+
+class _Result:
+    def __init__(self, out: str = "", err: str = "", code: int = 0):
+        self.stdout, self.stderr, self.returncode = out, err, code
+
+
+@pytest.fixture()
+def state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(tier.transport, "STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(tier.snapshot.transport, "STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def no_spawn(monkeypatch):
+    monkeypatch.setattr(tier.dispatcher, "start_poller",
+                        lambda *a, **k: pytest.fail("tier spawned a poller"))
+
+
+@pytest.fixture(autouse=True)
+def quiet_reconcile(monkeypatch):
+    monkeypatch.setattr(tier, "_reconcile_one", lambda p: ("", []))
+
+
+def _fake_gh(monkeypatch, rows):
+    monkeypatch.setattr(tier.subprocess, "run",
+                        lambda cmd, *a, **k: _Result(json.dumps(rows)))
+
+
+def _board(monkeypatch, rows, watched):
+    """One `radar_report` over `rows`, with everything but the board stubbed."""
+    monkeypatch.setattr(tier, "default_branch_report", lambda *a, **k: ([], True))
+    monkeypatch.setattr(tier, "repo_name",
+                        lambda: "Digital-Process-Tools/claude-supertool")
+    monkeypatch.setattr(tier, "watch_coverage", lambda: set(watched))
+    _fake_gh(monkeypatch, rows)
+    lines, _ = tier.radar_report({"_arg": "", "_watch": lambda *a, **k: "alive"})
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# the accounting the board has to be able to survive
+# ---------------------------------------------------------------------------
+
+_FOOTER_OPEN = re.compile(r"(\d+) open\b")
+_ELIDED = re.compile(r"(\d+) unchanged not shown\b")
+
+
+def _footer_line(lines: list[str], word: str) -> str:
+    hits = [ln for ln in lines if f" {word}" in ln and " | " in ln]
+    assert hits, f"no footer line among {lines!r}"
+    return hits[-1]
+
+
+def _rendered_ids(lines: list[str], sigil: str) -> set[str]:
+    """Identifiers of the rows actually printed, not of every line mentioning one.
+
+    A row is a rendered board row; a WARNING or NOTE that names `#1004` is the
+    disclosure, not the row, and counting it would make this test pass on the
+    very output it exists to reject.
+    """
+    out: set[str] = set()
+    for line in lines:
+        if line.lstrip().startswith(("radar:", "[", "scope ")) or " | " in line:
+            continue
+        found = re.search(rf"{re.escape(sigil)}(\d+)\s", line)
+        if found:
+            out.add(found.group(1))
+    return out
+
+
+def test_gh_prs_delta_board_accounts_for_every_open_pr(state_dir, monkeypatch):
+    """The live #1022 sequence: a full cold board, then two merges and a rebase.
+
+    #1005/#979 are failing and #1013 picks up a conflict, so three rows are
+    standing problems and print. #1004, #956 and #1018 are running and unmoved
+    — the exact three that vanished under a footer still counting all six.
+    """
+    _board(monkeypatch,
+           [_pr(1005, [RED_LEG]), _pr(979, [RED_LEG]), _pr(1004, [RUN_LEG]),
+            _pr(956, [RUN_LEG]), _pr(1013, [RUN_LEG]), _pr(1018, [RUN_LEG]),
+            _pr(1008, [RUN_LEG]), _pr(997, [RUN_LEG])],
+           {"1005", "979", "1004", "956", "1013", "1018", "1008", "997"})
+
+    lines = _board(
+        monkeypatch,
+        [_pr(1005, [RED_LEG]), _pr(979, [RED_LEG]), _pr(1004, [RUN_LEG]),
+         _pr(956, [RUN_LEG]), _pr(1013, [RUN_LEG], mergeable="CONFLICTING"),
+         _pr(1018, [RUN_LEG])],
+        {"1005", "979", "1004", "956", "1013", "1018"})
+
+    text = "\n".join(lines)
+    footer = _footer_line(lines, "open")
+    open_n = int(_FOOTER_OPEN.search(footer).group(1))
+    assert open_n == 6, footer
+
+    rows = _rendered_ids(lines, "#")
+    assert rows == {"1005", "979", "1013"}, (
+        "fixture drifted — this case is about the three that do NOT print")
+
+    hidden = _ELIDED.search(footer)
+    assert hidden, (
+        f"the footer counts {open_n} open PRs and the board printed "
+        f"{len(rows)} rows, and nothing on it says the other "
+        f"{open_n - len(rows)} were elided. A board that silently prints a "
+        f"subset is byte-identical to a board with less work on it.\n\n{text}")
+
+    assert len(rows) + int(hidden.group(1)) == open_n, (
+        f"rendered {len(rows)} + elided {hidden.group(1)} != {open_n} open"
+        f"\n\n{text}")
+
+    for number in ("1004", "956", "1018"):
+        assert f"#{number}" in text, (
+            f"#{number} was elided and never named; a count a reader cannot "
+            f"resolve back to a PR is not a disclosure.\n\n{text}")
+
+
+def test_gh_prs_full_board_claims_completeness_by_saying_nothing(
+        state_dir, monkeypatch):
+    """The absence of the elision line is the positive claim, so it must be
+    absent when nothing was elided — otherwise the marker stops meaning
+    anything and every board grows a line the reader learns to skip."""
+    lines = _board(monkeypatch, [_pr(1, [RED_LEG]), _pr(2, [RUN_LEG])],
+                   {"1", "2"})
+    footer = _footer_line(lines, "open")
+    assert not _ELIDED.search(footer), footer
+    assert "unchanged not shown" not in "\n".join(lines)
+
+
+def test_gh_prs_no_change_board_still_reconciles(state_dir, monkeypatch):
+    """Every row elided is the case that already had a line — `radar: no
+    change`. It must carry the same arithmetic, or the one board that is
+    entirely elision is the one that does not say so."""
+    rows = [_pr(1, [RUN_LEG]), _pr(2, [RUN_LEG]), _pr(3, [RUN_LEG])]
+    _board(monkeypatch, rows, {"1", "2", "3"})
+    lines = _board(monkeypatch, rows, {"1", "2", "3"})
+
+    text = "\n".join(lines)
+    assert any(ln.startswith("radar: no change") for ln in lines), text
+    footer = _footer_line(lines, "open")
+    hidden = _ELIDED.search(footer)
+    assert hidden, text
+    assert int(hidden.group(1)) == 3, footer
+    assert len(_rendered_ids(lines, "#")) + 3 == 3, text
+
+
+# ---------------------------------------------------------------------------
+# the same defect in the sibling tier — the GitLab board elides identically
+# ---------------------------------------------------------------------------
+
+def _mr(iid: int, status: str, **kw) -> dict:
+    """An *enriched* MR — `_enriched` is what says its status was actually read
+    (#659). Without it every row here is unchecked, which is a different
+    finding and would let this case pass for the wrong reason."""
+    row = {
+        "iid": iid, "title": f"mr {iid}", "source_branch": f"fix/{iid}",
+        "target_branch": "master", "draft": False,
+        "updated_at": "2026-08-07T10:00:00Z",
+        "_pipeline": status, "_pipeline_id": str(100 + iid), "_pipeline_url": "",
+        "_changes": 3, "_approved": True, "_approved_by": [],
+        "_failed_jobs": [] if status != "failed" else ["test_unit"],
+        "_enriched": True,
+    }
+    row.update(kw)
+    return row
+
+
+def test_gl_mrs_delta_board_accounts_for_every_open_mr(monkeypatch):
+    """Same construct, same file shape, same silence — `gl_mrs.render` elides
+    an unchanged non-problem row while `_footer` counts the population."""
+    mrs = [_mr(1, "running"), _mr(2, "running"), _mr(3, "failed")]
+    covered = {"1", "2", "3"}
+    previous = {"mrs": {str(m["iid"]): gl_tier._snap_entry(m) for m in mrs}}
+
+    lines = gl_tier.render(mrs, covered, [], {}, [], [], previous,
+                           label="scope author=@me")
+    text = "\n".join(lines)
+    footer = _footer_line(lines, "open")
+    open_n = int(_FOOTER_OPEN.search(footer).group(1))
+    assert open_n == 3, footer
+
+    rows = _rendered_ids(lines, "!")
+    assert rows == {"3"}, f"fixture drifted: {text}"
+
+    hidden = _ELIDED.search(footer)
+    assert hidden, (
+        f"the footer counts {open_n} open MRs, {len(rows)} row(s) printed, "
+        f"and nothing says the rest were elided.\n\n{text}")
+    assert len(rows) + int(hidden.group(1)) == open_n, text
+    for iid in ("1", "2"):
+        assert f"!{iid}" in text, text

--- a/tests/test_watch_radar.py
+++ b/tests/test_watch_radar.py
@@ -12,6 +12,7 @@ import datetime
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -26,6 +27,24 @@ def _module(name: str, path: Path):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _row_iids(out: str) -> set[str]:
+    """iids of the board rows actually printed.
+
+    Not `"!33172" in out`. Since #1022 a delta board *names* the rows it
+    elided, so a bare substring search finds the disclosure and reports it as
+    a row — which would make "this row was suppressed" and "this row was
+    suppressed silently" the same assertion, and the second is the defect.
+    """
+    iids = set()
+    for line in out.splitlines():
+        if line.startswith(("radar:", "[")) or " | " in line:
+            continue
+        found = re.search(r"!(\d+)\s", line)
+        if found:
+            iids.add(found.group(1))
+    return iids
 
 
 radar = _module("watch_radar", WATCH_DIR / "radar.py")
@@ -341,7 +360,8 @@ def test_second_run_with_nothing_moved_is_one_summary_line(env, capsys) -> None:
     _run(env, capsys)
     out = _run(env, capsys)
     assert out == ("radar: no change | scope author=@me,state=opened (default) | "
-                   "1 open | 1 green | 1 watched | feed ok\n")
+                   "1 open | 1 green | 1 watched | 1 unchanged not shown | "
+                   "feed ok\n")
 
 
 def test_nothing_moved_still_reports_coverage_rather_than_silence(env, capsys) -> None:
@@ -381,8 +401,12 @@ def test_unchanged_green_mr_is_suppressed_next_to_a_standing_red(env, capsys) ->
     ])
     _run(env, capsys)
     out = _run(env, capsys)
-    assert "!33161" in out
-    assert "!33172" not in out
+    assert _row_iids(out) == {"33161"}
+    # Suppressed, and said so (#1022): the footer counts both MRs, so a board
+    # that printed one row and no accounting is one a reader takes for the
+    # whole population.
+    assert "1 unchanged not shown" in out
+    assert "!33172" in out, "the elided row must be named, not merely counted"
 
 
 def test_new_open_mr_appears_on_the_next_run(env, capsys) -> None:
@@ -392,8 +416,8 @@ def test_new_open_mr_appears_on_the_next_run(env, capsys) -> None:
     _live_pid_file(env["dir"], "33199")
     _set_live(env, [_mr(33172, "success"), _mr(33199, "success")])
     out = _run(env, capsys)
-    assert "!33199" in out
-    assert "!33172" not in out
+    assert _row_iids(out) == {"33199"}
+    assert "1 unchanged not shown" in out
 
 
 def test_merged_mr_is_counted_as_no_longer_open(env, capsys) -> None:


### PR DESCRIPTION
Closes #1022

## The issue's framing was wrong, and this is what is actually happening

I filed #1022 believing rows were being **dropped** — a fetch, enrichment or render loss, with the footer and the row list computed from two populations that could disagree. None of that is true, and the correction is on the issue.

There is one population, read once by `live_open_prs`, counted by `_footer` and iterated by `render`. Nothing was lost. `render` **deliberately elides**: it is a delta board after the first tick, documented in its own docstring, and a row prints iff `cold or moved or notable or _is_standing_problem(p)`. `running` is not a standing problem. So three open PRs that had not moved since the previous snapshot were correctly suppressed, and the footer counting all six was correct too.

The observation that produced the issue is still a real defect. It is just one level up: **the elision was never accounted for**. A board showing three rows under a footer reading `6 open` is byte-identical to a board with three PRs on it, and the reader has no way to tell which they are looking at.

Two details from the live case that I had called indistinguishable and were not:

- **#1013 was distinguished twice over.** An `oss_train` rebase attempt had left it `CONFLICTING`, which makes it both `moved` (snapshot mismatch) and a standing problem. #1004, #956 and #1018 were neither.
- **The earlier board that rendered all 8 was a cold start** (`previous is None` → full board). The trigger was the two merges creating a snapshot, not the rebase.

## What changed

`render` now partitions every open PR into `shown` xor `elided`, and a partial board carries a note above the rows:

```
radar: NOTE — 3 of 6 open PRs are not on the board: unchanged since the previous run and not a
standing problem (#1004, #956, #1018). The footer counts all 6, so rows plus 'unchanged not
shown' is the whole population; `gh-prs` prints every row.
```

with a matching `3 unchanged not shown` token in the footer, so rows + elided = the population by arithmetic a reader can check.

`gl-mrs` had the verbatim same construct and the verbatim same silence; it is fixed on the same commit rather than left to lie about the GitLab board.

## Judgment calls

- **Kept the elision, fixed the silence.** A running PR that has not moved is genuinely no news, and re-printing it every tick is what the standing-exclusion mechanism exists to prevent. Suppressing the elision instead would trade a quiet defect for a noisy board.
- **Named the identifiers, not just the count** (capped at 12 plus a remainder). A count a reader cannot resolve back to a PR is a number, not a disclosure.
- **The note appears only on a partial board.** A fully-elided board already prints `radar: no change` and the footer token still carries the arithmetic.

## Three existing tests asserted the defect

`test_unchanged_green_mr_is_suppressed_next_to_a_standing_red`, `test_new_open_mr_appears_on_the_next_run` and `test_second_run_with_nothing_moved_is_one_summary_line` asserted `"!33172" not in out` — the identifier's absence from the **whole output** as a proxy for "the row was not printed".

That makes "this row was suppressed" and "this row was suppressed silently" the same assertion, and the second one is the bug. They now use a `_row_iids()` helper that ignores `radar:` disclosure lines, and additionally assert the elided row *is* named.

## Tests

RED, before the implementation, against the real `radar_report` with only `gh pr list` faked:

```
FAILED tests/test_radar_delta_elision_1022.py::test_gl_mrs_delta_board_accounts_for_every_open_mr
FAILED tests/test_radar_delta_elision_1022.py::test_gh_prs_no_change_board_still_reconciles
FAILED tests/test_radar_delta_elision_1022.py::test_gh_prs_delta_board_accounts_for_every_open_pr
3 failed, 1 passed in 3.77s
```

GREEN: `148 passed` across the radar suites, `7958 passed, 72 skipped` full suite (macOS).

## Out of scope, filed separately

- `N no longer open` also fires when a PR merely leaves the **filter** — an author reassigned, a label removed — so a maintainer reads "merged" where the truth is "still open, no longer yours". Both tiers.
- `_is_standing_problem` omits `running`, which is right for a delta but means a PR wedged in `running` for days never reappears on the board. The new note makes that visible; a staleness threshold would make it actionable.
