### PR TITLE
between: the line-range hint stops stating whether an out-of-boundary file exists

### DIFF
--- a/_supertool.py
+++ b/_supertool.py
@@ -5736,6 +5736,25 @@ def _between_numeric_hint(parts: List[str]) -> str:
     numeric token must not name a real path (a file called `12` is a range
     nobody asked for), and the path in front of it must resolve, or this
     would be guessing at a plain typo.
+
+    That resolve is a filesystem probe on parts[1], and parts[1] is a SYMBOL in
+    every other reading of `between` — so `_PATH_ARG_POSITIONS["between"] =
+    (2, 4)` does not cover it and dispatch's gate has already passed on a slot
+    this call did not use as a path. Unguarded, the two answers below differ by
+    whether the file is there, which is an existence oracle for anything the
+    process can stat (#1142):
+
+        between:/etc/hosts:3:5   -> the range redirect
+        between:/etc/nope:3:5    -> path not found: '5'
+
+    Contained here rather than in the table, the shape #1135 established: the
+    slot only becomes a path conditionally, so the guard has to be conditional
+    too — widening the table would refuse `between:/etc/passwd:code.py`, a
+    perfectly ordinary symbol lookup. And it refuses rather than falling
+    silent, because the redirect this hint would print is `read:PATH:START-END`
+    on a path `read` itself refuses: advice whose remedy is refused is worse
+    than the refusal. `_containment_error` never stats, so the refusal reads
+    the same whether or not the file exists.
     """
     if len(parts) not in (3, 4):
         return ""
@@ -5743,7 +5762,12 @@ def _between_numeric_hint(parts: List[str]) -> str:
     if not all(t.isdigit() and not os.path.exists(t) for t in nums):
         return ""
     path = parts[1]
-    if not path or not os.path.isfile(path):
+    if not path:
+        return ""
+    _contained = _containment_error([path])
+    if _contained:
+        return _contained
+    if not os.path.isfile(path):
         return ""
     lines = [
         f"ERROR: between does not take line ranges — it is between:SYMBOL:PATH"

--- a/changelog.d/1142.security.md
+++ b/changelog.d/1142.security.md
@@ -1,0 +1,10 @@
+- **`between`'s line-range hint no longer answers whether a file outside cwd exists** ([#1142](https://github.com/Digital-Process-Tools/claude-supertool/issues/1142)). `_between_numeric_hint` (0.27.0) asks `os.path.isfile` about parts[1] so it can redirect `between:PATH:START:END` to `read:PATH:START-END`. parts[1] is a SYMBOL in every other reading of `between`, so `_PATH_ARG_POSITIONS["between"]` is `(2, 4)` and does not cover it — the probe ran after dispatch's containment gate had already passed on a slot the call did not use as a path. The two answers differed by whether the file was there, which made the pair an existence oracle for anything the process could stat:
+
+  ```
+  between:/etc/hosts:3:5   ->  "between does not take line ranges …"
+  between:/etc/nope:3:5    ->  "path not found: '5'"
+  ```
+
+  Strictly weaker than [#1135](https://github.com/Digital-Process-Tools/claude-supertool/issues/1135) — existence only, never content, and present since 0.27.0 rather than a regression in this delta. Both calls now return the same containment refusal, which never stats and so cannot differ.
+
+  Contained at the moment the argument is used as a path — the shape #1135 established — rather than by widening the table: the slot only becomes a path conditionally, and containing it unconditionally would refuse `between:/etc/passwd:code.py`, an ordinary symbol lookup. The hint refuses rather than falling silent because the remedy it prints, `read:PATH:START-END`, is a call `read` itself refuses on that path; advice whose remedy is refused is worse than the refusal.

--- a/tests/test_between_numeric_hint_containment_1142.py
+++ b/tests/test_between_numeric_hint_containment_1142.py
@@ -1,0 +1,119 @@
+"""`between`'s line-range hint stats parts[1], a slot containment does not cover (#1142).
+
+`_PATH_ARG_POSITIONS["between"]` is `(2, 4)` -- the path slot in each of the two
+readings. `_between_numeric_hint` (#983) reads parts[1] as a filename and asks
+`os.path.isfile` about it, from `_dispatch_impl`, after the gate has passed on a
+slot this call did not use as a path.
+
+Two different messages come back depending on the answer, so the pair is an
+existence oracle for any path the process can stat:
+
+    between:/etc/hosts:3:5   -> "does not take line ranges"  (it is a file)
+    between:/etc/nope:3:5    -> "path not found: '5'"        (it is not)
+
+Strictly weaker than #1135 -- existence only, no bytes -- so these tests assert
+the two answers have become indistinguishable, not that content stayed unread.
+The refusal has to name containment: `path not found: '5'` is what the absent
+branch already says, and asserting merely "it errors" would pass with the hole
+wide open.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import supertool
+
+NL = chr(10)
+
+
+@pytest.fixture
+def outside(tmp_path: Path, monkeypatch) -> Path:
+    """cwd is a box under tmp_path; a real file sits one level above it.
+
+    conftest sets SUPERTOOL_ALLOW_OUTSIDE_CWD=1 so tmp_path fixtures work at
+    all, so a containment test has to put the boundary back or it asserts
+    nothing. Same reason applies to this repo's own `.supertool.json`, which
+    opts out -- containment does not apply inside the checkout.
+    """
+    monkeypatch.delenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", raising=False)
+    present = tmp_path / "outside_a.txt"
+    present.write_text("one" + NL + "two" + NL + "three" + NL, encoding="utf-8")
+    box = tmp_path / "box"
+    box.mkdir()
+    monkeypatch.chdir(box)
+    return present
+
+
+def test_the_probed_slot_refuses_an_absolute_escape(outside: Path) -> None:
+    out = supertool.dispatch("between:" + str(outside) + ":1:2")
+    assert "does not take line ranges" not in out, (
+        "the hint fired on a path outside cwd, which answers whether it "
+        "exists:" + NL + out)
+    assert "escapes cwd" in out, (
+        "refusing has to name containment -- `path not found` is what the "
+        "absent branch says and would pass with the oracle open:" + NL + out)
+
+
+def test_the_probed_slot_refuses_a_relative_escape(outside: Path) -> None:
+    out = supertool.dispatch("between:../outside_a.txt:1:2")
+    assert "does not take line ranges" not in out, out
+    assert "escapes cwd" in out, out
+
+
+def test_the_single_line_form_refuses_too(outside: Path) -> None:
+    """`between:PATH:LINE` is the other shape #983 redirects; same slot."""
+    out = supertool.dispatch("between:../outside_a.txt:2")
+    assert "does not take line ranges" not in out, out
+    assert "escapes cwd" in out, out
+
+
+def test_present_and_absent_outside_paths_are_indistinguishable(
+    outside: Path,
+) -> None:
+    """The oracle itself. Both names are the same length, so normalising the
+    one differing token makes the two answers comparable byte for byte."""
+    present = supertool.dispatch("between:../outside_a.txt:1:2")
+    absent = supertool.dispatch("between:../outside_b.txt:1:2")
+    assert present.replace("outside_a", "X") == absent.replace("outside_b", "X"), (
+        "the answer still depends on whether the outside file exists:"
+        + NL + "present:" + NL + present + NL + "absent:" + NL + absent)
+
+
+def test_a_contained_range_call_still_gets_the_redirect(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The boundary. #983 exists to turn a mis-split into a usable redirect; a
+    fix that killed the hint outright would trade this bug for that one."""
+    monkeypatch.delenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", raising=False)
+    box = tmp_path / "box"
+    box.mkdir()
+    (box / "many.txt").write_text(
+        NL.join("line" + str(i) for i in range(1, 21)) + NL, encoding="utf-8")
+    monkeypatch.chdir(box)
+    out = supertool.dispatch("between:many.txt:3:5")
+    assert "does not take line ranges" in out, out
+    assert "read:many.txt:3-5" in out, out
+
+
+def test_a_symbol_that_looks_like_an_outside_path_still_resolves(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The regression a table-widening fix would cause and this one must not.
+
+    parts[1] is a SYMBOL in every other reading of `between`. Containing it
+    unconditionally would refuse a legitimate symbol whose name happens to
+    look like an absolute path outside the tree.
+    """
+    monkeypatch.delenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", raising=False)
+    box = tmp_path / "box"
+    box.mkdir()
+    (box / "code.py").write_text(
+        "def f():" + NL + "    return 1" + NL, encoding="utf-8")
+    monkeypatch.chdir(box)
+    out = supertool.dispatch("between:/etc/passwd:code.py")
+    assert "escapes cwd" not in out, (
+        "a symbol is not a path -- containment must not filter what may be "
+        "looked up:" + NL + out)


### PR DESCRIPTION
Closes #1142

`_between_numeric_hint` probed `os.path.isfile` on `parts[1]` to decide whether to redirect `between:PATH:START:END` to `read:PATH:START-END`. `parts[1]` is a **symbol** in every other reading of `between`, so `_PATH_ARG_POSITIONS["between"] = (2, 4)` did not cover it and dispatch had already gated a slot this call never used as a path.

The redirect fired only when the file was there, so the pair of answers was an existence oracle for anything the process could stat:

```
between:/etc/hosts:3:5   -> the range redirect
between:/etc/nope:3:5    -> path not found: '5'
```

## The fix

`_containment_error([path])` before the stat, contained at the point of use — the shape #1135 established, not a widening of the table. Widening would refuse `between:/etc/passwd:code.py`, an ordinary symbol lookup.

It **refuses** rather than falling silent, against the issue's lean. The hint's whole payload is `read:PATH:START-END`, and `read` itself refuses on that path — advice whose remedy is refused is worse than the refusal. `_containment_error` never stats, so the refusal reads identically for a present and an absent file, which the test asserts as byte equality.

## Tests

6 new. RED first: 4 failed, 2 passed — the 2 passers are deliberate boundary controls (a contained call still gets the redirect; a symbol that looks like an outside path still resolves), so they guard against over-fixing and are green in both states. GREEN: 6 passed. Blast radius across `between`/`around`/`dispatch`/`cwd`/`safe_path` (15 files): 363 passed.

Full suite not run locally — the suite is non-hermetic on git and corrupts the worktree it runs in; the change is a three-line guard in one hint function. CI is the authority here.

## Review

The Sonnet reviewer spawn was interrupted, so **no automated review ran on this branch**. Recording that rather than letting it read as a clean pass. I read the diff myself instead: 26 lines, the guard sits ahead of the stat, no other surface touched.

## Related

Two follow-ups filed from this work, both reproduced independently before filing: #1163 (the same class one op over, and worse — fixed in a separate PR) and #1164 (the mirror, where the table over-contains a regex slot).
