### PR TITLE
tomllint declines instead of reporting clean, and html-check stops claiming nothing is lost

### DIFF
--- a/changelog.d/1157.fixed.md
+++ b/changelog.d/1157.fixed.md
@@ -1,0 +1,16 @@
+- `tomllint`: reported `ok: true, count: 0` when neither `tomllib` (Python
+  3.11+) nor `tomli` could be imported — a TOML file nothing parsed, published
+  as a file that parsed clean, in an adapter that predates
+  `validators/SCHEMA.md` §"Skipped: the third state" (#1157). It is now
+  `skipped` with the reason and the install command, and a loud `adapter` error
+  when `tomllint` is named in `$SUPERTOOL_REQUIRE_VALIDATORS` — the same shape
+  `shellcheck`, `eslint` and `gitleaks` already use. Rollback behaviour is
+  unchanged: `_validator_regressed` returns `False` for `ok: true` and for
+  `skipped` alike, so no `rollback_on_fail` decision moves.
+- `tomllint`: the stdlib import was guarded by `sys.version_info >= (3, 11)`
+  and nothing else, which answers "does this Python ship `tomllib`" rather than
+  "does `import tomllib` succeed". A `tomllib` that exists and raises on import
+  took a traceback out of the adapter with no JSON on stdout at all — an
+  adapter that exits non-zero having said nothing, where the contract is to
+  always answer. Both candidate imports are guarded now, and the version check
+  is gone.

--- a/changelog.d/1195.fixed.md
+++ b/changelog.d/1195.fixed.md
@@ -1,0 +1,14 @@
+- `docs/validators.md`: the `html-check` refusal section said "Nothing is lost:
+  the reason names the line to fix first, and the finding is still there on the
+  next run" two paragraphs after conceding that a fragment or a template
+  partial legitimately stops inside a block (#1195). For those files the
+  refusal is permanent, there is no line to fix, every finding in every
+  properly-closed block *above* the unclosed one is discarded, and
+  `rollback_on_fail` is inert on that file for as long as it stays a fragment.
+  The section now names that cost instead of denying it, and records why the
+  issue's preferred fix — publishing the already-extracted findings beside the
+  refusal — is not available: a `skipped` result omits `errors` by contract and
+  every core consumer branches on `skipped` before reading a verdict key, so
+  those findings would be emitted into a field nothing reads. Behaviour is
+  unchanged; the equivalent claim in `html-check.py`'s own comment is corrected
+  too.

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -186,7 +186,7 @@ Enable any of these by copying the relevant entry from `.supertool.example.json`
 | JavaScript          | `node-check`     | `node` on PATH                     | Uses `node --check`                        |
 | HTML (inline `<script>`) | `html-check` | `node` on PATH                  | Extracts non-external, JS-typed `<script>` blocks and runs each through `node --check`; does NOT validate HTML well-formedness (#833) — see below |
 | CSS / SCSS          | `stylelint`      | `stylelint` npm package            | Config from project `.stylelintrc`         |
-| TOML                | `tomllint`       | stdlib (3.11+) or `tomli`          | Falls back to `tomli` on 3.10              |
+| TOML                | `tomllint`       | stdlib (3.11+) or `tomli`          | Falls back to `tomli` on 3.10. Neither importable is `skipped`, never `ok` (#1157) — see below |
 | Markdown            | `markdownlint`   | `markdownlint` CLI                 | `npm install -g markdownlint-cli`          |
 | Ruby                | `ruby-check`     | `ruby` on PATH                     | Uses `ruby -c`                             |
 | Dockerfile          | `hadolint`       | `hadolint` on PATH                 | Catches both syntax and best-practice lint |
@@ -226,7 +226,11 @@ And so is the same failure one level out: a start tag that delimits perfectly op
 
 Resuming the scan past such a tag was never an option either, whatever the code used to claim: `</script` was not found at or after that point, so it is not found after any later `<script` either, and the tokenizer agrees — after an unclosed `<script>` every remaining byte of the file is script data, so a later well-formed-looking block is not a block at all.
 
-Both refusals are **per file, and they outrank findings already in hand**. A page with a broken block at line 3 and an undelimitable tag at line 40 reports `skipped`, not `ok: false, count: 1` — the latter is a verdict about a file that was never read past line 40, and this adapter does not make claims it cannot support. Nothing is lost: the reason names the line to fix first, and the finding is still there on the next run.
+Both refusals are **per file, and they outrank findings already in hand**. A page with a broken block at line 3 and an undelimitable tag at line 40 reports `skipped`, not `ok: false, count: 1` — the latter is a verdict about a file that was never read past line 40, and this adapter does not make claims it cannot support.
+
+**Something is lost by that, and the cost is worth naming (#1195).** The blocks above the refusal point were read completely, and any findings in them are discarded with the rest — so the page above reports nothing about line 3, while the identical page without the trailing tag reports it. Nor is "it is still there on the next run" reliable: for the fragment and the template partial conceded two paragraphs up the refusal is *permanent*, every run refuses, and `rollback_on_fail` is inert on that file for as long as it stays a fragment. The trade is defensible — a partial count published as a count is the misreport this whole file exists to stop — but it is a trade, not a free move, and a reader deciding whether to trust the row is entitled to see the invoice.
+
+Publishing those findings *alongside* the refusal is not the escape it looks like. A `skipped` result omits `ok`, `count` and `errors` by contract (`validators/SCHEMA.md`, "Skipped: the third state"), and every core consumer branches on `skipped` before it reads a verdict key — `_validator_render_row`, `_validator_render_diff`, `_validator_regressed`, `_validator_not_checked`. An `errors` array on a skip would be emitted into a field nothing reads, which makes the claim more false rather than less. The one shape that would carry them is `ok: false` with the unread region as an `adapter` error, and that is not "keeping both": it is this per-file refusal reversed, re-arming `rollback_on_fail` across the whole class of file. That is a behaviour decision to argue on its own terms, not a rider on a sentence of prose.
 
 **Switching it on.** Copy the `html-check` block out of `.supertool.example.json` into your project's `.supertool.json` under `validators`, the same as every other row in the table above. This repo registers it in its own `.supertool.json` too — a validator that ships here and does not run here is a checker nobody is checking, and it shipped that way once already: the adapter landed with no entry in any config, so `validate:` on a page with a stray brace ran only `git-status` and printed `0 with findings`, which is the silence #833 exists to close arriving inside the fix for it.
 
@@ -242,6 +246,14 @@ Two settings in that block are decisions rather than defaults:
 `shellcheck`, `eslint` and `gitleaks` are external binaries most machines do
 not have, which makes the same question three times: what does a validator
 report when its tool is absent?
+
+`tomllint` is the fourth, and it is the one that shows the question is not
+about binaries (#1157). Its "tool" is an import — stdlib `tomllib` on 3.11+,
+the third-party `tomli` below that — and on a 3.10 machine with no `tomli` it
+answered `ok: true, count: 0`: not a parser that failed, a parser that was
+never there, published as a clean parse of a file nothing opened. Whether the
+missing thing is on `PATH` or on `sys.path` changes nothing about what the
+adapter knows, so it gets the same three states and the same escalation.
 
 Reporting `ok` is the defect this repository has filed more than any other, so
 it is `skipped`, with the reason and the install command on the row. That is
@@ -263,10 +275,11 @@ tool that could not run becomes an `adapter` error whose message names the
 variable — so the reader is sent to the CI image rather than to the file. There
 is deliberately **no** value that turns a finding into a skip: that would be a
 mute button, and this repository declines those. `refusal.required()` is the
-one implementation, shared by all three adapters.
+one implementation, shared by every adapter that can find itself with nothing
+to say.
 
 The recommendation is to leave it unset locally and set it in CI for whichever
-of the three that pipeline installs. Setting it for a tool the image does not
+of them that pipeline actually provides. Setting it for a tool the image does not
 install produces a red on every edit, which is the same noise problem from the
 other end.
 

--- a/tests/test_html_check.py
+++ b/tests/test_html_check.py
@@ -517,8 +517,10 @@ def test_one_undelimited_tag_refuses_the_whole_file(tmp_path: Path) -> None:
     never read -- `ok: false, count: 1` says "here is what is wrong with this
     file", and the honest answer is "I could not read this file".
 
-    Nothing is lost by refusing: the reason names the line to fix first, and
-    the finding is still there on the next run. Nothing is claimed either.
+    The line-3 finding IS lost by refusing, and that is the price of the rule
+    rather than a free move (#1195) -- for a file whose refusal is permanent it
+    is lost on every run, not deferred to the next one. Nothing is claimed
+    either, which is what makes the trade the right way round.
     """
     f = tmp_path / "mixed.html"
     f.write_text(

--- a/tests/test_tomllint.py
+++ b/tests/test_tomllint.py
@@ -21,9 +21,10 @@ def _run(file_path: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Graceful degrade when tomllib unavailable (Python < 3.11, no tomli)
-# Covered implicitly — on 3.11+ stdlib is used; on older without tomli, ok=True
-# We test the output contract rather than mocking the import.
+# No TOML parser reachable (Python < 3.11, no tomli) is NOT covered here: it is
+# the third state, and it has its own file. `test_tomllint_no_parser_1157.py`
+# shims the imports so the branch is exercised on every interpreter, rather than
+# being asserted about on the one interpreter that cannot reach it.
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
@@ -34,8 +35,8 @@ def test_valid_toml_simple(tmp_path: Path) -> None:
     f = tmp_path / "good.toml"
     f.write_text('[package]\nname = "myapp"\nversion = "1.0.0"\n')
     out = _run(str(f))
-    # On Python < 3.11 without tomli, ok=True (graceful skip) — still acceptable
-    assert out["ok"] is True or (out["ok"] is True and out["count"] == 0)
+    assert out["ok"] is True
+    assert out["count"] == 0
     assert out["tool"] == "tomllint"
 
 

--- a/tests/test_tomllint_no_parser_1157.py
+++ b/tests/test_tomllint_no_parser_1157.py
@@ -1,0 +1,109 @@
+"""tomllint with no TOML parser reachable must report the third state (#1157).
+
+`ok: true, count: 0` on a machine where neither `tomllib` nor `tomli` can be
+imported is a file that was never opened, published as a pass. SCHEMA.md,
+"Skipped: the third state".
+
+The absence is produced with a shim on `PYTHONPATH` rather than by hunting for a
+3.10 interpreter: `PYTHONPATH` precedes the stdlib in `sys.path`, so a
+`tomllib.py` that raises `ImportError` reproduces exactly the failed import a
+3.10-without-tomli machine hits, on any interpreter and on any platform.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ADAPTER = Path(__file__).parent.parent / "validators" / "tomllint" / "tomllint.py"
+
+
+def _shim(tmp_path: Path) -> str:
+    d = tmp_path / "noparser"
+    d.mkdir(exist_ok=True)
+    for name in ("tomllib", "tomli"):
+        (d / f"{name}.py").write_text(
+            f'raise ImportError("{name} is not available here")\n', encoding="utf-8"
+        )
+    return str(d)
+
+
+def _run(tmp_path: Path, target: Path, **env_extra: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _shim(tmp_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env.pop("SUPERTOOL_REQUIRE_VALIDATORS", None)
+    env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(ADAPTER), str(target)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", env=env,
+    )
+
+
+def _toml(tmp_path: Path) -> Path:
+    f = tmp_path / "sample.toml"
+    f.write_text('[package]\nname = "x"\n', encoding="utf-8")
+    return f
+
+
+def test_no_parser_emits_json_at_all(tmp_path: Path) -> None:
+    """The adapter answers on stdout. The 3.11+ stdlib import was unguarded, so
+    a `tomllib` that fails to import crashed it before any `emit` -- no JSON,
+    exit 1, and nothing for the core to read but its own synthesised verdict."""
+    r = _run(tmp_path, _toml(tmp_path))
+    assert r.returncode == 0, r.stderr
+    assert json.loads(r.stdout)
+
+
+def test_no_parser_is_skipped_not_ok(tmp_path: Path) -> None:
+    out = json.loads(_run(tmp_path, _toml(tmp_path)).stdout)
+    assert "skipped" in out
+    assert "ok" not in out
+    assert "count" not in out
+    assert "errors" not in out
+    assert out["tool"] == "tomllint"
+    assert out["duration_ms"] >= 0
+
+
+def test_no_parser_reason_names_the_missing_parser(tmp_path: Path) -> None:
+    reason = json.loads(_run(tmp_path, _toml(tmp_path)).stdout)["skipped"]
+    assert "tomli" in reason
+    assert "pip install tomli" in reason
+    assert "NOT checked" in reason
+
+
+def test_no_parser_is_loud_when_required(tmp_path: Path) -> None:
+    """$SUPERTOOL_REQUIRE_VALIDATORS turns the quiet local skip into a red."""
+    out = json.loads(_run(tmp_path, _toml(tmp_path),
+                          SUPERTOOL_REQUIRE_VALIDATORS="tomllint").stdout)
+    assert "skipped" not in out
+    assert out["ok"] is False
+    assert out["count"] == 1
+    assert out["errors"][0]["code"] == "adapter"
+    assert "SUPERTOOL_REQUIRE_VALIDATORS" in out["errors"][0]["msg"]
+    assert "NOT checked" in out["errors"][0]["msg"]
+
+
+def test_parser_skip_precedes_the_missing_file_check(tmp_path: Path) -> None:
+    """No parser is the reason the caller can act on, and it is the true one:
+    without a parser the adapter would not have read the file either way."""
+    out = json.loads(_run(tmp_path, tmp_path / "gone.toml").stdout)
+    assert "skipped" in out
+
+
+def test_parser_present_still_reports_a_verdict(tmp_path: Path) -> None:
+    """The skip arm must not swallow the normal path. Same file, no shim."""
+    if sys.version_info < (3, 11):
+        import importlib.util
+        if importlib.util.find_spec("tomli") is None:
+            pytest.skip("no TOML parser on this interpreter")
+    f = _toml(tmp_path)
+    r = subprocess.run([sys.executable, str(ADAPTER), str(f)],
+                       capture_output=True, text=True, encoding="utf-8",
+                       errors="replace")
+    out = json.loads(r.stdout)
+    assert out["ok"] is True
+    assert out["count"] == 0

--- a/validators/html-check/html-check.py
+++ b/validators/html-check/html-check.py
@@ -391,9 +391,15 @@ def main() -> None:
     except UndelimitedTag as exc:
         # The whole file, not just this tag. A verdict naming one finding
         # would be a claim about a file that was not read past line
-        # `exc.line`, and `ok`/`count` are exactly that claim. Nothing is
-        # lost by declining: the reason names the line to fix first, and
-        # anything else wrong with the file is still there on the next run.
+        # `exc.line`, and `ok`/`count` are exactly that claim.
+        #
+        # This does discard findings from the blocks above `exc.line`, which
+        # were read completely (#1195). That is the price of the per-file
+        # rule and not a free move -- see docs/validators.md, which now says
+        # so instead of claiming nothing is lost. Publishing them next to the
+        # refusal is not available: SCHEMA.md omits `errors` from a skip and
+        # every core consumer branches on `skipped` first, so they would go
+        # into a field nothing reads.
         emit(skipped("html-check", file,
                      f"the <script> start tag at line {exc.line} is never closed "
                      f"({exc.cause}), so where it ends cannot be told -- "

--- a/validators/tomllint/tomllint.py
+++ b/validators/tomllint/tomllint.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
 """tomllint validator adapter — TOML syntax check via stdlib tomllib (3.11+) or tomli.
 
-Stdlib only on Python 3.11+. Falls back to tomli third-party package. Graceful skip
-if neither is available. Reference implementation per validators/SCHEMA.md.
+Stdlib only on Python 3.11+. Falls back to the third-party `tomli` package.
+
+**Neither reachable reports the third state — `skipped` with the reason — and
+never `ok`** (#1157; validators/SCHEMA.md, "Skipped: the third state"). This
+adapter predates that section and used to emit `ok: true, count: 0`, which is a
+file nothing parsed published as a file that parsed clean. Where that quiet is
+not acceptable — CI, where "no parser" means the gate is not running — name
+this validator in `$SUPERTOOL_REQUIRE_VALIDATORS` and the same absence becomes
+a loud `adapter` error instead. See `refusal.required`.
+
 Usage:  tomllint.py <file>
 """
 
@@ -15,42 +23,65 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
+from refusal import required, required_but_absent, skipped
+
+TOOL = "tomllint"
+
+NO_PARSER = ("no TOML parser available — `tomllib` needs Python 3.11+ and "
+             "`tomli` is not installed (`pip install tomli`), so this file "
+             "was NOT checked")
 
 
 def emit(d: dict) -> None:
     print(json.dumps(d))
 
 
+def _adapter_error(file: str, msg: str, dur_ms: int) -> None:
+    """No verdict was obtained, and the process is at fault rather than the file."""
+    emit({"tool": TOOL, "file": file, "ok": False, "count": 1,
+          "errors": [{"line": None, "col": None, "severity": "error",
+                      "code": "adapter", "msg": msg}],
+          "duration_ms": dur_ms})
+
+
+def resolve_parser():
+    """The TOML parser module, or None when neither candidate can be imported.
+
+    Both imports are guarded, including the stdlib one. `sys.version_info >=
+    (3, 11)` answers "does this Python ship tomllib", which is not the question
+    the next line depends on — whether `import tomllib` succeeds. A shadowing
+    module on `PYTHONPATH`, a partial install or a stripped stdlib all make the
+    two disagree, and the unguarded form turned that into a traceback with no
+    JSON on stdout at all: an adapter that exits non-zero having said nothing,
+    where the contract is to always answer.
+    """
+    try:
+        import tomllib
+        return tomllib
+    except ImportError:
+        pass
+    try:
+        import tomli
+        return tomli
+    except ImportError:
+        return None
+
+
 def main() -> None:
     if len(sys.argv) < 2 or not sys.argv[1]:
-        emit({"tool": "tomllint", "file": "", "ok": False, "count": 1,
-              "errors": [{"line": None, "col": None, "severity": "error",
-                          "code": "adapter", "msg": "no file arg"}],
-              "duration_ms": 0})
+        _adapter_error("", "no file arg", 0)
         return
 
     file = sys.argv[1]
     start = time.time()
 
-    # Resolve TOML parser: stdlib tomllib (3.11+) or third-party tomli
-    tomllib = None
-    if sys.version_info >= (3, 11):
-        import tomllib as _tomllib
-        tomllib = _tomllib
-    else:
-        try:
-            import tomli as _tomli
-            tomllib = _tomli
-        except ImportError:
-            pass
-
+    tomllib = resolve_parser()
     if tomllib is None:
-        print(
-            "tomllint: tomllib not available (Python < 3.11 and tomli not installed), skipping",
-            file=sys.stderr,
-        )
-        emit({"tool": "tomllint", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        dur = int((time.time() - start) * 1000)
+        if required(TOOL):
+            _adapter_error(file, required_but_absent(TOOL, NO_PARSER), dur)
+        else:
+            emit(skipped(TOOL, file, NO_PARSER, dur))
         return
 
     try:
@@ -76,10 +107,7 @@ def main() -> None:
               "duration_ms": int((time.time() - start) * 1000)})
         return
     except FileNotFoundError:
-        emit({"tool": "tomllint", "file": file, "ok": False, "count": 1,
-              "errors": [{"line": None, "col": None, "severity": "error",
-                          "code": "adapter", "msg": "file not found"}],
-              "duration_ms": int((time.time() - start) * 1000)})
+        _adapter_error(file, "file not found", int((time.time() - start) * 1000))
         return
 
     emit({"tool": "tomllint", "file": file, "ok": True, "count": 0,


### PR DESCRIPTION
Closes #1157
Closes #1195

## tomllint declined instead of reporting clean (#1157)

`validators/tomllint/tomllint.py` emitted `ok: true, count: 0` when no TOML parser was importable — a tool that never ran, reporting clean. That is the exact defect `validators/SCHEMA.md` §"Skipped: the third state" exists to prevent, in an adapter that predates the section. It now emits `skipped` with the reason, or escalates to an adapter error under `SUPERTOOL_REQUIRE_VALIDATORS`, copying `shellcheck.py`'s post-contract shape verbatim rather than inventing a fifth convention.

**A second defect on the same lines**, found while fixing the first: the parser resolution gated on `sys.version_info >= (3, 11)`, which answers "does this Python ship `tomllib`" and not "does `import tomllib` succeed". A shadowed or partial `tomllib` took a traceback out of the adapter with no JSON at all — worse than the reported bug. Both imports are now guarded and the version check is gone.

## html-check stopped claiming nothing is lost (#1195)

`docs/validators.md` kept the sentence "Nothing is lost: the reason names the line to fix first, and the finding is still there on the next run", two paragraphs after conceding that a fragment or template partial legitimately stops inside a block. For those files there is no line to fix, the refusal is permanent, and every finding in every *closed* block above the unclosed one is permanently suppressed. The prose now states what is actually lost.

**The issue's preferred fix — emit the already-extracted findings alongside the refusal — was measured and does not exist as described.** As literally written it writes findings into a field nothing reads: `_validator_render_row`, `_validator_render_diff`, `_validator_regressed`, `_validator_not_checked` and `_validator_baseline` all branch on `"skipped" in result` and return before touching a verdict key, and `SCHEMA.md:37` mandates omitting `errors` on a skip. That would make the claim *more* false. The only shape that carries them is `ok:false` plus an adapter-coded error for the unread region — which is #1185's per-file refusal reversed, re-arming `rollback_on_fail` across every fragment and template partial. A behaviour reversal of a deliberate, documented, tested decision is not a rider on a `priority-low` prose issue. Both findings are written into the docs so the next reader does not re-derive them.

## Scope note

`CHANGELOG.md:88` carries the released v0.31.0 wording of the retracted claim. Left alone deliberately — `docs/contributing.md:196` forbids editing `CHANGELOG.md` in a PR, and it is a record of what shipped.

## Verification

TDD, red first: 5 failing tests in `tests/test_tomllint_no_parser_1157.py` against master's behaviour, with `tomllib`/`tomli` shimmed to `ImportError` reproducing the bare traceback. Green after: 15 passed on the adapter's own suite, 46 across html-check and tomllint, and 1054 passed / 8 skipped on a `resolve or validator or refusal or skipped` selection covering the only downstream consumer (`presets/git/resolve.py`).

Reviewed by an independent Sonnet agent against the committed diff, briefed read-only and blind to the author's reasoning. It found the same retracted sentence in a test docstring one file outside the sweep — fixed in `b1c5e0b`. Three further findings were argued down with evidence rather than complied with.

Windows and the 3.9/3.10 legs are unverified locally; CI is the authority.
