### PR TITLE
read's git marker is position-dependent, and a glob-magic filename borrows its sibling's status

### DIFF
--- a/_supertool.py
+++ b/_supertool.py
@@ -4136,9 +4136,16 @@ def _path_meta_suffix(path: str, sample: bytes = b"") -> str:
             # same file — #1186. The cwd itself stays, because it is what keeps
             # this route and `_path_meta_repo_root` talking about the same
             # repository when a path crosses a repo boundary.
+            #
+            # `--literal-pathspecs` because a filename is not a pattern: a clean
+            # `t[a].txt` globbed onto its modified sibling `ta.txt` and reported
+            # that file's ` m` as its own. The bulk arm looks the name up in a
+            # dict, so it was already literal — this is the same two-answers
+            # divergence, in the direction that invents a marker rather than
+            # losing one.
             r = subprocess.run(
-                ["git", "status", "--porcelain", "--ignored=matching", "--",
-                 os.path.basename(absolute)],
+                ["git", "--literal-pathspecs", "status", "--porcelain",
+                 "--ignored=matching", "--", os.path.basename(absolute)],
                 capture_output=True, text=True, timeout=2,
                 cwd=os.path.dirname(absolute) or ".", encoding="utf-8", errors="replace",
             )

--- a/_supertool.py
+++ b/_supertool.py
@@ -4137,15 +4137,18 @@ def _path_meta_suffix(path: str, sample: bytes = b"") -> str:
             # this route and `_path_meta_repo_root` talking about the same
             # repository when a path crosses a repo boundary.
             #
-            # `--literal-pathspecs` because a filename is not a pattern: a clean
+            # `:(literal)` because a filename is not a pattern: a clean
             # `t[a].txt` globbed onto its modified sibling `ta.txt` and reported
             # that file's ` m` as its own. The bulk arm looks the name up in a
             # dict, so it was already literal — this is the same two-answers
             # divergence, in the direction that invents a marker rather than
-            # losing one.
+            # losing one. The magic prefix and not the `--literal-pathspecs`
+            # flag: that one has to precede the subcommand, and the shims the
+            # decline tests install match on `$1` being `status` (#705). A flag
+            # that silently un-shims a fixture is a test that stops testing.
             r = subprocess.run(
-                ["git", "--literal-pathspecs", "status", "--porcelain",
-                 "--ignored=matching", "--", os.path.basename(absolute)],
+                ["git", "status", "--porcelain", "--ignored=matching", "--",
+                 ":(literal)" + os.path.basename(absolute)],
                 capture_output=True, text=True, timeout=2,
                 cwd=os.path.dirname(absolute) or ".", encoding="utf-8", errors="replace",
             )

--- a/_supertool.py
+++ b/_supertool.py
@@ -4127,10 +4127,20 @@ def _path_meta_suffix(path: str, sample: bytes = b"") -> str:
 
     if code is None:
         try:
+            # The pathspec is the bare filename, not `path`: this runs with a
+            # cwd of the file's own directory, so a path written relative with a
+            # directory component in it (`sub/s.txt`, the form the CLI hands
+            # over) was resolved a second time against that directory. git
+            # warned on stderr, exited 0 with empty stdout, and the marker
+            # silently vanished while the bulk arm answered correctly for the
+            # same file — #1186. The cwd itself stays, because it is what keeps
+            # this route and `_path_meta_repo_root` talking about the same
+            # repository when a path crosses a repo boundary.
             r = subprocess.run(
-                ["git", "status", "--porcelain", "--ignored=matching", "--", path],
+                ["git", "status", "--porcelain", "--ignored=matching", "--",
+                 os.path.basename(absolute)],
                 capture_output=True, text=True, timeout=2,
-                cwd=os.path.dirname(os.path.abspath(path)) or ".", encoding="utf-8", errors="replace",
+                cwd=os.path.dirname(absolute) or ".", encoding="utf-8", errors="replace",
             )
             if r.returncode == 0:
                 code = r.stdout[:2]

--- a/changelog.d/1186.fixed.md
+++ b/changelog.d/1186.fixed.md
@@ -9,4 +9,12 @@
   pathspec is the bare filename now. The cwd is unchanged — it is what keeps
   this route and the repo-root walk answering about the same repository when a
   path crosses a repo boundary — and the parity test that missed this passed
-  only absolute paths and top-level filenames, both of which resolve fine.
+  only absolute paths and top-level filenames, neither of which is resolved
+  twice.
+- `read`: the same per-path query passed that filename as a git *pathspec*,
+  and a pathspec globs. A clean `t[a].txt` matched its modified sibling
+  `ta.txt` and printed that file's ` m` as its own. The repo-wide arm looks the
+  name up in a dict and was already literal, so this was the same
+  two-answers-for-one-file divergence — in the direction that invents a marker
+  rather than losing one, which is the worse one: the answer describes a
+  file nobody asked about. The query runs under `--literal-pathspecs` now.

--- a/changelog.d/1186.fixed.md
+++ b/changelog.d/1186.fixed.md
@@ -17,4 +17,4 @@
   name up in a dict and was already literal, so this was the same
   two-answers-for-one-file divergence — in the direction that invents a marker
   rather than losing one, which is the worse one: the answer describes a
-  file nobody asked about. The query runs under `--literal-pathspecs` now.
+  file nobody asked about. The pathspec carries `:(literal)` now.

--- a/changelog.d/1186.fixed.md
+++ b/changelog.d/1186.fixed.md
@@ -1,0 +1,12 @@
+- `read` (and every meta line carrying the working-tree marker): the per-path
+  `git status` ran with a cwd of the file's own directory while passing the path
+  **as written**, so a relative path with a directory component in it — the form
+  the CLI actually hands over — resolved a second time against that directory.
+  git warned on stderr, exited 0 with empty stdout, and no ` m`/` ?`/` !` marker
+  printed. The repo-wide arm added in 0.31.0 was correct, so the same file in
+  the same second got two different answers depending on where it sat in the
+  batch: first path in a call, no marker; anywhere after it, the right one. The
+  pathspec is the bare filename now. The cwd is unchanged — it is what keeps
+  this route and the repo-root walk answering about the same repository when a
+  path crosses a repo boundary — and the parity test that missed this passed
+  only absolute paths and top-level filenames, both of which resolve fine.

--- a/tests/test_path_meta_bulk_1126.py
+++ b/tests/test_path_meta_bulk_1126.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import pytest
 import supertool
+from _symlink import require_symlink
 
 
 def _init_repo(root: Path) -> None:
@@ -36,11 +37,19 @@ def _init_repo(root: Path) -> None:
     (root / ".gitignore").write_bytes(b"ignored.txt\n")
     for name in ("clean.txt", "dirty.txt", "also_clean.txt", "third.txt"):
         (root / name).write_bytes(b"orig\n")
+    # A subdirectory, so a path can be written with a directory component in it
+    # the way the CLI hands one over (#1186).
+    (root / "sub").mkdir()
+    for name in ("clean.txt", "dirty.txt"):
+        (root / "sub" / name).write_bytes(b"orig\n")
     run("add", "-A")
     run("commit", "-qm", "seed")
     (root / "dirty.txt").write_bytes(b"changed\n")
     (root / "untracked.txt").write_bytes(b"new\n")
     (root / "ignored.txt").write_bytes(b"hush\n")
+    (root / "sub" / "dirty.txt").write_bytes(b"changed\n")
+    (root / "sub" / "untracked.txt").write_bytes(b"new\n")
+    (root / "sub" / "ignored.txt").write_bytes(b"hush\n")
 
 
 def _reset_bulk() -> None:
@@ -121,6 +130,76 @@ def test_coalesced_markers_match_the_per_path_answer(repo: Path) -> None:
     assert " !" in per_path["ignored.txt"]
     assert " m" not in per_path["clean.txt"]
     assert " ?" not in per_path["clean.txt"]
+
+
+# The form the CLI actually hands the op: relative, with a directory component.
+_SUB_PATHS = ("sub/clean.txt", "sub/dirty.txt", "sub/untracked.txt",
+              "sub/ignored.txt")
+
+
+def test_a_relative_path_with_a_directory_answers_like_an_absolute_one(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1186 - the parity test above passes absolute paths and top-level names,
+    and both of those resolve fine. The per-path query runs with
+    cwd=dirname(abspath(path)) while passing the path *as written*, so
+    `sub/s.txt` resolved a second time against `<repo>/sub`: git warned on
+    stderr, exited 0 with empty stdout, and the marker silently vanished. The
+    bulk arm keys off `relpath(absolute, root)` and was always right, so the
+    same file got two different answers depending on its position in a batch."""
+    monkeypatch.chdir(repo)
+
+    for name in _SUB_PATHS:
+        _reset_bulk()                              # force the single-path route
+        relative = supertool._path_meta_suffix(name, b"x\n")
+        _reset_bulk()
+        absolute = supertool._path_meta_suffix(str(repo / name), b"x\n")
+        assert relative == absolute, (
+            f"{name}: written relative -> {relative!r}, written absolute -> "
+            f"{absolute!r}; the pathspec is being resolved against the wrong "
+            f"directory"
+        )
+
+    per_path = {}
+    for name in _SUB_PATHS:
+        _reset_bulk()
+        per_path[name] = supertool._path_meta_suffix(name, b"x\n")
+
+    _reset_bulk()
+    coalesced = {n: supertool._path_meta_suffix(n, b"x\n") for n in _SUB_PATHS}
+
+    assert coalesced == per_path
+    # and the answers are the real ones, not uniformly empty
+    assert " m" in per_path["sub/dirty.txt"]
+    assert " ?" in per_path["sub/untracked.txt"]
+    assert " !" in per_path["sub/ignored.txt"]
+    assert " m" not in per_path["sub/clean.txt"]
+    assert " ?" not in per_path["sub/clean.txt"]
+
+
+def test_a_relative_symlink_is_still_answered_about_its_own_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cwd the per-path query runs in is load-bearing, not incidental: it is
+    what keeps this route and the bulk route talking about the same repository
+    when a link points across a repo boundary (`_path_meta_repo_root`'s
+    docstring). A symlink skips the bulk arm entirely, so this pins the per-path
+    arm's repo choice for the relative-with-a-directory form too."""
+    require_symlink()
+    here, elsewhere = tmp_path / "here", tmp_path / "elsewhere"
+    here.mkdir()
+    elsewhere.mkdir()
+    _init_repo(here)
+    _init_repo(elsewhere)
+    _reset_bulk()
+    monkeypatch.chdir(here)
+
+    link = here / "sub" / "points_away.txt"
+    link.symlink_to(elsewhere / "clean.txt")
+
+    assert " ?" in supertool._path_meta_suffix(
+        os.path.join("sub", "points_away.txt"), b"x\n"
+    ), "an untracked link is untracked in the repo it sits in, not its target's"
 
 
 def test_a_single_path_costs_exactly_one_spawn(

--- a/tests/test_path_meta_bulk_1126.py
+++ b/tests/test_path_meta_bulk_1126.py
@@ -177,6 +177,44 @@ def test_a_relative_path_with_a_directory_answers_like_an_absolute_one(
     assert " ?" not in per_path["sub/clean.txt"]
 
 
+def test_a_filename_that_looks_like_a_glob_is_not_matched_against_a_sibling(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1186, second arm. The per-path route hands a filename to git as a
+    *pathspec*, and a pathspec globs: a clean `t[a].txt` matched its modified
+    sibling `ta.txt` and reported the sibling's ` m` as its own. The bulk arm
+    looks the name up in a dict, which is literal, so the two routes disagreed
+    again — this time by inventing a marker rather than by losing one, which is
+    the worse direction: the answer names a file that is not the one asked
+    about. `[`/`]` and not `*`/`?` in the fixture because Windows will not let a
+    filename contain those, and a test that cannot run on one platform proves
+    nothing there."""
+    monkeypatch.chdir(repo)
+    (repo / "sub" / "ta.txt").write_bytes(b"orig\n")
+    (repo / "sub" / "t[a].txt").write_bytes(b"orig\n")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True,
+                   capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "glob fixture"],
+                   check=True, capture_output=True)
+    (repo / "sub" / "ta.txt").write_bytes(b"changed\n")
+
+    literal = os.path.join("sub", "t[a].txt")
+    _reset_bulk()
+    alone = supertool._path_meta_suffix(literal, b"x\n")
+    _reset_bulk()
+    for name in _SUB_PATHS[:2]:
+        supertool._path_meta_suffix(name, b"x\n")   # build the snapshot
+    with_snapshot = supertool._path_meta_suffix(literal, b"x\n")
+
+    assert " m" not in alone, (
+        "t[a].txt is committed and unmodified; the ' m' belongs to ta.txt"
+    )
+    assert alone == with_snapshot
+    # the fixture is doing what it claims - the sibling really is modified
+    assert " m" in supertool._path_meta_suffix(os.path.join("sub", "ta.txt"),
+                                               b"x\n")
+
+
 def test_a_relative_symlink_is_still_answered_about_its_own_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #1186

## The filed defect

`read`'s git marker was position-dependent: the same file, in the same second, got two different answers depending on where it sat in a batch.

The per-path arm runs `git status --porcelain -- <path>` with `cwd` set to the file's own directory, while passing the path **as written**. A relative path with a directory component was therefore resolved twice — `sub/` plus `sub/s.txt`. git warns on stderr, exits 0 with empty stdout, and no marker printed. The bulk arm added by #1126 is correct, so the first path in a batch primed via the broken route and every later path was served correctly from the snapshot.

The pathspec is now `os.path.basename(absolute)`. The `cwd` override is deliberately unchanged — per `_path_meta_repo_root`'s docstring it is what keeps this route and the bulk route answering about the same repository when paths cross a repo boundary, and that property now has a test of its own for this input form.

## A second defect on the same line, bundled deliberately

A filename is not a pattern. A clean file named `t[a].txt` globbed onto its modified sibling `ta.txt` and printed that sibling's ` m`. Same line, same class, same user-visible symptom the issue was filed for — one file, two answers — differing only in direction: this one *invents* a marker naming a file nobody asked about, which is the worse direction. Fixed with a `:(literal)` pathspec magic prefix.

`--literal-pathspecs` was rejected: the flag must precede the subcommand, and `test_status_swallowed_705.py:76` shims git on `$1 = status`. The flag moved `status` to `$2`, real git ran, and two decline tests went red. `:(literal)` has the same effect and preserves the argv shape.

## Tests

The parity test that should have caught this already existed — `test_coalesced_markers_match_the_per_path_answer` — and passed **absolute** paths and top-level filenames, neither of which is resolved twice. Extended to the relative-with-directory form the op actually receives, plus a relative symlink into another repo (pinning the cwd property) and a glob-magic filename against a modified sibling.

The glob test uses `[` / `]` rather than `*` / `?` — Windows forbids the latter in filenames, and a test that cannot run on a platform proves nothing there.

## Verification

TDD, red first, against unmodified production code:

```
AssertionError: sub/dirty.txt: written relative -> '', written absolute -> ' m';
the pathspec is being resolved against the wrong directory
```

and for the sibling defect:

```
AssertionError: t[a].txt is committed and unmodified; the ' m' belongs to ta.txt
```

Full suite green: **9407 passed, 78 skipped in 191s**. It earned the four minutes — the first mechanism tried passed every targeted file and reddened two tests in `test_status_swallowed_705.py` that no targeted run would have reached.

Reviewed by an independent Sonnet agent against the committed diff, read-only and blind to the author's reasoning. It reproduced the glob-magic defect live before it was accepted, corrected a factually wrong sentence in the changelog fragment, and verified the new tests pin the fix by reverting the production line in a scratch copy and watching both fail.

Windows unverified locally; CI is the authority.
