### PR TITLE
An unreadable pid file is not an empty slot, and a FORWARDING verdict is not the writer's word for it

### DIFF
--- a/changelog.d/1192.security.md
+++ b/changelog.d/1192.security.md
@@ -1,0 +1,24 @@
+- `watch`: `channel:health` could not tell the process holding the socket from
+  the process that wrote the health file, so the whole `FORWARDING` verdict was
+  forgeable by any same-uid process — not only the pid line the report already
+  marked `self-reported`. It now asks the kernel who holds the socket
+  (`SO_PEERCRED` on Linux, `LOCAL_PEERPID` on macOS) and compares that against
+  the pid the health file names, in three states: they agree and the report says
+  the holder was verified; they disagree, which is a new `channel: CONTRADICTED`
+  verdict with its own exit code; or peer credentials are unavailable on this
+  platform, which is named on the report rather than folded into either.
+- `watch`: `CONTRADICTED` is exit code 4, deliberately not 3. `CANNOT DETERMINE`
+  means nothing was established, and a live impersonation is the opposite of
+  that — putting a finding in the no-findings bucket is the defect this op was
+  written to remove.
+- `watch`: not `LOCAL_PEERCRED` on macOS, which the issue named. That option
+  returns a `struct xucred` carrying a uid and no pid, and a uid check answers
+  nothing here — the threat is a same-uid process, which passes it trivially.
+  `LOCAL_PEERPID` is the option that yields the pid, and the pid is the only
+  field that can disagree with the health file. FreeBSD has the first and not
+  the second, so it is reported as unable rather than partially able.
+- `watch`: the check narrows the hole and does not close it, and the disclosure
+  in `docs/presets/watch.md` stays. A same-uid process that binds the socket
+  *and* writes the health file is its own peer, so the two agree. What is caught
+  is the mismatch — a forged or stale health file beside a legitimate consumer —
+  which previously drew no objection at all.

--- a/changelog.d/1200.security.md
+++ b/changelog.d/1200.security.md
@@ -1,0 +1,29 @@
+- `watch`: `transport.read_pid` returned `0` both for "there is no pid file"
+  and for "the pid file could not be read", the fifth call site of the pair
+  fixed at `channel.read_health` (#1184/#1187), `channel.stranded_watchers`
+  (#1191) and `transport.read_state` (#1197). `0` is not neutral there — it is
+  the sentinel meaning *the slot is free* — so a symlink at the predictable
+  `/tmp` name made `claim_pidfile` unlink a live poller's claim and start a
+  second poller on the same filter, which is the duplicate-watcher flood that
+  hid a real `pipeline_failed` for 23 minutes on 2026-08-01. The guarded
+  `read_pid_checked` now answers in three states: a PID, `0` for `ENOENT`, and
+  `None` with a reason when the read itself failed. `claim_pidfile` returns
+  `CLAIM_UNKNOWN` on that third state rather than claiming the slot,
+  `release_pidfile` declines to unlink what it could not verify it owns, and
+  `reap_dead` records no death from a file that names no process. A pid file
+  whose *content* is not a PID stays reclaimable on purpose: it can be
+  attributed to no process, and a slot nobody can claim leaves a population
+  unwatched, which renders exactly like one with nothing to report.
+- `watch`: `transport.list_active_pids` unlinked the pid file on any failed
+  read, so an unreadable one destroyed another process's claim unrecoverably
+  — the sixth call site, and the one whose failure path deletes. It now prunes
+  only a file whose content names no process and leaves an unreadable one
+  alone. Its row is omitted rather than published with a PID read out of
+  somebody else's file; the slot still reaches the board, because
+  `list_watchers` widens the scan and a real poller behind a tampered pid file
+  shows up as an `orphan` row.
+- `watch`: three surfaces stopped reporting an unread pid file as an absent
+  one. `watcher_pids` carries a `tracked_refusal` beside `tracked: 0`,
+  `unwatch` prints what it would not follow instead of "No active watcher",
+  and the `gl-mrs` feed diagnostics line prints the refusal instead of
+  "none recorded".

--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -1196,15 +1196,27 @@ ack to read, at either end. So the answer has three states:
 | `NOT DELIVERING` | 1 | A definite negative. No socket, or a socket that refuses: every event a poller emits right now is lost at the source. The report also names each watcher whose own `last_emit` already found nobody home, with the timestamp of that emit — and, on its own line, each state file it could not read |
 | `FORWARDING` | 0 | A consumer is bound and its published counters are fresh: N lines read, N forwarded, N dropped, last forwarded at T |
 | `CANNOT DETERMINE` | 3 | Bound, but publishing no counters, or counters written by a pid that is gone, or counters that stopped refreshing, or counters with no readable `forwarded` number, or a health file that is a symlink and was not followed. This is the state the old tooling reported as green |
+| `CONTRADICTED` | 4 | The process holding the socket is not the one the health file names ([#1192](https://github.com/Digital-Process-Tools/claude-supertool/issues/1192)). A finding, not a degraded read — a forged file, or a stale one left beside a legitimate consumer |
 
-**The pid in a `FORWARDING` report is self-reported, and the report says so.**
-Pids are reusable, and nothing outside the consumer can prove the process named
-in the health file is the one holding the socket — a crashed consumer whose pid
-was handed to a stranger looks identical from here. The liveness probe is
-therefore only ever an *objection*: a pid that no longer exists means the writer
-of those counters is gone, while a pid that does exist establishes nothing. What
-carries the positive verdict is the freshness of the stamp, because a file
-rewritten four seconds ago was written by something running four seconds ago.
+**`CONTRADICTED` is a fourth code and not a flavour of 3**, because "I could
+not tell" and "I can tell, and it is wrong" call for different actions. Folding
+an impersonation into the no-findings bucket is the defect this op exists to
+remove, rebuilt on its own headline.
+
+**The pid in a `FORWARDING` report is compared against the socket's peer, and
+the report says which of the three answers it got.**
+Pids are reusable, and the health file names its own writer — a crashed consumer
+whose pid was handed to a stranger looks identical from the file alone. So the
+kernel is asked who holds the socket (`SO_PEERCRED` on Linux, `LOCAL_PEERPID` on
+macOS), and the report distinguishes *verified* (holder and health file agree),
+*contradicted* (they do not) and *not checked* (no peer credentials on this
+platform — Windows, and FreeBSD, whose `LOCAL_PEERCRED` carries a uid and no
+pid). Not a uid check: the threat is a same-uid process, which passes one
+trivially. The liveness probe stays only an *objection*: a pid that no longer
+exists means the writer of those counters is gone, while a pid that does exist
+establishes nothing. What carries the positive verdict is the freshness of the
+stamp, because a file rewritten four seconds ago was written by something
+running four seconds ago.
 
 **A counter that is absent or not a number renders as `?`, never as `0`.** `0
 forwarded` is a real reading — a quiet morning — and printing it for a file the
@@ -1309,14 +1321,21 @@ the tool you reach for when the fleet looks down. Both arms catch `ValueError`,
 the base rather than the two leaves on purpose: a decode failure nobody has
 thought of yet must also decline.
 
-**What is still forgeable, and is disclosed rather than fixed.** Nothing checks
-the credentials of the process actually holding the socket, so a same-uid
-process can bind it, publish a health file naming its own live pid with a fresh
-stamp, and obtain a `FORWARDING` verdict. The report attributes the pid
-(`self-reported`) and states in its own text that nothing here proves the named
-process is the one holding the socket, which is why this is a documented
-ceiling rather than a defect — but the ceiling is the *whole* verdict, not only
-the pid line.
+**What is still forgeable, and is disclosed rather than fixed.** A same-uid
+process can bind the socket, publish a health file naming its own live pid with
+a fresh stamp, and obtain a `FORWARDING` verdict. [#1192](https://github.com/Digital-Process-Tools/claude-supertool/issues/1192)
+narrowed this and deliberately did not close it: the peer check compares the
+socket-holder against the health file, and an attacker holding both *is* its own
+peer, so the two agree. What the check catches is the **mismatch** — a forged or
+stale health file sitting beside a legitimate consumer — which previously drew
+no objection at all, and now reads `CONTRADICTED` rather than `FORWARDING`.
+
+The ceiling is therefore the *whole* verdict and not only the pid line, which is
+the correction #1192 made to the audit that closed #1187: `self-reported` was
+read as covering the pid, and the forgeable thing was the verdict. On a platform
+with no peer credentials nothing narrowed at all, and the report says so on its
+own line rather than leaving a reader to infer which of the two it is looking
+at.
 
 ## Event payload (locked contract)
 

--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -1235,10 +1235,10 @@ costume of a measurement, which is the defect this op exists to remove rather
 than relocate.
 
 **Branch on the report's first line, not on the exit code.** The distinct codes
-0/1/3 survive only when `presets/watch/channel.py` is run directly; the
+0/1/3/4 survive only when `presets/watch/channel.py` is run directly; the
 supertool wrapper collapses every non-zero to 1. The first line is
-`channel: FORWARDING` / `NOT DELIVERING` / `CANNOT DETERMINE` and is what the
-tests key on.
+`channel: FORWARDING` / `NOT DELIVERING` / `CANNOT DETERMINE` / `CONTRADICTED`
+and is what the tests key on.
 
 **Why the heartbeat exists.** An idle consumer and a wedged one publish the same
 numbers — the counters only distinguish them if the *stamp* moves. `channel.ts`

--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -1470,11 +1470,15 @@ It is never silent, and never rendered like a clean start. Exit status stays `0`
 
 There is a third outcome ([#693](https://github.com/Digital-Process-Tools/claude-supertool/issues/693)). If the pid file cannot be created at all — an unwritable or absent `SUPERTOOL_WATCH_STATE_DIR`, a path that is a directory — the slot was neither taken nor identified, and `claim_pidfile` used to answer `0` for that, which is the value meaning *you own it, go spawn*. It now answers `CLAIM_UNKNOWN`, `watch` prints `ERROR: could not claim the slot for …`, names the pid path and the env var, and exits `1` having started nothing. Radar's MR tier counts such a slot as still uncovered rather than losing it between "healed" and "failed".
 
+There is a fourth ([#1200](https://github.com/Digital-Process-Tools/claude-supertool/issues/1200)), and it is about *reading* the pid file rather than creating it. `read_pid` answered `0` both when there was no file and when the file could not be read, and `0` is the value meaning *the slot is free*. `/tmp` is world-writable and the name is fully predictable from the board, so a symlink planted at it made `claim_pidfile` delete a live poller's claim and start a second poller on the same filter — the duplicate flood that hid a real `pipeline_failed` for 23 minutes on 2026-08-01. The read is now `O_RDONLY|O_NOFOLLOW` with three answers: a PID, `0` for `ENOENT` alone, and a refusal carrying its reason. A claim on the refusal is `CLAIM_UNKNOWN`, not ownership.
+
+A pid file whose **content** is not a PID is deliberately *not* a refusal: it can be attributed to no process, so it stays reclaimable and prunable. That is the same trade as the first rule below — a file nobody can parse must not wedge a slot shut, because an unwatched population renders exactly like a quiet one.
+
 Three rules follow from "a missing watcher is worse than a duplicate one":
 
 - **A slot whose owner is dead is reclaimed**, after one retry. A crashed poller must not wedge its id shut forever; an unwatched population renders exactly like a quiet one.
 - **A failed spawn releases the slot.** A claim left by a poller that never started would refuse every future start for that id.
-- **A poller releases its PID file only if it still owns it.** One shutting down slowly, whose slot was meanwhile reclaimed, must not unlink its successor's claim on the way out.
+- **A poller releases its PID file only if it still owns it.** One shutting down slowly, whose slot was meanwhile reclaimed, must not unlink its successor's claim on the way out. A read that *failed* is not ownership either, so it takes the same arm (#1200): every unlink here is gated on a positive identification.
 
 For the feed tier the id is a *filter string*, so it is canonicalised (sorted keys, sorted deduped values) before it becomes a filename: `author=a,author=b` and `author=b,author=a` are one population and must be one poller. That merges only filters that are already the same set, so it can never refuse a filter that would have selected something different. Board labels still print the filter as you typed it.
 
@@ -1495,11 +1499,14 @@ So a slot is now read as a **set**, from two independent sources:
 
 It is a multi-kill, and that is a deliberate trade. The failure it replaces is a survivor nobody can reach whose only recovery was `pkill`; the failure it risks is stopping a process someone wanted. The breadth is bounded by evidence rather than by a pattern: every PID it acts on belongs to a process whose own argv names this exact source and id **as whole tokens**, so `33248` cannot match `332480` and an id appearing inside some other command's arguments cannot be mistaken for a poller. What it can still over-reach on is a poller started from a *different checkout* of supertool — which shares the same `/tmp` slot, and so genuinely is the same watcher.
 
-Three absences are now three different sentences, because they call for different actions:
+Four absences are four different sentences, because they call for different actions:
 
 - `No active watcher for … (no PID file, and no matching process)` — nothing is running, verified both ways.
 - `Tracked PID N … is not running` — the slot recorded a poller that died with nothing reporting it, so this id has been **unwatched** since. #511 caught two of those, and the board was silently blind on both MRs.
 - `… the process scan was unavailable` — `ps` could not be read, so an untracked poller could not be ruled out. Never rendered as "no watcher".
+- `No readable PID file for … — <reason>` — a pid file exists at the name and this process would not follow it (#1200). Somebody planted it; the file is left alone rather than pruned, and whether a poller holds the slot is not knowable from here. Inspect the path before re-arming.
+
+`watches` keeps the slot visible in that last case: the row is dropped from `list_active_pids`, because the only PID available came out of a file this slot never wrote, but the `ps` scan still finds a real poller and the union renders it as `no pidfile`.
 
 ### `radar` reaps duplicates before it respawns ([#749](https://github.com/Digital-Process-Tools/claude-supertool/issues/749))
 

--- a/presets/watch/channel.py
+++ b/presets/watch/channel.py
@@ -27,6 +27,13 @@ it is why the answer here has three states rather than two:
                      `forwarded` number for the verdict to be about, or a
                      health file that is a symlink and was not followed
                      (#1184).
+    CONTRADICTED     the process holding the socket is not the one the health
+                     file names (#1192). A fourth state on purpose: this is a
+                     finding, and `CANNOT DETERMINE` means no finding — putting
+                     an impersonation in that bucket would be this op's own
+                     defect. Peer credentials do not close the forgery, because
+                     a same-uid process that binds the socket *and* writes the
+                     file is its own peer; what they catch is the disagreement.
 
 `CANNOT DETERMINE` is the point of the op rather than its failure mode. It is
 the state today's tooling reports as green, and reporting it as green produced a
@@ -34,9 +41,10 @@ confidently wrong diagnosis in both directions on 2026-07-29 (#554's own
 account) — first "transport is fine" off `sent ok`, then "the radar is dead" off
 a drop line, while it had already recovered.
 
-Exit codes are the three states, on purpose: 0 forwarding, 1 not delivering, 3
-cannot determine. A single non-zero for the last two would put the two answers
-this op exists to separate back into one bucket.
+Exit codes are the states, on purpose: 0 forwarding, 1 not delivering, 3 cannot
+determine, 4 contradicted. A single non-zero would put answers this op exists to
+separate back into one bucket, and 4 is separate from 3 for the same reason —
+"I could not tell" and "I can tell, and it is wrong" call for different actions.
 
 **Measured caveat, so nobody builds on a code that is not there.** The supertool
 wrapper reports any non-zero op as `FAIL` and exits 1, so 3 survives only when
@@ -52,6 +60,7 @@ import errno
 import json
 import os
 import socket
+import struct
 import sys
 import time
 from pathlib import Path
@@ -96,6 +105,28 @@ CONNECT_TIMEOUT = 0.5
 RC_FORWARDING = 0
 RC_NOT_DELIVERING = 1
 RC_UNKNOWN = 3
+#: A fourth, because a contradiction is not an absence of findings (#1192).
+#: `CANNOT DETERMINE` says nothing was established; this says something was —
+#: the health file was written by a process that is not holding the socket.
+#: Folding it into 3 would be the defect this whole op exists to remove.
+RC_CONTRADICTED = 4
+
+#: Linux. `SO_PEERCRED` on a connected AF_UNIX socket yields `struct ucred` —
+#: three native ints, pid first — for the process on the other end. Read from
+#: the *client* side it is the process that called `listen`, which is exactly
+#: the socket-holder this op wants to name.
+_UCRED = "3i"
+
+#: macOS. Python exposes neither constant, so both are the raw values from
+#: `<sys/un.h>`: `SOL_LOCAL` is 0 and `LOCAL_PEERPID` is 2.
+#:
+#: **Not `LOCAL_PEERCRED`**, which #1192 named. That option returns a
+#: `struct xucred` carrying a uid and *no pid*, and a uid check answers nothing
+#: here: the threat is a same-uid process, which passes it trivially. The pid
+#: is the only field that can disagree with the health file, so the pid is the
+#: field this asks for.
+_SOL_LOCAL = 0
+_LOCAL_PEERPID = 2
 
 #: Printed in every report, including the healthy one. The ceiling belongs on
 #: the surface that would otherwise be read as proof: a reader who only ever
@@ -173,6 +204,73 @@ def probe_socket(path: str) -> tuple[str, str]:
             s.close()
         except OSError:
             pass
+
+
+def peer_credentials_supported() -> bool:
+    """Whether this platform can name the process holding an AF_UNIX socket.
+
+    Measured from `sys.platform` rather than assumed, and false on more than
+    Windows: FreeBSD has `LOCAL_PEERCRED` and no `LOCAL_PEERPID`, so it can
+    report the holder's uid and never its pid. A uid is not an answer to the
+    question this op asks — the threat is a same-uid process — so a platform
+    that can only supply one is reported as unable, not as partially able.
+    """
+    if not hasattr(socket, "AF_UNIX"):
+        return False
+    if sys.platform.startswith("linux"):
+        return hasattr(socket, "SO_PEERCRED")
+    return sys.platform == "darwin"
+
+
+def peer_pid(path: str) -> tuple[int | None, str]:
+    """The PID of the process holding this socket, or None and why not (#1192).
+
+    **What this buys, and what it does not.** It does not close the forgery:
+    a same-uid process that binds the socket *and* writes the health file is
+    its own peer, so the two agree and `FORWARDING` stands. What it catches is
+    a **mismatch** — a health file naming a process that is not the one holding
+    the socket, which previously drew no objection at all. The ceiling in
+    `docs/presets/watch.md` therefore stays exactly where it was.
+
+    Three states, like everything else on this op: a pid, a refusal because the
+    connect failed, and a refusal because this platform has no way to ask. The
+    last one is named rather than folded into the first, because a report that
+    cannot tell "nobody answered" from "I cannot ask here" is the shape this
+    file was written to remove.
+    """
+    if not peer_credentials_supported():
+        return None, (
+            f"peer credentials for an AF_UNIX socket are not available on "
+            f"{sys.platform}, so the process holding it cannot be named from here"
+        )
+    shown = _untrusted.flat(path)
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        s.settimeout(CONNECT_TIMEOUT)
+        s.connect(path)
+        if sys.platform == "darwin":
+            raw = s.getsockopt(_SOL_LOCAL, _LOCAL_PEERPID, struct.calcsize("i"))
+            (pid,) = struct.unpack("i", raw)
+        else:
+            raw = s.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED,
+                               struct.calcsize(_UCRED))
+            pid, _uid, _gid = struct.unpack(_UCRED, raw)
+    except OSError as err:
+        return None, f"{type(err).__name__} asking who holds {shown}"
+    except struct.error as err:
+        # A kernel that answered with a shorter option than the struct this
+        # unpacks. Not a pid, and not something to guess at.
+        return None, f"the peer credentials for {shown} were unreadable ({err})"
+    finally:
+        try:
+            s.close()
+        except OSError:
+            pass
+    if pid <= 0:
+        # Linux answers `0` for a socket whose peer is gone, and for one bound
+        # in a namespace this process cannot see into. Neither is a process.
+        return None, f"the kernel reported no pid for the process holding {shown}"
+    return pid, ""
 
 
 def read_health(path: str) -> tuple[dict | None, str]:
@@ -543,13 +641,52 @@ def health(path: str) -> tuple[int, str]:
             "", CEILING,
         ])
 
+    claimed = record.get("pid")
+    holder, holder_why = peer_pid(path)
+    if holder is not None and holder != claimed:
+        # Not `CANNOT DETERMINE`: something *was* determined, and it is the one
+        # thing the old report could never say (#1192). The counters are still
+        # printed — they are what the impersonator published, and an operator
+        # comparing them against the real consumer's needs to see them — but the
+        # verdict they sit under is no longer a positive one.
+        return RC_CONTRADICTED, "\n".join([
+            "channel: CONTRADICTED", *head,
+            _health_note(),
+            f"  consumer : the health file names pid {claimed}, but pid {holder} is "
+            f"the process holding this socket",
+            "             these are the same process on a healthy channel. They are",
+            "             not here, so the counters below were published by something",
+            "             that is not the consumer — a live impersonation, or a health",
+            "             file left behind beside a legitimate socket. Neither is a",
+            "             degraded read: check both pids before trusting any of it.",
+            f"  counters : {_num(_counter(record, 'lines_read'))} lines read, "
+            f"{_num(_counter(record, 'forwarded'))} forwarded, "
+            f"{_num(_counter(record, 'dropped'))} dropped",
+            "", CEILING,
+        ])
+
+    if holder is not None:
+        identity = [
+            f"  consumer : pid {claimed}, up since {_stamp(record, 'started')}",
+            "             socket-holder verified: the process holding this socket is",
+            "             the one the health file names. That rules out a stale or",
+            "             forged file beside a live consumer; it does not rule out a",
+            "             same-uid process that bound the socket and wrote the file,",
+            "             which is its own peer and agrees with itself.",
+        ]
+    else:
+        identity = [
+            f"  consumer : pid {claimed} (self-reported), up since "
+            f"{_stamp(record, 'started')}",
+            f"             socket-holder NOT checked — {holder_why}",
+            "             the health file names its own writer; pids are reusable, so",
+            "             nothing here proves that process is the one holding the socket",
+        ]
+
     return RC_FORWARDING, "\n".join([
         "channel: FORWARDING", *head,
         _health_note(),
-        f"  consumer : pid {record.get('pid')} (self-reported), up since "
-        f"{_stamp(record, 'started')}",
-        "             the health file names its own writer; pids are reusable, so",
-        "             nothing here proves that process is the one holding the socket",
+        *identity,
         f"  counters : {_num(_counter(record, 'lines_read'))} lines read, "
         f"{_num(_counter(record, 'forwarded'))} forwarded, "
         f"{_num(_counter(record, 'dropped'))} dropped",

--- a/presets/watch/dispatcher.py
+++ b/presets/watch/dispatcher.py
@@ -231,9 +231,16 @@ def cmd_unwatch(parts: list[str]) -> int:
     if skipped:
         print("Not signalling " + ", ".join(str(p) for p in skipped)
               + " — a watcher is never PID 1 nor this process.")
+    # An unreadable pid file is not released. `release_pidfile` with no `pid`
+    # unlinks unconditionally — that is correct for a poller giving up its own
+    # slot, and wrong here: this arm has just told the operator to inspect the
+    # path, and removing it is removing the thing to inspect. It also puts the
+    # unlink back on the one path #1200 took it off everywhere else.
+    releasable = not info.get("tracked_refusal")
     if not pids:
         _report_nothing_stopped(source, watcher_id, info)
-        transport.release_pidfile(source, watcher_id)
+        if releasable:
+            transport.release_pidfile(source, watcher_id)
         _acknowledge_deaths(source, watcher_id)
         return 0
     print(f"Stopping {len(pids)} poller(s) for {source}:{watcher_id}: "
@@ -251,7 +258,12 @@ def cmd_unwatch(parts: list[str]) -> int:
     if not info["scan_ok"]:
         print("Process scan unavailable — only the tracked PID was considered, "
               "so an untracked poller for this id would not have been found.")
-    transport.release_pidfile(source, watcher_id)
+    if releasable:
+        transport.release_pidfile(source, watcher_id)
+    else:
+        print(f"The PID file for {source}:{watcher_id} was left in place — "
+              f"{info['tracked_refusal']}. The pollers above were stopped; the "
+              f"slot stays unclaimable until somebody removes that path by hand.")
     _acknowledge_deaths(source, watcher_id)
     return 1 if failures else 0
 

--- a/presets/watch/dispatcher.py
+++ b/presets/watch/dispatcher.py
@@ -174,6 +174,15 @@ def _stop_pid(pid: int) -> str:
 
 def _report_nothing_stopped(source: str, watcher_id: str, info: dict[str, Any]) -> None:
     """Say which kind of nothing this is. There are three, and they differ."""
+    if info.get("tracked_refusal"):
+        # Not "no PID file": there is a name here and this process would not
+        # follow it. The two send an operator to different places, and the
+        # second one means somebody planted it (#1200).
+        print(f"No readable PID file for {source}:{watcher_id} — "
+              f"{info['tracked_refusal']}. Nothing was stopped, and whether a "
+              f"poller holds this slot is not known from here. Inspect the "
+              f"path before re-arming.")
+        return
     if info["tracked"] and not info["tracked_alive"]:
         print(f"Tracked PID {info['tracked']} for {source}:{watcher_id} is not "
               f"running — the watcher died without anything reporting it, and "
@@ -499,7 +508,8 @@ def reap_duplicate_pollers() -> list[str]:
                       if pid > 1 and pid != os.getpid() and transport._pid_alive(pid))
         if len(live) < 2:
             continue
-        tracked = transport.read_pid(source, watcher_id)
+        tracked, tracked_refusal = transport.read_pid_checked(source, watcher_id)
+        tracked = tracked or 0
         keep = tracked if tracked in live else live[0]
         stopped: list[int] = []
         failures: list[str] = []
@@ -518,7 +528,8 @@ def reap_duplicate_pollers() -> list[str]:
                 f"{source}:{watcher_id} — stopped "
                 + ", ".join(str(p) for p in stopped)
                 + f"; PID {keep} still polls it"
-                + ("" if keep == tracked else " (no pid file named one)") + ".")
+                + ("" if keep == tracked
+                   else f" ({tracked_refusal or 'no pid file named one'})") + ".")
         lines.extend(failures)
     return lines
 

--- a/presets/watch/tiers/gl_mrs.py
+++ b/presets/watch/tiers/gl_mrs.py
@@ -1214,10 +1214,14 @@ def radar_state(options: dict | None = None) -> list[str]:
                + (f"{len((previous or {}).get('mrs') or {})} MR(s)"
                   if previous is not None else "absent (cold start next run)"))
 
-    pid = feed_pid(scope)
+    pid, pid_refusal = transport.read_pid_checked(FEED_SOURCE, scope)
     err = feed_error(scope)
+    # `pid_refusal`, not `feed_pid`, because "none recorded" and "there is a
+    # pid file here and it would not be followed" are different facts and this
+    # line is the only place the second one would be seen (#1200).
     out.append(f"  feed      : scope {scope!r}, pid "
-               f"{pid or 'none recorded'}{f' — last error: {err}' if err else ''}")
+               f"{pid or pid_refusal or 'none recorded'}"
+               f"{f' — last error: {err}' if err else ''}")
     for other in other_feed_scopes(scope):
         out.append(f"  feed ALSO : scope {other!r} is live and is NOT on this board")
 

--- a/presets/watch/transport.py
+++ b/presets/watch/transport.py
@@ -115,16 +115,86 @@ def pid_path(source: str, watcher_id: str) -> str:
     return f"{STATE_DIR}/supertool-watch-{source}__{watcher_id}.pid"
 
 
-def read_pid(source: str, watcher_id: str) -> int:
-    """PID recorded for this slot, or 0 when there is no readable file."""
+def read_pid_checked(source: str, watcher_id: str) -> tuple[int | None, str]:
+    """The PID recorded for this slot, or None and why not (#1200).
+
+    Fifth call site of the read the four before it already carry guards on —
+    `channel.read_health` (#1184/#1187), `channel.stranded_watchers` (#1191),
+    `read_state_checked` (#1197) — against the same threat, in the same
+    world-writable directory, on a name anyone can predict from the board.
+    Same shape as `read_state_checked` deliberately: a fourth convention for
+    one read is how the third call site got missed.
+
+    **Three states, and which two collapse is the whole judgment here.**
+
+    * `(pid, "")` — a file was read and named a process.
+    * `(0, "")` — `ENOENT`. The honest absence, and the common answer.
+    * `(None, reason)` — the read failed. `0` is not a neutral value at this
+      function's callers: it is the sentinel meaning *the slot is free*, and
+      `claim_pidfile` acts on it by unlinking the file and spawning a poller.
+      Returning it for a file nobody could read converts *a poller holds this
+      slot* into *nobody does*, which is the duplicate-watcher condition of
+      2026-08-01 — a real `pipeline_failed` unannounced for 23 minutes under
+      the flood — and destroys the real owner's claim on the way.
+    * `(0, reason)` — a file was read and its content is not a PID. Grouped
+      with the absence, not with the refusal, and this is the deliberate half:
+      such a file cannot be attributed to any process, so it must stay
+      reclaimable. `claim_pidfile`'s own docstring says why — a slot nobody
+      can claim leaves a population unwatched, which renders exactly like one
+      with nothing to report, and that is worse than a duplicate. The reason
+      still travels, so a caller that reports rather than decides can print it.
+
+    `O_NOFOLLOW` and no existence pre-check, for the reasons written out at
+    length in `read_state_checked`: a dangling symlink answers `ELOOP`, not
+    `ENOENT`, so a pre-check would report somebody's redirect as no file at
+    all. The descriptor is closed on the `fdopen` arm — `O_NOFOLLOW` refuses a
+    symlink and does not refuse a directory, and this is called once per row
+    by `list_active_pids`.
+    """
+    path = pid_path(source, watcher_id)
+    shown = _untrusted.flat(path)
     try:
-        raw = Path(pid_path(source, watcher_id)).read_text(encoding="utf-8")
-    except OSError:
-        return 0
+        fd = os.open(path, os.O_RDONLY | _NOFOLLOW)
+    except FileNotFoundError:
+        return 0, ""
+    except OSError as err:
+        # ELOOP on Linux and macOS, EMLINK on the BSDs — both mean the name was
+        # a symlink and O_NOFOLLOW refused it.
+        if err.errno in (errno.ELOOP, errno.EMLINK):
+            return None, (
+                f"{shown} is a symlink and was not followed — a pid file is written "
+                "in place by the process that claims the slot, so this is somebody "
+                "redirecting the read at another file"
+            )
+        return None, f"{shown} could not be read ({type(err).__name__})"
     try:
-        return int(raw.strip())
+        handle = os.fdopen(fd, "r", encoding="utf-8")
+    except OSError as err:
+        os.close(fd)
+        return None, f"{shown} could not be read ({type(err).__name__})"
+    try:
+        with handle as f:
+            raw = f.read()
+    except (OSError, ValueError) as err:
+        # `UnicodeDecodeError` is a `ValueError`, and two bytes of invalid
+        # UTF-8 are the cheapest way to make a read fail (#1197).
+        return None, f"{shown} could not be read ({type(err).__name__})"
+    try:
+        return int(raw.strip()), ""
     except ValueError:
-        return 0
+        return 0, f"{shown} exists but its content is not a PID"
+
+
+def read_pid(source: str, watcher_id: str) -> int:
+    """PID recorded for this slot, or 0. Collapses the refusal — see below.
+
+    Kept for the callers that only ever *display* the number, where 0 renders
+    as "none recorded" and no decision hangs on it. Every caller that decides
+    whether to spawn, unlink or signal uses `read_pid_checked` instead, because
+    for those the collapse is the bug (#1200) rather than a convenience.
+    """
+    pid, _ = read_pid_checked(source, watcher_id)
+    return pid or 0
 
 
 def claim_pidfile(source: str, watcher_id: str) -> int:
@@ -155,7 +225,15 @@ def claim_pidfile(source: str, watcher_id: str) -> int:
                          os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW,
                          0o600)
         except FileExistsError:
-            existing = read_pid(source, watcher_id)
+            existing, _refusal = read_pid_checked(source, watcher_id)
+            if existing is None:
+                # The name is taken by something this process could not read —
+                # a symlink, most cheaply. Unreadable is not free, and the
+                # unlink below would destroy a live poller's claim while the
+                # `0` return told the caller to start a second one (#1200).
+                # `CLAIM_UNKNOWN` is the state this function already has for
+                # "no file was created and no owner was identified".
+                return CLAIM_UNKNOWN
             if existing and _pid_alive(existing):
                 return existing
             if existing:
@@ -204,8 +282,13 @@ def release_pidfile(source: str, watcher_id: str, pid: int | None = None) -> Non
     unlink its successor's claim on the way out — that would hand the next
     caller an empty slot and put a second poller back on the same filter.
     """
-    if pid is not None and read_pid(source, watcher_id) != pid:
-        return
+    if pid is not None:
+        owner, _ = read_pid_checked(source, watcher_id)
+        # `None` — the read failed — takes the same arm as a PID that is not
+        # ours, and for the same reason: this function unlinks, and an
+        # unverified unlink hands the next caller an empty slot (#1200).
+        if owner != pid:
+            return
     try:
         os.unlink(pid_path(source, watcher_id))
     except OSError:
@@ -457,7 +540,12 @@ def reap_dead_pidfile(source: str, watcher_id: str) -> int:
     alive, and reporting those as losses would flood the board on the first run
     after this lands.
     """
-    pid = read_pid(source, watcher_id)
+    pid, _ = read_pid_checked(source, watcher_id)
+    # A file that could not be read (`None`) is not evidence of a death: it
+    # names no process, so there is nothing to record and nothing to release.
+    # It is not evidence of life either, which is why this stays silent rather
+    # than reporting a clean slot — the disclosure belongs on `watcher_pids`,
+    # which is what the operator-facing surfaces read (#1200).
     if not pid or _pid_alive(pid):
         return 0
     record_death(source, watcher_id, pid)
@@ -621,6 +709,22 @@ def list_active_pids() -> list[dict[str, Any]]:
 
     Returns rows with: source, id, pid, started (mtime ISO), state file existence
     flag, and last event from the state file when readable.
+
+    **What is pruned, and what is only skipped (#1200).** This used to unlink
+    on any failed read. An unreadable pid file is not evidence that the slot is
+    stale — a symlink planted at the name reads as a failure and deletes a live
+    poller's claim, unrecoverably, and the owner has no way to notice. So the
+    two failures are separated: a file whose content is not a PID names no
+    process and is still pruned, while one the read itself could not perform is
+    left exactly where it is and its row is omitted.
+
+    Omitted rather than reported, because a `pid` here is a claim that a poller
+    is alive on that slot and the only PID available is one read out of
+    somebody else's file. The slot does not go dark: `list_watchers` widens
+    this with the process scan, so a real poller behind a tampered pid file
+    still reaches the board as an `orphan` row. The cost of declining is a
+    pid file nobody prunes — one per hostile name, which is the same file the
+    attacker had to plant.
     """
     rows: list[dict[str, Any]] = []
     prefix = "supertool-watch-"
@@ -628,20 +732,25 @@ def list_active_pids() -> list[dict[str, Any]]:
     for name in sorted(os.listdir(STATE_DIR)):
         if not (name.startswith(prefix) and name.endswith(suffix)):
             continue
+        # supertool-watch-{source}__{id}.pid. Parsed before the read, because
+        # the guarded reader is addressed by slot rather than by path.
+        stem = name[len(prefix):-len(suffix)]
+        if "__" not in stem:
+            continue
+        source, watcher_id = stem.split("__", 1)
         path = os.path.join(STATE_DIR, name)
-        try:
-            pid = int(Path(path).read_text(encoding="utf-8").strip())
-        except (OSError, ValueError):
+        pid, _refusal = read_pid_checked(source, watcher_id)
+        if pid is None:
+            continue
+        if not pid:
+            # No file (it vanished between the listdir and the read), or a file
+            # whose content names no process. Both are prunable; the unlink is
+            # a no-op on the first.
             try:
                 os.unlink(path)
             except OSError:
                 pass
             continue
-        # supertool-watch-{source}__{id}.pid
-        stem = name[len(prefix):-len(suffix)]
-        if "__" not in stem:
-            continue
-        source, watcher_id = stem.split("__", 1)
         if not _pid_alive(pid):
             # The row is still dropped — radar derives coverage from this
             # function and a dead PID is not coverage — but the death is
@@ -874,12 +983,18 @@ def watcher_pids(
     nobody recorded.
     """
     found, scan_ok = scan_poller_pids() if scan is None else scan
-    tracked = read_pid(source, watcher_id)
+    tracked, tracked_refusal = read_pid_checked(source, watcher_id)
+    tracked = tracked or 0
     tracked_alive = bool(tracked and _pid_alive(tracked))
     live = [pid for pid in found.get((source, watcher_id), []) if _pid_alive(pid)]
     pids = sorted(set(live) | ({tracked} if tracked_alive else set()))
     return {
         "tracked": tracked,
+        # "" when the pid file was read or is honestly absent. `tracked: 0` is
+        # documented above as "a slot with nothing in it", so an unread pid
+        # file rendered as that is the absence-read-as-presence shape; the
+        # renders print this instead of "no PID file" (#1200).
+        "tracked_refusal": tracked_refusal,
         "tracked_alive": tracked_alive,
         "pids": pids,
         "untracked": [pid for pid in pids if pid != tracked],

--- a/tests/test_watch_channel_health_554.py
+++ b/tests/test_watch_channel_health_554.py
@@ -77,9 +77,10 @@ needs_socket = pytest.mark.skipif(
     not CAN_BIND, reason="this platform cannot bind an AF_UNIX socket"
 )
 
-# Exit codes are the three states. A single non-zero for both "nothing is
-# listening" and "cannot tell" would put the two answers the issue is about
-# back into one bucket.
+# The three exit codes this module's tests are about. A single non-zero for both
+# "nothing is listening" and "cannot tell" would put the two answers the issue is
+# about back into one bucket. `channel` carries a fourth since #1192,
+# `RC_CONTRADICTED = 4`, which is exercised in its own file.
 RC_FORWARDING = 0
 RC_NOT_DELIVERING = 1
 RC_UNKNOWN = 3
@@ -344,12 +345,18 @@ def test_health_declines_when_the_health_file_belongs_to_a_dead_process(tmp_path
 def test_health_never_presents_the_published_pid_as_a_verified_identity(tmp_path):
     """The case the ubuntu legs actually exercised, kept rather than deleted.
 
-    Nothing checks that the pid in the health file is the process holding the
-    socket, and nothing can: pids are reusable, so a live pid is not evidence
-    that the consumer that wrote the file is the consumer that is bound. The op
-    still reports FORWARDING — the counters are fresh, and something is
-    refreshing them — but the report must attribute the pid to the file rather
-    than assert it as a fact it established.
+    Its docstring used to say "nothing checks that the pid in the health file is
+    the process holding the socket, and nothing can". The second half was wrong,
+    and #1192 is that correction: the kernel will name the socket's peer where
+    the platform exposes it, so this fixture — a health file naming a *stranger*
+    process while this test holds the socket — is now a contradiction rather
+    than an unverifiable claim, and the op says so.
+
+    Both arms are asserted rather than one, because the platform decides which
+    is reachable and a test that skipped on the other would report coverage it
+    does not have. Where the peer cannot be named, the old answer is still the
+    right one and the report still attributes the pid to the file instead of
+    asserting it.
     """
     stranger = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
     path = _sock_path(tmp_path)
@@ -357,9 +364,15 @@ def test_health_never_presents_the_published_pid_as_a_verified_identity(tmp_path
     _write_health(path, pid=stranger.pid, forwarded=39)
     try:
         result = _run_health(path)
-        assert result.returncode == RC_FORWARDING, result.stdout + result.stderr
-        assert "self-reported" in result.stdout
-        assert "pids are reusable" in result.stdout
+        if channel.peer_credentials_supported():
+            assert result.returncode == channel.RC_CONTRADICTED, (
+                result.stdout + result.stderr)
+            assert "CONTRADICTED" in result.stdout
+            assert str(stranger.pid) in result.stdout
+        else:
+            assert result.returncode == RC_FORWARDING, result.stdout + result.stderr
+            assert "self-reported" in result.stdout
+            assert "pids are reusable" in result.stdout
     finally:
         stranger.kill()
         stranger.wait()

--- a/tests/test_watch_channel_peer_identity_1192.py
+++ b/tests/test_watch_channel_peer_identity_1192.py
@@ -1,0 +1,230 @@
+"""`channel:health` could not tell the socket-holder from the health-file writer (#1192).
+
+Split out of #1187/#1184. The audit called the forgery acceptable because the
+report says `self-reported` — but that word covers the **pid line** only, and
+the forgeable thing is the whole `FORWARDING` verdict: a same-uid process binds
+the socket, writes a health file naming its own live pid with a fresh stamp, and
+the op prints `channel: FORWARDING`.
+
+**Peer credentials do not close that hole, and this file does not claim they
+do.** `SO_PEERCRED` / `LOCAL_PEERPID` yield the pid of the process holding the
+socket. A same-uid attacker that binds the socket *and* writes the health file
+is its own peer, so the two agree and the verdict stands. What the check buys is
+the **mismatch**: a health file naming a process that is not the one holding the
+socket — a forged or stale file left beside a legitimate consumer — which
+previously read as `FORWARDING` with no objection at all. The documented ceiling
+in `docs/presets/watch.md` stays regardless.
+
+**Three states, never two.** They match; they contradict each other, which is a
+live impersonation and is said loudly; or the credentials could not be obtained
+here, which is named rather than folded into either neighbour. The third is not
+hypothetical — Windows has no equivalent, and neither does FreeBSD, whose
+`LOCAL_PEERCRED` returns a `struct xucred` with a uid and no pid.
+
+**A contradiction is not `CANNOT DETERMINE`.** It is the opposite: something was
+determined. Folding it into the existing unknown would be this repo's own defect
+— a finding rendered as an absence of findings — so it has its own verdict line
+and its own exit code.
+
+**Platforms.** The tests that need a real peer pid are gated on
+`channel.peer_credentials_supported()`, which is measured rather than assumed.
+The unavailable-credentials arm is exercised everywhere, by stubbing the getter,
+because that arm is the one no CI platform of ours reaches naturally.
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+for _dir in (str(REPO / "presets" / "watch"), str(REPO / "presets"), str(REPO / "tests")):
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)
+
+import channel  # noqa: E402
+from _changelog_findable import assert_change_is_findable  # noqa: E402
+
+
+def _sock_path() -> str:
+    """macOS caps AF_UNIX paths near 104 bytes and pytest's `tmp_path` is long,
+    so the socket goes in the system temp dir. Measured the hard way: with the
+    socket under `tmp_path`, every test here skipped with "this platform cannot
+    bind an AF_UNIX socket" on the one platform that certainly can — a skip that
+    reads exactly like a platform limit and was a path length.
+
+    `gettempdir()` rather than a literal `/tmp`, because this module runs on
+    every leg of the matrix and `/tmp` on Windows is a drive-root path that need
+    not exist.
+    """
+    return str(Path(tempfile.gettempdir())
+               / f"st1192-{os.getpid()}-{time.time_ns()}.sock")
+
+
+def _can_bind_af_unix() -> bool:
+    """Measured once, not guessed from `os.name`: `hasattr(socket, "AF_UNIX")`
+    is True on Windows builds of CPython and the bind may still fail."""
+    if not hasattr(socket, "AF_UNIX"):
+        return False
+    probe = _sock_path()
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        s.bind(probe)
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+        try:
+            os.unlink(probe)
+        except OSError:
+            pass
+
+
+@pytest.fixture()
+def sock():
+    """A live listener held by this process, and the path it is bound to."""
+    if not _can_bind_af_unix():
+        pytest.skip("this platform cannot bind an AF_UNIX socket")
+    path = _sock_path()
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(path)
+    srv.listen(8)
+    try:
+        yield path
+    finally:
+        srv.close()
+        for leftover in (path, f"{path}.health.json"):
+            try:
+                os.unlink(leftover)
+            except OSError:
+                pass
+
+
+def _write_health(path: str, pid: int) -> None:
+    """A health file that clears every objection `_health_objection` makes, so
+    the only thing left for the verdict to turn on is who holds the socket."""
+    Path(f"{path}.health.json").write_text(json.dumps({
+        "pid": pid,
+        "started": "2026-08-09T10:00:00Z",
+        "updated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "lines_read": 12,
+        "forwarded": 11,
+        "dropped": 1,
+        "last_forwarded": "2026-08-09T10:00:05Z",
+    }), encoding="utf-8")
+
+
+#: Alive, and not the process holding the socket in these tests. A literal
+#: constant would be a coin flip: any pid may belong to somebody by the time
+#: this runs, and `_health_objection` refuses a dead one before the verdict is
+#: ever reached.
+def _other_live_pid() -> int:
+    parent = os.getppid()
+    assert parent and parent != os.getpid()
+    return parent
+
+
+needs_peer_creds = pytest.mark.skipif(
+    not channel.peer_credentials_supported(),
+    reason="this platform exposes no peer pid for an AF_UNIX socket",
+)
+
+
+# --- the primitive ---------------------------------------------------------
+
+@needs_peer_creds
+def test_the_peer_pid_of_a_socket_we_hold_ourselves_is_our_own(sock):
+    """The listener in the fixture is this process, so this is the one case
+    where the right answer is known independently of the op."""
+    pid, why = channel.peer_pid(sock)
+    assert pid == os.getpid(), (pid, why)
+    assert why == ""
+
+
+def test_no_socket_is_a_named_refusal_and_never_a_pid():
+    pid, why = channel.peer_pid(_sock_path())
+    assert pid is None
+    assert why, "a refusal that says nothing is the state this op exists to remove"
+
+
+# --- the three states of the verdict ---------------------------------------
+
+@needs_peer_creds
+def test_a_health_file_naming_another_process_contradicts_the_socket_holder(sock):
+    """The whole issue. Before this, the op printed FORWARDING with no
+    objection: nothing compared the two pids, so nothing could disagree."""
+    _write_health(sock, _other_live_pid())
+    rc, report = channel.health(sock)
+    assert report.splitlines()[0] == "channel: CONTRADICTED", report
+    assert rc == channel.RC_CONTRADICTED
+
+
+@needs_peer_creds
+def test_a_contradiction_is_not_the_cannot_determine_bucket(sock):
+    """`CANNOT DETERMINE` means nothing was established. Here something was:
+    the file was written by a process that is not holding this socket."""
+    _write_health(sock, _other_live_pid())
+    rc, _ = channel.health(sock)
+    assert rc not in (channel.RC_UNKNOWN, channel.RC_FORWARDING, channel.RC_NOT_DELIVERING)
+
+
+@needs_peer_creds
+def test_a_contradiction_names_both_pids_so_it_can_be_acted_on(sock):
+    _write_health(sock, _other_live_pid())
+    _, report = channel.health(sock)
+    assert str(_other_live_pid()) in report, report
+    assert str(os.getpid()) in report, report
+
+
+@needs_peer_creds
+def test_a_health_file_naming_the_socket_holder_still_forwards(sock):
+    """The check must not cost the healthy answer."""
+    _write_health(sock, os.getpid())
+    rc, report = channel.health(sock)
+    assert report.splitlines()[0] == "channel: FORWARDING", report
+    assert rc == channel.RC_FORWARDING
+
+
+@needs_peer_creds
+def test_a_matching_verdict_says_the_holder_was_checked_rather_than_assumed(sock):
+    """A verified match that renders identically to an unchecked one teaches a
+    reader that FORWARDING always meant this, which it did not."""
+    _write_health(sock, os.getpid())
+    _, report = channel.health(sock)
+    assert "socket-holder" in report, report
+
+
+def test_credentials_that_could_not_be_obtained_are_named_not_folded(sock, monkeypatch):
+    """The Windows arm, and the reason the disclosure stays. Neither a match
+    nor a contradiction was established, and the report must not read like
+    either."""
+    monkeypatch.setattr(
+        channel, "peer_pid",
+        lambda _path: (None, "peer credentials are not available on plan9"))
+    _write_health(sock, _other_live_pid())
+    rc, report = channel.health(sock)
+    assert report.splitlines()[0] == "channel: FORWARDING", report
+    assert rc == channel.RC_FORWARDING
+    assert "plan9" in report, report
+
+
+def test_the_forgeable_ceiling_is_still_disclosed(sock, monkeypatch):
+    """Narrowing the hole is not closing it: a same-uid process that binds the
+    socket *and* writes the health file is its own peer, so the two agree."""
+    monkeypatch.setattr(channel, "peer_pid", lambda _path: (os.getpid(), ""))
+    _write_health(sock, os.getpid())
+    _, report = channel.health(sock)
+    assert channel.CEILING in report
+
+
+# --- documentation ---------------------------------------------------------
+
+def test_the_change_is_findable():
+    assert_change_is_findable(1192)

--- a/tests/test_watch_pid_read_hostile_1200.py
+++ b/tests/test_watch_pid_read_hostile_1200.py
@@ -1,0 +1,263 @@
+"""`transport.read_pid` reads an unreadable pid file as an empty slot (#1200).
+
+Fifth and sixth call sites of the pair fixed at `channel.read_health`
+(#1184/#1187), `channel.stranded_watchers` (#1191) and `transport.read_state`
+(#1197). Same predictable `/tmp` name, same missing `O_NOFOLLOW` — and a
+different blast radius, which is why it is its own issue:
+
+* **`read_pid` returned `0` for "no file" and for "the file could not be
+  read".** `0` is not neutral: it is the sentinel meaning *the slot is free*.
+  `claim_pidfile` reads it, concludes nobody owns the slot, **unlinks the
+  file** and takes the claim — so a symlink planted at the pid path both
+  destroys the real poller's claim and starts a second poller on the same
+  filter. That is the duplicate-watcher condition of 2026-08-01, where a
+  genuine `pipeline_failed` went unannounced for 23 minutes under the flood.
+* **`list_active_pids` unlinked on a read it could not perform.** An
+  unreadable file is not evidence that a slot is stale, and the process that
+  owned it cannot get its claim back.
+
+**Absent, unreadable and unparseable are three answers, and only two of them
+are the same.** `read_pid_checked` returns `None` when the read itself failed,
+and `0` both when there is honestly no file and when a file exists whose
+content is not a PID. That second collapse is deliberate and is pinned below:
+a pidfile nobody can attribute to a process must stay reclaimable, or a poller
+that died mid-write wedges its slot shut forever — which `claim_pidfile`'s own
+docstring says is worse than a duplicate.
+
+Every test here builds the hostile file itself; none passes against code that
+does nothing.
+
+**Platforms.** The absent and unparseable tests write ordinary files and run
+everywhere. The symlink tests need `os.symlink` *and* a non-zero
+`transport._NOFOLLOW`, and the descriptor test needs POSIX lowest-free-fd
+allocation. All are measured capabilities and skip rather than passing
+vacuously on Windows.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+for _dir in (str(REPO / "presets" / "watch"), str(REPO / "presets"), str(REPO / "tests")):
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)
+
+import dispatcher  # noqa: E402
+import transport  # noqa: E402
+from _changelog_findable import assert_change_is_findable  # noqa: E402
+
+SOURCE = "gh"
+WATCHER = "9"
+
+#: The PID recorded in the file a hostile symlink points at. Nothing that
+#: follows the link may report it, and nothing may print it.
+ELSEWHERE_PID = 424242
+
+#: `_NOFOLLOW` is `getattr(os, "O_NOFOLLOW", 0)`, so on a platform without it
+#: the flag is a no-op and the symlink is followed. Refusing to run there beats
+#: asserting something the platform cannot deliver.
+needs_symlink = pytest.mark.skipif(
+    not hasattr(os, "symlink") or not getattr(transport, "_NOFOLLOW", 0),
+    reason="needs os.symlink and a real O_NOFOLLOW",
+)
+
+
+@pytest.fixture()
+def state_dir(tmp_path, monkeypatch):
+    """A state directory of our own, and no process scan.
+
+    The scan is stubbed empty because this machine has real pollers in the
+    real `/tmp`: `scan_poller_pids` reads `ps`, not `STATE_DIR`.
+    """
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(transport, "scan_poller_pids", lambda: ({}, True))
+    return tmp_path
+
+
+def _pid_file(tmp_path: Path, source: str = SOURCE, watcher_id: str = WATCHER) -> Path:
+    return tmp_path / f"supertool-watch-{source}__{watcher_id}.pid"
+
+
+def _hostile_symlink(tmp_path: Path) -> Path:
+    """A symlink where the pid file goes, pointing at a file we also own.
+
+    The target exists and holds a plausible PID, so following the link
+    succeeds — which is the whole failure: the read works, and answers about
+    a file this slot never wrote.
+    """
+    target = tmp_path / "elsewhere.pid"
+    target.write_text(f"{ELSEWHERE_PID}\n", encoding="utf-8")
+    path = _pid_file(tmp_path)
+    os.symlink(target, path)
+    return path
+
+
+# --- the read itself: three states -----------------------------------------
+
+def test_an_absent_pid_file_is_not_a_refusal(state_dir):
+    """The overwhelmingly common answer, and the one three states must not
+    complicate: this slot has published nothing."""
+    assert transport.read_pid_checked(SOURCE, WATCHER) == (0, "")
+
+
+def test_a_recorded_pid_is_returned_with_no_refusal(state_dir):
+    _pid_file(state_dir).write_text("31337\n", encoding="utf-8")
+    assert transport.read_pid_checked(SOURCE, WATCHER) == (31337, "")
+
+
+@needs_symlink
+def test_a_symlinked_pid_file_is_a_refusal_and_not_an_empty_slot(state_dir):
+    """`0` means the slot is free. An unread file says nothing about that."""
+    _hostile_symlink(state_dir)
+    pid, refusal = transport.read_pid_checked(SOURCE, WATCHER)
+    assert pid is None, (pid, refusal)
+    assert "symlink" in refusal, refusal
+    assert str(ELSEWHERE_PID) not in refusal, refusal
+
+
+def test_a_pid_file_whose_content_is_not_a_pid_stays_reclaimable(state_dir):
+    """Deliberately `0`, not `None` — see the module docstring. A poller that
+    died mid-write must not wedge its slot shut forever."""
+    _pid_file(state_dir).write_text("not-a-pid\n", encoding="utf-8")
+    pid, refusal = transport.read_pid_checked(SOURCE, WATCHER)
+    assert pid == 0
+    assert refusal, "an unparseable file is still worth saying out loud"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="needs POSIX lowest-free-fd allocation")
+def test_the_descriptor_is_not_leaked_when_the_path_is_a_directory(state_dir):
+    """`O_NOFOLLOW` refuses a symlink and does *not* refuse a directory:
+    `os.open` succeeds and `os.fdopen` raises without taking the descriptor.
+    One leak per call, and `list_active_pids` calls this once per row."""
+    _pid_file(state_dir).mkdir()
+    before = os.open(os.devnull, os.O_RDONLY)
+    os.close(before)
+    for _ in range(12):
+        pid, refusal = transport.read_pid_checked(SOURCE, WATCHER)
+        assert pid is None, (pid, refusal)
+    after = os.open(os.devnull, os.O_RDONLY)
+    os.close(after)
+    assert after == before, "a descriptor was leaked per call"
+
+
+# --- claim_pidfile: the decision that spawns a poller ----------------------
+
+@needs_symlink
+def test_claiming_a_slot_whose_pid_file_cannot_be_read_is_refused(state_dir):
+    """The whole issue. On master this returned `0` — *you own the slot now* —
+    and a second poller was spawned onto a filter already covered."""
+    _hostile_symlink(state_dir)
+    assert transport.claim_pidfile(SOURCE, WATCHER) == transport.CLAIM_UNKNOWN
+
+
+@needs_symlink
+def test_claiming_does_not_destroy_a_claim_it_could_not_read(state_dir):
+    """Unlinking another process's pid file is not recoverable by its owner.
+
+    `islink`, not `lexists`: master unlinks the symlink and then creates its
+    own pid file at the same name, so `lexists` is true on the broken code and
+    this test would assert nothing.
+    """
+    path = _hostile_symlink(state_dir)
+    transport.claim_pidfile(SOURCE, WATCHER)
+    assert os.path.islink(path), "the unread pid file was replaced"
+
+
+def test_claiming_still_reclaims_a_pid_file_that_names_no_process(state_dir):
+    """The pin on the deliberate half: garbage content stays reclaimable, so a
+    poller that crashed mid-write cannot wedge its slot shut."""
+    _pid_file(state_dir).write_text("not-a-pid\n", encoding="utf-8")
+    assert transport.claim_pidfile(SOURCE, WATCHER) == 0
+    assert _pid_file(state_dir).read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+# --- release_pidfile: the other way to destroy a claim ---------------------
+
+@needs_symlink
+def test_releasing_a_slot_does_not_unlink_when_ownership_cannot_be_confirmed(state_dir):
+    """`release_pidfile(..., pid)` exists to avoid unlinking a successor's
+    claim. A read that failed is not a confirmation that we still own it."""
+    path = _hostile_symlink(state_dir)
+    transport.release_pidfile(SOURCE, WATCHER, os.getpid())
+    assert os.path.lexists(path)
+
+
+# --- list_active_pids: the failure path that deletes -----------------------
+
+@needs_symlink
+def test_the_board_scan_does_not_unlink_a_pid_file_it_could_not_read(state_dir):
+    """`transport.py:636` on master. An unreadable file is not evidence that
+    the slot is stale."""
+    path = _hostile_symlink(state_dir)
+    transport.list_active_pids()
+    assert os.path.lexists(path), "the unread pid file was deleted"
+
+
+@needs_symlink
+def test_the_board_scan_does_not_report_a_slot_it_could_not_read_as_active(state_dir):
+    """Not-unlinking must not become claiming-it-is-live: the row would carry
+    a PID read out of a file this slot never wrote."""
+    _hostile_symlink(state_dir)
+    rows = transport.list_active_pids()
+    assert [r for r in rows if r["pid"] == ELSEWHERE_PID] == [], rows
+
+
+def test_the_board_scan_still_prunes_a_pid_file_that_names_no_process(state_dir):
+    """The pin: content that is not a PID stays prunable."""
+    path = _pid_file(state_dir)
+    path.write_text("not-a-pid\n", encoding="utf-8")
+    transport.list_active_pids()
+    assert not path.exists()
+
+
+# --- watcher_pids: the report that has to say it did not know --------------
+
+@needs_symlink
+def test_watcher_pids_names_the_unread_pid_file_rather_than_reporting_none(state_dir):
+    """`tracked: 0` is documented as *a slot with nothing in it*. Rendering an
+    unread file as that is the absence-read-as-presence shape this repo keeps
+    paying for."""
+    _hostile_symlink(state_dir)
+    info = transport.watcher_pids(SOURCE, WATCHER)
+    assert info["tracked"] == 0
+    assert info["tracked_refusal"], info
+
+
+def test_watcher_pids_carries_no_refusal_when_the_slot_is_honestly_empty(state_dir):
+    assert transport.watcher_pids(SOURCE, WATCHER)["tracked_refusal"] == ""
+
+
+# --- the render ------------------------------------------------------------
+
+@needs_symlink
+def test_unwatch_says_the_pid_file_was_unreadable_instead_of_no_pid_file(state_dir, capsys):
+    """A missing pid file and a pid file that would not be followed send an
+    operator to two different places."""
+    _hostile_symlink(state_dir)
+    dispatcher.cmd_unwatch([SOURCE, WATCHER])
+    out = capsys.readouterr().out
+    assert "No PID file" not in out, out
+    assert "could not be read" in out or "symlink" in out, out
+
+
+@needs_symlink
+def test_the_watches_board_still_shows_a_slot_whose_pid_file_is_unreadable(
+        state_dir, monkeypatch, capsys):
+    """Declining to prune must not make the slot invisible. The process scan
+    is the surface that keeps it on the board, as an orphan row."""
+    _hostile_symlink(state_dir)
+    monkeypatch.setattr(
+        transport, "scan_poller_pids",
+        lambda: ({(SOURCE, WATCHER): [os.getpid()]}, True))
+    assert dispatcher.cmd_list() == 0
+    assert WATCHER in capsys.readouterr().out
+
+
+# --- documentation ---------------------------------------------------------
+
+def test_the_change_is_findable():
+    assert_change_is_findable(1200)

--- a/tests/test_watch_pid_read_hostile_1200.py
+++ b/tests/test_watch_pid_read_hostile_1200.py
@@ -237,11 +237,33 @@ def test_watcher_pids_carries_no_refusal_when_the_slot_is_honestly_empty(state_d
 def test_unwatch_says_the_pid_file_was_unreadable_instead_of_no_pid_file(state_dir, capsys):
     """A missing pid file and a pid file that would not be followed send an
     operator to two different places."""
-    _hostile_symlink(state_dir)
+    path = _hostile_symlink(state_dir)
     dispatcher.cmd_unwatch([SOURCE, WATCHER])
     out = capsys.readouterr().out
     assert "No PID file" not in out, out
     assert "could not be read" in out or "symlink" in out, out
+    # The message tells the operator to inspect the path. `release_pidfile` with
+    # no `pid` unlinks unconditionally, so without this assertion the message and
+    # the behaviour disagreed and every test here still passed.
+    assert os.path.islink(path), "unwatch deleted the path it told us to inspect"
+
+
+@needs_symlink
+def test_unwatch_leaves_an_unreadable_pid_file_alone_after_stopping_pollers(
+        state_dir, monkeypatch, capsys):
+    """The other `release_pidfile` call in `cmd_unwatch`, on the arm that did
+    stop something. Stopping a poller says nothing about who wrote this name."""
+    path = _hostile_symlink(state_dir)
+    stopped: list[int] = []
+    monkeypatch.setattr(
+        transport, "scan_poller_pids",
+        lambda: ({(SOURCE, WATCHER): [4242]}, True))
+    monkeypatch.setattr(transport, "_pid_alive", lambda pid: pid == 4242)
+    monkeypatch.setattr(dispatcher, "_stop_pid", lambda pid: stopped.append(pid) or "")
+    dispatcher.cmd_unwatch([SOURCE, WATCHER])
+    assert stopped == [4242]
+    assert os.path.islink(path), "unwatch deleted a pid file it could not read"
+    assert "left in place" in capsys.readouterr().out
 
 
 @needs_symlink


### PR DESCRIPTION
Closes #1200
Closes #1192

## #1200 — an unreadable pid file read as an empty slot

`read_pid` returned `0` for both "no file" and "the file could not be read", and `0` is the sentinel meaning **the slot is free**. A symlink at the predictable, world-writable `/tmp` pid path therefore converted *a poller already holds this slot* into *nobody holds it*, and a second poller was spawned for the same watcher. `list_active_pids` **unlinked** the file on a read failure — deleting another process's claim, unrecoverably.

Fifth and sixth call sites of a pair already fixed at four others (#1197, #1184), reusing `read_state_checked`'s shape rather than inventing a fourth convention: `O_RDONLY | O_NOFOLLOW`, fd closed on the `fdopen` arm, and three states rather than two.

| Call site | Change |
| --- | --- |
| `transport.read_pid_checked` | pid / `0` for `ENOENT` only / `None` + reason |
| `claim_pidfile` | `None` becomes `CLAIM_UNKNOWN` — no longer unlinks a live claim it could not read, and no longer spawns a duplicate |
| `release_pidfile` | `None` takes the same arm as a foreign pid; the unlink is gated on positive identification |
| `reap_dead` | a file that names no process is not a death |
| `list_active_pids` | stem parsed before the read; prunes unparseable content, leaves an unreadable file alone |
| `watcher_pids`, dispatcher and feed reporting | print the refusal instead of "no PID file" / "none recorded" |

**`read_pid_checked` returns `int | None`, not a sentinel.** `CLAIM_UNKNOWN = -1` would pass every `if not pid` guard and reach `_pid_alive(-1)`; `None` forces each caller to state its arm. Cost: six call sites edited instead of zero.

**Unparseable content stays `0`, deliberately.** A pid file nobody can attribute to a process must stay reclaimable, or a poller that died mid-write wedges its slot forever — which `claim_pidfile`'s own docstring already calls worse than a duplicate. The reason string still travels for reporting.

**`list_active_pids` declines to unlink and omits the row.** An attacker-planted file accumulates, one per hostile name; that is not blindness, because `list_watchers` widens with the `ps` scan and a real poller behind a tampered file still renders as an `orphan`. Publishing a row with a PID read from a file the slot never wrote was the alternative, and it is worse.

## #1192 — a forgeable FORWARDING verdict

`channel:health` could not distinguish the socket-holder from the health-file writer, so any same-uid process could bind the socket, write a health file naming its own pid, and get `channel: FORWARDING`. Now: verified / `CONTRADICTED` / holder-not-checked-and-named.

`CONTRADICTED` is exit code **4**, not 3. `CANNOT DETERMINE` means nothing was established; an impersonation is the opposite, and folding them together would be this op's own defect on its own headline.

### Correction to the issue's stated mechanism

The issue named `LOCAL_PEERCRED` for macOS. **It cannot do the job** — it returns a `struct xucred`: uid and groups, **no pid**. A uid check is precisely the check the issue itself calls worthless, since the threat is a same-uid process. The pid is the only field that can disagree with the health file, and on macOS it comes from `LOCAL_PEERPID` (`SOL_LOCAL=0`, opt `2`), which Python does not expose — so both constants are hardcoded with a comment saying why.

Consequence for the third state: **FreeBSD** has `LOCAL_PEERCRED` and not `LOCAL_PEERPID`, so it reports as *unable* rather than partially able. Windows is not the only platform in the unavailable arm. Verified working on macOS — `test_the_peer_pid_of_a_socket_we_hold_ourselves_is_our_own` passes rather than skips.

## Verification

TDD, red first: 12 failing tests before any production change, plus a collection error on the #1192 module. Green: 17 + 9 on the new files, **738 passed / 43 skipped** across `-k "watch or channel"` — every test touching the changed surface.

Full suite skipped deliberately: it is non-hermetic here, the git-op tests corrupt the worktree they run in. CI is the authority.

Reviewed by an independent Sonnet agent against the committed diff, read-only. Three findings, all correct, all accepted:

- `cmd_unwatch` called `release_pidfile` with no `pid` — an unconditional unlink, putting back the exact behaviour #1200 removes, on the arm that had just printed "inspect the path before re-arming". Both calls are now gated.
- The test for that message asserted only the message and never the file, so it **passed with the bug present**. Fixed, and proved non-vacuous: forcing `releasable = True` gives `2 failed`, restoring gives `2 passed`.
- `docs/presets/watch.md` still enumerated exit codes `0/1/3` forty lines below the table this PR added the fourth to.

Platform audit clean across all four known Windows classes; every skip is a measured capability (`_can_bind_af_unix()`, `peer_credentials_supported()`) rather than a platform-name guess. Windows unverified locally.
