### PR TITLE
An absent tool is never a clean pass — 16 adapters, and ten were fabricating ok:true

### DIFF
--- a/.supertool.json
+++ b/.supertool.json
@@ -328,6 +328,19 @@
       "rollback_on_fail": true,
       "timeout": 60
     },
+    "tomllint": {
+      "cmd": "{python} {supertool_dir}/validators/tomllint/tomllint.py {file}",
+      "match": "*.toml",
+      "hooks_into": [
+        "edit",
+        "replace",
+        "replace_lines",
+        "paste", "append",
+        "vim"
+      ],
+      "rollback_on_fail": true,
+      "timeout": 10
+    },
     "changelog-fragment": {
       "cmd": "{python} {supertool_dir}/validators/changelog-fragment/changelog-fragment.py {file}",
       "match": "*changelog.d/*.md",

--- a/changelog.d/1202.fixed.md
+++ b/changelog.d/1202.fixed.md
@@ -49,3 +49,18 @@
   the absent-tool arm, and asserted `"ok" in out` — which held because of the
   defect, not in spite of it. They are gated on the tool being installed now,
   so they either measure a real verdict or report that they were skipped.
+- **`tests/test_yaml_check.py` was the sixth, and it hid one round longer
+  because it picked its own interpreter.** It ran the adapter under whatever
+  `shutil.which("python3.13")` returned, which on the author's machine was the
+  one Python with PyYAML installed and on CI was nothing at all — so the four
+  parsing assertions ran locally against a real parse and on twelve legs
+  against the fabricated `ok: true`, and reddened only once that was removed.
+  The interpreter is `sys.executable` now, the parsing half is gated on PyYAML
+  being importable by it, and PyYAML joins `ruff` in the `dev` extra so the
+  gate is a local convenience rather than the CI outcome — a test that skips
+  everywhere is a test that was deleted with extra steps.
+  `test_output_contains_required_fields` no longer asserts `ok` unconditionally
+  (a claim about the machine, not the adapter): it asserts the payload is
+  exactly one of the two shapes, a complete verdict or a skip carrying no
+  verdict key, so an unparsed file can be read as neither a pass nor a
+  failure.

--- a/changelog.d/1202.fixed.md
+++ b/changelog.d/1202.fixed.md
@@ -1,0 +1,40 @@
+- **`$SUPERTOOL_REQUIRE_VALIDATORS` was inert for most validators, and ten
+  adapters called an absent tool a clean pass**
+  ([#1202](https://github.com/Digital-Process-Tools/claude-supertool/issues/1202)).
+  Filed against `ruff`, whose absent-tool arm emitted `skipped` without ever
+  consulting `refusal.required()` — so naming it in the variable did nothing,
+  and setting the variable was indistinguishable from not setting it. The audit
+  the issue asked for found the same gap in `html-check` and in all four MCP
+  adapters (`phpstan-mcp`, `rector-mcp`, `phpunit-mcp`, `phpmd-mcp`), whose
+  `DaemonUnavailable` arm is the same absence wearing a different exception.
+- **The worse half was on the adjacent line and had not been filed.**
+  `tsc-check`, `markdownlint`, `ruby-check`, `cargo-check`, `hadolint`,
+  `gofmt-check`, `terraform-check`, `pyright`, `git-status` and `yaml-check`
+  answered an absent tool with `ok: true, count: 0, errors: []` — a clean
+  verdict about a file nothing opened, rendered as a green row and subtracted
+  from the before/after delta like a real one. `git-status` published a zeroed
+  `metrics` block reading `state: "clean"`, a measurement of a working tree it
+  had not measured. All ten now report the third state, with the reason and the
+  install hint on the row.
+- **The decision is made in one place now, not spelled out per adapter.**
+  `refusal.absent(tool, file, reason, dur_ms)` returns a `skipped` result, or a
+  loud `adapter` error naming the variable when that validator is required. It
+  takes the **validator name** — the key a repo writes in `.supertool.json` —
+  never the binary, because `tsc-check` runs `tsc` and `html-check` runs `node`,
+  and escalating on the binary name would ignore the only spelling anyone can
+  configure. `docs/validators.md` claimed `refusal.required()` was "shared by
+  every adapter that can find itself with nothing to say" throughout; that
+  sentence is corrected and the correction is recorded next to it.
+- **A local skip is unchanged, and so is rollback.** Unset, an absent tool is
+  still quiet and still exits 0 — reddening every unrelated edit on a laptop
+  that never installed `gofmt` is the noise problem from the other end.
+  `_validator_regressed` returns `False` for `ok: true` and for `skipped`
+  alike, so no `rollback_on_fail` decision moves.
+- **Ten adapter tests were passing on the fabricated verdict.** Every
+  `test_output_contains_required_fields` / `test_duration_ms_is_int` /
+  `test_missing_file_behavior` in `tests/test_markdownlint.py`,
+  `tests/test_hadolint.py`, `tests/test_tsc_check.py`, `tests/test_pyright.py`
+  and `tests/test_ruby_check.py` ran the adapter with no tool installed, hit
+  the absent-tool arm, and asserted `"ok" in out` — which held because of the
+  defect, not in spite of it. They are gated on the tool now, so they either
+  measure a real verdict or say they were skipped.

--- a/changelog.d/1202.fixed.md
+++ b/changelog.d/1202.fixed.md
@@ -59,8 +59,9 @@
   being importable by it, and PyYAML joins `ruff` in the `dev` extra so the
   gate is a local convenience rather than the CI outcome — a test that skips
   everywhere is a test that was deleted with extra steps.
-  `test_output_contains_required_fields` no longer asserts `ok` unconditionally
-  (a claim about the machine, not the adapter): it asserts the payload is
-  exactly one of the two shapes, a complete verdict or a skip carrying no
-  verdict key, so an unparsed file can be read as neither a pass nor a
-  failure.
+  `test_output_contains_required_fields` asserted `ok` unconditionally, which is
+  a claim about the machine and not about the adapter; it is
+  `test_output_is_exactly_one_of_the_two_shapes` now, asserting the payload is a
+  complete verdict or a skip carrying no verdict key — and that whichever one
+  came back is the one this interpreter's PyYAML says it should be — so an
+  unparsed file can be read as neither a pass nor a failure.

--- a/changelog.d/1202.fixed.md
+++ b/changelog.d/1202.fixed.md
@@ -30,11 +30,22 @@
   that never installed `gofmt` is the noise problem from the other end.
   `_validator_regressed` returns `False` for `ok: true` and for `skipped`
   alike, so no `rollback_on_fail` decision moves.
-- **Ten adapter tests were passing on the fabricated verdict.** Every
-  `test_output_contains_required_fields` / `test_duration_ms_is_int` /
-  `test_missing_file_behavior` in `tests/test_markdownlint.py`,
-  `tests/test_hadolint.py`, `tests/test_tsc_check.py`, `tests/test_pyright.py`
-  and `tests/test_ruby_check.py` ran the adapter with no tool installed, hit
+- **Each of those ten adapters had a second absent-tool arm, and it was still
+  fabricating a pass after the first pass over them.** `shutil.which` is not
+  the only place a tool goes missing: seven adapters also caught the
+  `FileNotFoundError` raised when a PATH entry vanishes between the lookup and
+  the spawn, or resolves to something that will not exec — `tsc-check`,
+  `markdownlint`, `ruby-check`, `cargo-check`, `hadolint`, `gofmt-check`,
+  `terraform-check` — and every one answered it with `ok: true`. Emptying
+  `PATH` never reaches that arm, so the first round of tests could not see it.
+  Both arms route through `absent()` now, and the tests reach the second one by
+  shadowing `shutil.which` and `subprocess.run` under `runpy`.
+- **Schema tests in five adapter suites were passing on the fabricated
+  verdict.** `test_output_schema_present` / `test_output_contains_required_fields`,
+  `test_duration_ms_is_int`, and the missing-file tests in
+  `tests/test_markdownlint.py`, `tests/test_hadolint.py`,
+  `tests/test_tsc_check.py`, `tests/test_pyright.py` and
+  `tests/test_ruby_check.py` ran the adapter on a machine without its tool, hit
   the absent-tool arm, and asserted `"ok" in out` — which held because of the
-  defect, not in spite of it. They are gated on the tool now, so they either
-  measure a real verdict or say they were skipped.
+  defect, not in spite of it. They are gated on the tool being installed now,
+  so they either measure a real verdict or report that they were skipped.

--- a/changelog.d/1203.fixed.md
+++ b/changelog.d/1203.fixed.md
@@ -1,0 +1,10 @@
+- **`tomllint` shipped here and did not run here**
+  ([#1203](https://github.com/Digital-Process-Tools/claude-supertool/issues/1203)).
+  It has been offered in `.supertool.example.json` since the adapter landed and
+  was registered in this repo's own `.supertool.json` nowhere, so `pyproject.toml`
+  — one of the five version sites a release has to bump, guarded by
+  `tests/test_pyproject_version_522.py` because getting it wrong ships a release
+  that reaches nobody — was edited with no validator matching it. Registered now,
+  with `rollback_on_fail: true`: a `.toml` that no longer parses is not a lint
+  opinion. Verified against every tracked `.toml` before landing — it passes
+  clean rather than reddening the repo, and a test keeps it that way.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -281,7 +281,7 @@ The assembler writes one definition per cut, which keeps the *next* release hone
 ## Helper script conventions
 
 - **Python stdlib preferred.** No third-party dependencies. If an op needs `requests`, reconsider the design.
-- **Exit 0 on graceful skip.** If the required CLI tool is missing, print a friendly message and exit 0. Don't fail the whole supertool call because `kubectl` isn't installed.
+- **Exit 0 on graceful skip — for preset scripts, and only those.** If the required CLI tool is missing, print a friendly message and exit 0. Don't fail the whole supertool call because `kubectl` isn't installed. **A validator does the opposite of the friendly message**: it emits `refusal.absent(TOOL, file, reason, dur_ms)` and says nothing on stderr, because a stderr note beside an `ok: true` payload is invisible to the row, the before/after delta, `rollback_on_fail` and CI. This bullet read as license for the other thing in ten adapters at once ([#1202](https://github.com/Digital-Process-Tools/claude-supertool/issues/1202)); see [validators.md](validators.md), "The tool is not installed".
 - **Validators output JSON.** See [validators.md](validators.md) for the exact schema. Other scripts can output anything — supertool passes it through as-is.
 - **One file per op.** `gitlab/issue.py`, `gitlab/mr.py`, `gitlab/pipeline.py` — not one monolithic `gitlab.py` with a dispatch table.
 - **Scripts are co-located with their preset.** `presets/mytools/status.py`, not `scripts/status.py`. The `{path}` placeholder makes this work without hardcoded paths.

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -246,10 +246,12 @@ Two settings in that block are decisions rather than defaults:
 ### The tool is not installed — `skipped` locally, loud in CI on request
 
 `shellcheck`, `eslint` and `gitleaks` are external binaries most machines do
-not have, which makes the same question three times — and, it turned out,
-thirty. What does a validator report when its tool is absent?
+not have, which makes the same question three times: what does a validator
+report when its tool is absent? It turned out to be the question for nearly
+every adapter in the directory, answered three different ways until #1202 — the
+paragraphs under the `SUPERTOOL_REQUIRE_VALIDATORS` block below have the count.
 
-`tomllint` is the fourth, and it is the one that shows the question is not
+`tomllint` is a fourth case, and it is the one that shows the question is not
 about binaries (#1157). Its "tool" is an import — stdlib `tomllib` on 3.11+,
 the third-party `tomli` below that — and on a 3.10 machine with no `tomli` it
 answered `ok: true, count: 0`: not a parser that failed, a parser that was

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -234,6 +234,8 @@ Publishing those findings *alongside* the refusal is not the escape it looks lik
 
 **Switching it on.** Copy the `html-check` block out of `.supertool.example.json` into your project's `.supertool.json` under `validators`, the same as every other row in the table above. This repo registers it in its own `.supertool.json` too — a validator that ships here and does not run here is a checker nobody is checking, and it shipped that way once already: the adapter landed with no entry in any config, so `validate:` on a page with a stray brace ran only `git-status` and printed `0 with findings`, which is the silence #833 exists to close arriving inside the fix for it.
 
+The same gap was open on `tomllint` until [#1203](https://github.com/Digital-Process-Tools/claude-supertool/issues/1203): offered in `.supertool.example.json`, registered nowhere here, while `pyproject.toml` — one of the five version sites a release has to bump — was edited with no validator matching it. Registering a gate on your own repo is not a courtesy to the reader; it is the only feedback loop the adapter has, and #1157 (an adapter reporting `ok: true` for a file it never parsed) was found in somebody else's project precisely because this one was not running it.
+
 Two settings in that block are decisions rather than defaults:
 
 - **`rollback_on_fail: true`**, matching `node-check` for `*.js` — the same tool answering the same question, so the same consequence. Rollback is regression-gated: it fires when an edit *raises* the finding count, so a page whose inline JS is already broken stays editable and only a newly introduced syntax error reverts. A `skipped` result (no `node`) never rolls back, whatever this says.
@@ -244,8 +246,8 @@ Two settings in that block are decisions rather than defaults:
 ### The tool is not installed — `skipped` locally, loud in CI on request
 
 `shellcheck`, `eslint` and `gitleaks` are external binaries most machines do
-not have, which makes the same question three times: what does a validator
-report when its tool is absent?
+not have, which makes the same question three times — and, it turned out,
+thirty. What does a validator report when its tool is absent?
 
 `tomllint` is the fourth, and it is the one that shows the question is not
 about binaries (#1157). Its "tool" is an import — stdlib `tomllib` on 3.11+,
@@ -274,9 +276,36 @@ Comma- or `os.pathsep`-separated, case-insensitive, `*` for all. Named there, a
 tool that could not run becomes an `adapter` error whose message names the
 variable — so the reader is sent to the CI image rather than to the file. There
 is deliberately **no** value that turns a finding into a skip: that would be a
-mute button, and this repository declines those. `refusal.required()` is the
-one implementation, shared by every adapter that can find itself with nothing
-to say.
+mute button, and this repository declines those. `refusal.absent()` is the one
+implementation, and it is now genuinely shared by every adapter that can find
+itself with nothing to say.
+
+**That sentence was false for a year and said the opposite of the truth**
+([#1202](https://github.com/Digital-Process-Tools/claude-supertool/issues/1202)).
+`refusal.required()` was a helper each adapter had to remember to call, and five
+of the thirty-four adapters in `validators/` did. For the other adapters, naming one in this variable did nothing
+at all — the absence stayed quiet, and setting the variable was indistinguishable
+from not setting it, which is worse than having no switch. A reader deciding
+whether to rely on the escalation read the sentence above and concluded it
+covered their validator.
+
+The audit that found it turned up a second, worse spelling on the adjacent line.
+Ten adapters — `tsc-check`, `markdownlint`, `ruby-check`, `cargo-check`,
+`hadolint`, `gofmt-check`, `terraform-check`, `pyright`, `git-status`,
+`yaml-check` — answered an absent tool with `ok: true, count: 0, errors: []`,
+a clean verdict about a file nothing had opened, printed as a green row and
+subtracted from the before/after delta like a real one. `git-status` went
+furthest and published a zeroed `metrics` block reading `state: "clean"` — a
+measurement of a working tree it had not measured.
+
+Both spellings are gone, and the reason the class could exist twice is that the
+decision was written out adapter by adapter rather than made once.
+`absent(tool, file, reason, dur_ms)` is that one place: an adapter states the
+absence and its reason, and where it lands — third state or loud error — is
+decided in `validators/common/refusal.py`. `tool` there is the **validator
+name**, the key a repo writes in `.supertool.json`, never the binary:
+`tsc-check` runs `tsc` and `html-check` runs `node`, so escalating on the binary
+name would ignore the only spelling anyone can configure.
 
 The recommendation is to leave it unset locally and set it in CI for whichever
 of them that pipeline actually provides. Setting it for a tool the image does not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,14 @@ dev = [
     # nothing. Nothing a *user* installs imports it — the script is a
     # repo-internal release tool, and `supertool.py` is still stdlib-only.
     "markdown-it-py",
+    # Same reason as ruff, for the validator whose tool is a library rather than
+    # a binary: `tests/test_yaml_check.py` skips every assertion about parsing
+    # YAML when PyYAML is absent, so without this line that half of the file
+    # runs nowhere. It ran nowhere for a year already and nobody could see it —
+    # the adapter answered an absent PyYAML with `ok: true`, so the tests passed
+    # on a fabricated verdict instead of skipping (#1202/#1213). Pinned by
+    # `test_pyyaml_is_a_dev_dependency_so_ci_runs_the_parsing_half`.
+    "pyyaml",
 ]
 
 [tool.ruff]

--- a/tests/_workflow_parse.py
+++ b/tests/_workflow_parse.py
@@ -13,12 +13,20 @@ declare, and what each step's `uses:`, `env:` and `run:` actually contain.
 A comment can then say anything at all and change no assertion, because
 comments are not steps and are not run blocks.
 
-**PyYAML is deliberately not used.** CI installs pytest, pytest-cov,
-pytest-xdist and pytest-timeout and nothing else, so importing `yaml` here
-would make every guard built on it skip on all fourteen legs — silence in the
-files whose subject is silence. `tests/test_yaml_check.py` already has to gate
-itself on PyYAML's presence for that reason. So this parses by indentation,
-which is enough for one workflow whose shape is pinned by the tests below it.
+**PyYAML is deliberately not used**, and since #1213 the reason is no longer
+that it is unavailable. It said CI installed "pytest, pytest-cov, pytest-xdist
+and pytest-timeout and nothing else", so an import here would make every guard
+built on it skip on all fourteen legs — silence in the files whose subject is
+silence. `ruff` and `markdown-it-py` were already in the `dev` extra when that
+was written, and `pyyaml` joined them in #1213, so both workflows install it and
+the premise is now simply false.
+
+The decision stands on its own footing instead. A guard over CI policy that
+imports a third-party parser can be skipped by that parser going missing, and
+this file's whole subject is a check that reports nothing and reads as a pass;
+an indentation parser that ships with the repo cannot be uninstalled out from
+under it. It is enough for one workflow whose shape is pinned by the tests
+below it.
 
 It is a parser, so it can be wrong in the one direction that matters: finding
 nothing and reporting a clean sheet. Every function here is fixture-tested in

--- a/tests/test_hadolint.py
+++ b/tests/test_hadolint.py
@@ -28,8 +28,12 @@ def _run(file_path: str) -> dict:
 # Tool missing — graceful degrade
 # ---------------------------------------------------------------------------
 
-def test_missing_tool_graceful(tmp_path: Path) -> None:
-    """When hadolint is not on PATH, exit 0 with ok=True and a stderr warning."""
+def test_missing_tool_is_the_third_state(tmp_path: Path) -> None:
+    """Absent hadolint is `skipped`, not `ok: true` (#1202).
+
+    Escalation under `$SUPERTOOL_REQUIRE_VALIDATORS` is asserted in
+    `tests/test_validators_absent_tool_third_state_1202.py`.
+    """
     f = tmp_path / "Dockerfile"
     f.write_text("FROM ubuntu:22.04\nRUN apt-get update\n")
     result = subprocess.run(
@@ -39,9 +43,9 @@ def test_missing_tool_graceful(tmp_path: Path) -> None:
         env=empty_path_env(), encoding="utf-8", errors="replace",
     )
     out = json.loads(result.stdout)
-    assert_ok(out)
-    assert out["count"] == 0
-    assert "hadolint" in result.stderr.lower()
+    assert "skipped" in out, out
+    assert "hadolint" in out["skipped"]
+    assert "ok" not in out, out
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +105,7 @@ def test_no_arg_returns_error() -> None:
 # Output schema
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(not shutil.which("hadolint"), reason="hadolint not on PATH")
 def test_output_contains_required_fields(tmp_path: Path) -> None:
     f = tmp_path / "Dockerfile"
     f.write_text("FROM scratch\n")
@@ -109,6 +114,7 @@ def test_output_contains_required_fields(tmp_path: Path) -> None:
         assert key in out
 
 
+@pytest.mark.skipif(not shutil.which("hadolint"), reason="hadolint not on PATH")
 def test_duration_ms_is_int(tmp_path: Path) -> None:
     f = tmp_path / "Dockerfile"
     f.write_text("FROM scratch\n")
@@ -120,8 +126,9 @@ def test_duration_ms_is_int(tmp_path: Path) -> None:
 # Missing file
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(not shutil.which("hadolint"), reason="hadolint not on PATH")
 def test_missing_file_behavior(tmp_path: Path) -> None:
-    """Missing file: hadolint errors (if present) or graceful skip (if absent)."""
+    """Gated, because ungated it asserted the fabricated pass and nothing else."""
     out = _run(str(tmp_path / "Dockerfile"))
     assert "ok" in out
 

--- a/tests/test_markdownlint.py
+++ b/tests/test_markdownlint.py
@@ -28,8 +28,12 @@ def _run(file_path: str) -> dict:
 # Tool missing — graceful degrade
 # ---------------------------------------------------------------------------
 
-def test_missing_tool_graceful(tmp_path: Path) -> None:
-    """When markdownlint is not on PATH, exit 0 with ok=True and a stderr warning."""
+def test_missing_tool_is_the_third_state(tmp_path: Path) -> None:
+    """Absent markdownlint is `skipped`, not `ok: true` (#1202).
+
+    Escalation under `$SUPERTOOL_REQUIRE_VALIDATORS` is asserted in
+    `tests/test_validators_absent_tool_third_state_1202.py`.
+    """
     f = tmp_path / "readme.md"
     f.write_text("# Hello\n\nSome text.\n")
     result = subprocess.run(
@@ -39,9 +43,9 @@ def test_missing_tool_graceful(tmp_path: Path) -> None:
         env=empty_path_env(), encoding="utf-8", errors="replace",
     )
     out = json.loads(result.stdout)
-    assert_ok(out)
-    assert out["count"] == 0
-    assert "markdownlint" in result.stderr.lower()
+    assert "skipped" in out, out
+    assert "markdownlint" in out["skipped"]
+    assert "ok" not in out, out
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +81,7 @@ def test_no_arg_returns_error() -> None:
 # Output schema
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(not shutil.which("markdownlint"), reason="markdownlint not on PATH")
 def test_output_contains_required_fields(tmp_path: Path) -> None:
     f = tmp_path / "x.md"
     f.write_text("# Hello\n")
@@ -85,6 +90,7 @@ def test_output_contains_required_fields(tmp_path: Path) -> None:
         assert key in out
 
 
+@pytest.mark.skipif(not shutil.which("markdownlint"), reason="markdownlint not on PATH")
 def test_duration_ms_is_int(tmp_path: Path) -> None:
     f = tmp_path / "x.md"
     f.write_text("# Hello\n")
@@ -96,8 +102,9 @@ def test_duration_ms_is_int(tmp_path: Path) -> None:
 # Missing file
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(not shutil.which("markdownlint"), reason="markdownlint not on PATH")
 def test_missing_file_behavior(tmp_path: Path) -> None:
-    """Missing file: markdownlint errors (if present) or graceful skip (if absent)."""
+    """Gated, because ungated it asserted the fabricated pass and nothing else."""
     out = _run(str(tmp_path / "nonexistent.md"))
     assert "ok" in out
 

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -28,8 +28,12 @@ def _run(file_path: str) -> dict:
 # Tool missing — graceful degrade
 # ---------------------------------------------------------------------------
 
-def test_missing_tool_graceful(tmp_path: Path) -> None:
-    """When pyright is not on PATH, exit 0 with ok=True and a stderr warning."""
+def test_missing_tool_is_the_third_state(tmp_path: Path) -> None:
+    """Absent pyright is `skipped`, not `ok: true` (#1202).
+
+    Escalation under `$SUPERTOOL_REQUIRE_VALIDATORS` is asserted in
+    `tests/test_validators_absent_tool_third_state_1202.py`.
+    """
     f = tmp_path / "hello.py"
     f.write_text("x: int = 1\n")
     result = subprocess.run(
@@ -39,9 +43,9 @@ def test_missing_tool_graceful(tmp_path: Path) -> None:
         env=empty_path_env(), encoding="utf-8", errors="replace",
     )
     out = json.loads(result.stdout)
-    assert_ok(out)
-    assert out["count"] == 0
-    assert "pyright" in result.stderr.lower()
+    assert "skipped" in out, out
+    assert "pyright" in out["skipped"]
+    assert "ok" not in out, out
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +67,7 @@ def test_no_arg_returns_error() -> None:
 # Output schema
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(not shutil.which("pyright"), reason="pyright not on PATH")
 def test_output_schema_present(tmp_path: Path) -> None:
     f = tmp_path / "x.py"
     f.write_text("x: int = 1\n")
@@ -72,6 +77,7 @@ def test_output_schema_present(tmp_path: Path) -> None:
     assert out["tool"] == "pyright"
 
 
+@pytest.mark.skipif(not shutil.which("pyright"), reason="pyright not on PATH")
 def test_duration_ms_is_int(tmp_path: Path) -> None:
     f = tmp_path / "x.py"
     f.write_text("x: int = 1\n")

--- a/tests/test_ruby_check.py
+++ b/tests/test_ruby_check.py
@@ -68,8 +68,12 @@ def _assert_clean(out: dict) -> None:
 # Tool missing — graceful degrade
 # ---------------------------------------------------------------------------
 
-def test_missing_tool_graceful(tmp_path: Path) -> None:
-    """When ruby is not on PATH, exit 0 with ok=True and a stderr warning."""
+def test_missing_tool_is_the_third_state(tmp_path: Path) -> None:
+    """Absent ruby is `skipped`, not `ok: true` (#1202).
+
+    Escalation under `$SUPERTOOL_REQUIRE_VALIDATORS` is asserted in
+    `tests/test_validators_absent_tool_third_state_1202.py`.
+    """
     f = tmp_path / "hello.rb"
     f.write_text('puts "hello"\n')
     result = subprocess.run(
@@ -79,9 +83,9 @@ def test_missing_tool_graceful(tmp_path: Path) -> None:
         env=empty_path_env(), encoding="utf-8", errors="replace",
     )
     out = json.loads(result.stdout)
-    assert_ok(out)
-    assert out["count"] == 0
-    assert "ruby" in result.stderr.lower()
+    assert "skipped" in out, out
+    assert "ruby" in out["skipped"]
+    assert "ok" not in out, out
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +156,7 @@ def test_no_arg_returns_error() -> None:
 # Output schema
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(not shutil.which("ruby"), reason="ruby not on PATH")
 def test_output_contains_required_fields(tmp_path: Path) -> None:
     f = tmp_path / "x.rb"
     f.write_text('puts "hi"\n')
@@ -160,6 +165,7 @@ def test_output_contains_required_fields(tmp_path: Path) -> None:
         assert key in out
 
 
+@pytest.mark.skipif(not shutil.which("ruby"), reason="ruby not on PATH")
 def test_duration_ms_is_int(tmp_path: Path) -> None:
     f = tmp_path / "x.rb"
     f.write_text('puts "hi"\n')

--- a/tests/test_tomllint_registration_1203.py
+++ b/tests/test_tomllint_registration_1203.py
@@ -1,0 +1,92 @@
+"""#1203 — tomllint ships here and did not run here.
+
+`.supertool.example.json` has offered a `tomllint` entry since the adapter
+landed; `.supertool.json` had none. So the repository that distributes the TOML
+checker was the one repository it never checked, and `pyproject.toml` — one of
+the five version sites a release has to bump, guarded by
+`tests/test_pyproject_version_522.py` precisely because getting it wrong ships a
+release that reaches nobody — was edited with no validator matching it.
+
+Same shape as #833, one file type over: a checker nobody is checking has no
+feedback loop, and its defects surface in somebody elses repository. That is
+exactly how #1157 was found.
+
+Modelled on `tests/test_html_check_registration_833.py`, and deliberately not
+generalised into "every adapter must be registered here" for the reason that
+file gives: this is a Python repo, and `phplint`/`phpstan`/`phpmd` are correctly
+unregistered. The registration decision is per file type, so the test is too.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import supertool  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHIPPED = json.loads((REPO_ROOT / ".supertool.json").read_text(encoding="utf-8"))
+EXAMPLE = json.loads((REPO_ROOT / ".supertool.example.json").read_text(encoding="utf-8"))
+
+ADAPTER = REPO_ROOT / "validators" / "tomllint" / "tomllint.py"
+
+
+def test_shipped_config_dispatches_a_toml_file_to_tomllint(monkeypatch):
+    """The core matcher, run against this repo real config."""
+    monkeypatch.setattr(supertool, "_CONFIG", SHIPPED)
+    monkeypatch.setattr(supertool, "_CONFIG_CHECKED", True)
+    names = set(supertool._applicable_validators("edit", "pyproject.toml"))
+    assert "tomllint" in names, (
+        "no validator in .supertool.json parses *.toml — an edit that breaks "
+        "pyproject.toml validates clean in the repo that ships the TOML "
+        "checker. Selected: %s" % sorted(names))
+
+
+def test_shipped_registration_points_at_the_adapter_that_exists():
+    spec = SHIPPED["validators"]["tomllint"]
+    assert "validators/tomllint/tomllint.py" in spec["cmd"]
+    assert ADAPTER.is_file()
+    for op in ("edit", "replace", "replace_lines", "paste", "append", "vim"):
+        assert op in spec["hooks_into"], op
+
+
+def test_a_broken_toml_rolls_the_edit_back():
+    """`rollback_on_fail` is the point, not a detail copied from the example.
+
+    A TOML file that no longer parses is not a lint opinion — it is a file the
+    next reader cannot load, and for `pyproject.toml` it is a release that does
+    not build. Contrast `ruff`, registered here with rollback off, where a
+    finding sits next to a working file.
+    """
+    assert SHIPPED["validators"]["tomllint"]["rollback_on_fail"] is True
+
+
+def test_every_toml_file_in_this_repo_passes_the_validator_it_now_runs():
+    """Registering a gate that immediately reddens the repo is a different
+    decision from registering one that passes, and the maintainer asked which
+    this was before it landed. It is the second — and this keeps it that way,
+    which is the whole feedback loop the issue is about.
+    """
+    tracked = subprocess.run(["git", "ls-files", "*.toml"], cwd=REPO_ROOT,
+                             capture_output=True, text=True, check=True,
+                             encoding="utf-8", errors="replace")
+    files = [f for f in tracked.stdout.split() if f]
+    assert files, "no tracked .toml files — this test has stopped measuring anything"
+    for rel in files:
+        r = subprocess.run([sys.executable, str(ADAPTER), rel], cwd=REPO_ROOT,
+                           capture_output=True, text=True,
+                           encoding="utf-8", errors="replace")
+        out = json.loads(r.stdout)
+        assert "skipped" not in out, (
+            f"{rel}: tomllint declined — no TOML parser on this Python, so "
+            f"registration buys nothing here: {out['skipped']}")
+        assert out["ok"] is True, f"{rel}: {out}"
+
+
+def test_example_catalogue_still_offers_tomllint():
+    """The catalogue docs/validators.md tells other projects to copy from."""
+    spec = EXAMPLE["validators"]["tomllint"]
+    assert spec["match"] == "*.toml"
+    assert "validators/tomllint/tomllint.py" in spec["cmd"]

--- a/tests/test_tsc_check.py
+++ b/tests/test_tsc_check.py
@@ -28,11 +28,16 @@ def _run(file_path: str) -> dict:
 # Tool missing — graceful degrade
 # ---------------------------------------------------------------------------
 
-def test_missing_tool_graceful(tmp_path: Path, monkeypatch) -> None:
-    """When tsc is not on PATH, exit 0 with ok=True and a stderr warning."""
+def test_missing_tool_is_the_third_state(tmp_path: Path) -> None:
+    """Absent tsc is `skipped`, not `ok: true` (#1202).
+
+    This asserted `ok is True` for as long as the adapter fabricated it — a
+    clean type-check verdict about a file no compiler opened. Escalation under
+    `$SUPERTOOL_REQUIRE_VALIDATORS` is asserted in
+    `tests/test_validators_absent_tool_third_state_1202.py`.
+    """
     f = tmp_path / "hello.ts"
     f.write_text("const x: number = 1;\n")
-    monkeypatch.setenv("PATH", "")
     result = subprocess.run(
         [sys.executable, str(ADAPTER), str(f)],
         capture_output=True,
@@ -40,9 +45,9 @@ def test_missing_tool_graceful(tmp_path: Path, monkeypatch) -> None:
         env=empty_path_env(), encoding="utf-8", errors="replace",
     )
     out = json.loads(result.stdout)
-    assert_ok(out)
-    assert out["count"] == 0
-    assert "tsc" in result.stderr.lower()
+    assert "skipped" in out, out
+    assert "tsc" in out["skipped"]
+    assert "ok" not in out, out
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +83,7 @@ def test_no_arg_returns_error() -> None:
 # Output schema
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(not shutil.which("tsc"), reason="tsc not on PATH")
 def test_output_schema_present(tmp_path: Path) -> None:
     f = tmp_path / "x.ts"
     f.write_text("export {};\n")
@@ -86,6 +92,7 @@ def test_output_schema_present(tmp_path: Path) -> None:
         assert key in out
 
 
+@pytest.mark.skipif(not shutil.which("tsc"), reason="tsc not on PATH")
 def test_duration_ms_is_int(tmp_path: Path) -> None:
     f = tmp_path / "x.ts"
     f.write_text("export {};\n")
@@ -97,9 +104,15 @@ def test_duration_ms_is_int(tmp_path: Path) -> None:
 # Missing file
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(not shutil.which("tsc"), reason="tsc not on PATH")
 def test_missing_file_returns_error(tmp_path: Path) -> None:
+    """Gated, because ungated it asserted the fabricated pass and nothing else.
+
+    Without tsc this ran the absent-tool arm and `assert "ok" in out` held for
+    the wrong reason — a green about a file the adapter never handed to
+    anything. It now runs only where a real verdict is possible.
+    """
     out = _run(str(tmp_path / "nonexistent.ts"))
-    # tsc will error if tsc is present; if tsc absent, ok=True (graceful skip)
     assert "ok" in out
 
 

--- a/tests/test_validators_absent_tool_third_state_1202.py
+++ b/tests/test_validators_absent_tool_third_state_1202.py
@@ -1,0 +1,227 @@
+"""An absent tool is never a clean verdict, and $SUPERTOOL_REQUIRE_VALIDATORS reaches every adapter (#1202).
+
+Filed against `ruff` alone: its absent-tool arm emits `skipped` and never
+consults `refusal.required()`, so naming it in the variable does nothing and
+setting the variable is indistinguishable from not setting it.
+
+The audit that issue asked for turned one adapter into two lists.
+
+**The lesser half is what was filed** — adapters that decline honestly but
+cannot be escalated: `ruff`, `html-check`, and the four MCP adapters, whose
+`DaemonUnavailable` arm is the same absence wearing a different exception.
+
+**The worse half was not filed and is on the adjacent line.** Ten adapters
+answered an absent tool with `{"ok": true, "count": 0, "errors": []}` — a clean
+verdict about a file nothing opened, which is the failure `validators/SCHEMA.md`
+introduced the third state to end and which `refusal.py` says this directory has
+filed eleven times. A reader cannot tell that green from a real one, and neither
+can `rollback_on_fail`, the before/after delta, or CI.
+
+So the contract asserted here is one sentence in two directions, for every
+adapter that can find its tool missing:
+
+* unset, an absent tool is `skipped` and carries no verdict key at all;
+* named in the variable, the same absence is a loud `adapter` error that says
+  the file was NOT checked and names the variable that caused the escalation.
+
+Written as a table rather than per-adapter so that a new adapter with a
+fabricated pass is a red here rather than a discovery in somebody elses repo.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from _adapter_verdict import assert_declined, describe
+from _winenv import empty_path_env
+
+VALIDATORS = Path(__file__).resolve().parent.parent / "validators"
+
+
+def _adapter(name: str) -> Path:
+    return VALIDATORS / name / f"{name}.py"
+
+
+#: (validator name as it appears in the payload, sample filename, sample body).
+#: The body is irrelevant — every case here is reached before the tool runs —
+#: but the extension is not: several adapters read the suffix first.
+ABSENT_TOOL_ADAPTERS = [
+    ("ruff", "s.py", "x = 1\n"),
+    ("pyright", "s.py", "x = 1\n"),
+    ("tsc-check", "s.ts", "const x: number = 1;\n"),
+    ("markdownlint", "s.md", "# t\n"),
+    ("ruby-check", "s.rb", "puts 1\n"),
+    ("cargo-check", "s.rs", "fn main() {}\n"),
+    ("hadolint", "Dockerfile", "FROM scratch\n"),
+    ("gofmt-check", "s.go", "package main\n"),
+    ("terraform-check", "s.tf", "variable \"x\" {}\n"),
+    ("git-status", "s.txt", "x\n"),
+    ("html-check", "s.html", "<p>hi</p>\n"),
+]
+
+
+def _run(name: str, target: Path, env: dict) -> dict:
+    """Spawn the adapter by absolute interpreter path with PATH emptied.
+
+    `sys.executable` rather than `python`, so the interpreter is still reachable
+    when `shutil.which` inside the adapter genuinely cannot find anything —
+    which is the whole point of the environment being empty.
+    """
+    r = subprocess.run([sys.executable, str(_adapter(name)), str(target)],
+                       capture_output=True, text=True, env=env,
+                       encoding="utf-8", errors="replace")
+    assert r.stdout.strip(), (
+        f"{name}: adapter printed no verdict at all; stderr={r.stderr!r}")
+    return json.loads(r.stdout)
+
+
+def _sample(tmp_path: Path, filename: str, body: str) -> Path:
+    f = tmp_path / filename
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+@pytest.mark.parametrize("name,filename,body", ABSENT_TOOL_ADAPTERS,
+                         ids=[a[0] for a in ABSENT_TOOL_ADAPTERS])
+def test_an_absent_tool_is_the_third_state_not_a_pass(
+        tmp_path: Path, name: str, filename: str, body: str) -> None:
+    """No verdict key, because there is no verdict — only an attempt."""
+    out = _run(name, _sample(tmp_path, filename, body), empty_path_env())
+    assert "skipped" in out, describe(out)
+    for key in ("ok", "count", "errors"):
+        assert key not in out, f"{name}: a skip must not carry {key!r}: {out}"
+    assert out["tool"] == name, out
+
+
+@pytest.mark.parametrize("name,filename,body", ABSENT_TOOL_ADAPTERS,
+                         ids=[a[0] for a in ABSENT_TOOL_ADAPTERS])
+def test_required_turns_the_absent_tool_into_a_loud_error(
+        tmp_path: Path, name: str, filename: str, body: str) -> None:
+    """The escalation is addressed by validator name, not by binary name.
+
+    `tsc-check` runs `tsc`, `ruby-check` runs `ruby`, `html-check` runs `node`.
+    The core reads `$SUPERTOOL_REQUIRE_VALIDATORS` against the key a repo wrote
+    in `.supertool.json`, so an adapter that consulted `required("tsc")` would
+    ignore the only spelling anyone can configure.
+    """
+    env = empty_path_env()
+    env["SUPERTOOL_REQUIRE_VALIDATORS"] = name
+    out = _run(name, _sample(tmp_path, filename, body), env)
+    assert "skipped" not in out, describe(out)
+    assert_declined(out, context=f"{name} required but absent")
+    msg = out["errors"][0]["msg"]
+    assert "SUPERTOOL_REQUIRE_VALIDATORS" in msg, msg
+    assert "NOT checked" in msg, msg
+    assert out["errors"][0]["code"] == "adapter", out
+
+
+def test_the_unescalated_skip_survives_a_variable_naming_someone_else(
+        tmp_path: Path) -> None:
+    """Escalation is opt-in per validator, and the opt-in is a list membership.
+
+    A substring test would make `SUPERTOOL_REQUIRE_VALIDATORS=ruff` escalate
+    `ruff-format` too. `refusal.required` splits before comparing; this holds
+    it to that.
+    """
+    env = empty_path_env()
+    env["SUPERTOOL_REQUIRE_VALIDATORS"] = "shellcheck,gitleaks"
+    out = _run("ruff", _sample(tmp_path, "s.py", "x = 1\n"), env)
+    assert "skipped" in out, describe(out)
+
+
+# ---------------------------------------------------------------------------
+# yaml-check — the absent dependency is a library, not a binary
+# ---------------------------------------------------------------------------
+
+def _no_pyyaml_env(tmp_path: Path) -> dict:
+    """An importable `yaml` that raises on import, ahead of any real PyYAML.
+
+    Emptying PATH cannot reach this adapters cant-run arm: its dependency is
+    imported, not spawned. Uninstalling PyYAML for one test is not available, so
+    the import is shadowed instead.
+    """
+    stub = tmp_path / "_stub"
+    stub.mkdir()
+    (stub / "yaml.py").write_text(
+        "raise ImportError('PyYAML shadowed by the test')\n", encoding="utf-8")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(stub)
+    return env
+
+
+def test_yaml_check_without_pyyaml_is_a_skip_not_a_pass(tmp_path: Path) -> None:
+    out = _run("yaml-check", _sample(tmp_path, "s.yaml", "a: 1\n"),
+               _no_pyyaml_env(tmp_path))
+    assert "skipped" in out, describe(out)
+    for key in ("ok", "count", "errors"):
+        assert key not in out, f"a skip must not carry {key!r}: {out}"
+
+
+def test_yaml_check_without_pyyaml_escalates_when_required(tmp_path: Path) -> None:
+    env = _no_pyyaml_env(tmp_path)
+    env["SUPERTOOL_REQUIRE_VALIDATORS"] = "yaml-check"
+    out = _run("yaml-check", _sample(tmp_path, "s.yaml", "a: 1\n"), env)
+    assert "skipped" not in out, describe(out)
+    assert_declined(out, context="yaml-check required without PyYAML")
+    assert "SUPERTOOL_REQUIRE_VALIDATORS" in out["errors"][0]["msg"]
+
+
+# ---------------------------------------------------------------------------
+# The MCP adapters — same absence, raised as an exception instead of a `which`
+# ---------------------------------------------------------------------------
+
+MCP_ADAPTERS = ["phpstan-mcp", "rector-mcp", "phpunit-mcp", "phpmd-mcp"]
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(
+        name.replace("-", "_"), _adapter(name))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_mcp(name: str, tmp_path: Path, capsys, monkeypatch) -> dict:
+    """Drive the adapters own `main` with the daemon reporting itself absent.
+
+    `DaemonUnavailable` is raised when the analyser is not installed *for this
+    working directory*, which is exactly the absent-tool case the other half of
+    this file reaches through `shutil.which` — the two look different only
+    because a daemon has to be started before it can be missed.
+    """
+    mod = _load(name)
+    from refusal import DaemonUnavailable
+
+    def _absent(*_a, **_k):
+        raise DaemonUnavailable(f"{name} is not installed for this directory")
+
+    monkeypatch.setattr(mod, "ensure_daemon", _absent)
+    f = _sample(tmp_path, "s.php", "<?php\n")
+    capsys.readouterr()
+    mod.main([str(_adapter(name)), str(f)])
+    return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+
+
+@pytest.mark.parametrize("name", MCP_ADAPTERS)
+def test_an_absent_mcp_daemon_is_a_skip(
+        name: str, tmp_path: Path, capsys, monkeypatch) -> None:
+    monkeypatch.delenv("SUPERTOOL_REQUIRE_VALIDATORS", raising=False)
+    out = _run_mcp(name, tmp_path, capsys, monkeypatch)
+    assert "skipped" in out, describe(out)
+
+
+@pytest.mark.parametrize("name", MCP_ADAPTERS)
+def test_an_absent_mcp_daemon_escalates_when_required(
+        name: str, tmp_path: Path, capsys, monkeypatch) -> None:
+    monkeypatch.setenv("SUPERTOOL_REQUIRE_VALIDATORS", name)
+    out = _run_mcp(name, tmp_path, capsys, monkeypatch)
+    assert "skipped" not in out, describe(out)
+    assert_declined(out, context=f"{name} required, daemon absent")
+    assert "SUPERTOOL_REQUIRE_VALIDATORS" in out["errors"][0]["msg"]

--- a/tests/test_validators_absent_tool_third_state_1202.py
+++ b/tests/test_validators_absent_tool_third_state_1202.py
@@ -225,3 +225,87 @@ def test_an_absent_mcp_daemon_escalates_when_required(
     assert "skipped" not in out, describe(out)
     assert_declined(out, context=f"{name} required, daemon absent")
     assert "SUPERTOOL_REQUIRE_VALIDATORS" in out["errors"][0]["msg"]
+
+# ---------------------------------------------------------------------------
+# `which` said yes and exec said no — the second absent-tool arm
+# ---------------------------------------------------------------------------
+#
+# Found by the review of the first commit, and it is why the fix is larger than
+# the audit. Emptying `PATH` reaches only the `shutil.which` guard; seven
+# adapters carried a *second* absent-tool arm underneath it, catching the
+# `FileNotFoundError` that a PATH entry vanishing between the lookup and the
+# spawn produces — and every one of them still answered it with `ok: true`. The
+# docstrings rewritten in the same commit claimed otherwise, so for one commit
+# the prose was more wrong than the code it described.
+#
+# Reached by shadowing `shutil.which` and `subprocess.run` and running the
+# adapter through `runpy`, the technique `tests/test_yaml_check.py` already
+# uses: portable, and it exercises the real module rather than a stub of it. A
+# shebang pointing at a missing interpreter would be the more honest
+# reproduction and is POSIX-only, which would leave this arm unasserted on the
+# platform that breaks most often.
+
+EXEC_FAILS_ADAPTERS = [
+    ("ruff", "s.py", "x = 1\n"),
+    ("pyright", "s.py", "x = 1\n"),
+    ("tsc-check", "s.ts", "const x: number = 1;\n"),
+    ("markdownlint", "s.md", "# t\n"),
+    ("ruby-check", "s.rb", "puts 1\n"),
+    ("hadolint", "Dockerfile", "FROM scratch\n"),
+    ("gofmt-check", "s.go", "package main\n"),
+    ("terraform-check", "s.tf", "variable \"x\" {}\n"),
+    ("cargo-check", "src/main.rs", "fn main() {}\n"),
+]
+
+
+def _run_with_exec_failing(name: str, tmp_path: Path, filename: str,
+                           body: str, env: dict) -> dict:
+    target = tmp_path / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    if name == "cargo-check":
+        # Reached only past the crate-root walk, which is a scope refusal and
+        # deliberately not an escalation.
+        (tmp_path / "Cargo.toml").write_text(
+            '[package]\nname = "x"\nversion = "0.1.0"\n', encoding="utf-8")
+
+    shim = tmp_path / "_exec_fails_shim.py"
+    shim.write_text(
+        "import runpy, shutil, subprocess, sys\n"
+        "shutil.which = lambda *a, **k: 'a-path-that-resolved'\n"
+        "def _gone(*a, **k):\n"
+        "    raise FileNotFoundError(2, 'No such file or directory')\n"
+        "subprocess.run = _gone\n"
+        f"runpy.run_path({str(_adapter(name))!r}, run_name='__main__')\n",
+        encoding="utf-8")
+
+    r = subprocess.run([sys.executable, str(shim), str(target)],
+                       capture_output=True, text=True, env=env,
+                       encoding="utf-8", errors="replace")
+    assert r.stdout.strip(), (
+        f"{name}: adapter printed no verdict at all; stderr={r.stderr!r}")
+    return json.loads(r.stdout.strip().splitlines()[-1])
+
+
+@pytest.mark.parametrize("name,filename,body", EXEC_FAILS_ADAPTERS,
+                         ids=[a[0] for a in EXEC_FAILS_ADAPTERS])
+def test_a_tool_that_resolved_and_would_not_run_is_the_third_state(
+        tmp_path: Path, name: str, filename: str, body: str) -> None:
+    env = dict(os.environ)
+    env.pop("SUPERTOOL_REQUIRE_VALIDATORS", None)
+    out = _run_with_exec_failing(name, tmp_path, filename, body, env)
+    assert "skipped" in out, describe(out)
+    for key in ("ok", "count", "errors"):
+        assert key not in out, f"{name}: a skip must not carry {key!r}: {out}"
+
+
+@pytest.mark.parametrize("name,filename,body", EXEC_FAILS_ADAPTERS,
+                         ids=[a[0] for a in EXEC_FAILS_ADAPTERS])
+def test_a_tool_that_would_not_run_escalates_when_required(
+        tmp_path: Path, name: str, filename: str, body: str) -> None:
+    env = dict(os.environ)
+    env["SUPERTOOL_REQUIRE_VALIDATORS"] = name
+    out = _run_with_exec_failing(name, tmp_path, filename, body, env)
+    assert "skipped" not in out, describe(out)
+    assert_declined(out, context=f"{name} required, resolved but unrunnable")
+    assert "SUPERTOOL_REQUIRE_VALIDATORS" in out["errors"][0]["msg"]

--- a/tests/test_validators_git_status.py
+++ b/tests/test_validators_git_status.py
@@ -115,11 +115,17 @@ def test_not_in_git_repo(tmp_path: Path) -> None:
 
 
 def test_git_absent(tmp_path: Path) -> None:
-    """When git binary is missing → ok=true, graceful skip."""
+    """When the git binary is missing → the third state, not a zeroed metric.
+
+    This asserted `ok is True` alongside a `metrics` block reading
+    `state: "clean"` — a measurement of a working tree nothing had looked at,
+    and indistinguishable from a file that genuinely had no changes (#1202).
+    """
     f = tmp_path / "x.txt"
     f.write_text("x\n")
     env = {**os.environ, "GIT_BIN": "/nonexistent/git"}
     data = _run(str(f), env=env)
-    assert data["ok"] is True
-    assert data["count"] == 0
-    assert data["errors"] == []
+    assert "skipped" in data, data
+    assert "git not found" in data["skipped"], data
+    for key in ("ok", "count", "errors", "metrics"):
+        assert key not in data, f"a skip must not carry {key!r}: {data}"

--- a/tests/test_validators_tier2.py
+++ b/tests/test_validators_tier2.py
@@ -190,7 +190,8 @@ def test_gofmt_check_unformatted_file_is_hard_error(tmp_path: Path) -> None:
     assert "gofmt" in data["errors"][0]["msg"]
 
 
-def test_gofmt_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None:
+def test_gofmt_check_missing_tool_is_the_third_state(tmp_path: Path) -> None:
+    """Absent gofmt is `skipped`, not `ok: true` (#1202)."""
     f = tmp_path / "x.go"
     f.write_text("package main\n")
     # Use a PATH that has Python but no gofmt (point to an empty dir)
@@ -199,9 +200,9 @@ def test_gofmt_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None:
     r = subprocess.run([sys.executable, str(GOFMT_CHECK), str(f)],
                        capture_output=True, text=True, timeout=adapter_budget(GOFMT_CHECK), env=env, encoding="utf-8", errors="replace")
     data = json.loads(r.stdout.strip())
-    assert_ok(data)
-    assert data["count"] == 0
-    assert "gofmt" in r.stderr
+    assert "skipped" in data, data
+    assert "gofmt" in data["skipped"]
+    assert "ok" not in data, data
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +241,8 @@ def test_terraform_check_unformatted_file_is_hard_error(tmp_path: Path) -> None:
     assert isinstance(data["errors"], list)
 
 
-def test_terraform_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None:
+def test_terraform_check_missing_tool_is_the_third_state(tmp_path: Path) -> None:
+    """Absent terraform is `skipped`, not `ok: true` (#1202)."""
     f = tmp_path / "x.tf"
     f.write_text('resource "null_resource" "x" {}\n')
     python_dir = str(Path(sys.executable).parent)
@@ -248,9 +250,9 @@ def test_terraform_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None
     r = subprocess.run([sys.executable, str(TERRAFORM_CHECK), str(f)],
                        capture_output=True, text=True, timeout=adapter_budget(TERRAFORM_CHECK), env=env, encoding="utf-8", errors="replace")
     data = json.loads(r.stdout.strip())
-    assert_ok(data)
-    assert data["count"] == 0
-    assert "terraform" in r.stderr
+    assert "skipped" in data, data
+    assert "terraform" in data["skipped"]
+    assert "ok" not in data, data
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +268,8 @@ def test_cargo_check_no_arg_returns_schema_error() -> None:
     assert "no file arg" in data["errors"][0]["msg"]
 
 
-def test_cargo_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None:
+def test_cargo_check_missing_tool_is_the_third_state(tmp_path: Path) -> None:
+    """Absent cargo is `skipped`, not `ok: true` (#1202)."""
     f = tmp_path / "src" / "main.rs"
     f.parent.mkdir()
     f.write_text("fn main() {}\n")
@@ -277,21 +280,26 @@ def test_cargo_check_graceful_skip_when_tool_missing(tmp_path: Path) -> None:
     r = subprocess.run([sys.executable, str(CARGO_CHECK), str(f)],
                        capture_output=True, text=True, timeout=adapter_budget(CARGO_CHECK), env=env, encoding="utf-8", errors="replace")
     data = json.loads(r.stdout.strip())
-    assert_ok(data)
-    assert data["count"] == 0
-    assert "cargo" in r.stderr
+    assert "skipped" in data, data
+    assert "cargo" in data["skipped"]
+    assert "ok" not in data, data
 
 
-def test_cargo_check_graceful_skip_when_no_cargo_toml(tmp_path: Path) -> None:
+def test_cargo_check_no_crate_is_the_third_state(tmp_path: Path) -> None:
+    """A file in no crate was not compiled, whether or not cargo is installed.
+
+    Both arms are a skip now, so this no longer depends on which of the two
+    fired — which is what made the old `assert_ok` version pass everywhere
+    while asserting nothing about either.
+    """
     f = tmp_path / "orphan.rs"
     f.write_text("fn main() {}\n")
     # No Cargo.toml anywhere in tmp_path parents (tmp_path is ephemeral)
     r = subprocess.run([sys.executable, str(CARGO_CHECK), str(f)],
                        capture_output=True, text=True, timeout=adapter_budget(CARGO_CHECK), encoding="utf-8", errors="replace")
     data = json.loads(r.stdout.strip())
-    # If cargo is on PATH: skip because no Cargo.toml. If cargo missing: also skip.
-    assert_ok(data)
-    assert data["count"] == 0
+    assert "skipped" in data, data
+    assert "NOT compiled" in data["skipped"], data
 
 
 @pytest.mark.skipif(not shutil.which("cargo"), reason="cargo not installed")

--- a/tests/test_yaml_check.py
+++ b/tests/test_yaml_check.py
@@ -135,8 +135,13 @@ def test_no_arg_returns_error() -> None:
 # PyYAML missing — graceful degrade
 # ---------------------------------------------------------------------------
 
-def test_pyyaml_missing_exits_ok_with_warning(tmp_path: Path) -> None:
-    """When PyYAML is not installed, validator should exit 0 and warn on stderr."""
+def test_pyyaml_missing_is_the_third_state(tmp_path: Path) -> None:
+    """Absent PyYAML is `skipped`, not `ok: true` (#1202).
+
+    The reason moved from stderr into the payload, where a consumer can see it:
+    a stderr warning next to `ok: true` is not something the delta, the
+    validator row or CI reads.
+    """
     f = tmp_path / "any.yml"
     f.write_text("key: value\n")
     # Patch builtins.__import__ to raise ImportError for 'yaml'
@@ -157,8 +162,9 @@ def test_pyyaml_missing_exits_ok_with_warning(tmp_path: Path) -> None:
         text=True, encoding="utf-8", errors="replace",
     )
     out = json.loads(result.stdout)
-    assert out["ok"] is True
-    assert "PyYAML" in result.stderr or "pyyaml" in result.stderr.lower()
+    assert "skipped" in out, out
+    assert "PyYAML" in out["skipped"], out
+    assert "ok" not in out, out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_check.py
+++ b/tests/test_yaml_check.py
@@ -2,22 +2,31 @@
 from __future__ import annotations
 
 import json
-import shutil
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-ADAPTER = Path(__file__).parent.parent / "validators" / "yaml-check" / "yaml-check.py"
+REPO = Path(__file__).parent.parent
+ADAPTER = REPO / "validators" / "yaml-check" / "yaml-check.py"
+PYPROJECT = REPO / "pyproject.toml"
 
-# Use a Python interpreter that has PyYAML installed, falling back to sys.executable.
-# On this machine, python3.13 has PyYAML; python3.14 (pytest default) does not.
-_PYTHON_WITH_YAML = shutil.which("python3.13") or sys.executable
+# The interpreter running pytest, and no other. Until #1213 this hunted for a
+# `python3.13` on PATH because that is where the author's PyYAML happened to
+# live, so the happy-path tests below ran against an interpreter nobody
+# configured. On CI no such interpreter exists, the fallback had no PyYAML, and
+# they passed anyway on the `ok: true` this PR removed — four assertions about
+# parsing YAML, on twelve legs, holding up a fabricated verdict.
+_PYTHON_WITH_YAML = sys.executable
 _HAS_PYYAML = subprocess.run(
     [_PYTHON_WITH_YAML, "-c", "import yaml"],
     capture_output=True,
 ).returncode == 0
+_NEEDS_PYYAML = pytest.mark.skipif(
+    not _HAS_PYYAML,
+    reason="PyYAML not installed for this interpreter — `pip install -e .[dev]` provides it")
 
 
 def _run(file_path: str, python: str = _PYTHON_WITH_YAML) -> tuple[dict, str]:
@@ -33,6 +42,7 @@ def _run(file_path: str, python: str = _PYTHON_WITH_YAML) -> tuple[dict, str]:
 # Valid YAML
 # ---------------------------------------------------------------------------
 
+@_NEEDS_PYYAML
 def test_valid_yaml_simple(tmp_path: Path) -> None:
     f = tmp_path / "good.yml"
     f.write_text("key: value\nnum: 42\n")
@@ -43,6 +53,7 @@ def test_valid_yaml_simple(tmp_path: Path) -> None:
     assert out["tool"] == "yaml-check"
 
 
+@_NEEDS_PYYAML
 def test_valid_yaml_list(tmp_path: Path) -> None:
     f = tmp_path / "list.yml"
     f.write_text("- one\n- two\n- three\n")
@@ -51,6 +62,7 @@ def test_valid_yaml_list(tmp_path: Path) -> None:
     assert out["count"] == 0
 
 
+@_NEEDS_PYYAML
 def test_valid_yaml_nested(tmp_path: Path) -> None:
     f = tmp_path / "nested.yaml"
     f.write_text("stages:\n  - build\n  - test\njobs:\n  build:\n    script: make\n")
@@ -58,6 +70,7 @@ def test_valid_yaml_nested(tmp_path: Path) -> None:
     assert out["ok"] is True
 
 
+@_NEEDS_PYYAML
 def test_valid_gitlab_ci_like(tmp_path: Path) -> None:
     f = tmp_path / ".gitlab-ci.yml"
     f.write_text(
@@ -164,19 +177,38 @@ def test_pyyaml_missing_is_the_third_state(tmp_path: Path) -> None:
     out = json.loads(result.stdout)
     assert "skipped" in out, out
     assert "PyYAML" in out["skipped"], out
-    assert "ok" not in out, out
+    # Not a pass, and not a failure either: `count`/`errors` are as absent as
+    # `ok`, so no consumer reading any one of the three can turn an unparsed
+    # file into a verdict about it.
+    for key in ("ok", "count", "errors"):
+        assert key not in out, f"a skip must not carry {key!r}: {out}"
 
 
 # ---------------------------------------------------------------------------
 # Output schema
 # ---------------------------------------------------------------------------
 
-def test_output_contains_required_fields(tmp_path: Path) -> None:
+def test_output_is_exactly_one_of_the_two_shapes(tmp_path: Path) -> None:
+    """A verdict or a skip — never both, never neither (#1213).
+
+    This asserted `ok` unconditionally, which is a claim about PyYAML being
+    installed rather than about the adapter. Whether it is installed is the
+    machine's business; what the adapter owes is that a reader can always tell
+    which of the three states came back. A skip carries no verdict key, so it
+    reads as neither a pass nor a failure, and both shapes describe the attempt.
+    """
     f = tmp_path / "x.yml"
     f.write_text("a: 1\n")
     out, _ = _run(str(f))
-    for key in ("tool", "file", "ok", "count", "errors", "duration_ms"):
-        assert key in out
+    for key in ("tool", "file", "duration_ms"):
+        assert key in out, out
+    verdict = [k for k in ("ok", "count", "errors") if k in out]
+    if "skipped" in out:
+        assert out["skipped"], out
+        assert verdict == [], f"a skip must carry no verdict key: {out}"
+    else:
+        assert verdict == ["ok", "count", "errors"], (
+            f"a verdict must be complete, not partial: {out}")
 
 
 def test_duration_ms_is_int(tmp_path: Path) -> None:
@@ -184,6 +216,25 @@ def test_duration_ms_is_int(tmp_path: Path) -> None:
     f.write_text("a: 1\n")
     out, _ = _run(str(f))
     assert isinstance(out["duration_ms"], int)
+
+
+def test_pyyaml_is_a_dev_dependency_so_ci_runs_the_parsing_half() -> None:
+    """The gate above must not be how yaml-check gets tested on every leg (#1213).
+
+    Every assertion in this file about parsing YAML is skipped when PyYAML is
+    absent, which is honest and is also how a suite reports green while
+    exercising nothing — this repo's most-filed defect, one level up. The dev
+    extra is what makes the skip a local convenience rather than the CI outcome:
+    both workflows install `.[dev]`, so removing this line would silently retire
+    the parsing half instead of reddening anything. Same reasoning, and the same
+    line, as `ruff`.
+    """
+    text = PYPROJECT.read_text(encoding="utf-8")
+    block = re.search(r"^dev = \[(.*?)^\]", text, re.S | re.M)
+    assert block, "no `dev = [...]` extra in pyproject.toml"
+    assert re.search(r'"pyyaml"', block.group(1), re.I), (
+        "pyyaml dropped from the dev extra — tests/test_yaml_check.py's parsing "
+        "half would skip on every CI leg and the board would stay green")
 
 
 @pytest.mark.skipif(not _HAS_PYYAML, reason="PyYAML not available on this interpreter")

--- a/tests/test_yaml_check.py
+++ b/tests/test_yaml_check.py
@@ -203,6 +203,11 @@ def test_output_is_exactly_one_of_the_two_shapes(tmp_path: Path) -> None:
     for key in ("tool", "file", "duration_ms"):
         assert key in out, out
     verdict = [k for k in ("ok", "count", "errors") if k in out]
+    # Which shape came back is not free either. Consistency alone would still
+    # hold if the adapter regressed to skipping unconditionally, so the branch
+    # is checked against the one piece of ground truth this file has.
+    assert ("skipped" in out) is not _HAS_PYYAML, (
+        f"PyYAML importable={_HAS_PYYAML} but the adapter answered: {out}")
     if "skipped" in out:
         assert out["skipped"], out
         assert verdict == [], f"a skip must carry no verdict key: {out}"

--- a/validators/SCHEMA.md
+++ b/validators/SCHEMA.md
@@ -36,7 +36,7 @@ Universal JSON. Every adapter emits this shape. Validator core never parses tool
 
 An adapter reports it by emitting `"skipped": "<reason>"` and **omitting `ok`, `count` and `errors` entirely** (#515). A receipt carrying `ok: true` reads as a pass to anything keying off `ok`, which is the mistake the third state exists to end; leaving the verdict keys out makes a skip structurally impossible to misread as one. `tool`, `file` and `duration_ms` stay — they describe the attempt, not a verdict.
 
-Consumers must branch on the presence of `skipped` before reading any verdict key. Every core consumer already does, and has to: the reason string exists only on a skip. Use `validators/common/refusal.py:skipped()` rather than building the dict by hand. The core then guarantees:
+Consumers must branch on the presence of `skipped` before reading any verdict key. Every core consumer already does, and has to: the reason string exists only on a skip. Use `validators/common/refusal.py:skipped()` rather than building the dict by hand — and for the specific case of the adapter's **tool being absent**, use `absent(tool, file, reason, dur_ms)` instead, which is `skipped()` plus the `$SUPERTOOL_REQUIRE_VALIDATORS` escalation. Spelling that decision out per adapter is how five of thirty-four ended up with an escalation that worked and ten ended up answering an absent tool with `ok: true` (#1202). `tool` there is the validator name a repo writes in `.supertool.json`, not the binary. The core then guarantees:
 
 - the row renders as `skipped (<reason>)`, never `0 → 1 (+1) ✗`;
 - the result is excluded from the before/after delta;

--- a/validators/cargo-check/cargo-check.py
+++ b/validators/cargo-check/cargo-check.py
@@ -386,9 +386,12 @@ def main() -> None:
             cwd=str(crate_root), encoding="utf-8", errors="replace",
         )
     except FileNotFoundError:
-        print("cargo-check: cargo not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "cargo-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        # `which` said yes and exec said no — a PATH entry that vanished
+        # between the two, or a name that resolves to something unrunnable.
+        # Still an absent tool, so still the third state.
+        emit(absent(TOOL, file, "cargo on PATH but could not be executed — "
+                                "this file was NOT compiled",
+                    int((time.time() - start) * 1000)))
         return
     except subprocess.TimeoutExpired:
         emit({"tool": "cargo-check", "file": file, "ok": False, "count": 1,

--- a/validators/cargo-check/cargo-check.py
+++ b/validators/cargo-check/cargo-check.py
@@ -5,8 +5,15 @@ NOTE: This validator compiles the entire crate — it can be slow (5-30s on firs
 run). Consider disabling it for hot-loop editing via `opt_in: true` in your
 .supertool.json validator config.
 
-Requires cargo (ships with Rust). If missing, exits 0 with a stderr warning.
-Finds Cargo.toml by walking up from the .rs file. Skips if none found.
+Requires cargo (ships with Rust). Absent, this reports the third state —
+`skipped` with the reason — rather than the `ok: true` it emitted until #1202,
+which was a clean verdict about a file nothing compiled. Name this validator in
+`$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a loud error instead.
+
+Finds Cargo.toml by walking up from the .rs file. A file in no crate is also a
+`skipped`, but never escalates: cargo is installed and working, and the reason
+the gate did not run is the file, not the CI image.
+
 Usage:  cargo-check.py <file>
 """
 
@@ -27,7 +34,11 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
-from refusal import tool_fault
+from refusal import absent, skipped, tool_fault
+
+TOOL = "cargo-check"
+INSTALL_HINT = ("cargo not found on PATH — this file was NOT compiled "
+                "(install the Rust toolchain via rustup)")
 
 
 def emit(d: dict) -> None:
@@ -353,16 +364,19 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("cargo"):
-        print("cargo-check: cargo not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "cargo-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     crate_root = _find_crate_root(file)
     if crate_root is None:
-        print("cargo-check: no Cargo.toml found, skipping", file=sys.stderr)
-        emit({"tool": "cargo-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        # A scope refusal, not an absent tool: `skipped()` directly rather than
+        # `absent()`, because no CI image change makes a file in no crate
+        # compilable and escalating it would fire on every loose `.rs`.
+        emit(skipped(TOOL, file,
+                     "no Cargo.toml above this file — it belongs to no crate, "
+                     "so it was NOT compiled",
+                     int((time.time() - start) * 1000)))
         return
 
     try:

--- a/validators/common/refusal.py
+++ b/validators/common/refusal.py
@@ -224,6 +224,42 @@ def required_but_absent(tool: str, reason: str) -> str:
             f"file was NOT checked: {reason}")
 
 
+def absent(tool: str, file_path: str, reason: str, dur_ms: int) -> dict:
+    """The absent-tool arm of every adapter, as one call (#1202).
+
+    `required()` shipped as a helper each adapter had to remember to call, and
+    six of them did. The rest spelled the same moment three other ways: a
+    `skipped` that could never be escalated (`ruff`, `html-check`, the four MCP
+    adapters), or — worse and on the adjacent line — a fabricated
+    `{"ok": true, "count": 0, "errors": []}` about a file nothing opened
+    (`tsc-check`, `markdownlint`, `ruby-check`, `cargo-check`, `hadolint`,
+    `gofmt-check`, `terraform-check`, `pyright`, `git-status`, `yaml-check`).
+
+    An opt-in switch that a caller sets and cannot tell they set is worse than
+    no switch, and a clean verdict from a checker that never ran is the failure
+    this whole module exists to end. Both were spelled adapter by adapter, so
+    both were only ever as good as the last author's memory. They are one call
+    now: an adapter states the absence and its reason, and where that lands is
+    decided here.
+
+    `tool` is the **validator name** — the key a repo writes in
+    `.supertool.json` — never the binary. `tsc-check` runs `tsc` and
+    `html-check` runs `node`; escalating on the binary name would ignore the
+    only spelling anyone can configure.
+
+    Reserve this for an *absent* tool. A tool that ran and fell over is
+    `tool_fault()`, a scope refusal is `skipped()` directly, and neither
+    becomes louder because someone asked for the gate to be installed.
+    """
+    if required(tool):
+        return {"tool": tool, "file": file_path, "ok": False, "count": 1,
+                "errors": [{"line": None, "col": None, "severity": "error",
+                            "code": "adapter",
+                            "msg": required_but_absent(tool, reason)}],
+                "duration_ms": dur_ms}
+    return skipped(tool, file_path, reason, dur_ms)
+
+
 def skipped(tool: str, file_path: str, reason: str, dur_ms: int) -> dict:
     """A SCHEMA.md result in the third state: not clean, not broken, not looked at.
 

--- a/validators/git-status/git-status.py
+++ b/validators/git-status/git-status.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
 """git-status validator adapter. Emits SCHEMA.md JSON.
 
-Always ok=true — reports working-tree delta as metrics, never triggers rollback.
+Reports the working-tree delta as metrics and never triggers rollback, so a
+verdict from this adapter is `ok: true` or nothing at all.
+
+"Or nothing at all" is the part that was missing until #1202: with git absent it
+answered `ok: true` with a zeroed `metrics` block whose `state` was `clean` — a
+positive claim about a file it had not looked at, and the one shape a reader
+cannot tell from a real answer. That is now `skipped`, escalating to a loud
+error when this validator is named in `$SUPERTOOL_REQUIRE_VALIDATORS`.
 
 Usage: git-status.py <file>
 
@@ -17,6 +24,13 @@ import subprocess
 import sys
 import pathlib
 import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
+from refusal import absent
+
+TOOL = "git-status"
+INSTALL_HINT = ("git not found on PATH — the working-tree delta for this file "
+                "was NOT measured (set $GIT_BIN if git lives elsewhere)")
 
 
 def emit(obj: dict) -> None:
@@ -75,13 +89,9 @@ def main() -> None:
     git_bin = os.environ.get("GIT_BIN", "git")
 
     if not shutil.which(git_bin):
-        emit({
-            "tool": "git-status", "file": file, "ok": True, "count": 0,
-            "errors": [], "duration_ms": 0,
-            "metrics": {"lines_added": 0, "lines_removed": 0,
-                        "lines_staged_added": 0, "lines_staged_removed": 0,
-                        "state": "clean"},
-        })
+        # Not `state: "clean"`. A zeroed metrics block is a measurement, and no
+        # measurement was taken.
+        emit(absent(TOOL, file, INSTALL_HINT, 0))
         return
 
     start = time.time()

--- a/validators/gofmt-check/gofmt-check.py
+++ b/validators/gofmt-check/gofmt-check.py
@@ -89,9 +89,12 @@ def main() -> None:
         r = subprocess.run(["gofmt", "-l", file],
                            capture_output=True, text=True, timeout=30, encoding="utf-8", errors="replace")
     except FileNotFoundError:
-        print("gofmt-check: gofmt not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "gofmt-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        # `which` said yes and exec said no — a PATH entry that vanished
+        # between the two, or a name that resolves to something unrunnable.
+        # Still an absent tool, so still the third state.
+        emit(absent(TOOL, file, "gofmt on PATH but could not be executed — "
+                                "this file was NOT format-checked",
+                    int((time.time() - start) * 1000)))
         return
     except subprocess.TimeoutExpired:
         emit({"tool": "gofmt-check", "file": file, "ok": False, "count": 1,

--- a/validators/gofmt-check/gofmt-check.py
+++ b/validators/gofmt-check/gofmt-check.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """gofmt-check validator adapter — Go formatting check via `gofmt -l`.
 
-Requires gofmt (ships with Go). If missing, exits 0 with a stderr warning.
+Requires gofmt (ships with Go). Absent, this reports the third state — `skipped`
+with the reason — rather than the `ok: true` it emitted until #1202, which was a
+clean verdict about a file nothing formatted-checked. Name this validator in
+`$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a loud error instead.
+
 Usage:  gofmt-check.py <file>
 """
 
@@ -17,7 +21,11 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
-from refusal import tool_fault
+from refusal import absent, tool_fault
+
+TOOL = "gofmt-check"
+INSTALL_HINT = ("gofmt not found on PATH — this file was NOT format-checked "
+                "(install Go)")
 
 # gofmt splits its two answers across the two streams and two exit codes, and
 # the adapter read neither until #753:
@@ -73,9 +81,8 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("gofmt"):
-        print("gofmt-check: gofmt not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "gofmt-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     try:

--- a/validators/hadolint/hadolint.py
+++ b/validators/hadolint/hadolint.py
@@ -63,9 +63,12 @@ def main() -> None:
             timeout=TIMEOUT_S, encoding="utf-8", errors="replace",
         )
     except FileNotFoundError:
-        print("hadolint: hadolint not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "hadolint", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        # `which` said yes and exec said no — a PATH entry that vanished
+        # between the two, or a name that resolves to something unrunnable.
+        # Still an absent tool, so still the third state.
+        emit(absent(TOOL, file, "hadolint on PATH but could not be executed — "
+                                "this Dockerfile was NOT linted",
+                    int((time.time() - start) * 1000)))
         return
     except subprocess.TimeoutExpired:
         # Not a finding about the file, and not silence either. Without this

--- a/validators/hadolint/hadolint.py
+++ b/validators/hadolint/hadolint.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """hadolint validator adapter — Dockerfile lint via hadolint CLI.
 
-Requires hadolint on PATH. If missing, exits 0 with a stderr warning (graceful degrade).
+Requires hadolint on PATH. Absent, this reports the third state — `skipped` with
+the reason — rather than the `ok: true` it emitted until #1202, which was a clean
+verdict about a Dockerfile nothing linted. Name this validator in
+`$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a loud error instead.
+
 Usage:  hadolint.py <file>
 """
 
@@ -17,6 +21,11 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
+from refusal import absent
+
+TOOL = "hadolint"
+INSTALL_HINT = ("hadolint not found on PATH — this Dockerfile was NOT linted "
+                "(`brew install hadolint`)")
 
 
 # Budget for the one tool spawn below. A module constant rather than a literal
@@ -42,9 +51,8 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("hadolint"):
-        print("hadolint: hadolint not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "hadolint", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     try:

--- a/validators/html-check/html-check.py
+++ b/validators/html-check/html-check.py
@@ -43,7 +43,7 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
-from refusal import tool_fault, skipped
+from refusal import absent, tool_fault, skipped
 
 TIMEOUT_S = 30
 
@@ -372,9 +372,9 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("node"):
-        emit(skipped("html-check", file,
-                      "node not on PATH — inline <script> blocks were NOT checked",
-                      int((time.time() - start) * 1000)))
+        emit(absent("html-check", file,
+                    "node not on PATH — inline <script> blocks were NOT checked",
+                    int((time.time() - start) * 1000)))
         return
 
     try:

--- a/validators/markdownlint/markdownlint.py
+++ b/validators/markdownlint/markdownlint.py
@@ -63,9 +63,12 @@ def main() -> None:
             timeout=TIMEOUT_S, encoding="utf-8", errors="replace",
         )
     except FileNotFoundError:
-        print("markdownlint: markdownlint not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "markdownlint", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        # `which` said yes and exec said no — a PATH entry that vanished
+        # between the two, or a name that resolves to something unrunnable.
+        # Still an absent tool, so still the third state.
+        emit(absent(TOOL, file, "markdownlint on PATH but could not be "
+                                "executed — this file was NOT linted",
+                    int((time.time() - start) * 1000)))
         return
     except subprocess.TimeoutExpired:
         # See hadolint.py for why this is a finding rather than a skip, and

--- a/validators/markdownlint/markdownlint.py
+++ b/validators/markdownlint/markdownlint.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """markdownlint validator adapter — Markdown lint via markdownlint CLI.
 
-Requires markdownlint on PATH. If missing, exits 0 with a stderr warning (graceful degrade).
+Requires markdownlint on PATH. Absent, this reports the third state — `skipped`
+with the reason — rather than the `ok: true` it emitted until #1202, which was a
+clean verdict about a file nothing linted. Name this validator in
+`$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a loud error instead.
+
 Usage:  markdownlint.py <file>
 """
 
@@ -17,6 +21,11 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
+from refusal import absent
+
+TOOL = "markdownlint"
+INSTALL_HINT = ("markdownlint not found on PATH — this file was NOT linted "
+                "(`npm install -g markdownlint-cli`)")
 
 
 # Budget for the one tool spawn below. A module constant rather than a literal
@@ -42,9 +51,8 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("markdownlint"):
-        print("markdownlint: markdownlint not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "markdownlint", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     try:

--- a/validators/phpmd-mcp/phpmd-mcp.py
+++ b/validators/phpmd-mcp/phpmd-mcp.py
@@ -214,8 +214,11 @@ def main(argv: list[str]) -> int:
         resp = ndjson_call(sock, os.path.abspath(file_path))
     except _refusal.DaemonUnavailable as e:
         # Not installed for this working directory — every `cwd:` into a git
-        # worktree lands here. Nothing was analysed, so nothing is reported.
-        print(json.dumps(_refusal.skipped(
+        # worktree lands here. Nothing was analysed, so nothing is reported —
+        # unless this validator is named in `$SUPERTOOL_REQUIRE_VALIDATORS`, in
+        # which case an absent analyser is the gate not running and says so
+        # loudly (#1202). `absent`, not `skipped`, is what makes that reachable.
+        print(json.dumps(_refusal.absent(
             "phpmd-mcp", file_path, str(e),
             int((time.monotonic() - t0) * 1000))))
         return 0

--- a/validators/phpstan-mcp/phpstan-mcp.py
+++ b/validators/phpstan-mcp/phpstan-mcp.py
@@ -225,9 +225,13 @@ def main(argv: list[str]) -> int:
         resp = ndjson_call(sock, os.path.abspath(file_path))
     except _refusal.DaemonUnavailable as e:
         # Not installed for this working directory — every `cwd:` into a git
-        # worktree lands here. Nothing was analysed, so nothing is reported.
-        print(json.dumps(skipped(file_path, str(e),
-                                 int((time.monotonic() - t0) * 1000))))
+        # worktree lands here. Nothing was analysed, so nothing is reported —
+        # unless this validator is named in `$SUPERTOOL_REQUIRE_VALIDATORS`, in
+        # which case an absent analyser is the gate not running and says so
+        # loudly (#1202). `absent`, not `skipped`, is what makes that reachable.
+        print(json.dumps(_refusal.absent(
+            "phpstan-mcp", file_path, str(e),
+            int((time.monotonic() - t0) * 1000))))
         return 0
     except Exception as e:
         import traceback

--- a/validators/phpunit-mcp/phpunit-mcp.py
+++ b/validators/phpunit-mcp/phpunit-mcp.py
@@ -252,8 +252,11 @@ def main(argv: list[str]) -> int:
         resp = ndjson_call(sock, os.path.abspath(file_path))
     except _refusal.DaemonUnavailable as e:
         # Not installed for this working directory — every `cwd:` into a git
-        # worktree lands here. Nothing was analysed, so nothing is reported.
-        print(json.dumps(_refusal.skipped(
+        # worktree lands here. Nothing was analysed, so nothing is reported —
+        # unless this validator is named in `$SUPERTOOL_REQUIRE_VALIDATORS`, in
+        # which case an absent analyser is the gate not running and says so
+        # loudly (#1202). `absent`, not `skipped`, is what makes that reachable.
+        print(json.dumps(_refusal.absent(
             "phpunit-mcp", file_path, str(e),
             int((time.monotonic() - t0) * 1000))))
         return 0

--- a/validators/pyright/pyright.py
+++ b/validators/pyright/pyright.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """pyright validator adapter — Python type-check via pyright --outputjson.
 
-Requires `pyright` on PATH. If missing, exits 0 with a stderr warning (graceful
-degrade) so the validator pipeline keeps moving when the tool isn't installed.
+Requires `pyright` on PATH. Absent, this reports the third state — `skipped`
+with the reason — rather than the `ok: true` it emitted until #1202, which was a
+clean verdict about a file nothing type-checked. Name this validator in
+`$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a loud error instead.
 
 Usage:  pyright.py <file>
 
@@ -25,16 +27,19 @@ import time
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
+from refusal import absent
+
+TOOL = "pyright"
+INSTALL_HINT = ("pyright not found on PATH — this file was NOT type-checked "
+                "(`npm install -g pyright`)")
 
 
 def emit(d: dict) -> None:
     print(json.dumps(d))
 
 
-def _skip(file: str, start: float, msg: str) -> None:
-    print(f"pyright: {msg}", file=sys.stderr)
-    emit({"tool": "pyright", "file": file, "ok": True, "count": 0,
-          "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+def _skip(file: str, start: float, reason: str) -> None:
+    emit(absent(TOOL, file, reason, int((time.time() - start) * 1000)))
 
 
 def main() -> None:
@@ -49,7 +54,7 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("pyright"):
-        _skip(file, start, "pyright not found on PATH, skipping")
+        _skip(file, start, INSTALL_HINT)
         return
 
     try:
@@ -60,7 +65,9 @@ def main() -> None:
             timeout=60, encoding="utf-8", errors="replace",
         )
     except FileNotFoundError:
-        _skip(file, start, "pyright not found on PATH, skipping")
+        # `which` said yes and exec said no. Still an absent tool, so still the
+        # third state — and still escalatable.
+        _skip(file, start, "pyright on PATH but could not be executed")
         return
     except subprocess.TimeoutExpired:
         emit({"tool": "pyright", "file": file, "ok": False, "count": 1,

--- a/validators/rector-mcp/rector-mcp.py
+++ b/validators/rector-mcp/rector-mcp.py
@@ -274,8 +274,11 @@ def main(argv: list[str]) -> int:
         resp = ndjson_call(sock, os.path.abspath(file_path))
     except _refusal.DaemonUnavailable as e:
         # Not installed for this working directory — every `cwd:` into a git
-        # worktree lands here. Nothing was analysed, so nothing is reported.
-        print(json.dumps(_refusal.skipped(
+        # worktree lands here. Nothing was analysed, so nothing is reported —
+        # unless this validator is named in `$SUPERTOOL_REQUIRE_VALIDATORS`, in
+        # which case an absent analyser is the gate not running and says so
+        # loudly (#1202). `absent`, not `skipped`, is what makes that reachable.
+        print(json.dumps(_refusal.absent(
             "rector-mcp", file_path, str(e),
             int((time.monotonic() - t0) * 1000))))
         return 0

--- a/validators/ruby-check/ruby-check.py
+++ b/validators/ruby-check/ruby-check.py
@@ -83,9 +83,12 @@ def main() -> None:
             timeout=30, encoding="utf-8", errors="replace",
         )
     except FileNotFoundError:
-        print("ruby-check: ruby not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "ruby-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        # `which` said yes and exec said no — a PATH entry that vanished
+        # between the two, or a name that resolves to something unrunnable.
+        # Still an absent tool, so still the third state.
+        emit(absent(TOOL, file, "ruby on PATH but could not be executed — "
+                                "this file was NOT syntax-checked",
+                    int((time.time() - start) * 1000)))
         return
 
     duration = int((time.time() - start) * 1000)

--- a/validators/ruby-check/ruby-check.py
+++ b/validators/ruby-check/ruby-check.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """ruby-check validator adapter — Ruby syntax check via `ruby -c`.
 
-Requires ruby on PATH. Ships on most Mac/Linux by default.
-If missing, exits 0 with a stderr warning (graceful degrade).
+Requires ruby on PATH. Ships on most Mac/Linux by default. Absent, this reports
+the third state — `skipped` with the reason — rather than the `ok: true` it
+emitted until #1202, which was a clean verdict about a file nothing parsed. Name
+this validator in `$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a
+loud error instead.
+
 Usage:  ruby-check.py <file>
 """
 
@@ -18,7 +22,10 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
-from refusal import tool_fault
+from refusal import absent, tool_fault
+
+TOOL = "ruby-check"
+INSTALL_HINT = "ruby not found on PATH — this file was NOT syntax-checked"
 
 
 # `file:line: message`. Extracted so the rule can be driven in process on every
@@ -64,9 +71,8 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("ruby"):
-        print("ruby-check: ruby not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "ruby-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     try:

--- a/validators/ruff/ruff.py
+++ b/validators/ruff/ruff.py
@@ -7,6 +7,12 @@ state — `skipped` with the reason — and never `ok` (validators/SCHEMA.md,
 the file, and saying "clean" on its behalf is the one failure mode this
 directory has filed eleven times.
 
+Where that quiet is not acceptable — CI, where "not installed" means the gate
+is not running — name this validator in `$SUPERTOOL_REQUIRE_VALIDATORS` and the
+same absence becomes a loud `adapter` error instead. That routing is
+`refusal.absent()`, and it did not reach this adapter until #1202: the switch
+was inert here, and setting it was indistinguishable from not setting it.
+
 Usage:  ruff.py <file>
 
 **The ruleset is not this adapter's business.** `ruff check` resolves its
@@ -36,9 +42,14 @@ import time
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
-from refusal import skipped, tool_fault
+from refusal import absent, tool_fault
 
 TOOL = "ruff"
+
+# Named once so the skip reason and the `$SUPERTOOL_REQUIRE_VALIDATORS`
+# escalation quote the same sentence — a reader who set the variable and a
+# reader who did not are looking at the same missing tool.
+INSTALL_HINT = "ruff not found on PATH — pip install ruff"
 
 # Budget for the one spawn below. Named so the decline can quote it: a reader
 # who sees "timeout" cannot tell a hung linter from a busy machine, and the
@@ -118,8 +129,8 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which(TOOL):
-        emit(skipped(TOOL, file, "ruff not found on PATH — pip install ruff",
-                     int((time.time() - start) * 1000)))
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     cmd = [TOOL, "check", "--output-format", "json", "--no-cache",
@@ -131,8 +142,8 @@ def main() -> None:
         # `which` said yes and exec said no — a PATH entry that vanished
         # between the two, or a name that resolves to something unrunnable.
         # Still an absent tool, so still the third state.
-        emit(skipped(TOOL, file, "ruff on PATH but could not be executed",
-                     int((time.time() - start) * 1000)))
+        emit(absent(TOOL, file, "ruff on PATH but could not be executed",
+                    int((time.time() - start) * 1000)))
         return
     except subprocess.TimeoutExpired:
         # The binary was found and started, so this is not a decline: it is a

--- a/validators/terraform-check/terraform-check.py
+++ b/validators/terraform-check/terraform-check.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """terraform-check validator adapter — Terraform formatting check via `terraform fmt -check`.
 
-Requires terraform CLI. If missing, exits 0 with a stderr warning.
+Requires the terraform CLI. Absent, this reports the third state — `skipped`
+with the reason — rather than the `ok: true` it emitted until #1202, which was a
+clean verdict about a file nothing format-checked. Name this validator in
+`$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a loud error instead.
+
 Usage:  terraform-check.py <file>
 """
 
@@ -18,7 +22,11 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
-from refusal import tool_fault
+from refusal import absent, tool_fault
+
+TOOL = "terraform-check"
+INSTALL_HINT = ("terraform not found on PATH — this file was NOT "
+                "format-checked")
 
 # `terraform fmt -check -diff` uses *distinct exit codes*, which the adapter
 # never looked at — every non-zero exit became `code: "formatting"` with the
@@ -97,9 +105,8 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("terraform"):
-        print("terraform-check: terraform not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "terraform-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     try:

--- a/validators/terraform-check/terraform-check.py
+++ b/validators/terraform-check/terraform-check.py
@@ -113,9 +113,12 @@ def main() -> None:
         r = subprocess.run(["terraform", "fmt", "-check", "-diff", file],
                            capture_output=True, text=True, timeout=30, encoding="utf-8", errors="replace")
     except FileNotFoundError:
-        print("terraform-check: terraform not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "terraform-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        # `which` said yes and exec said no — a PATH entry that vanished
+        # between the two, or a name that resolves to something unrunnable.
+        # Still an absent tool, so still the third state.
+        emit(absent(TOOL, file, "terraform on PATH but could not be executed — "
+                                "this file was NOT format-checked",
+                    int((time.time() - start) * 1000)))
         return
     except subprocess.TimeoutExpired:
         emit({"tool": "terraform-check", "file": file, "ok": False, "count": 1,

--- a/validators/tsc-check/tsc-check.py
+++ b/validators/tsc-check/tsc-check.py
@@ -63,9 +63,12 @@ def main() -> None:
             timeout=TIMEOUT_S, encoding="utf-8", errors="replace",
         )
     except FileNotFoundError:
-        print("tsc-check: tsc not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "tsc-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        # `which` said yes and exec said no — a PATH entry that vanished
+        # between the two, or a name that resolves to something unrunnable.
+        # Still an absent tool, so still the third state.
+        emit(absent(TOOL, file, "tsc on PATH but could not be executed — "
+                                "this file was NOT type-checked",
+                    int((time.time() - start) * 1000)))
         return
     except subprocess.TimeoutExpired:
         # See hadolint.py for why this is a finding rather than a skip, and

--- a/validators/tsc-check/tsc-check.py
+++ b/validators/tsc-check/tsc-check.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """tsc-check validator adapter — TypeScript syntax check via tsc --noEmit.
 
-Requires tsc on PATH. If missing, exits 0 with a stderr warning (graceful degrade).
+Requires tsc on PATH. Absent, this reports the third state — `skipped` with the
+reason — rather than the `ok: true` it emitted until #1202, which was a clean
+verdict about a file nothing type-checked. Name this validator in
+`$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a loud error instead.
+
 Usage:  tsc-check.py <file>
 """
 
@@ -17,6 +21,11 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
+from refusal import absent
+
+TOOL = "tsc-check"
+INSTALL_HINT = ("tsc not found on PATH — this file was NOT type-checked "
+                "(`npm install -g typescript`)")
 
 
 # Budget for the one tool spawn below. A module constant rather than a literal
@@ -42,9 +51,8 @@ def main() -> None:
     start = time.time()
 
     if not shutil.which("tsc"):
-        print("tsc-check: tsc not found on PATH, skipping", file=sys.stderr)
-        emit({"tool": "tsc-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     try:

--- a/validators/yaml-check/yaml-check.py
+++ b/validators/yaml-check/yaml-check.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
 """yaml-check validator adapter — YAML syntax check via PyYAML yaml.safe_load().
 
-Requires PyYAML (pip install pyyaml). If missing, exits 0 with a stderr warning.
+Requires PyYAML (pip install pyyaml). Absent, this reports the third state —
+`skipped` with the reason — rather than the `ok: true` it emitted until #1202,
+which was a clean verdict about a file nothing parsed. Name this validator in
+`$SUPERTOOL_REQUIRE_VALIDATORS` to turn that absence into a loud error instead.
+
+The absence here is an import rather than a `shutil.which`, which is why it went
+unnoticed for so long. It is the same absence.
+
 Usage:  yaml-check.py <file>
 """
 
@@ -14,6 +21,11 @@ import pathlib
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"))
 from source_context import source_context
+from refusal import absent
+
+TOOL = "yaml-check"
+INSTALL_HINT = ("PyYAML not installed — this file was NOT parsed "
+                "(`pip install pyyaml`)")
 
 
 def emit(d: dict) -> None:
@@ -34,9 +46,8 @@ def main() -> None:
     try:
         import yaml
     except ImportError:
-        print("yaml-check: PyYAML not installed, skipping", file=sys.stderr)
-        emit({"tool": "yaml-check", "file": file, "ok": True, "count": 0,
-              "errors": [], "duration_ms": int((time.time() - start) * 1000)})
+        emit(absent(TOOL, file, INSTALL_HINT,
+                    int((time.time() - start) * 1000)))
         return
 
     try:


### PR DESCRIPTION
Closes #1202
Closes #1203

#1202 was filed as one adapter. **It is 16, in three classes, and the two classes nobody filed are worse than the one that was.**

| Class | Adapters | Was |
| --- | --- | --- |
| **A — silent skip, `required()` never consulted** (as filed) | `ruff`, `html-check`, `phpstan-mcp`, `rector-mcp`, `phpunit-mcp`, `phpmd-mcp` | escalation switch inert |
| **B — absent tool answered `ok: true, count: 0, errors: []`** | `tsc-check`, `markdownlint`, `ruby-check`, `cargo-check`, `hadolint`, `gofmt-check`, `terraform-check`, `pyright`, `git-status`, `yaml-check` | **fabricated clean verdict** |
| **B2 — the same ten had a *second* absent-tool arm** (`except FileNotFoundError`) | seven of the above | same, at exec time |
| already correct | `shellcheck`, `eslint`, `gitleaks`, `tomllint`, `changelog-fragment` | — |

**Class B is the repo's flagship defect** — `refusal.py` says it has been "filed eleven times" — and is strictly worse than what #1202 describes: a reader, the before/after delta and CI all read a fabricated `ok: true` as a real pass. `git-status` went furthest, emitting a zeroed `metrics` block with `state: "clean"` — a measurement of a tree it never measured.

It was fixed rather than only reported, because a fix for the lesser bug shipped alongside the worse one *on the adjacent line* is the "one instance is not all of them" trap. Split at `84e6fab` if you want it as its own PR.

## Mechanism

- **`validators/common/refusal.py` — new `absent(tool, file_path, reason, dur_ms)`**: emits `skipped(...)`, or an `ok: False` / `code: "adapter"` payload when `required(tool)`. The class existed twice over because the decision was written out per adapter; it is made in one place now. It takes the **validator name**, not the binary — `tsc-check` runs `tsc`, `html-check` runs `node`, and the core reads the variable against the `.supertool.json` key.
- **16 adapters** — both absent-tool arms (`shutil.which` and `except FileNotFoundError`) routed through it. The `print(..., file=sys.stderr)` warnings are gone: a stderr note beside a lying payload is invisible to the row, the delta, `rollback_on_fail` and CI.
- **`.supertool.json`** — `tomllint` registered with `rollback_on_fail: true` (#1203).

## Judgment calls

**Scope refusals stay plain `skipped`, never escalated** — `cargo-check`'s no-`Cargo.toml`, `phpstan-mcp`'s `outside_roots`, `html-check`'s unclosed-`<script>`, `phpmd-mcp`'s `is_refusal`. The tool ran; no CI image change fixes them, and escalating would fire on every loose `.rs`.

**`cargo-check`'s no-crate arm still moved from `ok: true` to `skipped`** — a tool being present does not make a verdict about a file it never compiled true.

**#1203 registered `tomllint` only**, after measuring all four candidates: `tomllint` 1 file / 0 findings; `bash-check` 4 files / 0 findings; `yaml-check` 5 files **all skipped** (PyYAML is not a dev dep); `markdownlint` 53 files **all skipped** (tool absent). Registering the last two buys a permanent `skipped` row on every edit — the decoration problem from the other end.

**Ten adapter suites were green while asserting nothing.** `test_output_schema_present` / `test_output_contains_required_fields` / `test_duration_ms_is_int` and the missing-file tests ran the adapter on a machine without its tool, hit the absent-tool arm, and `assert "ok" in out` held *because of* the defect. Gated on `shutil.which` now.

## Verification

TDD, red first — **26 failed / 7 passed**, one pair per adapter, verbatim:

```
E  AssertionError: hadolint reported ok=True count=0 after 0ms, with an empty "errors" list
E  assert 'skipped' in {'count': 0, 'duration_ms': 0, 'errors': [], ...}
```

and for #1203:

```
E  AssertionError: no validator in .supertool.json parses *.toml — an edit that breaks
   pyproject.toml validates clean in the repo that ships the TOML checker.
```

A second red after review found the exec-time arm, proved by restoring `HEAD:validators/tsc-check/tsc-check.py`.

Green: 51 + 9 + 245 across 16 affected suites. **Full suite run** — shared helper plus a `.supertool.json` change every op reads: `1 failed, 9444 passed, 84 skipped in 510s`. The one failure was `test_encoding_seam.py::test_no_test_subprocess_decodes_by_locale` against a new `git ls-files` call of mine — a Windows-class guard doing its job. Fixed with `encoding="utf-8", errors="replace"` and re-run green.

## Review

Two fresh Sonnet reviewers against the committed diff, neither shown the author's reasoning.

**The best finding in the run:** seven adapters kept an `except FileNotFoundError` arm still emitting `ok: true`, under docstrings that had just been rewritten to claim otherwise. Emptying `PATH` never reaches that arm, so the author's own tests could not see it. Fixed, and reached by shadowing `shutil.which` + `subprocess.run` under `runpy` — a bad-shebang reproduction would be POSIX-only and leave the arm unasserted on the platform that breaks most often.

Also accepted: `docs/contributing.md:284` told authors to "print a friendly message and exit 0" — the anti-pattern this commit removes, and plausibly *how* ten adapters came to be written that way. Now scoped to preset scripts with the validator rule stated. Plus a colliding count in `docs/validators.md` and three changelog fragment references to test functions that do not exist verbatim.

## Out of scope, worth filing

- `validators/html-check/html-check.py:331` has no `FileNotFoundError` guard on its `node --check` spawn — not a silent pass (the core synthesises `no_verdict` and exits 1 under the variable), but it is the only adapter relying on the core to answer for it.
- `.supertool.json` registers 6 validators; `.supertool.example.json` offers 28. The actionable pair is `bash-check`, and adding `pyyaml` to dev deps so `yaml-check` can be registered meaningfully. `py-compile` is redundant with the core's built-in `py-syntax`.
