### PR TITLE
Wire this repo to claude-jit-context, and make the hooks harmless without it

### DIFF
--- a/.claude/jit-context/paths/00-manual/00-index.tsv
+++ b/.claude/jit-context/paths/00-manual/00-index.tsv
@@ -1,0 +1,9 @@
+changelog.d/	changelog-d.md
+docs/	docs-index.md
+.github/workflows/	github-workflows.md
+presets/git/	presets-git.md
+presets/github/	presets-github.md
+presets/gitlab/	presets-gitlab.md
+presets/watch/	presets-watch.md
+tests/	tests-suite.md
+validators/	validators.md

--- a/.claude/jit-context/paths/00-manual/changelog-d.md
+++ b/.claude/jit-context/paths/00-manual/changelog-d.md
@@ -1,0 +1,48 @@
+---
+title: "changelog.d/ — CommonMark-gated fragments"
+match: "changelog.d/"
+mode: once, remind
+---
+
+# Filename grammar
+
+`<issue>.<section>[.<slug>].md` — sections (Keep a Changelog headings):
+
+```
+added | changed | deprecated | removed | fixed | security
+```
+
+# Never edit CHANGELOG.md in a PR
+
+Add a fragment under `changelog.d/` instead. Rule: `docs/contributing.md:196`.
+
+# The guard is a real parser, not a scanner
+
+Validator = CommonMark (`markdown-it-py`). A hand-rolled scanner was bypassed across four rounds: #927 → #930 → #932 → #934 → #935 → #936. Refused at any depth:
+- headings
+- link-reference definitions
+- raw HTML
+- an unclosed fence
+- top level that isn't a single `-` bullet list
+
+# No parser installed → `skipped`, not `ok`
+
+There is deliberately no text-scanning fallback. `skipped` ≠ validated — don't read it as a pass.
+
+# Quoting a heading inside a bullet
+
+Fence it at the **bullet's own indent (2 columns)**, not 4 — CommonMark's 4-column code threshold is relative to the containing block, not the file.
+
+```md
+- Summary line.
+
+  ```
+  ## Quoted Heading
+  ```
+```
+
+Closing fence at column 0 ends the fence early **and** the bullet **and** the list. Keep opener/closer both at 2.
+
+# When it fires
+
+`changelog-fragment` validator runs on any mutating op under `changelog.d/` **at write time**, not just in CI — #1132.

--- a/.claude/jit-context/paths/00-manual/docs-index.md
+++ b/.claude/jit-context/paths/00-manual/docs-index.md
@@ -1,0 +1,50 @@
+---
+title: "docs/ — index, not a summary"
+match: "docs/"
+mode: once, remind
+---
+
+# `docs/contributing.md` (98KB / ~1255 lines) — section map
+
+| Heading | Line | When you need it |
+|---|---|---|
+| Quick start | 7 | first-time setup |
+| Checking syntax against the supported floor | 17 | before claiming "works on 3.9" |
+| What the repo-wide Python guards scan/skip | 44 | guard false-positive on a new dir |
+| Custom ops | 62 | adding an op to `.supertool.json` |
+| Op schema | 83 | table of `cmd`/`timeout`/`syntax`/etc |
+| Placeholders | 96 | `{file}`/`{dir}`/`{arg}`/`{args}`/`{path}` |
+| Dispatch order | 108 | builtin vs custom vs preset vs alias |
+| Extra config keys as env vars | 112 | passing config into an op's subprocess |
+| Presets | 132 | writing a preset manifest |
+| File layout | 136 | where preset JSON + helper scripts live |
+| Resolution order | 148 | project vs user vs shipped preset wins |
+| Preset schema | 156 | same as op schema, wrapped in manifest |
+| Validators | 188 | stub only — real doc is `docs/validators.md` |
+| Changelog fragments | 194 | `changelog.d/NNN.section.md` naming |
+| Cutting a release | 239 | assembling fragments into `CHANGELOG.md` |
+| Helper script conventions | 281 | writing `presets/*/foo.py` |
+| HTTP requests go through `presets/_http.py` | 293 | any preset that calls a URL |
+| Fetching a URL somebody else chose | 329 | user-supplied URL handling |
+| The body is bounded, in bytes and wall clock | 365 | streaming/size-limit rules |
+| Text encoding | 384 | UTF-8 read/write rules, Windows console traps |
+
+## Load-bearing details, don't re-derive
+
+- **Syntax floor is 3.9–3.12.** `ast.parse(src, feature_version=(3,9))` is NOT sufficient — it only gates grammar (walrus/match/except*), not the tokenizer. PEP 701 nested same-quote f-strings parse clean under `feature_version` on a 3.12 host but `SyntaxError` on 3.9/3.10/3.11 (shipped as #473, caught by #478). Use `supertool._syntax_floor_check(paths)` / `pytest tests/test_syntax_floor_478.py`, or `$PYTHON39=/path pytest ...`.
+- **Python guards** (`tests/_repo_walk.py`) decide source-vs-machine-state in order: (1) hardcoded name list (`__pycache__`, `.venv`, `.git`, etc. — git can't see these, esp. `.git` and untracked venvs), (2) `git ls-files --others --ignored --exclude-standard --directory`, (3) denylist fallback if git is unavailable. A dot-prefix alone is NOT exempt (#593 — `.github/`, `.githooks/` are source).
+- **Custom op `syntax` field is PARSED, not just displayed**, for any op whose `syntax` contains `:::` — e.g. `MESSAGE[:::PATHS...]` derives field names `message`, `paths` for the `@file`/`@payload` route. Rewording that string for readability can silently break field derivation, silently deleting the op's payload route (no error) — docs still describe a route that no longer exists. Pinned by `tests/test_at_file_route.py::TestPayloadRoutePin`. Ref #770.
+- **Preset resolution order**: `./presets/{name}.json` (project) → `~/.config/supertool/presets/{name}.json` (user) → `{install dir}/presets/{name}.json` (shipped). First found wins; project always overrides preset on name conflict.
+- **Changelog fragments**: never edit `CHANGELOG.md` directly in a PR — add `changelog.d/<issue>.<section>.md`. Section = `added`/`fixed`/etc. Enforced by `.github/workflows/changelog.yml`.
+
+## Sibling docs — what each owns
+
+| File | Owns |
+|---|---|
+| `docs/validators.md` (117KB) | authoritative validator contract — contributing.md's Validators section just points here |
+| `docs/configuration.md` | `.supertool.json` config keys |
+| `docs/formatters.md` / `docs/notifiers.md` | formatter / notifier adapter contracts |
+| `docs/input-forms.md` | `@file`/`@payload`/`@-` input-form mechanics |
+| `docs/mcp-integration.md`, `docs/mcp-warm-process-servers.md` | MCP server usage/config, warm-process pattern |
+| `docs/presets/{index,edits,map,meta,reads,search}.md` | shipped preset catalog + per-op-family reference |
+| `docs/operations/{git,github,gitlab,watch}.md` (largest: `watch.md` 165KB) | per-integration op reference; plus `bluesky.md`, `claude-log.md`, `dashboard.md`, `devto.md`, `hashnode.md`, `xml.md` |

--- a/.claude/jit-context/paths/00-manual/github-workflows.md
+++ b/.claude/jit-context/paths/00-manual/github-workflows.md
@@ -1,0 +1,43 @@
+---
+title: ".github/workflows/ — CI shape and log-reading"
+match: ".github/workflows/"
+mode: once, remind
+---
+
+# Workflows that exist (only these three)
+
+| File | Trigger | What it does |
+|---|---|---|
+| `tests.yml` | `push: [master]`, `pull_request` | `pytest` matrix (12 legs), `coverage`, `notifiers` |
+| `slow-tests.yml` | `schedule: 0 6 * * *`, `workflow_dispatch` | `pytest -m slow`, ubuntu/3.12 only |
+| `changelog.yml` | `pull_request: [opened, synchronize, reopened, labeled, unlabeled]` | fragment/`CHANGELOG.md` policy check |
+
+A workflow not in this list, or a job whose trigger doesn't match the event you're looking at, is **UNKNOWN — not a pass**. `slow` tests never run on a normal push; don't read their absence from a PR's checks as green.
+
+# `pytest` job (`tests.yml:17-129`)
+
+- Matrix: `{ubuntu,macos,windows}-latest × py{3.9,3.10,3.11,3.12}` = 12 legs. `notifiers` job: ubuntu+macos only (no windows — AF_UNIX socket).
+- Command: `pytest -m 'not slow and not benchmark' --tb=no --no-cov --durations=25 --junit-xml=junit.xml -q` (line 117).
+- **`--tb=no` means no traceback ever reaches the raw pytest log.** Read the failure via the next step instead.
+- Next step (always runs): `python .github/scripts/junit_summary.py junit.xml` — parses `junit.xml`, prints the full failing assertion. **This is the log to read, not the pytest step above.**
+- `coverage` job: separate, ubuntu-only, one leg — not per-OS. Gate: `.github/scripts/coverage_gate.py`.
+- Job timeouts are deliberate hang-guards (30min pytest, 20min coverage, 10min notifiers), sized ~3x the worst observed run — a timeout firing means a hang, not just "slow runner."
+
+# Reading a red leg
+
+1. `gh run view --log` first. If it comes back empty for a genuinely failed job: `gh api repos/OWNER/REPO/actions/jobs/<id>/logs`.
+2. Don't `gh run rerun <id> --failed` before reading the log — it destroys the evidence and costs the same API call.
+3. **A single-platform red is usually real, not a flake.** Running score here: 10 genuine to 2 flakes.
+4. Best discriminator: **which tests passed on that leg.** `2 failed, 4793 passed` = product not disarmed, fault is in fixtures/env, not a mass failure.
+
+# Known Windows-specific failure classes
+
+- `PermissionError` where POSIX raises `IsADirectoryError`.
+- Hardcoded POSIX path literals in a test.
+- `MAX_ARG_STRLEN` (128 KB per string) — applies to `envp` too, not just `argv`.
+- Symlink creation needs Developer Mode / `SeCreateSymbolicLinkPrivilege`; ungated `symlink_to()` fails loudly instead of skipping (`tests/_symlink.py::require_symlink()`).
+
+# Other
+
+- `-X utf8` on pytest, not `PYTHONUTF8`/`PYTHONIOENCODING` env vars — the flag isn't inherited by subprocesses, so tests reproducing Windows encoding bugs on purpose stay unaffected.
+- Every third-party action pinned to a commit SHA, not a floating tag (`tests/test_ci_action_pinning_925.py`).

--- a/.claude/jit-context/paths/00-manual/presets-git.md
+++ b/.claude/jit-context/paths/00-manual/presets-git.md
@@ -1,0 +1,42 @@
+---
+title: "presets/git/ — every splitlines() here is judged, not swept"
+match: "presets/git/"
+mode: once, remind
+---
+
+**Register test — first gate a new site hits.** A new `x.splitlines()` under
+`presets/git/` is RED until judged — `tests/test_preset_git_splitlines_register_1130.py`,
+keyed `path::enclosing function`, 30 entries / 42 call sites. Add a site via
+`REGISTER["presets/git/foo.py::func"] = "reason"` (>40 chars), or use
+`_untrusted.split_lines` instead (absent from register by construction).
+Current: 42 sites / 11 files, AST-verified (grep also hits docstring mentions
+of `splitlines()` as text — don't trust it here). Pre-#1130-fix: 44 / 12
+files; `diff.py` dropped to 0 native calls.
+
+**Deciding rule for a new site: does the reader disable quoting?**
+`core.quotePath` defaults ON — git octal-quotes bytes above 0x7F (incl.
+U+2028) before a split sees them, quoting absorbs the separator for free.
+**Only `git-diff` runs `-c core.quotepath=false`** (`diff.py:203,233`); every
+other reader here leaves quoting on. Test: does the site's `_git([...])` call
+pass `core.quotepath=false`? Yes → narrow to `_untrusted.split_lines`. No →
+quoting already does the job, leave `.splitlines()` alone.
+
+**`resolve.py` — 9 sites, deliberately unchanged.** Conflict-marker state
+machines split file content, key on `<<<<<<<` at column 0. A forged separator
+grants nothing a plain newline doesn't already grant. `_scan_markers`/
+`_count_blocks` can only over-report (fail-safe, just refuses a stage);
+`_union_attr_paths` is fail-closed.
+
+**Registered risks, not yet fixed:**
+- `investigate.py::main` (~112) — blame `--line-porcelain` parse keys on file
+  CONTENT → a crafted line can misattribute author/date.
+- `worktrees.py::remote_branch_names` (~537) — `for-each-ref` into a
+  pushed/unpushed set; `check-ref-format` ACCEPTS U+2028 (#1119) → a hostile
+  remote ref can spell your branch name in its tail, unpushed reads as pushed.
+
+**Dead code:** `status.py:336-341` assigns `current_branch`/`tracking` from
+`branch -vv` — never read; render uses `rev-parse --abbrev-ref HEAD` at `:344`.
+
+**Op traps:** `git-push` refuses an ambiguous upstream rather than guessing —
+use `git-push:set-upstream`. `git-resolve` leaves a branch conflicted on
+refusal, doesn't skip it.

--- a/.claude/jit-context/paths/00-manual/presets-github.md
+++ b/.claude/jit-context/paths/00-manual/presets-github.md
@@ -1,0 +1,38 @@
+---
+title: "presets/github/ — GitHub op quirks"
+match: "presets/github/"
+mode: once, remind
+---
+
+# Location
+
+Directory is `presets/github/`. **`presets/gh/` does not exist** — `gh-` is only the op-name prefix.
+
+# Check-state buckets (`presets/_checks.py`)
+
+`_checks.summarize()` sums every leg to the leg count — no state is dropped (#445/#454).
+
+| Bucket    | States |
+|-----------|--------|
+| PASSED    | `SUCCESS` |
+| FAILED    | `FAILURE`, `FAILED`, `ERROR`, `STARTUP_FAILURE`, `TIMED_OUT`, `ACTION_REQUIRED` |
+| PENDING   | `IN_PROGRESS`, `RUNNING`, `QUEUED`, `PENDING`, `WAITING`, `REQUESTED`, `EXPECTED`, `CREATED`, `SCHEDULED`, `PREPARING` |
+| BENIGN    | `SKIPPED`, `NEUTRAL`, `MANUAL` |
+| other/red | `CANCELLED` and anything unrecognized — counts red on triage boards, never silently fine |
+
+`TIMED_OUT`/`ACTION_REQUIRED` are FAILED, not benign — don't lump them with SKIPPED.
+
+# Open defects — check before trusting output
+
+- **#1181**: `gh-pr:N:status` prints `TALLY UNVERIFIED` on every PR because the Copilot review check-run has no workflow to count against. Code tries to stay silent when nothing is missing (`_reconcile_checks` in `pr.py:219`) — this is the case that slips through.
+- **#1207**: `gh-prs` defaults to `author=@me` (deliberate, disclosed in footer) but a maintainer wants every author. Use `gh-prs:anyauthor` or dependabot/outside-contributor PRs are invisible.
+- **#1180**: `presets/github/issues.py:251` — `parts[2].endswith("github.com")` matches `evilgithub.com`.
+
+# `gh-issues` flags
+
+`DEFAULT_PER_PAGE = 50` (`issues.py:73`) — output says `capped at --limit 50 — more may exist, raise with per=N`. Use `per=100`.
+Other flags (`_FLAGS`, `issues.py:82`): `nopipe`, `iids`, `external`, `stale`, `nomilestone`. Also `label=`, `milestone=` key=value filters.
+
+# Repo targeting
+
+`repo:OWNER/NAME` as the **leading** op sets `SUPERTOOL_REPO` for every `gh-*` op in the call (`presets/_repo_target.py`, #673) — without it, ops read the cwd's git remote. `gh-pr:N:diff` in particular carries `--repo` through, so running it from the wrong directory silently answers about the wrong repo if no `repo:` target is given (#677/#678).

--- a/.claude/jit-context/paths/00-manual/presets-gitlab.md
+++ b/.claude/jit-context/paths/00-manual/presets-gitlab.md
@@ -1,0 +1,32 @@
+---
+title: "presets/gitlab/ — host check is depth-1 by design"
+match: "presets/gitlab/"
+mode: once, remind
+---
+
+# Host guard is depth-1, on purpose
+
+`path_refusal` calls `decoded_host_naming_reason(urllib.parse.unquote(path))` — **one** `unquote`, not to a fixed point.
+
+Two readers, two depths:
+- depth 0 = glab's own endpoint parse → `host_naming_reason`
+- depth 1 = a consumer that decodes once → `decoded_host_naming_reason`
+
+**Do not "fix" this to decode-to-fixed-point.** That would refuse `%252F%252Fx` — the only valid encoding for a file literally named `%2F%2Fx`.
+
+Call site: `presets/gitlab/api.py` in `path_refusal`, the `host_naming_reason(path) or decoded_host_naming_reason(unquote(path))` pair. Grep the symbol, not a line number — this file moves.
+
+Corpora that must all stay green under any change here:
+- `tests/test_gl_api_url_refusal_1035.py`
+- `tests/test_gl_api_encoded_backslash_1043.py`
+- `tests/test_gl_api_decode_depth_1194.py` — arrives with PR #1211; it is the only one that fails under a fixed-point rewrite. The other two pass under it, which is why prose alone was not enough.
+
+# Why the guard exists at all
+
+`gl-api` forwards its endpoint straight to `glab api`, which attaches the live `Private-Token`. No guard = arbitrary host gets the real token. That's the threat the depth-1 check defends against.
+
+# glab is unauthenticated here
+
+In agent sandboxes `glab` has no token — `gh` does (authenticated + networked). Expect GitLab-path work to come back "could not verify end to end." That's expected, not a bug:
+- Say what you'd run to verify it for real (the `glab` command), don't fake a result.
+- Use `gh` equivalents only when the target is actually GitHub.

--- a/.claude/jit-context/paths/00-manual/presets-watch.md
+++ b/.claude/jit-context/paths/00-manual/presets-watch.md
@@ -1,0 +1,57 @@
+---
+title: "presets/watch/ — pidfile sentinels, poller identity, radar --state, channel.health"
+match: "presets/watch/"
+mode: once, remind
+---
+
+# pidfile reads — `transport.py`
+
+`read_pid_checked` / `read_state_checked`: `os.open(path, O_RDONLY | O_NOFOLLOW)`, fd closed on
+the `fdopen` arm. Three return states:
+
+| Return | Meaning |
+| --- | --- |
+| `(pid, "")` | file read, names a process |
+| `(0, "")` | `ENOENT` — the honest absence |
+| `(0, reason)` | file exists, content is not a PID — still reclaimable |
+| `(None, reason)` | read failed for any other reason — **do not treat as free** |
+
+`0` is the sentinel meaning *slot is free*. Returning it for "unreadable" spawns a duplicate
+watcher (the 2026-08-01 flood: a real `pipeline_failed` unannounced 23min). `read_pid_checked` is
+the **5th** call site of this read pattern (`transport.py:118`); the other 4 already carried the
+same guard: `channel.read_health` (#1184/#1187), `channel._read_state_file`/`stranded_watchers`
+(#1191), `read_state_checked` (#1197). Fixed in `read_pid_checked` by #1200.
+
+`claim_pidfile` (`transport.py:200`) → `CLAIM_UNKNOWN` (`= -1`) on an unsettled claim (`None` from
+the read, or any `OSError` other than "already exists"). `release_pidfile` unlinks only on
+positive identification. `list_active_pids` (`transport.py:707`) does **not** unlink a pid file it
+could not read — omits the row instead; `list_watchers`' process scan still surfaces the real
+poller as `orphan`.
+
+# poller identity — DECIDED, do not re-derive
+
+`dispatcher._exec_labelled` (`dispatcher.py:612`) execs into a labelled argv (#511). This is
+settled. **Re-deriving it cost a 212k-token agent run on #749.**
+
+Processes spawned before labelling existed wear their parent's argv and are invisible to the scan
+**by design**. Clear them by hand, per-PID (`kill <pid>`) — no clear-by-heuristic command exists.
+Killing on inference has stopped two live watchers before.
+
+# `radar:--state`
+
+`main()` (`radar.py:389`) branches on `args[0] == "--state"` straight into `state_main` —
+**spawns nothing, reaps nothing.** Safe inside a live worktree.
+
+Plain `radar` is an action: `_spawner()` (`radar.py:239`) runs the reap
+(`dispatcher.reap_duplicate_pollers()`) guarding the **first** spawn of the run (#957) — not off
+`main()`, not on every tier. `radar_report` alone (no `_spawner` call) spawns and reaps nothing.
+
+# `channel.health` (`channel.py:606`)
+
+Three states: verified / `CONTRADICTED` (`RC_CONTRADICTED = 4`) / unable. Peer-pid check uses
+`LOCAL_PEERPID` on macOS (`channel.py:129,252`) — **not** `LOCAL_PEERCRED`, which returns a
+`struct xucred` with uid only, no pid (#1192).
+
+`peer_credentials_supported()` (`channel.py:209`): False unless Linux+`SO_PEERCRED` or `darwin`.
+FreeBSD has `LOCAL_PEERCRED` but not `LOCAL_PEERPID` → lands in the **unable** arm too — Windows is
+not the only platform that can't answer.

--- a/.claude/jit-context/paths/00-manual/tests-suite.md
+++ b/.claude/jit-context/paths/00-manual/tests-suite.md
@@ -1,0 +1,36 @@
+---
+title: "tests/ — the full suite is non-hermetic"
+match: "tests/"
+mode: once, remind
+---
+
+# Before you run the full suite
+
+**The suite is non-hermetic: its git-op tests corrupt the worktree they run in.** Not a warning about flakiness — it rewrites the index of the checkout you are standing in.
+
+Observed 2026-08-09 in `st-wt/1205`: an agent committed its work, launched the full suite in its own worktree, and the index came back with nine paths staged as `D` (deleted) *and* present as `??` (untracked), plus eight stray `.coverage.*` shards. The commit survived; the working state did not.
+
+## Run it in a disposable clone
+
+```bash
+git clone ~/Documents/claude-supertool /tmp/st-suite-$$ && cd /tmp/st-suite-$$
+git remote set-url origin https://github.com/Digital-Process-Tools/claude-supertool.git
+```
+
+**The `set-url` is not optional.** A plain clone points `origin` at a local path, which reddens `test_live_board_over_this_repo` and `test_no_cli_at_all_is_not_an_absence_either`. Both fail identically on the base commit, so without it you manufacture two failures on every run and cannot tell them from real ones.
+
+**Targeted runs in your own worktree are fine.** It is the full suite that does the damage.
+
+# Two ways a test here lies about the platform
+
+**Symlinks.** `tests/_symlink.py` exposes `require_symlink()`; use it. Windows without Developer Mode or `SeCreateSymbolicLinkPrivilege` raises `OSError` on `symlink_to()`, so an ungated test **fails** where every gated sibling **skips** — and a failure points at product code that is fine. Filed as #1205.
+
+**Git shims that stop shimming.** `tests/test_status_swallowed_705.py` builds its fake git by matching `$1`. git accepts global flags *before* the subcommand, so `git --literal-pathspecs status` moves `status` to `$2`, the shim's test fails, and the `exec` fallthrough runs **real git**. On a test asserting a refusal that fails loudly; on a test asserting a pass it goes vacuous and silent. Filed as #1206. Match the subcommand anywhere in `"$@"`, not at `$1`.
+
+# What CI will tell you that a local green will not
+
+`pytest` runs with `--tb=no` (`.github/workflows/tests.yml`), so **no traceback ever reaches the logs** — the `junit_summary.py` step prints the failing assertion from `junit.xml` instead. A missing traceback is the workflow's choice, not a truncated reader.
+
+A single-platform red is usually real, not a flake: the running score is 10 genuine to 2 flakes, and the platform you write on is the one that cannot see its own constraint. Read the log before re-running; a re-run costs the same call and destroys the evidence.
+
+The best discriminator on a red leg is **which tests passed on it** — `2 failed, 4793 passed` tells you the product is not disarmed and the fault is in the fixtures.

--- a/.claude/jit-context/paths/00-manual/validators.md
+++ b/.claude/jit-context/paths/00-manual/validators.md
@@ -1,0 +1,69 @@
+---
+title: "validators/ — one contract, 35 adapters"
+match: "validators/"
+mode: once, remind
+---
+
+# The contract (all adapters, one shape)
+
+Three states only: `ok` (bool), a finding (`ok:false` + `errors`), or `skipped`. A checker that
+could not run must say so — never report clean. Canonical write-up:
+`docs/validators.md` §"Declining instead of guessing". Cite that exact path — it's repo-specific,
+mis-cited across a repo boundary before.
+
+**Absent tool → copy `validators/shellcheck/shellcheck.py:131-137` verbatim:**
+```python
+if not shutil.which(TOOL):
+    if required(TOOL):
+        _adapter_error(file, required_but_absent(TOOL, INSTALL_HINT), dur)
+    else:
+        emit(skipped(TOOL, file, INSTALL_HINT, dur))
+    return
+```
+Do not invent a variant.
+
+# Open defect #1202 — `required()` gate is inert on most adapters
+
+`validators/ruff/ruff.py:120-121` emits `skipped` on absent tool unconditionally — never calls
+`refusal.required()`. `SUPERTOOL_REQUIRE_VALIDATORS=ruff` is silently inert: it can never force a
+loud failure for ruff.
+
+Grepped every adapter for `required(`: only **shellcheck, eslint, gitleaks, tomllint,
+changelog-fragment** gate on it. 16 adapters check tool presence at all; the other **13 have the
+same gap as ruff**: `tsc-check, phpstan, markdownlint, ruby-check, prettier-check, git-status,
+cargo-check, hadolint, gofmt-check, terraform-check, pyright, psr, html-check`. Verified by name —
+they check `shutil.which`/binary-exists and go straight to `emit(skipped(...))`, no `required()`
+call anywhere in the file.
+
+# `skipped` and rollback
+
+A `skipped` never rolls back (`docs/validators.md:650`, "No verdict never rolls back an edit") —
+so turning `ok:true` into `skipped` changes rollback reachability. Don't do it casually.
+
+# Schema fields — `validators/SCHEMA.md`
+
+- `:37` — a skip **omits** `ok`, `count`, `errors` entirely. Only `tool`, `file`, `duration_ms`,
+  `skipped` (reason string) survive. `ok:true` on a skip is exactly the misread the third state
+  exists to prevent.
+- `:79-84` — cargo-check precedent for a mixed payload: a diagnostic about *another* file in the
+  same crate keeps `ok:false` + the real error, but `line/col:null`, `code:"adapter"`,
+  `source_context` absent. Don't fold a whole-crate error into `skipped` — that drops `errors`
+  entirely, which is worse.
+
+# Open defect #1203
+
+`tomllint` is declared in `.supertool.example.json:666-667` and **absent** from this repo's own
+`.supertool.json` — a validator that ships and isn't registered here checks nothing here.
+
+# changelog-fragment
+
+Fires on any mutating op under `changelog.d/` and republishes the assembler's own messages. No
+`markdown-it-py` parser available → `skipped`, not `ok` (`validators/changelog-fragment/changelog-fragment.py:24,173`).
+
+# Run one by hand
+
+```
+./supertool 'validate:PATH[:tool1,tool2][:verbose]'
+```
+`verbose` = uncapped errors + source context + raw stdout/stderr. Colon-in-filename → use
+`validate:@payload.toml` or `validate:@-` (fields: `path`|`paths`, `tools`, `verbose`).

--- a/.claude/jit-context/tools/00-manual/00-index.tsv
+++ b/.claude/jit-context/tools/00-manual/00-index.tsv
@@ -1,0 +1,4 @@
+Bash	~gh (issue|pr) list	gh-list-limit.md	remind	--limit	
+Edit|Write|Read|Grep|Glob|MultiEdit|NotebookEdit	~.	harness-tools-blocked.md	block		
+Bash	~supertool[^|]*'(gh-prs|gl-mrs|gh-issues|gl-issues|radar|watches)	op-defaults-that-narrow.md	remind		
+Bash	~supertool[^|]*\|[^|]*(head|tail|sed|cut|awk)	supertool-no-cut.md	block		

--- a/.claude/jit-context/tools/00-manual/gh-list-limit.md
+++ b/.claude/jit-context/tools/00-manual/gh-list-limit.md
@@ -1,0 +1,28 @@
+---
+title: "gh issue/pr list without --limit returns one page, and a short page looks like the whole board"
+tool: Bash
+match: ~gh (issue|pr) list
+mode: remind
+require: --limit
+---
+
+`gh issue list` and `gh pr list` return **one default page**, not the set. A capped read is indistinguishable from a complete one — there is no marker in the output saying more exist.
+
+**Measured 2026-08-09.** `gh issue list --state open --milestone v0.31.0` with no `--limit` returned a page I counted as **31** stale-milestone issues and reported as fact. The real number was **72**. An agent re-measured with a limit and corrected it.
+
+Pass `--limit` explicitly and make it larger than you expect the answer to be:
+
+```bash
+gh issue list --state open --limit 200 --json number,title
+```
+
+**Better: use the op.** `gh-issues` renders the board, and when it caps it *says so* — `capped at --limit 50 — more may exist`. Raw `gh` just hands you a short list:
+
+```
+supertool 'gh-issues:per=100'
+supertool 'gh-issues:nomilestone'
+supertool 'gh-issues:label=cohort-3,per=100'
+supertool 'gh-prs:anyauthor,state=open'
+```
+
+`gh-prs` defaults to `author=@me` and discloses it in the footer — pass `anyauthor` or dependabot and outside contributors are invisible. That is how three green PRs sat unseen for five hours on 2026-08-09.

--- a/.claude/jit-context/tools/00-manual/harness-tools-blocked.md
+++ b/.claude/jit-context/tools/00-manual/harness-tools-blocked.md
@@ -1,0 +1,37 @@
+---
+title: "Read/Edit/Write/Grep/Glob go through supertool here"
+tool: Edit|Write|Read|Grep|Glob|MultiEdit|NotebookEdit
+match: ~.
+mode: block
+---
+
+**This repo is supertool. Use it.** The harness file tools are blocked here on purpose — not because they are broken, but because every one of them is a strictly worse version of an op this repo ships, and a maintainer who does not call their own tool never finds its defects.
+
+| Instead of | Use |
+| --- | --- |
+| `Read` | `read:PATH`, `read:PATH:OFF:LIM`, `read:PATH:::grep=PATTERN`, `around_line:PATH:LINE:N`, `between:SYMBOL:PATH` |
+| `Grep` | `grep:PATTERN:PATH:LIMIT:CONTEXT`, `grep_around:PATTERN:PATH:N`, `grep:…:count` |
+| `Glob` | `glob:PATTERN`, `tree:PATH:DEPTH`, `map:PATH`, `ls:PATH` |
+| `Edit` | `edit:::OLD:::NEW:::PATH` or `edit:@-` with a TOML payload |
+| `Write` | `paste:::PATH:::CONTENT` or `paste:@-` |
+| several at once | one call, 6-7 ops — `read`, `grep`, `glob`, `map`, `around`, `between`, `tree` |
+
+## Why this blocks rather than reminds
+
+**Validators.** A mutating op runs the validator chain after the write and **rolls the file back on a syntax failure**. `Edit` does not. On this repo that is `py-syntax`, `ruff`, the changelog-fragment guard, the syntax-floor check — a broken fragment or an unparseable module is caught at write time instead of twenty minutes later on a 20-leg matrix.
+
+**Round-trips.** 37 individual `Read` calls re-pay the cached prefix 37 times; six batched op calls pay it six. An agent that reads one file at a time burns its own context before it reaches the judgment it was delegated for.
+
+**Receipts.** The ops report what they did and what is next — `scanned N files`, `no regex match; showing N literal matches`, `OFFSET is a skip count, not a start line`, the exact op to run instead. A silent tool teaches nothing.
+
+## Inside a branch worktree
+
+The global binary resolves to the live clone, so in `st-wt/NNN` it runs **master's core against your branch's presets** — it warns `mixed supertool trees` but still runs the wrong code. There:
+
+```
+python3 supertool.py 'op:args'
+```
+
+Everywhere else, including `~/Documents/claude-supertool` on master, bare `supertool` is correct.
+
+`supertool 'ops'` lists everything.

--- a/.claude/jit-context/tools/00-manual/op-defaults-that-narrow.md
+++ b/.claude/jit-context/tools/00-manual/op-defaults-that-narrow.md
@@ -1,0 +1,26 @@
+---
+title: "These ops answer a narrower question than you asked"
+tool: Bash
+match: ~supertool[^|]*'(gh-prs|gl-mrs|gh-issues|gl-issues|radar|watches)
+mode: remind
+---
+
+Each of these has a default that **narrows the population**. The render says so in its footer — this fires because the footer gets skimmed.
+
+| Op | Silent default | Widen with |
+| --- | --- | --- |
+| `gh-prs` / `gl-mrs` | `author=@me` — your PRs, not the repo's | `gh-prs:anyauthor,state=open` |
+| `gh-issues` / `gl-issues` | caps at **50**, prints `capped at --limit 50 — more may exist` | `gh-issues:per=100` |
+| `radar` | tiers come from the **CWD's** `.supertool.json`; the GitHub tier inherits `author=@me` | `cwd:~/Documents/claude-supertool` first, then widen the tier |
+| `watches` | shows tracked pollers; ones predating the labelling are invisible **by design** | cross-check `pgrep -f 'presets/watch/'` before concluding a slot is free |
+
+## What it costs when you skip the flag
+
+- **2026-08-09** — two dependabot PRs (green, 5h) and one external contributor's PR (green, 1 day) were invisible on `gh-prs`. Found by a human opening GitHub in a browser.
+- **2026-08-09** — `gh issue list --milestone v0.31.0` with no `--limit` returned one page. Reported as **31**; the real count was **72**.
+
+## The general shape
+
+A filtered board and an empty board render almost identically, and the difference is one footer line. Before treating any count from these as a fact about the world, ask **which population answered**.
+
+`radar` also spawns and reaps pollers. `radar:--state` does neither (#957) and is safe inside a live worktree.

--- a/.claude/jit-context/tools/00-manual/supertool-no-cut.md
+++ b/.claude/jit-context/tools/00-manual/supertool-no-cut.md
@@ -1,0 +1,36 @@
+---
+title: "Piping a supertool op through head/tail/sed selects against the answer"
+tool: Bash
+match: ~supertool[^|]*\|[^|]*(head|tail|sed|cut|awk)
+mode: block
+---
+
+**Do not cut a supertool op's output.** The ops are already compressed — that is the premise — and they put the meaning at the **top**: header, then meta (`state`, `mergeable`, the summed check tally, `scanned N files`), then the body.
+
+So the two cuts fail in opposite directions and both throw away the answer:
+
+- **`tail`** shows whichever section happened to be last — validators output, a stash list, an MR's prose. It selects *against* the header where the verdict lives.
+- **`head`** is not the safe half. `gh-issue:N` puts the body under the header, so `| head -90` silently drops the tail of every body — including a `Comments (1)` block that was the whole reason an issue was reopened.
+
+**Three times on 2026-08-09, self-inflicted:**
+
+| Cut | What it cost |
+| --- | --- |
+| `supertool 'grep:…' \| head -80` | dropped 3 of 5 verifications; two claims went into a brief unchecked |
+| `git-status \| tail -12` | returned stashes and the MR block, no working-tree section — reported as reproducing a defect that was my own pipe |
+| `git-status \| sed -n '1,25p'` | cut the working-tree section again, in the same session, an hour after filing the issue about it |
+
+## What to do instead
+
+**Narrow the op, never the output.**
+
+```
+supertool 'gh-pr:1208:status'          not  gh-pr:1208:full | head
+supertool 'grep:PAT:PATH:10:2'         not  grep … | head -20
+supertool 'read:PATH:::grep=PATTERN'   not  read:PATH | grep
+supertool 'gh-job:N:fail'              not  gh-job:N:raw | tail
+```
+
+`[result]` lines exist so a one-line verdict survives a pipe. That is a floor for the summary — not a licence to truncate everything above it.
+
+**The general rule, which is why this blocks rather than reminds:** when a read is about to become a fact, do not throw away part of it on the way in. A reminder gets skimmed at 18:30 on a long session; this one had been written, said out loud twice, and set in bold — and was still violated three times in six hours.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,43 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "S=\"$HOME\"/Documents/claude-jit-context/scripts/session-start-hook.sh; [ -f \"$S\" ] && bash \"$S\" || true"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "S=\"$HOME\"/Documents/claude-jit-context/scripts/pre-prompt-hook.sh; [ -f \"$S\" ] && bash \"$S\" || true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "S=\"$HOME\"/Documents/claude-jit-context/scripts/pre-tool-hook.sh; [ -f \"$S\" ] && bash \"$S\" || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Edit|Write|Glob|Grep|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "S=\"$HOME\"/Documents/claude-jit-context/scripts/pre-path-hook.sh; [ -f \"$S\" ] && bash \"$S\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dist/
 .DS_Store
 supertool
 .claude/worktrees/
+.claude/jit-context/.discovery/
 
 .max/
 .max-ci.log


### PR DESCRIPTION
The dynamic-rules system this repo has been maintained with lived in exactly one working copy and nowhere else. The rules are repo knowledge — where the presets live, which op defaults narrow a read, that supertool output must never be piped through `tail` — so they belong beside the code they describe rather than in one person's home directory.

### What is here

- `.claude/jit-context/` — 9 path rules, 4 tool rules, and the generated `00-index.tsv` the hooks actually read.
- `.claude/settings.json` — the four hook registrations (SessionStart, UserPromptSubmit, and two PreToolUse).
- `.gitignore` — `.claude/jit-context/.discovery/` is per-machine runtime state.

### The one non-obvious bit

Each hook command is guarded on the script existing:

```
S="$HOME"/Documents/claude-jit-context/scripts/pre-prompt-hook.sh; [ -f "$S" ] && bash "$S" || true
```

Without the guard, anyone who clones this repo and does not have `claude-jit-context` checked out gets a failing hook on **every prompt**. The guard makes it a silent no-op. The path stays a plain `$HOME` reference because the plugin is not published yet — once it is, this becomes a marketplace reference and the guard can go.

No product code is touched.