### PR TITLE
Port oss_train here, and fix the two bugs it arrived with

### DIFF
--- a/.github/scripts/coverage_gate.py
+++ b/.github/scripts/coverage_gate.py
@@ -218,6 +218,14 @@ MEASURED_NOT_ENFORCED: "dict[str, str]" = {
         "same shape as validators/ — prettier, phpcbf, php-cs-fixer are not "
         "installed here, and their absence is not a test failure"
     ),
+    "scripts/": (
+        "the maintainer ops (`oss_train`, #1216). Their reachable half is "
+        "covered — argument parsing, the refusals, the read-only `dry` path "
+        "and the BUSY guard — and the rest is `git rebase` / `git push "
+        "--force-with-lease` against real branches. A floor here would be a "
+        "standing invitation to raise the number by writing a fixture that "
+        "force-pushes, so the number is printed and left alone"
+    ),
     "notifiers/": (
         "the Python half is two small files; the part of this directory that "
         "matters is TypeScript and is listed under NOT measured below, which "

--- a/.supertool.json
+++ b/.supertool.json
@@ -261,6 +261,14 @@
         { "pattern": "\\bimport i?pdb\\b", "ext": ".py", "label": "import pdb" },
         { "pattern": "\\bfrom i?pdb\\b", "ext": ".py", "label": "from pdb import" }
       ]
+    },
+    "oss_train": {
+      "cmd": "{python} scripts/oss_train.py {file}",
+      "timeout": 1200,
+      "wt_root": "~/Documents/st-wt",
+      "description": "Rebase+resolve+push a merge train of this repo's branches, one worktree per issue under wt_root. Arg: '862,860' or 'all'; add ',dry' (comma, never colon) for a read-only report that rebases nothing. Five states per branch — PUSHED / CURRENT / BUSY / REFUSED / FAILED — a git-resolve refusal leaves the branch conflicted rather than skipping it. Exit 1 if anything needs a human; a bare invocation is refused",
+      "example": "oss_train:862,860,861",
+      "hint": true
     }
   },
   "aliases": {},

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -102,6 +102,7 @@ Shorthand string ops (`"lint": "ruff check {file}"`) work with a 60s default tim
 | `{arg}` | First argument, shell-quoted, no path validation | `glab issue view {arg}` |
 | `{args}` | All arguments, each shell-quoted | `python3 tool.py {args}` |
 | `{path}` | Preset directory with trailing `/` (presets only) | `python3 {path}gitlab/issue.py {arg}` |
+| `{python}` | The interpreter supertool is running under | `{python} scripts/oss_train.py {file}` |
 
 Use `{file}`/`{dir}` for file operations, `{arg}`/`{args}` for non-file arguments (issue numbers, job IDs, etc.).
 
@@ -111,7 +112,7 @@ Built-in ops → custom ops (including preset ops) → aliases. Built-ins always
 
 ### Extra config keys as environment variables
 
-Any key in an op config that isn't a reserved key (`cmd`, `timeout`, `description`, `syntax`, `example`, `status`) is passed to the subprocess as a `SUPERTOOL_`-prefixed environment variable:
+Any key in an op config that isn't a reserved key (`cmd`, `timeout`, `description`, `syntax`, `example`, `status`, `restartMcp`) is passed to the subprocess as a `SUPERTOOL_`-prefixed environment variable:
 
 ```json
 {
@@ -126,6 +127,20 @@ Any key in an op config that isn't a reserved key (`cmd`, `timeout`, `descriptio
 ```
 
 The script receives `SUPERTOOL_LINES=80` and `SUPERTOOL_ERROR_PATTERNS=ERROR,FAIL,Fatal`. Use this to tune op behavior from JSON without modifying scripts.
+
+### `scripts/` — this repo's own maintainer ops
+
+`scripts/` holds project ops that drive *this* repository and are registered in this repository's `.supertool.json`. They are not part of the wheel (`py-modules` is `supertool` and `_supertool`), they are not in `.supertool.example.json`, and they are not in the README: an op that reads `~/Documents/st-wt` answers for one machine's layout, and advertising it to users of the released tool would be documenting something they cannot run.
+
+`oss_train` is the one that exists. It rebases every open branch onto `master`, resolves the conflicts, and force-pushes — 55 of the last 60 merged PRs touched `CHANGELOG.md`, so with N open PRs each merge re-conflicts the other N-1 ([#906](https://github.com/Digital-Process-Tools/claude-supertool/issues/906)). Three things about it are load-bearing:
+
+- **The flag is comma-separated.** `oss_train:all,dry`, never `all:dry` — only the first `:`-token reaches a project op's `{file}` and the rest is discarded silently, so a colon form runs the train it looked like it was previewing.
+- **A bare `oss_train` is refused**, and the refusal names how many branches it would have touched. It used to mean `all`, and typing it to find out whether the op was registered force-pushed fourteen worktrees ([#993](https://github.com/Digital-Process-Tools/claude-supertool/issues/993)).
+- **`dry` stops above the rebase, not below it** ([#910](https://github.com/Digital-Process-Tools/claude-supertool/issues/910)). It used to perform the rebase and skip only the push while the header said `DRY RUN`; those worktrees hold live agents, so the safe-sounding flag moved `HEAD` underneath somebody's work. The `BUSY` guard sees *uncommitted* changes only, so an agent between two commits reads as idle — which is why the preview is not allowed to buy "would it conflict?" with someone else's `HEAD`.
+
+Each branch is labelled by the branch `git symbolic-ref` reports, never by the worktree directory: `st-wt/749` holds `lane-watch`, and every follow-up command a reader would run takes a branch name.
+
+`tests/test_oss_train_1216.py` covers the argument parsing, the refusals, the `BUSY` guard and the read-only `dry` path, and names what it does not cover — the `PUSHED` and `REFUSED` paths cannot be exercised without force-pushing real refs, so no fixture pretends to.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -140,7 +140,9 @@ The script receives `SUPERTOOL_LINES=80` and `SUPERTOOL_ERROR_PATTERNS=ERROR,FAI
 
 Each branch is labelled by the branch `git symbolic-ref` reports, never by the worktree directory: `st-wt/749` holds `lane-watch`, and every follow-up command a reader would run takes a branch name.
 
-`tests/test_oss_train_1216.py` covers the argument parsing, the refusals, the `BUSY` guard and the read-only `dry` path, and names what it does not cover — the `PUSHED` and `REFUSED` paths cannot be exercised without force-pushing real refs, so no fixture pretends to.
+`tests/test_oss_train_1216.py` covers the argument parsing, the refusals, the `BUSY` guard, the read-only `dry` path and the reading of `git-push`'s verdict, and names what it does not cover — the rebase, the `git-resolve` refusal and the push itself cannot be exercised without force-pushing real refs, so no fixture pretends to.
+
+**The verdict is read as a prefix, and that is not a style choice.** `"PUSHED" in verdict` is true of `NOT PUSHED - REJECTED`, `- UNVERIFIED`, `- REBASE PAUSED`, `- TIMED OUT`, `- already up to date` and `- no push attempted` — every failure `git-push` emits. The op that exists to relay a verified verdict instead of assuming its own success ended on a membership test that tallied all six as `PUSHED`, with a detail line reading "NOT PUSHED - ..." next to the tick. `classify_push` is a separate function for the same reason: it is the one part of the push path that can be tested without a remote.
 
 ---
 

--- a/scripts/oss_train.py
+++ b/scripts/oss_train.py
@@ -144,6 +144,30 @@ def parse_tokens(argv):
     return ",".join(t for t in tokens if t != "dry"), dry
 
 
+def classify_push(push_output):
+    """(state, detail) from git-push's own `[result]` verdict.
+
+    Read as a PREFIX of the verdict text, never as `"PUSHED" in verdict`:
+    `PUSHED` is a substring of `NOT PUSHED`, so that membership test was true
+    for every failure git-push emits — `NOT PUSHED - REJECTED`, `- UNVERIFIED`,
+    `- REBASE PAUSED`, `- TIMED OUT`, `- already up to date`, `- no push
+    attempted`. All six fell through and were tallied as PUSHED, under a detail
+    line that read "NOT PUSHED - ..." out loud. An op whose stated purpose is to
+    relay git-push's verified verdict rather than assume its own success
+    finished by assuming its own success.
+    """
+    verdict = ""
+    for line in push_output.splitlines():
+        if line.startswith("[result]"):
+            verdict = line[len("[result]"):].strip()
+            break
+    if not verdict:
+        return "FAILED", "git-push printed no [result] verdict — " + push_output.strip()[-250:]
+    if not verdict.startswith("PUSHED"):
+        return "FAILED", verdict
+    return "PUSHED", verdict
+
+
 def train(num, dry):
     wt = os.path.join(wt_root(), num)
     if not os.path.isdir(wt):
@@ -159,7 +183,13 @@ def train(num, dry):
     # itself refused the rebase (which is the only reason nothing was lost), so
     # this guard turns luck into a decision.
     rc, dirty = run(["git", "status", "--porcelain"], wt)
-    if rc == 0 and dirty.strip():
+    if rc != 0:
+        # A status this op could not read is not a clean tree. `rc == 0 and
+        # dirty.strip()` read it as one, so the single guard between this op and
+        # a live agent's worktree opened exactly when the command it depends on
+        # stopped answering, and the run went on to fetch, rebase and force-push.
+        return "FAILED", f"could not read the worktree status: {dirty.strip()[:200]}"
+    if dirty.strip():
         n = len(dirty.strip().splitlines())
         return "BUSY", f"{n} uncommitted change(s) — someone is working here, not touching it"
 
@@ -225,16 +255,7 @@ def train(num, dry):
             return "FAILED", "conflicts remain after resolve+continue"
 
     _, push = st(wt, "git-push:force-with-lease:no-verify")
-    verdict = ""
-    for line in push.splitlines():
-        if line.startswith("[result]"):
-            verdict = line.strip()
-            break
-    if not verdict:
-        return "FAILED", "git-push printed no [result] verdict — " + push.strip()[-250:]
-    if "PUSHED" not in verdict:
-        return "FAILED", verdict
-    return "PUSHED", verdict[len("[result]"):].strip()
+    return classify_push(push)
 
 
 def main():

--- a/scripts/oss_train.py
+++ b/scripts/oss_train.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""oss_train — rebase / resolve / push a merge train of this repo's branches.
+
+Usage: oss_train.py <ARG>
+    862,860,861   explicit issue numbers -> worktree ~/Documents/st-wt/NNN
+    all           every ~/Documents/st-wt/NNN worktree that exists
+    dry           as a COMMA element (all,dry) -> report only; reads, rebases
+                  nothing, pushes nothing. Stops ABOVE the rebase, not below it.
+
+A bare `oss_train` with no argument is REFUSED rather than treated as `all`.
+
+The flag is comma-separated rather than colon-separated because supertool passes
+only the first ':'-token into {file} and drops the rest silently, so `:dry` never
+arrives.
+
+Where this came from
+--------------------
+It was a DVSI project op, which is an accident of where it was written: DVSI is
+a different repository on a different forge and this train drives *this* one, so
+the op only answered from a checkout that has nothing to do with it. Every other
+op the maintainer loop needs already answers here; this was the single measured
+reason a session rooted in claude-supertool could not run the loop (#1216).
+
+Why it exists at all
+--------------------
+Eight PRs in a milestone all touch CHANGELOG.md, so every merge re-conflicts
+every other open PR. The loop below therefore runs once per PR *per merge* —
+closer to eighteen times across a release than eight. Every individual step
+already had an op (git-conflicts, git-resolve, git-push); only the composition
+was hand-written, and every mistake made during the 2026-08-05 train was in that
+glue rather than in the ops: a resolver that assumed one conflicted file when
+there were two, a `rebase --continue` redirected to /dev/null, a
+`git push | tail -1` that swallowed the verdict for five branches at once.
+
+Five states per branch, never two
+---------------------------------
+    PUSHED    rebased (or already rebased) and the new sha was read back off the
+              remote
+    CURRENT   already on top of the default branch with nothing to push — a
+              no-op, said out loud, which is what makes the op idempotent
+    BUSY      uncommitted changes; someone is working there, leave it
+    REFUSED   git-resolve declined (a source file, or a Markdown heading a union
+              would duplicate). The branch is LEFT CONFLICTED on purpose so git
+              itself blocks rebase --continue. Never skipped silently.
+    FAILED    anything else, with the command output that caused it
+    DRY       nothing was done, and the report says what would have been
+
+A train that quietly drops the one branch it could not resolve is this repo's own
+defect class wearing a new hat, so REFUSED is a first-class outcome and the exit
+code reflects it.
+
+Never pushes without reading the result. `git-push` verifies the remote sha
+itself; this op relays that verdict rather than assuming its own success.
+"""
+import os
+import subprocess
+import sys
+
+#: Overridable through the op's `wt_root` config key, which supertool passes in
+#: as SUPERTOOL_WT_ROOT. A constant here would make every path below reach the
+#: real worktrees of the machine running the tests.
+DEFAULT_WT_ROOT = "~/Documents/st-wt"
+
+#: The branch every train rebases onto. claude-supertool's default branch is
+#: master; claude-remember's is main, and porting this there means changing this
+#: line rather than discovering it from a failed fetch.
+UPSTREAM = "origin/master"
+
+
+def wt_root():
+    """The directory holding the per-issue worktrees, expanded."""
+    return os.path.expanduser(os.environ.get("SUPERTOOL_WT_ROOT") or DEFAULT_WT_ROOT)
+
+
+def run(args, cwd, timeout=900):
+    """Run a command and ALWAYS return (rc, combined output). Never raises."""
+    try:
+        p = subprocess.run(
+            args, cwd=cwd, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=timeout,
+        )
+        return p.returncode, (p.stdout or "") + (p.stderr or "")
+    except subprocess.TimeoutExpired:
+        return 124, f"timed out after {timeout}s: {' '.join(args)}"
+    except OSError as exc:
+        return 125, f"could not run {' '.join(args)}: {exc}"
+
+
+def st(wt, *ops):
+    """Run supertool from inside the worktree.
+
+    `sys.executable supertool.py`, never the global `supertool`: inside a
+    claude-supertool worktree the PATH wrapper resolves to the live clone
+    (master), so a global call would exercise master's code and report on the
+    branch's (#678).
+    """
+    return run([sys.executable, "supertool.py", *ops], wt)
+
+
+def discover():
+    """Every numbered worktree directory under the root, sorted."""
+    root = wt_root()
+    if not os.path.isdir(root):
+        return []
+    return sorted(n for n in os.listdir(root)
+                  if n.isdigit() and os.path.isdir(os.path.join(root, n)))
+
+
+def branch_of(wt):
+    """The branch actually checked out, or None when detached.
+
+    NEVER infer it from the directory name. st-wt/749 holds `lane-watch`, not
+    `fix/749`, so every `fix/{num}` this op used to print was a guess that
+    happened to be right while the convention held (#910). A guessed branch name
+    breaks two ways at once: the CURRENT check looks up a ref that does not
+    exist, so an up-to-date branch gets rebased anyway, and every follow-up
+    command printed for the reader names a branch git will not resolve.
+    """
+    rc, out = run(["git", "symbolic-ref", "--quiet", "--short", "HEAD"], wt)
+    if rc != 0 or not out.strip():
+        return None
+    return out.strip()
+
+
+def parse_tokens(argv):
+    """(target, dry) from the raw argument list.
+
+    COMMA, not colon. supertool passes only the FIRST ':'-token after the op
+    name into {file} and silently discards the rest, so `oss_train:all:dry`
+    arrives as plain "all" and the run pushes. Measured: `oss_train:dry`
+    honours the flag, `oss_train:999:dry` does not. Two earlier parses "fixed"
+    this and neither did, because both were tested against a shape the tool
+    never produces.
+
+        oss_train:all,dry        oss_train:862,860,dry        oss_train:dry
+
+    A colon is still read as a separator, for the case where one does survive:
+    treating `all:dry` as an unknown target and running the un-dry path is the
+    worse of the two failures by a wide margin.
+    """
+    tokens = [t.strip() for a in argv for t in a.replace(":", ",").split(",")
+              if t.strip()]
+    dry = "dry" in tokens
+    return ",".join(t for t in tokens if t != "dry"), dry
+
+
+def train(num, dry):
+    wt = os.path.join(wt_root(), num)
+    if not os.path.isdir(wt):
+        return "FAILED", f"no worktree at {wt}"
+
+    branch = branch_of(wt)
+    if branch is None:
+        return "FAILED", "detached HEAD — no branch here to rebase or push"
+
+    # A dirty tree means somebody is working here — almost always a live agent.
+    # Never touch an agent's active worktree: that rule predates this op and this
+    # op broke it on its own first run, walking into st-wt/835 mid-task. git
+    # itself refused the rebase (which is the only reason nothing was lost), so
+    # this guard turns luck into a decision.
+    rc, dirty = run(["git", "status", "--porcelain"], wt)
+    if rc == 0 and dirty.strip():
+        n = len(dirty.strip().splitlines())
+        return "BUSY", f"{n} uncommitted change(s) — someone is working here, not touching it"
+
+    remote, _, ref = UPSTREAM.partition("/")
+    rc, out = run(["git", "fetch", "-q", remote, ref], wt)
+    if rc != 0:
+        return "FAILED", f"fetch: {out.strip()[:200]}"
+
+    # Already on top of the default branch and nothing unpushed? Say so; do not
+    # force-push.
+    rc, behind = run(["git", "rev-list", "--count", f"HEAD..{UPSTREAM}"], wt)
+    rc2, ahead = run(["git", "rev-list", "--count", f"{UPSTREAM}..HEAD"], wt)
+    if rc == 0 and rc2 == 0 and behind.strip() == "0":
+        rc3, local = run(["git", "rev-parse", "HEAD"], wt)
+        rc4, remote_ls = run(["git", "ls-remote", remote, f"refs/heads/{branch}"], wt)
+        if rc3 == 0 and rc4 == 0 and remote_ls.split():
+            if local.strip() == remote_ls.split()[0]:
+                return "CURRENT", (f"{branch} on top of {ref}, remote matches "
+                                   f"({ahead.strip()} commit(s))")
+
+    # DRY STOPS HERE, above the rebase — not below it.
+    # It used to sit after `git rebase` and skip only the push, so a run whose
+    # header said DRY RUN left every branch rewritten. Those branches are checked
+    # out in worktrees where agents are working, so the safe-sounding flag moved
+    # HEAD underneath live work (#910). A preview that mutates is not a preview,
+    # and the three surfaces asserting simulation made it worse.
+    #
+    # The other reading — keep rebasing, rename the flag honestly — was rejected:
+    # what the rebase adds to the report is "would it conflict", and the BUSY
+    # guard above only sees UNCOMMITTED work, so an agent between two commits
+    # reads as idle. Paying for that answer with somebody else's HEAD is the
+    # wrong trade, and a caller who wants it can run the train.
+    if dry:
+        n_behind = behind.strip() if rc == 0 else "?"
+        return "DRY", (f"{branch} is {n_behind} commit(s) behind {UPSTREAM} — would "
+                       "rebase and force-push; nothing was touched")
+
+    rc, out = run(["git", "rebase", UPSTREAM], wt)
+    if rc != 0:
+        # Enumerate EVERY conflicted file. Assuming one is how a branch ended
+        # detached with the failure invisible on 2026-08-05.
+        _, conflicts = st(wt, "git-conflicts")
+        n_files = ""
+        for line in conflicts.splitlines():
+            if line.startswith("Conflicts:"):
+                n_files = line.strip()
+                break
+
+        _, res = st(wt, "git-resolve:both:all")
+        refused = [ln.strip() for ln in res.splitlines() if ln.strip().startswith("⊘")]
+        if refused:
+            # Leave it conflicted. git blocks rebase --continue, which is the
+            # only signal that does not depend on reading a receipt.
+            return "REFUSED", f"{n_files}; " + " | ".join(refused)[:400]
+
+        rc_c, cont = run(["git", "rebase", "--continue"], wt, timeout=300)
+        if rc_c != 0:
+            run(["git", "rebase", "--abort"], wt)
+            return "FAILED", f"rebase --continue: {cont.strip()[:250]} (aborted, branch restored)"
+
+        _, still = st(wt, "git-conflicts")
+        if "No conflicted files" not in still:
+            return "FAILED", "conflicts remain after resolve+continue"
+
+    _, push = st(wt, "git-push:force-with-lease:no-verify")
+    verdict = ""
+    for line in push.splitlines():
+        if line.startswith("[result]"):
+            verdict = line.strip()
+            break
+    if not verdict:
+        return "FAILED", "git-push printed no [result] verdict — " + push.strip()[-250:]
+    if "PUSHED" not in verdict:
+        return "FAILED", verdict
+    return "PUSHED", verdict[len("[result]"):].strip()
+
+
+def main():
+    arg, dry = parse_tokens(sys.argv[1:])
+
+    # A BARE INVOCATION IS REFUSED. It used to mean `all`, so `oss_train` typed
+    # to find out whether the op was even registered rebased and force-pushed
+    # every worktree on the machine — fourteen of them on 2026-08-07 (#993).
+    #
+    # A force-push is not `fails-to-preserve`, it is `destroys`: the commits it
+    # drops were never in this op's custody, and any commit reachable only from
+    # the old ref — a colleague's push you have not fetched, a reflog on a
+    # machine you do not own — is gone from the only place it existed. That
+    # afternoon survived because every flattened branch happened to be a merged
+    # PR, which is a property of that board and not of this op. The correlation
+    # runs the wrong way, too: a bare run is most likely on a board whose state
+    # you do not know, which is the board most likely to hold a branch nobody
+    # has fetched.
+    #
+    # So a better error message is the wrong fix — the failure is that the
+    # caller never formed an intention. Refuse, and name the live count, because
+    # "every branch" is abstract and "14 right now" is not.
+    if arg == "":
+        found = discover()
+        print(f"ERROR: oss_train needs an explicit target. This would rebase and "
+              f"force-push {len(found)} branch(es) right now"
+              + (": " + ", ".join(found) if found else ""))
+        print("Say which, once:")
+        print("  oss_train:all          every worktree under " + wt_root())
+        print("  oss_train:862,860      only these")
+        print("  oss_train:all,dry      report only — reads, rebases nothing, pushes nothing")
+        return 2
+
+    nums = discover() if arg == "all" else [n.strip() for n in arg.split(",") if n.strip()]
+    # Header first, so the mode is stated even when there is nothing to do — a
+    # run that says nothing about whether it would have pushed is unreadable.
+    print(f"# oss_train ({len(nums)} branch(es)){' — DRY RUN' if dry else ''}")
+    if not nums:
+        print("no worktrees to run — nothing under " + wt_root())
+        return 0
+    tally = {}
+    for num in nums:
+        # Label by the branch git reports, never by the directory (#910).
+        # `fix/{num}` was invisible whenever the convention held and
+        # actionable-but-wrong when it did not: st-wt/749 renders as fix/749,
+        # and no such branch exists anywhere.
+        label = branch_of(os.path.join(wt_root(), num)) or f"st-wt/{num} (no branch)"
+        state, detail = train(num, dry)
+        tally[state] = tally.get(state, 0) + 1
+        mark = {"PUSHED": "✓", "CURRENT": "·", "DRY": "~",
+                "REFUSED": "⊘", "BUSY": "⏸"}.get(state, "✗")
+        print(f"  {mark} {label}: {state} — {detail}")
+
+    print("[result] " + " | ".join(f"{k}: {v}" for k, v in sorted(tally.items())))
+    # Non-zero when anything needs a human: a refusal or a failure.
+    return 1 if (tally.get("REFUSED") or tally.get("FAILED")) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_oss_train_1216.py
+++ b/tests/test_oss_train_1216.py
@@ -1,0 +1,316 @@
+"""`oss_train` answers from this checkout, and its two #910 renders are honest.
+
+The op was a DVSI project op (`.claude/scripts/oss_train.py` plus a block in that
+project's `.supertool.json`), so a session rooted in claude-supertool could not
+run the maintainer loop at all — `unknown operation: oss_train` (#1216). It is
+ported here unchanged in behaviour, with the two defects filed as #910 fixed:
+
+* `dry` used to rebase and skip only the push while three surfaces said DRY RUN.
+  Those branches are checked out in worktrees where agents work, so the
+  safe-sounding flag moved HEAD underneath live work. `dry` now stops ABOVE the
+  rebase, and `test_dry_leaves_the_branch_exactly_where_it_found_it` is the pin:
+  it fails the moment the stop moves back below.
+* each branch was labelled by its worktree DIRECTORY. `st-wt/749` rendered as
+  `fix/749` for a tree holding `lane-watch`, and every follow-up command a reader
+  would run takes a branch name.
+
+What is deliberately NOT covered, because covering it means force-pushing real
+refs: the PUSHED path, the REFUSED path (which needs `git-resolve` to decline
+inside a real supertool checkout), and `rebase --continue` / `--abort`. Every
+test below stops at or before the rebase, and none of them has a remote outside
+`tmp_path`. Saying so is worth more than a fixture that pretends.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "oss_train.py"
+
+
+def _load_oss_train():
+    spec = importlib.util.spec_from_file_location("oss_train_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None, SCRIPT
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+oss_train = _load_oss_train()
+
+
+# ---------------------------------------------------------------------------
+# fixtures — every remote lives inside tmp_path, nothing is ever pushed
+# ---------------------------------------------------------------------------
+
+def _git(*args: str, cwd: Path) -> str:
+    proc = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True,
+                          text=True, encoding="utf-8", errors="replace")
+    assert proc.returncode == 0, f"git {' '.join(args)}: {proc.stdout}{proc.stderr}"
+    return proc.stdout
+
+
+def _commit(clone: Path, name: str, body: str) -> None:
+    (clone / name).write_text(body, encoding="utf-8")
+    _git("add", name, cwd=clone)
+    _git("-c", "user.email=t@example.invalid", "-c", "user.name=t",
+         "commit", "-q", "-m", name, cwd=clone)
+
+
+@pytest.fixture()
+def train_world(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A clone whose branch `feature/xyz` sits in a worktree named `999`.
+
+    The worktree DIRECTORY and the BRANCH deliberately disagree: that
+    disagreement is the whole of the second #910 defect, and it is invisible
+    whenever the fix/NNN convention holds.
+    """
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", "-b", "master", str(origin)],
+                   check=True, capture_output=True)
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", origin.as_posix(), str(clone)],
+                   check=True, capture_output=True)
+
+    _commit(clone, "base.txt", "base")
+    _git("push", "-q", "origin", "master", cwd=clone)
+    _git("checkout", "-q", "-b", "feature/xyz", cwd=clone)
+    _commit(clone, "feature.txt", "feature")
+    _git("checkout", "-q", "master", cwd=clone)
+    _commit(clone, "later.txt", "later")
+    _git("push", "-q", "origin", "master", cwd=clone)
+
+    wt_root = tmp_path / "st-wt"
+    wt = wt_root / "999"
+    _git("worktree", "add", "-q", str(wt), "feature/xyz", cwd=clone)
+
+    monkeypatch.setenv("SUPERTOOL_WT_ROOT", str(wt_root))
+    return {"origin": origin, "clone": clone, "wt_root": wt_root, "wt": wt}
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, arg: str) -> int:
+    monkeypatch.setattr(sys, "argv", ["oss_train.py", arg])
+    return oss_train.main()
+
+
+# ---------------------------------------------------------------------------
+# the flag arrives as a COMMA element
+# ---------------------------------------------------------------------------
+
+class TestArgumentParsing:
+    """Only the first ':'-token reaches a project op's {file}; the rest is
+    discarded silently, so `all:dry` never carries the flag anywhere."""
+
+    @pytest.mark.parametrize("raw, arg, dry", [
+        ("all,dry", "all", True),
+        ("dry", "", True),
+        ("862,860,dry", "862,860", True),
+        ("all", "all", False),
+        ("862,860,861", "862,860,861", False),
+        (" all , dry ", "all", True),
+        ("", "", False),
+    ])
+    def test_comma_form(self, raw: str, arg: str, dry: bool) -> None:
+        assert oss_train.parse_tokens([raw]) == (arg, dry)
+
+    def test_a_colon_that_did_survive_is_still_read(self) -> None:
+        """Defensive, not a supported form: if a colon ever does arrive intact,
+        reading it as a separator is strictly safer than treating `all:dry` as
+        an unknown target and running the un-dry path."""
+        assert oss_train.parse_tokens(["all:dry"]) == ("all", True)
+
+
+# ---------------------------------------------------------------------------
+# a bare invocation is refused, and names the live count
+# ---------------------------------------------------------------------------
+
+def test_a_bare_invocation_refuses_and_counts_what_it_would_have_touched(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
+    wt_root = tmp_path / "st-wt"
+    for name in ("101", "202", "notanumber"):
+        (wt_root / name).mkdir(parents=True)
+    monkeypatch.setenv("SUPERTOOL_WT_ROOT", str(wt_root))
+
+    assert _run_main(monkeypatch, "") == 2
+    out = capsys.readouterr().out
+    assert "needs an explicit target" in out
+    assert "2 branch(es)" in out, out
+    assert "101, 202" in out
+    assert "notanumber" not in out
+
+
+def test_discover_lists_only_numeric_worktrees(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    wt_root = tmp_path / "st-wt"
+    for name in ("7", "12", "lane-watch"):
+        (wt_root / name).mkdir(parents=True)
+    (wt_root / "88").write_text("a file, not a worktree", encoding="utf-8")
+    monkeypatch.setenv("SUPERTOOL_WT_ROOT", str(wt_root))
+    assert oss_train.discover() == ["12", "7"]
+
+
+def test_a_missing_worktree_is_FAILED_and_exits_one(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv("SUPERTOOL_WT_ROOT", str(tmp_path / "st-wt"))
+    assert _run_main(monkeypatch, "424242") == 1
+    out = capsys.readouterr().out
+    assert "FAILED" in out
+    assert "[result] FAILED: 1" in out
+
+
+# ---------------------------------------------------------------------------
+# #910 (1) — dry is read-only
+# ---------------------------------------------------------------------------
+
+def test_dry_leaves_the_branch_exactly_where_it_found_it(
+        train_world, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
+    wt = train_world["wt"]
+    before = _git("rev-parse", "HEAD", cwd=wt).strip()
+
+    assert _run_main(monkeypatch, "999,dry") == 0
+
+    after = _git("rev-parse", "HEAD", cwd=wt).strip()
+    assert after == before, (
+        "dry rebased the branch. It stops ABOVE the rebase precisely because "
+        "these worktrees hold live agents (#910)")
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "DRY" in out
+    assert "1 commit(s) behind" in out, out
+
+
+def test_dry_pushes_nothing(train_world, monkeypatch: pytest.MonkeyPatch) -> None:
+    _run_main(monkeypatch, "999,dry")
+    refs = _git("ls-remote", "--heads", train_world["origin"].as_posix(),
+                cwd=train_world["clone"])
+    assert "feature/xyz" not in refs, refs
+
+
+def test_dry_does_not_leave_a_rebase_in_progress(
+        train_world, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rebase that started and stopped is not 'nothing was touched' either."""
+    _run_main(monkeypatch, "999,dry")
+    git_dir = Path(_git("rev-parse", "--absolute-git-dir",
+                        cwd=train_world["wt"]).strip())
+    assert not (git_dir / "rebase-merge").exists()
+    assert not (git_dir / "rebase-apply").exists()
+
+
+# ---------------------------------------------------------------------------
+# #910 (2) — the label is the branch git reports
+# ---------------------------------------------------------------------------
+
+def test_the_label_is_the_branch_not_the_directory(
+        train_world, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
+    assert _run_main(monkeypatch, "999,dry") == 0
+    out = capsys.readouterr().out
+    assert "feature/xyz" in out, out
+    assert "fix/999" not in out, out
+
+
+def test_a_dirty_worktree_is_BUSY_and_is_still_named_by_its_branch(
+        train_world, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
+    """BUSY returns before the fetch, so this exercises the label on the one
+    path that touches no remote at all."""
+    (train_world["wt"] / "agent-scratch.txt").write_text("mid-task", encoding="utf-8")
+
+    assert _run_main(monkeypatch, "999") == 0
+    out = capsys.readouterr().out
+    assert "BUSY" in out
+    assert "feature/xyz" in out, out
+    assert "fix/999" not in out, out
+    assert "someone is working here" in out
+
+
+def test_a_detached_worktree_is_FAILED_rather_than_guessed_at(
+        train_world, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
+    wt = train_world["wt"]
+    _git("checkout", "-q", "--detach", "HEAD", cwd=wt)
+
+    assert _run_main(monkeypatch, "999") == 1
+    out = capsys.readouterr().out
+    assert "detached HEAD" in out
+    assert "no branch" in out
+
+
+# ---------------------------------------------------------------------------
+# registration — the op has to actually answer from this checkout
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+
+    @staticmethod
+    def _entry() -> dict:
+        config = json.loads((REPO / ".supertool.json").read_text(encoding="utf-8"))
+        assert "oss_train" in config["ops"], (
+            "the whole point of #1216 is that this op answers from "
+            "claude-supertool; an unregistered script answers from nowhere")
+        return config["ops"]["oss_train"]
+
+    def test_the_cmd_points_at_a_file_that_exists(self) -> None:
+        cmd = self._entry()["cmd"]
+        assert "scripts/oss_train.py" in cmd, cmd
+        assert SCRIPT.is_file(), SCRIPT
+
+    def test_it_runs_the_interpreter_supertool_is_running(self) -> None:
+        """`{python}` rather than a literal `python3`: the placeholder resolves
+        to the running interpreter, which is the only one guaranteed present."""
+        assert "{python}" in self._entry()["cmd"]
+
+    def test_the_worktree_root_is_configuration_not_a_constant(self) -> None:
+        """Extra config keys arrive as SUPERTOOL_<KEY> env vars, which is what
+        lets every test above point the op at a tmp_path instead of at the
+        machine's real worktrees."""
+        assert self._entry()["wt_root"] == "~/Documents/st-wt"
+
+    def test_the_timeout_outlives_a_real_train(self) -> None:
+        assert self._entry().get("timeout", 60) >= 600
+
+    def test_the_description_does_not_promise_the_colon_form(self) -> None:
+        """The description shipped in DVSI said 'append :dry', which is the one
+        form measured NOT to arrive."""
+        description = self._entry()["description"]
+        assert ":dry" not in description, description
+        assert ",dry" in description, description
+
+
+def test_the_script_is_not_packaged_into_the_wheel() -> None:
+    """A maintainer op that reads ~/Documents/st-wt is not part of the tool."""
+    pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'py-modules = ["supertool", "_supertool"]' in pyproject
+
+
+def test_the_coverage_gate_accounts_for_the_new_directory() -> None:
+    """`docs/validators.md` §"Declining instead of guessing": an unmeasured
+    directory that nothing names reads exactly like one that passed."""
+    sys.path.insert(0, str(REPO / ".github" / "scripts"))
+    try:
+        import coverage_gate
+    finally:
+        sys.path.pop(0)
+    named = (set(coverage_gate.ENFORCED)
+             | set(coverage_gate.MEASURED_NOT_ENFORCED)
+             | set(coverage_gate.NOT_MEASURED_PY))
+    assert "scripts/" in named, sorted(named)
+
+
+def test_the_module_imports_without_touching_the_machine(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """Import must not expand or stat the real worktree root: the tests point
+    it elsewhere by env var AFTER import."""
+    monkeypatch.setenv("SUPERTOOL_WT_ROOT", os.path.join("nowhere", "at", "all"))
+    assert oss_train.wt_root().endswith(os.path.join("nowhere", "at", "all"))

--- a/tests/test_oss_train_1216.py
+++ b/tests/test_oss_train_1216.py
@@ -314,3 +314,88 @@ def test_the_module_imports_without_touching_the_machine(
     it elsewhere by env var AFTER import."""
     monkeypatch.setenv("SUPERTOOL_WT_ROOT", os.path.join("nowhere", "at", "all"))
     assert oss_train.wt_root().endswith(os.path.join("nowhere", "at", "all"))
+
+# ---------------------------------------------------------------------------
+# the push verdict is READ, not pattern-matched loosely
+# ---------------------------------------------------------------------------
+
+#: Every failure verdict `git-push` actually emits, as literal prefixes.
+#: `presets/git/push.py` writes them; `test_the_failure_verdicts_still_read_this_way`
+#: below is what stops this list rotting into a set of strings nobody produces.
+NOT_PUSHED_VERDICTS = (
+    "NOT PUSHED - REJECTED  fix/1 -> origin/master - remote rejected",
+    "NOT PUSHED - REJECTED (non-fast-forward)  fix/1 -> origin/master",
+    "NOT PUSHED - UNVERIFIED  fix/1 -> origin/master - push timed out",
+    "NOT PUSHED - REBASE PAUSED (conflict in 2 file(s))  fix/1 -> origin/master",
+    "NOT PUSHED - already up to date  fix/1 -> origin/master",
+    "NOT PUSHED - no push attempted (detached HEAD - checkout a branch)",
+    "NOT PUSHED - push TIMED OUT (120s)  fix/1 -> origin/master",
+)
+
+
+@pytest.mark.parametrize("verdict", NOT_PUSHED_VERDICTS)
+def test_a_not_pushed_verdict_is_not_a_push(verdict: str) -> None:
+    """`"PUSHED" not in verdict` is FALSE for every one of these, because
+    `PUSHED` is a substring of `NOT PUSHED`. The whole receipt-reading
+    apparatus — git-push verifying the remote sha, this op relaying that
+    verdict instead of assuming its own success — ended at a membership test
+    that said "landed" for a rejected push, an unverified one, and a rebase
+    left PAUSED mid-conflict. Carried in from the DVSI copy, which still has it.
+    """
+    state, detail = oss_train.classify_push("[result] " + verdict + "\n")
+    assert state == "FAILED", (state, detail)
+    assert verdict in detail
+
+
+def test_a_real_push_is_reported_as_one() -> None:
+    state, detail = oss_train.classify_push(
+        "some output\n[result] PUSHED  fix/1 -> origin/master @ abc1234  (forced)\n")
+    assert state == "PUSHED"
+    assert detail.startswith("PUSHED")
+
+
+def test_no_verdict_line_at_all_is_a_failure_not_a_push() -> None:
+    state, detail = oss_train.classify_push("git-push exploded\n")
+    assert state == "FAILED"
+    assert "no [result] verdict" in detail
+
+
+def test_the_failure_verdicts_still_read_this_way() -> None:
+    """The list above is a claim about another file. Pin it, or the day
+    git-push renames a verdict this suite goes on passing about nothing."""
+    push = (REPO / "presets" / "git" / "push.py").read_text(encoding="utf-8")
+    for prefix in ("NOT PUSHED - REJECTED", "NOT PUSHED - UNVERIFIED",
+                   "NOT PUSHED - REBASE PAUSED", "NOT PUSHED - already up to date",
+                   "NOT PUSHED - no push attempted", "TIMED OUT"):
+        assert prefix in push, prefix
+    assert '_result(f"PUSHED ' in push
+
+
+# ---------------------------------------------------------------------------
+# the BUSY guard fails closed
+# ---------------------------------------------------------------------------
+
+def test_an_unreadable_worktree_status_stops_the_train(
+        train_world, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`git status --porcelain` failing is not "the tree is clean".
+
+    It was read as clean, so the one guard standing between this op and a live
+    agent's worktree was bypassed exactly when the command it depends on
+    stopped answering — and the run went on to fetch, rebase and force-push.
+    """
+    real_run = oss_train.run
+    reached = []
+
+    def fake_run(args, cwd, timeout=900):
+        if args[:2] == ["git", "status"]:
+            return 128, "fatal: not a git repository"
+        if args[:2] == ["git", "fetch"]:
+            reached.append(args)
+        return real_run(args, cwd, timeout)
+
+    monkeypatch.setattr(oss_train, "run", fake_run)
+    state, detail = oss_train.train("999", dry=False)
+
+    assert state == "FAILED", (state, detail)
+    assert "not a git repository" in detail
+    assert reached == [], "it fetched anyway after failing to read the status"


### PR DESCRIPTION
Closes #1216

`oss_train` was a project op in a different checkout, which made it the one measured reason a session rooted here could not run the maintainer loop. Every other op it needs already answers from this repo.

### Two bugs found while porting, both inherited, both still live in the original

**`"PUSHED" not in verdict` is true for every failure `git-push` emits.** `PUSHED` is a substring of `NOT PUSHED`. So `REJECTED`, `UNVERIFIED`, `REBASE PAUSED`, `TIMED OUT`, `already up to date` and `no push attempted` all fell through to the success arm and were tallied **`PUSHED`** — printed directly above a detail line reading "NOT PUSHED — …". A merge train that force-pushes branches reporting success on failure.

Fixed by reading the verdict as a prefix, tested against every verdict string `presets/git/push.py` writes, with a companion test pinning that list against the file so it cannot rot.

**`if rc == 0 and dirty.strip()` read a failed `git status --porcelain` as a clean tree.** That guard is the only thing standing between this op and a live agent's worktree, and it opened precisely when the command it depends on stopped answering. Now three states: clean / BUSY / could-not-tell.

### `dry` is genuinely read-only now

The old flag rebased local branches and only skipped the push, while printing `DRY RUN`. The judgment call was whether to make it read-only or rename it honestly — read-only, because the rebase's only extra information is "would it conflict", and the `BUSY` guard sees uncommitted changes only, so an agent between two commits reads as idle. The preview would buy its answer with someone else's `HEAD`, on a branch it does not own. `DRY` is a sixth per-branch state.

### Also fixed

The label came from the worktree **directory**, so a tree at `st-wt/899` holding `fix/codeql-5` printed `fix/899` — a name that exists nowhere, in a render whose every follow-up command takes a branch name. Now read per branch via `git symbolic-ref`.

### Not covered, named rather than faked

The rebase, the `git-resolve` refusal, and the push itself: exercising them means force-pushing real refs. `classify_push` was split out precisely because it is the one part of that path testable without a remote.

36 new tests. Full suite green twice — `9523 passed, 78 skipped`. Windows unverified; no leg of this ran off macOS.

### Follow-up, not in this PR

The original still carries both bugs. It lives in a separate GitLab repo, so it cannot be touched from here — removing it is a manual step, and these findings make it more urgent rather than less.