### PR TITLE
The JIT files were teaching a wrong fact on every matching call, one of them inverted

### DIFF
--- a/.claude/jit-context/paths/00-manual/docs-index.md
+++ b/.claude/jit-context/paths/00-manual/docs-index.md
@@ -46,5 +46,11 @@ mode: once, remind
 | `docs/formatters.md` / `docs/notifiers.md` | formatter / notifier adapter contracts |
 | `docs/input-forms.md` | `@file`/`@payload`/`@-` input-form mechanics |
 | `docs/mcp-integration.md`, `docs/mcp-warm-process-servers.md` | MCP server usage/config, warm-process pattern |
-| `docs/presets/{index,edits,map,meta,reads,search}.md` | shipped preset catalog + per-op-family reference |
-| `docs/operations/{git,github,gitlab,watch}.md` (largest: `watch.md` 165KB) | per-integration op reference; plus `bluesky.md`, `claude-log.md`, `dashboard.md`, `devto.md`, `hashnode.md`, `xml.md` |
+| `docs/operations/{index,edits,map,meta,reads,search}.md` | per-op-family reference for the builtin file ops |
+| `docs/presets/{git,github,gitlab,watch}.md` (largest: `watch.md` 165KB) | per-integration op reference; plus `bluesky.md`, `claude-log.md`, `dashboard.md`, `devto.md`, `hashnode.md`, `index.md`, `xml.md` |
+
+**These two rows were swapped until 2026-08-09**, and the swap was load-bearing: two agents in one evening went looking for `docs/operations/watch.md`, found `docs/operations/` holding a different six files, and concluded *"the index points at a directory layout that is gone"* — so one of them documented `radar` by guessing at a file and the other reported the whole index as rotten. Neither read the 165KB doc that actually existed one directory over.
+
+Note what made it convincing: **`watch.md` really is 165KB.** The size was right and the path was wrong, so the entry corroborated itself. Verify a path by listing the directory, not by recognising a detail in the row.
+
+There is no `docs/presets/radar.md`. `radar` is documented inside `docs/presets/watch.md`.

--- a/.claude/jit-context/paths/00-manual/presets-github.md
+++ b/.claude/jit-context/paths/00-manual/presets-github.md
@@ -22,11 +22,26 @@ Directory is `presets/github/`. **`presets/gh/` does not exist** — `gh-` is on
 
 `TIMED_OUT`/`ACTION_REQUIRED` are FAILED, not benign — don't lump them with SKIPPED.
 
-# Open defects — check before trusting output
+# Open defects — ask the tracker, do not read a list here
 
-- **#1181**: `gh-pr:N:status` prints `TALLY UNVERIFIED` on every PR because the Copilot review check-run has no workflow to count against. Code tries to stay silent when nothing is missing (`_reconcile_checks` in `pr.py:219`) — this is the case that slips through.
-- **#1207**: `gh-prs` defaults to `author=@me` (deliberate, disclosed in footer) but a maintainer wants every author. Use `gh-prs:anyauthor` or dependabot/outside-contributor PRs are invisible.
-- **#1180**: `presets/github/issues.py:251` — `parts[2].endswith("github.com")` matches `evilgithub.com`.
+This section used to enumerate open defects. On 2026-08-09 **all four of them were closed** and the list was still being injected into every call that touched this directory — including one telling the reader to pass `gh-prs:anyauthor` to widen a board whose default had already been widened, which is worse than stale, it is inverted.
+
+A hand-maintained list of open defects inside an auto-injected file cannot stay true, because nothing closes the loop when the defect is fixed. So it is a query now:
+
+```
+supertool 'gh-issues:label=lane-tracker-ops,per=100'
+```
+
+For the record, since the entries were load-bearing while they lasted — closed and verified against master on 2026-08-09:
+
+| Was | Closed by | Now |
+| --- | --- | --- |
+| #1180 — `parts[2].endswith("github.com")` matches `evilgithub.com` | #1212 | `_is_github_host()` (`issues.py:242`) — exact host or `.`-boundary subdomain, userinfo and port stripped |
+| #1207 — `gh-prs` defaults to `author=@me` | #1212 | **the bare op is the whole repo**; `author=@me` is a filter you write |
+| #1181 — `TALLY UNVERIFIED` on every PR | #1212 | the tally cap was the cause |
+| #1202 — `required()` inert on 13 adapters | #1213 | all 13 route through `refusal.absent()` |
+
+**`gh-prs` is repo-wide by default. Do not add `anyauthor` expecting it to widen anything** — it is accepted and names what the bare op already does. `gl-mrs` is the one that still defaults to `author=@me` (`presets/gitlab/mrs.py:153`).
 
 # `gh-issues` flags
 

--- a/.claude/jit-context/paths/00-manual/validators.md
+++ b/.claude/jit-context/paths/00-manual/validators.md
@@ -11,33 +11,30 @@ could not run must say so — never report clean. Canonical write-up:
 `docs/validators.md` §"Declining instead of guessing". Cite that exact path — it's repo-specific,
 mis-cited across a repo boundary before.
 
-**Absent tool → copy `validators/shellcheck/shellcheck.py:131-137` verbatim:**
+**Absent tool → one call, `refusal.absent()`** (`validators/common/refusal.py:227`):
 ```python
 if not shutil.which(TOOL):
-    if required(TOOL):
-        _adapter_error(file, required_but_absent(TOOL, INSTALL_HINT), dur)
-    else:
-        emit(skipped(TOOL, file, INSTALL_HINT, dur))
+    emit(absent(TOOL, file, INSTALL_HINT, int((time.time() - start) * 1000)))
     return
 ```
-Do not invent a variant.
+`tool` is the **validator name** — the key a repo writes in `.supertool.json` — never the binary. `tsc-check` runs `tsc` and `html-check` runs `node`; escalating on the binary name would ignore the only spelling anyone can configure. Reserve it for an *absent* tool; a tool that ran and fell over is a different arm.
 
-# Open defect #1202 — `required()` gate is inert on most adapters
+Where the absence lands — `skipped`, or a loud failure under `$SUPERTOOL_REQUIRE_VALIDATORS` — is decided inside `absent()`, not by the adapter. That is the point of #1202: `required()` was a helper each adapter had to remember to call, **six of them did**, and the other ten spelled the moment as a fabricated `{"ok": true, "count": 0, "errors": []}` about a file nothing opened.
 
-`validators/ruff/ruff.py:120-121` emits `skipped` on absent tool unconditionally — never calls
-`refusal.required()`. `SUPERTOOL_REQUIRE_VALIDATORS=ruff` is silently inert: it can never force a
-loud failure for ruff.
+**This block used to say "copy `shellcheck.py:131-137` verbatim, do not invent a variant".** That code is still there and still correct — shellcheck is one of the six that always gated — but copying it now reproduces the pre-#1202 shape, one adapter's memory at a time, which is the thing that broke. Grepping an adapter for `required(` will come back empty and mean nothing: the call is indirect through `absent()`. One agent read that emptiness as "html-check is still inert" on 2026-08-09 and was wrong.
 
-Grepped every adapter for `required(`: only **shellcheck, eslint, gitleaks, tomllint,
-changelog-fragment** gate on it. 16 adapters check tool presence at all; the other **13 have the
-same gap as ruff**: `tsc-check, phpstan, markdownlint, ruby-check, prettier-check, git-status,
-cargo-check, hadolint, gofmt-check, terraform-check, pyright, psr, html-check`. Verified by name —
-they check `shutil.which`/binary-exists and go straight to `emit(skipped(...))`, no `required()`
-call anywhere in the file.
+# #1202 is CLOSED — do not go looking for this gap
+
+**#1202 shipped in #1213** ("An absent tool is never a clean pass — 16 adapters, and ten were
+fabricating `ok:true`"). Every adapter now routes its absent-tool arm through `refusal.absent()`,
+which consults `required()` internally. Verified 2026-08-09 against master.
+
+This section used to enumerate 13 adapters with the gap, and was still being injected at every
+call touching `validators/` after all 13 were fixed.
 
 # `skipped` and rollback
 
-A `skipped` never rolls back (`docs/validators.md:650`, "No verdict never rolls back an edit") —
+A `skipped` never rolls back (`docs/validators.md:681`, "No verdict never rolls back an edit") —
 so turning `ok:true` into `skipped` changes rollback reachability. Don't do it casually.
 
 # Schema fields — `validators/SCHEMA.md`
@@ -50,10 +47,18 @@ so turning `ok:true` into `skipped` changes rollback reachability. Don't do it c
   `source_context` absent. Don't fold a whole-crate error into `skipped` — that drops `errors`
   entirely, which is worse.
 
-# Open defect #1203
+# #1203 is CLOSED
 
-`tomllint` is declared in `.supertool.example.json:666-667` and **absent** from this repo's own
-`.supertool.json` — a validator that ships and isn't registered here checks nothing here.
+`tomllint` was declared in `.supertool.example.json` and absent from this repo's own
+`.supertool.json`. Fixed and verified CLOSED 2026-08-09.
+
+**Both stale entries above shared a heading that begins `Open defect`**, which is what made them
+mechanically findable: `claims:PATH` checks that every issue cited under such a heading is actually
+OPEN. It needs no semantics, because the heading is the author saying "this is a live gap". That
+lens is 5-for-5 across `.claude/jit-context/`, where a lexical rule over the same corpus scored 13%.
+So: if you write a heading like that, the tracker is the thing that keeps you honest — and if you
+are tempted to hand-maintain a defect list in an auto-injected file, read the two corpses above
+first.
 
 # changelog-fragment
 

--- a/.claude/jit-context/tools/00-manual/00-index.tsv
+++ b/.claude/jit-context/tools/00-manual/00-index.tsv
@@ -2,3 +2,4 @@ Bash	~gh (issue|pr) list	gh-list-limit.md	remind	--limit
 Edit|Write|Read|Grep|Glob|MultiEdit|NotebookEdit	~.	harness-tools-blocked.md	block		
 Bash	~supertool[^|]*'(gh-prs|gl-mrs|gh-issues|gl-issues|radar|watches)	op-defaults-that-narrow.md	remind		
 Bash	~supertool[^|]*\|[^|]*(head|tail|sed|cut|awk)	supertool-no-cut.md	block		
+Bash	~git\s+(branch|for-each-ref)[^|]*--merged	merged-is-not-ancestry.md	block	--merged	

--- a/.claude/jit-context/tools/00-manual/merged-is-not-ancestry.md
+++ b/.claude/jit-context/tools/00-manual/merged-is-not-ancestry.md
@@ -1,0 +1,44 @@
+---
+title: "Do not ask git whether a branch is merged — this repo squash-merges"
+tool: Bash
+match: ~git\s+(branch|for-each-ref)[^|]*--merged
+mode: block
+---
+
+**Use `git-worktrees`.** It owns this question, for every worktree at once, with the branch, the path, the tracker state and an occupancy verdict alongside it:
+
+```
+supertool 'git-worktrees'              # the whole fleet
+supertool 'git-worktrees:<PATH>'       # one tree, exit 0 only for idle
+```
+
+## Why the raw command is blocked rather than discouraged
+
+`--merged` is an **ancestry** test. This repo squash-merges every PR, and a squash creates a commit with no parent link to the branch — so a fully merged branch is not an ancestor of `master` and `--merged` never names it.
+
+It does not fail loudly. It returns a short, well-formed, wrong list:
+
+- `git branch -r --merged` reported **4** on a repo holding **99** remote branches, **96** of them merged.
+- 2026-08-09, six live worktrees: three fully-merged branches (`fix/1207`, `fix/1216`, `docs/contributor-skill`, merged as #1212, #1217, #1215) were absent from the merged set. Read the natural way, that says three branches hold unproposed work — an argument for opening three redundant PRs.
+
+**A short answer and a correct answer look identical here**, which is why this blocks.
+
+## The same trap in `git diff`
+
+`git diff origin/master...HEAD` diffs against the **merge-base**, which predates the squash, so every already-merged line reappears as an addition. On `docs/contributor-skill` it claimed **1384 added lines across 5 files** — all five already on master.
+
+If you need to know whether specific content landed, ask master for the content, not for the ancestry:
+
+```bash
+git cat-file -e origin/master:path/to/file && echo present || echo ABSENT
+```
+
+## When you genuinely need the raw list
+
+GitHub is authoritative about squashes; git is not:
+
+```bash
+gh pr list --state merged --limit 400 --json headRefName -q '.[].headRefName'
+```
+
+Intersect with the live branch list. What is left over has no merged PR and is real work.

--- a/.claude/jit-context/tools/00-manual/op-defaults-that-narrow.md
+++ b/.claude/jit-context/tools/00-manual/op-defaults-that-narrow.md
@@ -9,10 +9,15 @@ Each of these has a default that **narrows the population**. The render says so 
 
 | Op | Silent default | Widen with |
 | --- | --- | --- |
-| `gh-prs` / `gl-mrs` | `author=@me` — your PRs, not the repo's | `gh-prs:anyauthor,state=open` |
+| `gh-prs` | **none — the bare op is the whole repo** (#1207, shipped in #1212) | nothing to widen; `anyauthor` is accepted and names what it already does |
+| `gl-mrs` | `author=@me` — your MRs, not the project's (`presets/gitlab/mrs.py:153`) | `gl-mrs:author=` or another role filter |
 | `gh-issues` / `gl-issues` | caps at **50**, prints `capped at --limit 50 — more may exist` | `gh-issues:per=100` |
-| `radar` | tiers come from the **CWD's** `.supertool.json`; the GitHub tier inherits `author=@me` | `cwd:~/Documents/claude-supertool` first, then widen the tier |
+| `radar` | tiers come from the **CWD's** `.supertool.json`, **and the GitHub tier still applies its own `author=@me`** — `radar:--state` prints `filter: author=@me (default)`. It did not inherit this from `gh-prs`; it kept it after `gh-prs` dropped it | `cwd:` first, then widen the tier |
 | `watches` | shows tracked pollers; ones predating the labelling are invisible **by design** | cross-check `pgrep -f 'presets/watch/'` before concluding a slot is free |
+
+**The `gh-prs` row was inverted for an unknown number of sessions** — it told the reader to add `anyauthor` to widen a board that had already been widened, which is a reminder actively teaching a wrong fact. Corrected 2026-08-09 against `presets/github/prs.py:27` (*"The default is the whole repo… It used to be `author=@me`"*) and a live footer reading `no author filter (default)`.
+
+**`radar` is now the surface carrying the defect `gh-prs` was fixed for**, and it is the op a maintainer tick opens with. Verified with `radar:--state`, which is read-only.
 
 ## What it costs when you skip the flag
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,20 @@ Two habits that catch it:
 - **Check the thing, not the citation.** A closed issue number proves little — measured over 193 citations in the maintainer skill, "the issue closed and the sentence claims an absence" was right 13% of the time. What settles it is the op's own signature in `supertool 'ops'`, or the file on disk.
 - **Re-derive a load-bearing claim at the moment it is about to enter a brief**, because that is where a stale line acquires an agent and a CI run.
 
+### Writing one, not just fixing one
+
+The same duty runs forward. **When you learn something durable — a trap, a mechanism, a number that decides a call — write it down before the session ends**, because you will not be here to remember it and neither will the next reader.
+
+The auto-injected notes live in `.claude/jit-context/`, in two families: `paths/00-manual/` fires on a file path appearing in a call, `tools/00-manual/` on a tool invocation matching a regex. Each entry is a markdown file with frontmatter (`title`, `match`, `mode: remind|block`, and `tool:` for the tools family).
+
+**The `.md` alone is inert. `00-index.tsv` in the same directory is what the hook reads** — `tool⇥match⇥file⇥mode⇥keyword`. A file with no index row is a rule that exists on disk and never runs, which reads exactly like a rule that runs and never matches.
+
+Three rules for what goes in one:
+
+- **Point at the op. Never teach a way around it.** If the entry you are about to write explains how to get an answer by hand, the thing to change is the op that should have answered. A draft of `merged-is-not-ancestry.md` was 39 lines of `git cat-file` and `gh pr list | intersect` recipes for a question `git-worktrees` already owns and answers wrongly on one line. Documenting the detour makes it permanent and leaves the defect. Fix the op; the note then shrinks to a pointer.
+- **A `block` must anchor on the invocation, not on a word.** `supertool-no-cut.md` matches `~supertool[^|]*\|[^|]*(head|tail|…)`, and the word it matches is usually the **directory name** — every command run from this repo contains it. On 2026-08-09 it blocked a plain `git status | head`, a `pytest | tail`, a `venv` under a scratchpad path, and a `gh-job:N:grep:A|B` whose `|` was inside the op's own pattern. A blocking rule that fires on commands it was not written for teaches people to route around the block.
+- **Carry the number that made you write it.** A rule with its evidence stripped is folklore, and folklore is what this tool exists to replace.
+
 ## The defect this codebase keeps having
 
 **An absence produced by the tool, read as an absence in the world.** A grep that truncated silently. A check tally where a cancelled leg counted as neither pass nor pending. Empty stdout from a refusal read as "zero errors". It has been filed more than a dozen times under different surfaces.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,25 @@ This file loads on every session here, so it holds only what is true regardless 
 
 **CI runs pytest with `--tb=no`, so no traceback ever reaches the logs.** That is deliberate, not truncation. The `junit_summary` step prints the failing assertion and its context — read that. Before blaming a reader for what is absent, check whether the writer ever wrote it.
 
+## The notes are yours to fix, not just to follow
+
+`CLAUDE.md`, the maintainer skill and the `.claude/jit-context/` files exist to help you. They are also written by people with no memory, about a repo that moves faster than they do, so **some of what they tell you is false right now.**
+
+**When you find a wrong line in any of them, correcting it is part of the task you are already doing.** Not a follow-up, not an issue to file instead, not somebody else's. You are the person who has the evidence in front of them, and that is the only moment the fix is cheap.
+
+This is not hypothetical. On 2026-08-09, in one session:
+
+- The maintainer skill said no op rendered a commit's run list and nothing tallied label distribution. Both had shipped — `gh-branch:COMMIT_SHA` and `gh-labels:tally=PREFIX` — and the second was the cohort burn-down the same file orders the maintainer to report **every tick**.
+- A JIT file listed four open defects. All four were closed.
+- Another JIT file said `gh-prs` defaults to `author=@me` and told the reader to pass `anyauthor` to widen it. The default had been changed to the whole repo; the advice was **inverted**, and it fired on every matching call.
+
+**A wrong claim in your own notes does not merely risk being wrong — it produces the behaviour it describes.** The worst instance on record: this repo's notes stated in bold that no op could reach a sibling repo, days after that was fixed, and a whole queue got read through raw `gh` in obedience to it. A stale line about a *missing* capability is the most dangerous shape, because it suppresses the call that would disprove it.
+
+Two habits that catch it:
+
+- **Check the thing, not the citation.** A closed issue number proves little — measured over 193 citations in the maintainer skill, "the issue closed and the sentence claims an absence" was right 13% of the time. What settles it is the op's own signature in `supertool 'ops'`, or the file on disk.
+- **Re-derive a load-bearing claim at the moment it is about to enter a brief**, because that is where a stale line acquires an agent and a CI run.
+
 ## The defect this codebase keeps having
 
 **An absence produced by the tool, read as an absence in the world.** A grep that truncated silently. A check tally where a cancelled leg counted as neither pass nor pending. Empty stdout from a refusal read as "zero errors". It has been filed more than a dozen times under different surfaces.


### PR DESCRIPTION
Auto-injected context is the highest-authority prose in the repo — it arrives at the moment of the tool call, unrequested, and is read as current by construction. Two of those files were not.

## What was wrong

**`paths/00-manual/presets-github.md`** carried an "Open defects — check before trusting output" list of four. **All four are closed** — #1180, #1207 and #1181 by PR #1212, #1202 by #1213. Verified against master rather than against issue state: the lookalike-host check is now `_is_github_host()` at `issues.py:242`, exact host or `.`-boundary subdomain, userinfo and port stripped.

**`tools/00-manual/op-defaults-that-narrow.md`** was worse than stale — it was **inverted**. It said `gh-prs` silently defaults to `author=@me` and told the reader to pass `anyauthor` to widen it. #1207 changed the default to the whole repo. `presets/github/prs.py:27` says it outright:

> The default is the whole repo, and the board says which population it is. It used to be `author=@me`.

A live footer confirms: `no author filter (default) — every author's open PRs on this repo`. That file fires on every call matching its pattern, so it was actively teaching a wrong fact.

## Two structural changes, not four corrections

**The open-defects list is a query now.** A hand-maintained list of open defects inside an auto-injected file cannot stay true — nothing closes the loop when the defect is fixed. The four entries survive as a closed-and-verified table, because the reasoning was load-bearing while it lasted.

**`radar` gets its own row, and it is a finding rather than drift.** `radar:--state` reports `filter: author=@me (default)`. Radar did not *inherit* that from `gh-prs` — it kept it after `gh-prs` dropped it. So the board op a maintainer tick opens with still carries the exact defect #1207 removed from the op underneath it, and #1071's evidence (two dependabot PRs and an outside contributor's PR invisible, found by a human opening GitHub in a browser) applies to it unchanged. Filed separately; this PR only documents it.

## CLAUDE.md

A section making the duty explicit rather than implicit: these files exist to help, some of what they say is false right now, and **correcting a wrong line is part of whatever task found it** — not a follow-up, not an issue filed instead.

It carries the measurement that says how to check: over 193 citations in the maintainer skill, "the cited issue is closed and the sentence claims an absence" was right **13%** of the time. What settles a claim is the op's own signature in `supertool 'ops'`, or the file on disk — not the citation.

## Verification

- `gh-issue:1180`, `:1207`, `:1181`, `:1202` — all CLOSED
- `presets/github/issues.py:242-255` read directly; no `endswith("github.com")` survives as a check (the two remaining hits are comments explaining the fix)
- `presets/gitlab/mrs.py:153` — `gl-mrs` **does** still default to `author=@me`, so that row stays and is now split from `gh-prs` rather than sharing a cell with it
- `radar:--state` — read-only, spawns and reaps nothing (#957)

Docs-only: no `changelog.d/` fragment, since none of these paths are in the gate's user-visible set.