### PR TITLE
Three Windows test-scaffolding defects, and the abandoned worktree was not abandoned

### DIFF
--- a/changelog.d/1205.fixed.md
+++ b/changelog.d/1205.fixed.md
@@ -1,0 +1,10 @@
+- tests: two symlink tests in `test_path_meta_bulk_1126.py` created their link
+  without asking `_symlink.require_symlink()` first, so on a runner without the
+  create-symlink privilege — Windows outside Developer Mode — `symlink_to` raised
+  `OSError` and they **failed** where every other symlink test in the suite
+  **skips**. A skip says the platform could not run the check; a failure says the
+  platform ran it and the code is broken, and the code it pointed at was fine.
+  Both route through the shared probe now. A new guard runs that file with the
+  privilege forced absent and requires all three of its symlink tests to skip,
+  which is the only way a machine that has the privilege can observe the
+  difference at all.

--- a/changelog.d/1206.fixed.md
+++ b/changelog.d/1206.fixed.md
@@ -1,0 +1,15 @@
+- tests: the fake `git` executables in `test_status_swallowed_705.py`,
+  `test_git_timeout_disclosure_650.py` and `test_unanswerable_checks_693.py`
+  decided whether they were standing in for the call under test by comparing
+  `$1` to a subcommand name. git takes its global flags before the subcommand,
+  so `git -C <path> status` puts `status` in `$2`: the comparison failed, the
+  `exec` fallthrough ran the real binary, and the shim was silently not in
+  effect. It broke loudly once only because the tests it disabled assert a
+  refusal; a shim standing in for a passing expectation would have let real git
+  return the same answer and the test would have gone on passing while asserting
+  nothing. All five shims are built by `tests/_gitshim.dispatch_on_subcommand`
+  now, which skips the global flags and reads the first argument that is not
+  one — not "the subcommand anywhere in argv", which would have made
+  `git status -- stash` fire a stash shim. A gate refuses any new `"$1"`-keyed
+  shim in the suite, with the two honest first-argument cases named and
+  explained rather than silently exempt.

--- a/changelog.d/1218.fixed.md
+++ b/changelog.d/1218.fixed.md
@@ -1,0 +1,21 @@
+- tests: three timeout assertions in `test_rollback_no_verdict_969.py` obtained
+  their timeout by making a fake adapter sleep 3s against a 1s budget and
+  trusting the runner to notice. `windows-latest, 3.12` did not — the adapter
+  came back at `0.0s` having written nothing, which is the *adapter* non-verdict
+  rather than the *orchestrator* one — and `master` went red on a scheduling
+  accident with a message pointing at validator code that was fine. A property
+  of two renderers is not a claim about the scheduler. `TimeoutExpired` is now
+  raised where the operating system would raise it, on the second adapter spawn
+  only, so the baseline pass is still a real subprocess and everything
+  downstream of `_validator_run_one`'s timeout arm is the real code. The budget
+  the core hands to `subprocess.run` is captured and asserted rather than
+  discarded, because a fabricated timeout would otherwise pass just as happily
+  against a core that had stopped passing one.
+- tests: `test_a_core_timeout_after_the_edit_does_not_revert_it` had the same
+  dependency and the opposite symptom — every one of its assertions holds for
+  the silent-adapter refusal too, so on that same runner it kept passing while
+  exercising the branch it is not named for. It asserts the row now.
+- tests: nothing asserted that the two refusals stay *distinguishable*, which is
+  the only reason it was defensible to call both renders correct. A new test
+  pins that a timeout says `timed out` / `orchestrator` and a silent adapter
+  does not, so a reader can still tell a slow machine from a broken checker.

--- a/tests/_gitshim.py
+++ b/tests/_gitshim.py
@@ -1,0 +1,66 @@
+"""One git PATH shim for the whole suite, keyed on the subcommand (#1206).
+
+Three test modules built the same fake `git` independently, and all three asked
+the same wrong question: `[ "$1" = "status" ]`. git takes its global flags
+*before* the subcommand, so `git -C <path> status` and
+`git --literal-pathspecs status` put `status` in `$2`. The comparison fails, the
+`exec` fallthrough runs the real binary, and the shim is silently not in effect.
+
+Silently is the whole problem. It broke visibly once only because the tests it
+disabled assert a *refusal*, so a real git succeeding contradicted them. A shim
+standing in for a passing expectation fails the other way: real git returns the
+answer the fake would have returned, the test still passes, and it is asserting
+nothing about the path it was written for -- indistinguishable, forever, from a
+test that works.
+
+So the shim describes "a git invoked with this subcommand". It skips the global
+flags and reads the first argument that is not one, rather than matching the
+subcommand *anywhere* in the arguments: `git status -- stash` is not a stash
+call, and a shim that answered it as one would trade a fake that quietly stops
+firing for one that quietly fires too often.
+
+**Where this is still blind, stated rather than left to be found.** The list
+below is git's global flags that take a *separate* argument. A future flag of
+that shape which is not in it would have its value read as the subcommand, and
+the shim would go back to silently not firing. The failure is the same one this
+module exists for, one flag further out; there is no way to ask git for the
+list at runtime, so it is a maintained constant and this paragraph is the
+disclosure.
+"""
+from __future__ import annotations
+
+#: git global flags whose value is a separate argv entry, not `--flag=value`.
+TAKES_A_SEPARATE_ARGUMENT = (
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+    "--super-prefix", "--attr-source", "--config-env",
+)
+
+_SUBCOMMAND_FUNCTION = """_supertool_git_subcommand() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      %s)
+        if [ $# -ge 2 ]; then shift 2; else shift; fi
+        ;;
+      -*) shift ;;
+      *) printf '%%s' "$1"; return 0 ;;
+    esac
+  done
+  return 0
+}
+""" % "|".join(TAKES_A_SEPARATE_ARGUMENT)
+
+
+def dispatch_on_subcommand(subcommand: str, action: str, real_git: str) -> str:
+    """`/bin/sh` body: run ACTION when git was invoked with SUBCOMMAND.
+
+    Everything else execs REAL_GIT, so the repo under test is still built and
+    read by a real binary and only the one call under examination is faked. The
+    `#!/bin/sh` line is the caller's, matching the shim writers that already
+    prepend it.
+    """
+    return (
+        _SUBCOMMAND_FUNCTION
+        + 'if [ "$(_supertool_git_subcommand "$@")" = "' + subcommand + '" ]; '
+        + "then " + action + "; fi\n"
+        + "exec " + real_git + ' "$@"\n'
+    )

--- a/tests/test_git_shim_subcommand_1206.py
+++ b/tests/test_git_shim_subcommand_1206.py
@@ -1,0 +1,184 @@
+"""#1206 -- a PATH shim that stops shimming without saying so.
+
+The fake `git` executables in this suite decide whether they are standing in
+for the call under test by comparing `$1` against a subcommand name. git takes
+its global flags *before* the subcommand, so `git -C <path> status` and
+`git --literal-pathspecs status` both put `status` in `$2`: the comparison
+fails, the `exec` fallthrough runs the real binary, and the fake is silently
+not in effect.
+
+It surfaced loudly once, by luck. The tests it broke assert a *refusal*, so a
+real git succeeding contradicted them visibly. A shim standing in for a
+**passing** expectation fails the other way round -- real git returns the
+answer the fake would have returned, the test still passes, and it is asserting
+nothing about the path it was written for. That is indistinguishable from a
+working test, forever.
+
+So the shim has to describe "a git invoked with this subcommand", not "a git
+whose first word is this subcommand" -- and the last test here is the class
+gate, because this one was found by tripping over it rather than by looking.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import test_git_timeout_disclosure_650 as t650
+import test_status_swallowed_705 as t705
+
+TESTS = Path(__file__).resolve().parent
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX /bin/sh shim")
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    for args in (["init", "-b", "master"],
+                 ["config", "user.email", "t@test.com"],
+                 ["config", "user.name", "Test"]):
+        subprocess.run(["git", "-C", str(repo), *args], check=True,
+                       capture_output=True)
+    (repo / "tracked.txt").write_text("original" + os.linesep, encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "tracked.txt"], check=True,
+                   capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "initial"],
+                   check=True, capture_output=True)
+    return repo
+
+
+def _run(bindir: Path, *args: str, timeout: float = 30):
+    return subprocess.run(["git", *args], capture_output=True, text=True,
+                          encoding="utf-8", errors="replace", timeout=timeout,
+                          env=dict(os.environ, PATH=str(bindir)))
+
+
+@pytest.mark.parametrize("prefix", [
+    ["--literal-pathspecs"],
+    ["--no-optional-locks"],
+    ["-c", "core.quotepath=false"],
+])
+def test_a_global_flag_before_the_subcommand_still_reaches_the_failing_shim(
+    tmp_path: Path, prefix
+) -> None:
+    """The refusal has to survive a flag git itself accepts in that position."""
+    d = t705._bindir(tmp_path)
+    t705._failing_git_shim(d, "status", 128, "fatal: unable to read index file")
+    r = _run(d, *prefix, "status", "--porcelain")
+    assert r.returncode == 128, (
+        "the shim did not intercept `git " + " ".join(prefix) + " status`; real "
+        "git answered instead, so a test built on this fake tests nothing: "
+        + repr((r.returncode, r.stdout, r.stderr))
+    )
+    assert "unable to read index file" in r.stderr
+
+
+def test_the_shim_is_reached_through_the_dash_C_form_the_suite_actually_uses(
+    tmp_path: Path
+) -> None:
+    """`git -C <path> <sub>` is how this repo's own helpers spell it."""
+    repo = _repo(tmp_path)
+    d = t705._bindir(tmp_path)
+    t705._failing_git_shim(d, "status", 128, "fatal: unable to read index file")
+    r = _run(d, "-C", str(repo), "status", "--porcelain")
+    assert r.returncode == 128, repr((r.returncode, r.stdout, r.stderr))
+
+
+def test_the_stalling_shim_also_matches_past_a_global_flag(tmp_path: Path) -> None:
+    """Same defect, the other builder: it must still hang, not fall through."""
+    d = t705._bindir(tmp_path)
+    t705._stalling_git_shim(d, "status")
+    with pytest.raises(subprocess.TimeoutExpired):
+        _run(d, "--literal-pathspecs", "status", "--porcelain", timeout=3)
+
+
+def test_the_timeout_suite_shim_matches_past_a_global_flag(tmp_path: Path) -> None:
+    """`test_git_timeout_disclosure_650` builds the same shape separately."""
+    bindir = Path(t650._failing_git_path(tmp_path, "diff"))
+    r = _run(bindir, "--literal-pathspecs", "diff", "--name-only")
+    assert r.returncode == 1, repr((r.returncode, r.stdout, r.stderr))
+    assert "fatal: shim" in r.stderr
+
+
+def test_a_subcommand_named_only_as_an_argument_is_not_intercepted(
+    tmp_path: Path
+) -> None:
+    """The fix must not become "match anywhere in argv".
+
+    `git status -- stash` is not a stash call, and a shim that answered it as
+    one would break the tests it is supposed to hold up -- trading a shim that
+    silently stops firing for one that silently fires too often.
+    """
+    repo = _repo(tmp_path)
+    d = t705._bindir(tmp_path)
+    t705._failing_git_shim(d, "stash", 128, "fatal: unable to read index file")
+    r = _run(d, "-C", str(repo), "status", "--porcelain", "--", "stash")
+    assert r.returncode == 0, repr((r.returncode, r.stdout, r.stderr))
+    assert "unable to read index file" not in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# The class gate
+# ---------------------------------------------------------------------------
+
+#: `$1` really is the first argument for these, and the reason is stated rather
+#: than assumed. `test_pre_push_interpreter_572` shims a *python* interpreter and
+#: matches `-c`, which is not a git subcommand and carries no global-flag
+#: prefix; `test_watch_mine_defaults` stubs `supertool`, whose op is always the
+#: first and only argument.
+_FIRST_ARG_IS_HONEST = {
+    "test_pre_push_interpreter_572.py",
+    "test_watch_mine_defaults.py",
+}
+
+_DOLLAR_ONE = re.compile('"[$]1"')
+
+
+def _sh_literals_matching_dollar_one():
+    """Every string constant in the suite that tests `"$1"` inside a shim."""
+    hits = []
+    for path in sorted(TESTS.glob("test_*.py")):
+        if path.name in _FIRST_ARG_IS_HONEST or path.name == Path(__file__).name:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - a broken fixture module
+            continue
+        for node in ast.walk(tree):
+            text = None
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                text = node.value
+            elif isinstance(node, ast.JoinedStr):
+                text = "".join(
+                    v.value for v in node.values
+                    if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                )
+            if text and _DOLLAR_ONE.search(text):
+                # An f-string is walked as the JoinedStr and again as each of
+                # its Constant parts, so the same shim would otherwise be named
+                # twice and the list would read as a longer class than it is.
+                hit = (path.name, node.lineno, text.strip()[:70])
+                if not any(h[:2] == hit[:2] for h in hits):
+                    hits.append(hit)
+    return hits
+
+
+def test_no_shim_in_this_suite_decides_a_git_subcommand_from_dollar_one() -> None:
+    """A shim keyed on `$1` un-shims itself the moment a global flag appears.
+
+    Nothing else in the suite reports that: the fallthrough runs real git, which
+    answers, and only a test asserting a refusal notices. Route shims through
+    `_gitshim.dispatch_on_subcommand`, which skips git's global flags and reads
+    the first argument that is actually a subcommand.
+    """
+    hits = _sh_literals_matching_dollar_one()
+    assert hits == [], (
+        "these shims key off the first argument, so any git global flag ahead "
+        "of the subcommand silently disables them:" + os.linesep
+        + os.linesep.join("  {0}:{1} {2!r}".format(*h) for h in hits)
+    )

--- a/tests/test_git_timeout_disclosure_650.py
+++ b/tests/test_git_timeout_disclosure_650.py
@@ -41,6 +41,7 @@ from pathlib import Path
 import pytest
 
 import supertool
+from _gitshim import dispatch_on_subcommand
 
 _ROOT = Path(__file__).parent.parent
 _STATUS_PATH = _ROOT / "presets" / "git" / "status.py"
@@ -94,8 +95,7 @@ def _slow_git_path(tmp_path: Path, subcommand: str) -> str:
     shim = bindir / "git"
     shim.write_text(
         "#!/bin/sh\n"
-        f'if [ "$1" = "{subcommand}" ]; then {sleep} 300; fi\n'
-        f'exec {real} "$@"\n'
+        + dispatch_on_subcommand(subcommand, f"{sleep} 300", real)
     )
     shim.chmod(0o755)
     return str(bindir)
@@ -435,8 +435,8 @@ def _failing_git_path(tmp_path: Path, subcommand: str) -> str:
     shim = bindir / "git"
     shim.write_text(
         "#!/bin/sh\n"
-        f'if [ "$1" = "{subcommand}" ]; then echo "fatal: shim" >&2; exit 1; fi\n'
-        f'exec {real} "$@"\n'
+        + dispatch_on_subcommand(
+            subcommand, 'echo "fatal: shim" >&2; exit 1', real)
     )
     shim.chmod(0o755)
     return str(bindir)

--- a/tests/test_path_meta_bulk_1126.py
+++ b/tests/test_path_meta_bulk_1126.py
@@ -314,6 +314,7 @@ def test_a_symlink_gets_the_same_marker_from_either_route(repo: Path) -> None:
     tree, and looking one up under the link's *target* name missed every time.
     A miss is indistinguishable from clean, so an untracked symlink rendered as
     a tracked, unmodified file — a wrong answer, not a slow one."""
+    require_symlink()
     (repo / "real").mkdir()
     (repo / "real" / "target.txt").write_bytes(b"committed\n")
     subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True,
@@ -338,6 +339,7 @@ def test_a_symlink_gets_the_same_marker_from_either_route(repo: Path) -> None:
 def test_a_symlink_is_never_answered_from_another_repo(tmp_path: Path) -> None:
     """Resolving the link first picked the repo the *target* lives in, so the
     marker beside a file in one repo was computed from another one's status."""
+    require_symlink()
     here, elsewhere = tmp_path / "here", tmp_path / "elsewhere"
     here.mkdir()
     elsewhere.mkdir()

--- a/tests/test_rollback_no_verdict_969.py
+++ b/tests/test_rollback_no_verdict_969.py
@@ -60,8 +60,7 @@ BEFORE = '{"a": 1}\n'
 AFTER = '{"b": 1}\n'
 
 
-def _two_pass_adapter(tmp_path: Path, first: str, second: str,
-                      sleep_second: float = 0.0) -> str:
+def _two_pass_adapter(tmp_path: Path, first: str, second: str) -> str:
     """An adapter that answers `first` on call 1 and `second` on every call after.
 
     The baseline pass and the post-edit pass are two separate spawns of the
@@ -75,12 +74,10 @@ def _two_pass_adapter(tmp_path: Path, first: str, second: str,
     state = tmp_path / "_calls.txt"
     script = tmp_path / "_adapter.py"
     script.write_text(
-        "import pathlib, sys, time" + chr(10)
+        "import pathlib, sys" + chr(10)
         + f"state = pathlib.Path({str(state)!r})" + chr(10)
         + "n = int(state.read_text()) if state.exists() else 0" + chr(10)
         + "state.write_text(str(n + 1))" + chr(10)
-        + f"if n and {sleep_second!r}:" + chr(10)
-        + f"    time.sleep({sleep_second!r})" + chr(10)
         + f"sys.stdout.write({first!r} if n == 0 else {second!r})" + chr(10),
         encoding="utf-8",
     )
@@ -147,16 +144,28 @@ def test_the_surviving_edit_is_disclosed_and_exits_nonzero(
 
 
 def test_a_core_timeout_after_the_edit_does_not_revert_it(
-        tmp_path: Path, capsys) -> None:
+        tmp_path: Path, capsys, monkeypatch) -> None:
     """`code: "orchestrator"` is the core's own absence, and it reverted edits too.
 
     Not a variant worth splitting off: it reaches the same two-line comparison
     with the same fabricated `count: 1`, and unlike a vanished binary it needs
     nothing but a slow machine.
+
+    It used to *be* a slow machine — a 3s adapter against a 1s budget — and on
+    a runner that declined to be slow the adapter returned empty instead, which
+    is the `adapter` non-verdict rather than the `orchestrator` one. Every
+    assertion below holds for both, so this test kept passing while silently
+    exercising the other branch (#1218). The timeout is injected at the
+    subprocess boundary now, and the row is asserted, so the branch it names is
+    the branch it runs.
     """
-    _configure(_two_pass_adapter(tmp_path, CLEAN, CLEAN, sleep_second=3.0),
-               timeout=1)
+    budgets = _timeout_the_second_adapter_spawn(monkeypatch, 1)
+    _configure(_two_pass_adapter(tmp_path, CLEAN, CLEAN), timeout=1)
     rc, out, text = _edit(tmp_path, capsys)
+    assert budgets == [1, 1], budgets
+    assert "timed out" in out and "orchestrator" in out, (
+        "this test is named for the core's own timeout and did not reach that "
+        f"branch:{chr(10)}{out}")
     assert text == AFTER, (
         f"a timed-out checker reverted an edit it never looked at:{chr(10)}{out}")
     assert "1 write" in _result_line(out), out
@@ -239,6 +248,58 @@ def test_an_adapter_error_mixed_with_real_findings_still_regresses() -> None:
     clean = {"tool": "fake", "ok": True, "count": 0}
     assert supertool._validator_regressed(clean, mixed) is True
 
+def _silent_adapter(tmp_path: Path) -> str:
+    """An adapter that exits without writing anything to stdout.
+
+    The other non-verdict. `_validator_unusable_reply` renders it, and the row
+    is the one `windows-latest, 3.12` printed where a timeout was expected.
+    """
+    script = tmp_path / "_silent.py"
+    script.write_text("import sys" + chr(10) + "sys.exit(0)" + chr(10),
+                      encoding="utf-8")
+    return f"{{python}} {script.as_posix()}"
+
+
+def _timeout_the_second_adapter_spawn(monkeypatch, budget: int) -> "list":
+    """Raise `TimeoutExpired` where the OS would, instead of waiting for one.
+
+    #1218. The test below is about how two *renders* of one timeout compare,
+    and it used to obtain its timeout by making the fake adapter sleep past a
+    1s budget and trusting the runner to notice. `windows-latest, 3.12` did
+    not: the adapter came back at `0.0s` having written nothing, which is a
+    different — and equally correct — refusal, so the test went red on a
+    scheduling accident with a message pointing at validator code that was
+    fine. A property of two renderers should not be a claim about the
+    scheduler.
+
+    Only the *second* spawn is intercepted, so the baseline pass is still a
+    real subprocess returning a real clean result and the scenario is the one
+    #969 is about: a validator that answered before the edit and could not
+    after it. Everything downstream of `_validator_run_one`'s `TimeoutExpired`
+    arm — both renderers, the gate, the exit code — is the real code.
+
+    Returns the list of `timeout=` values the core handed to `subprocess.run`
+    for this adapter. The caller asserts on it: a fabricated timeout would
+    otherwise pass just as happily against a core that had stopped passing a
+    budget to the OS at all, which is the one regression this seam could hide.
+    """
+    import subprocess
+
+    real_run = subprocess.run
+    budgets: list = []
+
+    def _run(cmd, *a, **kw):
+        parts = cmd if isinstance(cmd, (list, tuple)) else [cmd]
+        if any("_adapter.py" in str(p) for p in parts):
+            budgets.append(kw.get("timeout"))
+            if len(budgets) > 1:
+                raise subprocess.TimeoutExpired(cmd, budget)
+        return real_run(cmd, *a, **kw)
+
+    monkeypatch.setattr(subprocess, "run", _run)
+    return budgets
+
+
 def test_a_timeout_reads_the_same_whether_or_not_it_was_required(
         tmp_path: Path, capsys, monkeypatch) -> None:
     """One failure, one spelling.
@@ -252,6 +313,7 @@ def test_a_timeout_reads_the_same_whether_or_not_it_was_required(
     Compared on the status and reason columns, not the whole row: the elapsed
     time legitimately differs between two runs.
     """
+    budgets = _timeout_the_second_adapter_spawn(monkeypatch, 1)
     whys = []
     for required in (False, True):
         if required:
@@ -260,15 +322,58 @@ def test_a_timeout_reads_the_same_whether_or_not_it_was_required(
             monkeypatch.delenv("SUPERTOOL_REQUIRE_VALIDATORS", raising=False)
         d = tmp_path / ("req" if required else "unreq")
         d.mkdir()
-        _configure(_two_pass_adapter(d, CLEAN, CLEAN, sleep_second=3.0),
-                   timeout=1)
+        del budgets[:]
+        _configure(_two_pass_adapter(d, CLEAN, CLEAN), timeout=1)
         _rc, out, _text = _edit(d, capsys)
+        assert budgets == [1, 1], (
+            "the core did not hand its configured 1s budget to both adapter "
+            f"spawns, so the timeout this test injects is not the one the "
+            f"real path would ever raise: {budgets!r}")
         row = [ln for ln in out.splitlines() if ln.startswith("fake ")]
         assert row, out
         assert "NOT CHECKED" in row[0], row[0]
         whys.append(row[0].split("NOT CHECKED", 1)[1].rsplit("  ", 1)[0].strip())
     assert whys[0] == "(timed out — no verdict about this file)", whys
     assert whys[0] == whys[1], whys
+
+
+def test_a_timeout_and_a_silent_adapter_are_not_the_same_refusal(
+        tmp_path: Path, capsys, monkeypatch) -> None:
+    """Both are non-verdicts; only one of them is a statement about the clock.
+
+    #1218 arrived as a leg printing the silent-adapter row where the test
+    above demanded the timeout row — and *both* renders were correct. That is
+    only a defensible thing to say if the two are distinguishable on the page,
+    and nothing asserted that they are. Neither may drift into the other's
+    wording: `orchestrator` is the core saying it stopped waiting, `adapter` is
+    the tool saying nothing, and a reader who cannot tell them apart cannot
+    tell a slow machine from a broken checker.
+    """
+    budgets = _timeout_the_second_adapter_spawn(monkeypatch, 1)
+    monkeypatch.delenv("SUPERTOOL_REQUIRE_VALIDATORS", raising=False)
+
+    timed = tmp_path / "timed"
+    timed.mkdir()
+    _configure(_two_pass_adapter(timed, CLEAN, CLEAN), timeout=1)
+    _rc, timed_out, _text = _edit(timed, capsys)
+
+    silent = tmp_path / "silent"
+    silent.mkdir()
+    _configure(_silent_adapter(silent), timeout=1)
+    _rc, silent_out, _text = _edit(silent, capsys)
+    assert budgets == [1, 1], budgets
+
+    rows = []
+    for out in (timed_out, silent_out):
+        row = [ln for ln in out.splitlines() if ln.startswith("fake ")]
+        assert row, out
+        rows.append(row[0])
+
+    assert "timed out" in rows[0] and "orchestrator" in timed_out, rows[0]
+    assert "produced no output" in rows[1], rows[1]
+    assert "timed out" not in rows[1], (
+        "an adapter that said nothing is being reported as a timeout, so the "
+        f"reader cannot tell a slow machine from a broken checker: {rows[1]}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_status_swallowed_705.py
+++ b/tests/test_status_swallowed_705.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import pytest
 
 import supertool
+from _gitshim import dispatch_on_subcommand
 
 _ROOT = Path(__file__).parent.parent
 _STATUS_PATH = _ROOT / "presets" / "git" / "status.py"
@@ -71,19 +72,13 @@ def _real_git_shim(d: Path) -> None:
 
 def _failing_git_shim(d: Path, subcommand: str, code: int, message: str) -> None:
     """A git that refuses one subcommand the way a locked index refuses it."""
-    _write_shim(
-        d, "git",
-        f'if [ "$1" = "{subcommand}" ]; then echo "{message}" >&2; exit {code}; fi\n'
-        f'exec {_real("git")} "$@"\n',
-    )
+    _write_shim(d, "git", dispatch_on_subcommand(
+        subcommand, f'echo "{message}" >&2; exit {code}', _real("git")))
 
 
 def _stalling_git_shim(d: Path, subcommand: str) -> None:
-    _write_shim(
-        d, "git",
-        f'if [ "$1" = "{subcommand}" ]; then {_real("sleep")} 300; fi\n'
-        f'exec {_real("git")} "$@"\n',
-    )
+    _write_shim(d, "git", dispatch_on_subcommand(
+        subcommand, f'{_real("sleep")} 300', _real("git")))
 
 
 def _git(repo: Path, *args: str) -> str:

--- a/tests/test_symlink_gating_1205.py
+++ b/tests/test_symlink_gating_1205.py
@@ -1,0 +1,112 @@
+"""#1205 -- symlink tests that fail where their siblings skip.
+
+`tests/_symlink.py` (#1143) exists so the suite takes the "can I make a symlink
+here" decision once, by probing, and reports the answer as a skip carrying a
+stated reason. A test that creates a symlink without asking it does something
+different on a runner without the privilege: `symlink_to` raises `OSError` and
+the test **fails**.
+
+A skip and a failure carry opposite meanings to whoever reads the leg. A skip
+says the platform could not run the check. A failure says the platform ran it
+and the code is broken -- pointing, here, at path-meta code that is fine. That
+is this repo's own defect class landing in the harness: an environmental
+inability rendered as a product verdict.
+
+This runs `test_path_meta_bulk_1126.py`'s symlink tests in a subprocess with the
+privilege forced absent, which is the only way to observe the difference from a
+machine that has it. Not `skipif(os.name == "nt")` on the assertion -- that
+would be the vacuous-on-one-platform branch #1143 was written to remove.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS = Path(__file__).resolve().parent
+ROOT = TESTS.parent
+
+#: The privilege is refused for the child process only, in the two places a test
+#: can reach it. `_symlink._PROBE` is pinned as well: the probe would otherwise
+#: succeed against the patched-out `os.symlink` and report a capability the
+#: child no longer has.
+_PLUGIN = """
+import errno
+import os
+import pathlib
+import sys
+
+
+def pytest_configure(config):
+    sys.path.insert(0, {tests!r})
+    import _symlink
+    _symlink._PROBE = (False, "forced absent by the #1205 guard")
+
+    def _refuse(*a, **k):
+        raise OSError(errno.EPERM, "symlink creation refused (#1205 guard)")
+
+    os.symlink = _refuse
+    pathlib.Path.symlink_to = _refuse
+"""
+
+
+@pytest.fixture(scope="module")
+def without_the_privilege(tmp_path_factory) -> subprocess.CompletedProcess:
+    d = tmp_path_factory.mktemp("nosymlink")
+    (d / "nosymlinkplugin.py").write_text(
+        _PLUGIN.format(tests=str(TESTS)), encoding="utf-8")
+    env = dict(os.environ, PYTHONPATH=str(d),
+               PYTEST_ADDOPTS="", PYTEST_DISABLE_PLUGIN_AUTOLOAD="")
+    return subprocess.run(
+        [sys.executable, "-m", "pytest",
+         "tests/test_path_meta_bulk_1126.py", "-k", "symlink", "-rs",
+         "-p", "nosymlinkplugin", "-p", "no:cacheprovider", "-p", "no:xdist",
+         "-p", "no:cov", "-q", "--no-header", "-o", "addopts="],
+        cwd=str(ROOT), capture_output=True, text=True, timeout=300,
+        encoding="utf-8", errors="replace", env=env)
+
+
+def test_every_symlink_test_in_the_bulk_file_skips_rather_than_fails(
+    without_the_privilege
+) -> None:
+    """The whole point: no failures, no errors, on a runner that cannot link."""
+    r = without_the_privilege
+    assert r.returncode == 0, (
+        "with the create-symlink privilege absent, the symlink tests in "
+        "test_path_meta_bulk_1126.py did not all skip -- an environment limit "
+        "is being reported as a defect in the code under test:"
+        + os.linesep + r.stdout + os.linesep + r.stderr
+    )
+    assert " failed" not in r.stdout and " error" not in r.stdout, r.stdout
+
+
+def test_the_run_actually_exercised_the_tests_it_claims_to_have_skipped(
+    without_the_privilege
+) -> None:
+    """A green from a run that collected nothing would prove nothing.
+
+    Deselection, a renamed test or a typo in `-k` all produce `0 passed` and
+    exit 0, which reads exactly like the skips this file exists to require.
+    """
+    r = without_the_privilege
+    assert "3 skipped" in r.stdout, (
+        "expected the three symlink-creating tests of "
+        "test_path_meta_bulk_1126.py to be collected and skipped: "
+        + os.linesep + r.stdout + os.linesep + r.stderr
+    )
+
+
+def test_the_skips_name_the_shared_reason_rather_than_a_local_wording(
+    without_the_privilege
+) -> None:
+    """A skip nobody can grep for is not a legible blind spot (#1143)."""
+    import _symlink
+
+    assert _symlink.TOKEN in without_the_privilege.stdout, (
+        "the skips did not carry " + _symlink.TOKEN + ", so they are "
+        "indistinguishable from the ~680 others in a Windows leg:"
+        + os.linesep + without_the_privilege.stdout
+    )

--- a/tests/test_unanswerable_checks_693.py
+++ b/tests/test_unanswerable_checks_693.py
@@ -33,6 +33,8 @@ from pathlib import Path
 
 import pytest
 
+from _gitshim import dispatch_on_subcommand
+
 ROOT = Path(__file__).parent.parent
 PRESETS = ROOT / "presets"
 DIFF = PRESETS / "git" / "diff.py"
@@ -279,8 +281,9 @@ def test_a_failed_stash_query_does_not_render_as_no_stashes(
     passthrough = _bin("okbin", f'exec {real_git} "$@"\n')
     refusing = _bin(
         "badbin",
-        'if [ "$1" = "stash" ]; then echo "fatal: unable to read index" >&2; exit 128; fi\n'
-        f'exec {real_git} "$@"\n',
+        dispatch_on_subcommand(
+            "stash", 'echo "fatal: unable to read index" >&2; exit 128',
+            real_git),
     )
 
     def _status(bindir: Path) -> str:


### PR DESCRIPTION
Closes #1205
Closes #1206
Closes #1218

## The commit that looked backed out

`fix/1205` was found mid-`git revert` with 403 deletions staged, nine paths simultaneously `D` and `??`, and eight stray `.coverage.*` shards. I read that as somebody deciding to back the work out, and briefed the agent to decide whether the commit was right before finishing it.

**It was not a revert.** It was the non-hermetic suite eating its own worktree — the repo's JIT note records the shape verbatim, and the arithmetic confirms it: nine paths are exactly the nine that commit touched, and 403 deletions are exactly its own 403 insertions. The previous agent committed, ran the full suite in its own worktree, and the working state did not survive. There was no decision to recover. Commit kept, rebased clean.

**My #1218 framing was also wrong.** I said it concerned `test_git_timeout_disclosure_650.py`, a file `5a0daf6` touches. It concerns `tests/test_rollback_no_verdict_969.py`, which that commit does not touch — the two are unrelated, and the commit was never pushed and could not have reddened master.

## Red, byte-identical to job #93281453855

Reproduced the Windows condition locally by forcing the adapter to return without spending time:

```
>           assert "NOT CHECKED" in row[0], row[0]
E           AssertionError: fake : skipped (fake adapter produced no output — this file was not checked) 0.0s
tests/test_rollback_no_verdict_969.py:268: AssertionError
1 failed in 1.68s
```

Green: `209 passed in 13.76s`.

Non-vacuity proved rather than asserted — collapsing both renderer branches in a throwaway clone: `3 failed, 12 passed`.

## What still exercises each of these on Windows

This is the question that decides whether gating deleted coverage, and it has three different answers:

- **#1205.** The two newly-gated tests skip on a Windows runner lacking the privilege — but `test_symlink_gating_1205.py` **forces the privilege absent in a child pytest on every platform**, so the gate itself is exercised on Windows, Linux and macOS alike rather than waiting for a platform that happens to lack it. The coverage moved; it did not vanish.
- **#1206.** Nothing exercises it on Windows and nothing should — the shims are `/bin/sh` and never run there. The module is `skipif(os.name == "nt")`.
- **#1218.** The opposite of coverage loss. The old tests exercised the timeout branch only when the runner felt like it; on the failing leg they exercised the **adapter** branch under a timeout name. `test_a_core_timeout_after_the_edit_does_not_revert_it` **had the same bug with the opposite symptom** — every assertion in it holds for the silent-adapter refusal too, so it kept *passing* while exercising the branch it is not named for. A new test pins that the two non-verdicts stay distinguishable, which is the only thing making "both renders are correct" defensible.

## Argued down

Reviewer: `tests/_gitshim.py`'s `-*) shift` also swallows a bare `--`, so `git -- status` would read `status` as the subcommand. **Refused** — `git -- status` is not a valid invocation and git has no subcommand-bearing form where `--` precedes it. Hardening a shim against argv shapes git itself rejects adds a branch nobody can test. The module already discloses the one real gap: an unlisted global flag taking a separate argument.

Review was a spawned Sonnet agent against the committed diff, **not the `code-review` plugin**. No correctness bugs, no vacuous tests, no stale prose.

## Full suite deliberately skipped

It is the thing that destroyed the previous agent's worktree. The only shared surface is a module-local helper with no external callers (grepped), and the #1206 class gate that scans all 550 test files by AST ran and passed. Windows unverified — CI is the authority.

## #1205's premise is two sites; the class is at least 13 files

Sweeping `tests/` for `symlink_to(` / `os.symlink(`: **31 files create symlinks and 13 have no gate of any kind** — `test_append_op_383`, `test_edge_cases_at_file_security`, `test_edge_cases_paste_security`, `test_edge_cases_replace_lines`, `test_edge_cases_vim`, `test_gc_474`, `test_mixed_tree_guard_678`, `test_review_regressions_395`, `test_security_claude_log`, `test_security_safe_path`, `test_security_xml`, `test_stat`, plus scattered sites. ~19 call sites, every one the #1205 defect.

Separate PR, and it probably wants the AST class-gate treatment #1206 got. Filing.