### PR TITLE
Two block rules read as enforced and had never fired

### DIFF
--- a/.claude/jit-context/paths/00-manual/00-index.tsv
+++ b/.claude/jit-context/paths/00-manual/00-index.tsv
@@ -7,3 +7,6 @@ presets/gitlab/	presets-gitlab.md
 presets/watch/	presets-watch.md
 tests/	tests-suite.md
 validators/	validators.md
+.claude/jit-context/	jit-context.md
+.claude-plugin/	version-sites.md
+pyproject.toml	version-sites.md

--- a/.claude/jit-context/paths/00-manual/jit-context.md
+++ b/.claude/jit-context/paths/00-manual/jit-context.md
@@ -1,0 +1,15 @@
+---
+title: "Writing a jit rule"
+match: .claude/jit-context/
+mode: remind
+---
+
+- **The `.md` is inert.** `00-index.tsv` in the same directory is what the hook reads. Tools: `tool⇥match⇥file⇥mode⇥keyword⇥` (6 fields, trailing tab). Paths: `prefix⇥file` (2 fields). No row = a rule that never runs, which reads exactly like a rule that never matches.
+- **Verify by running the forbidden command.** Nothing else distinguishes the two. The hook logs to `.discovery/logs/hooks.log`; a non-firing rule shows `(none) [shown:0]` on the very command it was written for.
+- **Keep it short.** Injected in full on every match — length is a cost paid forever. Table of replacement ops, the measurement, stop.
+- **Point at the op, never at a way around it.** If the entry explains how to get the answer by hand, fix the op instead.
+
+Two `match` traps, measured 2026-08-10:
+
+- **awk, not PCRE.** macOS ships one-true-awk (`match(tolower(full_command), ...)`, `pre-tool-hook.sh:80`), which drops `\s`/`\d`/`\w` as undefined escapes — `gh\s+pr` compiles to `ghs+pr` and matches nothing. Two of six tool rules were dead this way, both `block`. Use `[[:space:]]`. `\n` is a valid escape and does survive.
+- **`^` anchors the whole command, not each line**, and the match runs against the entire string — so anchor `(^|[;&|\n] *)`, or a rule misses line 3 of a heredoc and fires on a mere mention of the command inside a payload.

--- a/.claude/jit-context/paths/00-manual/version-sites.md
+++ b/.claude/jit-context/paths/00-manual/version-sites.md
@@ -1,0 +1,17 @@
+---
+title: "The version lives in five places"
+match: .claude-plugin/
+mode: remind
+---
+
+`.claude-plugin/plugin.json`, `_supertool.py` (`VERSION`), `pyproject.toml`, `CHANGELOG.md`, and the `README.md` badge.
+
+Four are guarded by tests — `test_plugin_manifest_version_matches_code`, `tests/test_pyproject_version_522.py`, `test_changelog_link_refs_918`, `test_readme_version_badge_matches_code`. Believing a site is unguarded is what justifies skipping the sweep; the sweep's real value is finding a **sixth** site no test covers. When one turns up, add its guard in the same commit.
+
+```bash
+git grep -n "0\.32\.0"          # no path filter, no --include
+```
+
+- **No extension allowlist.** `--include="*.py" --include="*.json" --include="*.toml"` cannot see `README.md`, which is why the badge sat at `0.14.1` for fifteen releases, hyperlinked to the file it disagreed with. Unquoted globs also let zsh expand them, and the resulting error reads exactly like "no matches".
+- **Sweep both directions.** A sweep keyed on the outgoing version only finds sites that are half-bumped. It cannot see one frozen at some third value — the badge case. A zero means "nothing is half-done", never "everything is right".
+- **The tag is not the delivery.** The updater compares manifest versions and nothing else, so a tag whose manifest was not bumped reaches nobody already installed.

--- a/.claude/jit-context/tools/00-manual/00-index.tsv
+++ b/.claude/jit-context/tools/00-manual/00-index.tsv
@@ -2,4 +2,5 @@ Bash	~gh (issue|pr) list	gh-list-limit.md	remind	--limit
 Edit|Write|Read|Grep|Glob|MultiEdit|NotebookEdit	~.	harness-tools-blocked.md	block		
 Bash	~supertool[^|]*'(gh-prs|gl-mrs|gh-issues|gl-issues|radar|watches)	op-defaults-that-narrow.md	remind		
 Bash	~supertool[^|]*\|[^|]*(head|tail|sed|cut|awk)	supertool-no-cut.md	block		
-Bash	~git\s+(branch|for-each-ref)[^|]*--merged	merged-is-not-ancestry.md	block	--merged	
+Bash	~(^|[;&|] *)(rtk +)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged	merged-is-not-ancestry.md	block	--merged	
+Bash	~(^|[;&|] *)(rtk +)?gh[[:space:]]+pr[[:space:]]+(view|merge)	gh-pr-view-merge-have-ops.md	block	gh pr	

--- a/.claude/jit-context/tools/00-manual/00-index.tsv
+++ b/.claude/jit-context/tools/00-manual/00-index.tsv
@@ -2,5 +2,6 @@ Bash	~gh (issue|pr) list	gh-list-limit.md	remind	--limit
 Edit|Write|Read|Grep|Glob|MultiEdit|NotebookEdit	~.	harness-tools-blocked.md	block		
 Bash	~supertool[^|]*'(gh-prs|gl-mrs|gh-issues|gl-issues|radar|watches)	op-defaults-that-narrow.md	remind		
 Bash	~supertool[^|]*\|[^|]*(head|tail|sed|cut|awk)	supertool-no-cut.md	block		
-Bash	~(^|[;&|] *)(rtk +)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged	merged-is-not-ancestry.md	block	--merged	
-Bash	~(^|[;&|] *)(rtk +)?gh[[:space:]]+pr[[:space:]]+(view|merge)	gh-pr-view-merge-have-ops.md	block	gh pr	
+Bash	~(^|[;&|\n] *)(rtk +)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged	merged-is-not-ancestry.md	block	--merged	
+Bash	~(^|[;&|\n] *)(rtk +)?gh[[:space:]]+pr[[:space:]]+(view|merge)	gh-pr-view-merge-have-ops.md	block	gh pr	
+Bash	~(^|[;&|\n] *)(rtk +)?(command +)?git[[:space:]]+([^;&|\n]*[[:space:]])?push	git-push-has-an-op.md	block	push	

--- a/.claude/jit-context/tools/00-manual/gh-pr-view-merge-have-ops.md
+++ b/.claude/jit-context/tools/00-manual/gh-pr-view-merge-have-ops.md
@@ -1,7 +1,7 @@
 ---
 title: "`gh pr view` and `gh pr merge` are hand-rolled renders of ops this repo ships"
 tool: Bash
-match: ~(^|[;&|] *)(rtk +)?gh[[:space:]]+pr[[:space:]]+(view|merge)
+match: ~(^|[;&|\n] *)(rtk +)?gh[[:space:]]+pr[[:space:]]+(view|merge)
 mode: block
 ---
 

--- a/.claude/jit-context/tools/00-manual/gh-pr-view-merge-have-ops.md
+++ b/.claude/jit-context/tools/00-manual/gh-pr-view-merge-have-ops.md
@@ -1,0 +1,84 @@
+---
+title: "`gh pr view` and `gh pr merge` are hand-rolled renders of ops this repo ships"
+tool: Bash
+match: ~(^|[;&|] *)(rtk +)?gh[[:space:]]+pr[[:space:]]+(view|merge)
+mode: block
+---
+
+Both have an op. Hand-writing the projection is how a field gets omitted, and hand-writing the
+merge gate is how `CANCELLED` got counted as pending (#454).
+
+## `gh pr view` to `gh-pr:NUMBER_OR_BRANCH`
+
+| What you were about to ask                   | The op                     |
+| -------------------------------------------- | -------------------------- |
+| `--json state,mergeable,statusCheckRollup`   | `gh-pr:N:status` (~250B)   |
+| `--json body`, description, `Closes` lines   | `gh-pr:N`, `gh-pr:N:full`  |
+| `--json files`, blast radius by filename     | `gh-pr:N:diff`             |
+| one file s hunks                             | `gh-pr:N:diff:PATH`        |
+| everything at once                           | `gh-pr:N`                  |
+
+## `gh pr merge` to `gh-pr-merge:N:squash`
+
+Without `|force` it previews the gate and merges nothing. What it does that the raw command
+cannot:
+
+- **Refuses first**, on the #454 arithmetic: not OPEN, draft, CONFLICTING, `mergeable=UNKNOWN`,
+  zero check runs, an unreadable rollup, and every leg that is not a pass named individually
+  because cancelled, skipped, timed_out, neutral and action_required are each not permission.
+  There is no green-bypass; a refusal names the manual command instead.
+- **Reads `state`/`mergedAt`/`mergeCommit` back off the remote.** A zero exit is not a merge.
+- **Checks every linked issue individually**, reconciling the body s own closing refs against
+  GitHub s `closingIssuesReferences`, so a ref GitHub never bound is named. That is PR #908 s
+  shape exactly: the body said `Closes #899`, GitHub bound nothing, no error anywhere.
+- **Reports the default branch after the squash.** A green PR is a statement about its
+  merge-base, not about master once the squash lands.
+- Exits 0 only when the merge is verified AND every linked issue is verified closed.
+
+## The measurement
+
+One maintainer tick on 2026-08-10 ran **12** `gh pr view` invocations across four PRs, every one
+answered by `gh-pr:N` or `gh-pr:N:diff`. Two of the twelve were reading `Closes` lines out of a
+body with a pattern match, which is the check `gh-pr` performs with the same closing-reference
+reader `gh-pr-merge` uses to catch a malformed `Closes #A B` before the merge rather than after.
+
+## Why blocking rather than reminding
+
+A bare PR number resolves against the CWD s forge. Run from the wrong root, `gh pr view 1057`
+once returned a well-formed answer about a GitLab MR. `gh-pr` and `gh-pr-merge` both honour
+`repo:OWNER/NAME`. The failure mode is a correct-looking render of a different repository, which
+a skimmed reminder does not stop.
+
+**The tell that this rule fired correctly:** you were about to pipe a `gh` read into a `--jq`
+expression. That means an op s render is being rebuilt by hand.
+
+## What still legitimately needs raw `gh`
+
+Tagging, releasing, deleting a ref, re-running a workflow. Reads go through supertool, those
+writes do not have an op yet.
+
+## Two things this rule got wrong before it worked
+
+**`\s` is not a character class in the awk that runs the hook.** The matcher is
+`match(tolower(full_command), ...)` in `scripts/pre-tool-hook.sh:80`, and macOS ships the
+one-true-awk (version 20200816), where the undefined string escape is dropped, so the pattern
+becomes the regex `ghs+pr` and matches nothing. Measured on this machine 2026-08-10:
+
+    backslash-s : no
+    space-plus  : MATCH
+    posix class : MATCH
+
+This rule was written, indexed, and did not fire — the command it was written for ran twice and
+returned. The same defect had been sitting in `merged-is-not-ancestry.md` since it was written:
+a `block` listed in the index, reading as enforced, that had never once fired. Both are now
+`[[:space:]]+`. Use a POSIX class; it is portable across one-true-awk and gawk.
+
+**An unanchored pattern matches the payload, not the invocation.** The first working version
+blocked the very `append` that was writing this file, because the prose quotes the command it
+forbids. The regex is deliberately tested against the whole command (so a rule survives
+`cd X && ...`), which means position is the only thing separating an invocation from a mention.
+Hence the `(^|[;&|] *)` prefix: start of command, or just after a chain operator.
+
+The hook logs its haystack to `.claude/jit-context/.discovery/logs/hooks.log`. A rule that is not
+firing shows as `(none) [shown:0]` on the exact command it was written for — that log is how to
+tell a rule that never matched from a rule that never ran.

--- a/.claude/jit-context/tools/00-manual/gh-pr-view-merge-have-ops.md
+++ b/.claude/jit-context/tools/00-manual/gh-pr-view-merge-have-ops.md
@@ -1,84 +1,19 @@
 ---
-title: "`gh pr view` and `gh pr merge` are hand-rolled renders of ops this repo ships"
+title: "`gh pr view` / `gh pr merge` have ops"
 tool: Bash
 match: ~(^|[;&|\n] *)(rtk +)?gh[[:space:]]+pr[[:space:]]+(view|merge)
 mode: block
 ---
 
-Both have an op. Hand-writing the projection is how a field gets omitted, and hand-writing the
-merge gate is how `CANCELLED` got counted as pending (#454).
+| Instead of | Use |
+| --- | --- |
+| `--json state,mergeable,statusCheckRollup` | `gh-pr:N:status` |
+| `--json body`, `Closes` lines | `gh-pr:N`, `gh-pr:N:full` |
+| `--json files` | `gh-pr:N:diff` |
+| one file's hunks | `gh-pr:N:diff:PATH` |
+| `gh pr merge` | `gh-pr-merge:N:squash` (add `|force`; bare = preview) |
 
-## `gh pr view` to `gh-pr:NUMBER_OR_BRANCH`
-
-| What you were about to ask                   | The op                     |
-| -------------------------------------------- | -------------------------- |
-| `--json state,mergeable,statusCheckRollup`   | `gh-pr:N:status` (~250B)   |
-| `--json body`, description, `Closes` lines   | `gh-pr:N`, `gh-pr:N:full`  |
-| `--json files`, blast radius by filename     | `gh-pr:N:diff`             |
-| one file s hunks                             | `gh-pr:N:diff:PATH`        |
-| everything at once                           | `gh-pr:N`                  |
-
-## `gh pr merge` to `gh-pr-merge:N:squash`
-
-Without `|force` it previews the gate and merges nothing. What it does that the raw command
-cannot:
-
-- **Refuses first**, on the #454 arithmetic: not OPEN, draft, CONFLICTING, `mergeable=UNKNOWN`,
-  zero check runs, an unreadable rollup, and every leg that is not a pass named individually
-  because cancelled, skipped, timed_out, neutral and action_required are each not permission.
-  There is no green-bypass; a refusal names the manual command instead.
-- **Reads `state`/`mergedAt`/`mergeCommit` back off the remote.** A zero exit is not a merge.
-- **Checks every linked issue individually**, reconciling the body s own closing refs against
-  GitHub s `closingIssuesReferences`, so a ref GitHub never bound is named. That is PR #908 s
-  shape exactly: the body said `Closes #899`, GitHub bound nothing, no error anywhere.
-- **Reports the default branch after the squash.** A green PR is a statement about its
-  merge-base, not about master once the squash lands.
-- Exits 0 only when the merge is verified AND every linked issue is verified closed.
-
-## The measurement
-
-One maintainer tick on 2026-08-10 ran **12** `gh pr view` invocations across four PRs, every one
-answered by `gh-pr:N` or `gh-pr:N:diff`. Two of the twelve were reading `Closes` lines out of a
-body with a pattern match, which is the check `gh-pr` performs with the same closing-reference
-reader `gh-pr-merge` uses to catch a malformed `Closes #A B` before the merge rather than after.
-
-## Why blocking rather than reminding
-
-A bare PR number resolves against the CWD s forge. Run from the wrong root, `gh pr view 1057`
-once returned a well-formed answer about a GitLab MR. `gh-pr` and `gh-pr-merge` both honour
-`repo:OWNER/NAME`. The failure mode is a correct-looking render of a different repository, which
-a skimmed reminder does not stop.
-
-**The tell that this rule fired correctly:** you were about to pipe a `gh` read into a `--jq`
-expression. That means an op s render is being rebuilt by hand.
-
-## What still legitimately needs raw `gh`
-
-Tagging, releasing, deleting a ref, re-running a workflow. Reads go through supertool, those
-writes do not have an op yet.
-
-## Two things this rule got wrong before it worked
-
-**`\s` is not a character class in the awk that runs the hook.** The matcher is
-`match(tolower(full_command), ...)` in `scripts/pre-tool-hook.sh:80`, and macOS ships the
-one-true-awk (version 20200816), where the undefined string escape is dropped, so the pattern
-becomes the regex `ghs+pr` and matches nothing. Measured on this machine 2026-08-10:
-
-    backslash-s : no
-    space-plus  : MATCH
-    posix class : MATCH
-
-This rule was written, indexed, and did not fire — the command it was written for ran twice and
-returned. The same defect had been sitting in `merged-is-not-ancestry.md` since it was written:
-a `block` listed in the index, reading as enforced, that had never once fired. Both are now
-`[[:space:]]+`. Use a POSIX class; it is portable across one-true-awk and gawk.
-
-**An unanchored pattern matches the payload, not the invocation.** The first working version
-blocked the very `append` that was writing this file, because the prose quotes the command it
-forbids. The regex is deliberately tested against the whole command (so a rule survives
-`cd X && ...`), which means position is the only thing separating an invocation from a mention.
-Hence the `(^|[;&|] *)` prefix: start of command, or just after a chain operator.
-
-The hook logs its haystack to `.claude/jit-context/.discovery/logs/hooks.log`. A rule that is not
-firing shows as `(none) [shown:0]` on the exact command it was written for — that log is how to
-tell a rule that never matched from a rule that never ran.
+- `gh-pr-merge` refuses on the #454 arithmetic, reads `state`/`mergedAt`/`mergeCommit` back off the remote, checks each linked issue against `closingIssuesReferences`, then reports master after the squash.
+- A bare PR number resolves against the CWD's forge — `gh pr view 1057` once answered about a GitLab MR. The ops honour `repo:OWNER/NAME`.
+- Measured 2026-08-10: one tick ran 12 `gh pr view` invocations, all answered by an op.
+- Tell you skipped an op: a `--jq` against a `gh` read.

--- a/.claude/jit-context/tools/00-manual/git-push-has-an-op.md
+++ b/.claude/jit-context/tools/00-manual/git-push-has-an-op.md
@@ -1,0 +1,56 @@
+---
+title: "Raw `git push` skips the receipt that says whether it landed"
+tool: Bash
+match: ~(^|[;&|\n] *)(rtk +)?(command +)?git[[:space:]]+([^;&|\n]*[[:space:]])?push
+mode: block
+---
+
+Use **`git-push`**, and its flags for the cases that used to need a raw line.
+
+| Instead of                                   | Use                        |
+| -------------------------------------------- | -------------------------- |
+| a plain push                                 | `git-push`                 |
+| `--force-with-lease`                         | `git-push:force-with-lease`|
+| a first push from `git worktree add -b`      | `git-push:set-upstream`    |
+| pushing onto a tracked ref on purpose        | `git-push:to-upstream`     |
+| `--no-verify`                                | `git-push:no-verify`       |
+| push then watch the pipeline                 | `git-push:watch`           |
+
+The op pushes the **current branch**, so `cd` into the worktree rather than reaching in with `-C`.
+
+## Why blocking
+
+**A zero exit is not a push.** `git-push` reads the post-push sha back off the real remote with
+`ls-remote` and labels it verified or unverified — a sha it did not read is never printed as though
+it were. That is the whole point: this repo has a filed instance of `git push -q` followed by an
+unconditional `echo "pushed"` printing success while the remote head had not moved, and a separate
+one where the `rtk` wrapper killed a tag push with `process terminated by signal 13` and the tag
+simply did not exist. Both read exactly like success.
+
+The receipt also carries what you were going to ask next anyway: remote before and after, ahead and
+behind, the PR and its pipeline, mergeability, the count of uncommitted leftovers, and the watch
+command. A non-fast-forward auto-rebases and hands back `git-conflicts` on a conflict instead of a
+wall of git output.
+
+**The upstream trap is the specific one that bites here.** `git worktree add -b <new> <base>` leaves
+the new branch tracking `<base>`, which is where every `st-wt/NNN` branch starts, so a plain push
+either goes to the wrong ref or is refused with advice the caller cannot act on. `:set-upstream` and
+`:to-upstream` are that decision made explicitly, and asking for both is refused by name rather than
+resolved by precedence.
+
+## What has no op yet
+
+Tags. `gh api -X POST repos/OWNER/REPO/git/refs -f ref=refs/tags/vX.Y.Z -f sha=$SHA` with a **full**
+sha, then verify with `ls-remote --tags`. Deleting a remote ref is `gh api -X DELETE`, which also
+skips the pre-push hook that would otherwise run the entire suite once per deletion.
+
+## Writing this match
+
+`\n` is in the separator class on purpose. The matcher tests the whole command, and awk anchors `^`
+at the start of the **string**, not of each line — so without it a push on the second line of a
+multi-line script is invisible. That is not hypothetical: the invocation that prompted this rule was
+`command git -C "$W" push`, three lines into a heredoc, with `command` in front of it to bypass the
+`rtk` wrapper.
+
+Unlike `\s`, which this awk silently drops, `\n` is a valid string escape and survives into the
+compiled pattern. Verified, both directions, before this rule was indexed.

--- a/.claude/jit-context/tools/00-manual/git-push-has-an-op.md
+++ b/.claude/jit-context/tools/00-manual/git-push-has-an-op.md
@@ -1,56 +1,21 @@
 ---
-title: "Raw `git push` skips the receipt that says whether it landed"
+title: "`git push` has an op"
 tool: Bash
 match: ~(^|[;&|\n] *)(rtk +)?(command +)?git[[:space:]]+([^;&|\n]*[[:space:]])?push
 mode: block
 ---
 
-Use **`git-push`**, and its flags for the cases that used to need a raw line.
+`git-push` — pushes the **current branch**, so `cd` into the worktree instead of `-C`.
 
-| Instead of                                   | Use                        |
-| -------------------------------------------- | -------------------------- |
-| a plain push                                 | `git-push`                 |
-| `--force-with-lease`                         | `git-push:force-with-lease`|
-| a first push from `git worktree add -b`      | `git-push:set-upstream`    |
-| pushing onto a tracked ref on purpose        | `git-push:to-upstream`     |
-| `--no-verify`                                | `git-push:no-verify`       |
-| push then watch the pipeline                 | `git-push:watch`           |
+| Instead of | Use |
+| --- | --- |
+| plain push | `git-push` |
+| `--force-with-lease` | `git-push:force-with-lease` |
+| first push after `git worktree add -b` | `git-push:set-upstream` |
+| push onto the tracked ref on purpose | `git-push:to-upstream` |
+| `--no-verify` | `git-push:no-verify` |
+| push + watch pipeline | `git-push:watch` |
 
-The op pushes the **current branch**, so `cd` into the worktree rather than reaching in with `-C`.
-
-## Why blocking
-
-**A zero exit is not a push.** `git-push` reads the post-push sha back off the real remote with
-`ls-remote` and labels it verified or unverified — a sha it did not read is never printed as though
-it were. That is the whole point: this repo has a filed instance of `git push -q` followed by an
-unconditional `echo "pushed"` printing success while the remote head had not moved, and a separate
-one where the `rtk` wrapper killed a tag push with `process terminated by signal 13` and the tag
-simply did not exist. Both read exactly like success.
-
-The receipt also carries what you were going to ask next anyway: remote before and after, ahead and
-behind, the PR and its pipeline, mergeability, the count of uncommitted leftovers, and the watch
-command. A non-fast-forward auto-rebases and hands back `git-conflicts` on a conflict instead of a
-wall of git output.
-
-**The upstream trap is the specific one that bites here.** `git worktree add -b <new> <base>` leaves
-the new branch tracking `<base>`, which is where every `st-wt/NNN` branch starts, so a plain push
-either goes to the wrong ref or is refused with advice the caller cannot act on. `:set-upstream` and
-`:to-upstream` are that decision made explicitly, and asking for both is refused by name rather than
-resolved by precedence.
-
-## What has no op yet
-
-Tags. `gh api -X POST repos/OWNER/REPO/git/refs -f ref=refs/tags/vX.Y.Z -f sha=$SHA` with a **full**
-sha, then verify with `ls-remote --tags`. Deleting a remote ref is `gh api -X DELETE`, which also
-skips the pre-push hook that would otherwise run the entire suite once per deletion.
-
-## Writing this match
-
-`\n` is in the separator class on purpose. The matcher tests the whole command, and awk anchors `^`
-at the start of the **string**, not of each line — so without it a push on the second line of a
-multi-line script is invisible. That is not hypothetical: the invocation that prompted this rule was
-`command git -C "$W" push`, three lines into a heredoc, with `command` in front of it to bypass the
-`rtk` wrapper.
-
-Unlike `\s`, which this awk silently drops, `\n` is a valid string escape and survives into the
-compiled pattern. Verified, both directions, before this rule was indexed.
+- **A zero exit is not a push.** The op reads the post-push sha back off the remote via `ls-remote` and labels it verified. Filed instances both ways: `git push -q` + unconditional success echo while the remote head had not moved; an rtk-wrapped tag push killed by SIGPIPE that left no tag.
+- `git worktree add -b <new> <base>` leaves the branch tracking `<base>` — every `st-wt/NNN` starts wrong. `:set-upstream` / `:to-upstream` make that explicit.
+- No op for tags: `gh api -X POST .../git/refs -f ref=refs/tags/vX.Y.Z -f sha=$FULL_SHA`, verify with `ls-remote --tags`. Ref delete is `gh api -X DELETE` (skips the per-deletion pre-push suite).

--- a/.claude/jit-context/tools/00-manual/merged-is-not-ancestry.md
+++ b/.claude/jit-context/tools/00-manual/merged-is-not-ancestry.md
@@ -1,7 +1,7 @@
 ---
 title: "Do not ask git whether a branch is merged — this repo squash-merges"
 tool: Bash
-match: ~(^|[;&|] *)(rtk +)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged
+match: ~(^|[;&|\n] *)(rtk +)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged
 mode: block
 ---
 

--- a/.claude/jit-context/tools/00-manual/merged-is-not-ancestry.md
+++ b/.claude/jit-context/tools/00-manual/merged-is-not-ancestry.md
@@ -1,7 +1,7 @@
 ---
 title: "Do not ask git whether a branch is merged — this repo squash-merges"
 tool: Bash
-match: ~git\s+(branch|for-each-ref)[^|]*--merged
+match: ~(^|[;&|] *)(rtk +)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged
 mode: block
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,12 +76,7 @@ Three rules for what goes in one:
 - **Carry the number that made you write it.** A rule with its evidence stripped is folklore, and folklore is what this tool exists to replace.
 - **Keep it short.** The file is injected in full on every match, so its length is a cost paid every time, forever. A table of replacement ops, the measurement that justified the rule, and stop.
 
-Two constraints on the `match` column, both measured 2026-08-10:
-
-- **The matcher is awk, so `\s`/`\d`/`\w` are not character classes** — macOS ships the one-true-awk, which drops the undefined escape, so `gh\s+pr` compiles to `ghs+pr` and matches nothing. Two of six tool rules were dead this way, both `block`, one of them for however long `merged-is-not-ancestry.md` had existed. Use `[[:space:]]`. `\n` *is* a valid escape and does survive.
-- **`^` anchors the whole command, not each line.** `full_command` is the entire string, so a rule anchored `(^|[;&|] *)` never sees an invocation on the second line of a multi-line script. Put `\n` in the separator class.
-
-A rule that never matches and a rule that never runs look identical everywhere, including the hook's own log, which shows `(none) [shown:0]` for both. After indexing one, run the command it forbids and check it is refused.
+**A rule that never matches and a rule that never runs look identical everywhere**, including the hook's own log. So after indexing one, run the command it forbids and check it is refused — two of six tool rules turned out to be dead on 2026-08-10, both `block`, both from a `match` written in PCRE for a matcher that is awk. The `match`-column traps are in `.claude/jit-context/paths/00-manual/jit-context.md`, which fires when you edit one.
 
 ## The defect this codebase keeps having
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,14 @@ Three rules for what goes in one:
 - **Point at the op. Never teach a way around it.** If the entry you are about to write explains how to get an answer by hand, the thing to change is the op that should have answered. A draft of `merged-is-not-ancestry.md` was 39 lines of `git cat-file` and `gh pr list | intersect` recipes for a question `git-worktrees` already owns and answers wrongly on one line. Documenting the detour makes it permanent and leaves the defect. Fix the op; the note then shrinks to a pointer.
 - **A `block` must anchor on the invocation, not on a word.** `supertool-no-cut.md` matches `~supertool[^|]*\|[^|]*(head|tail|…)`, and the word it matches is usually the **directory name** — every command run from this repo contains it. On 2026-08-09 it blocked a plain `git status | head`, a `pytest | tail`, a `venv` under a scratchpad path, and a `gh-job:N:grep:A|B` whose `|` was inside the op's own pattern. A blocking rule that fires on commands it was not written for teaches people to route around the block.
 - **Carry the number that made you write it.** A rule with its evidence stripped is folklore, and folklore is what this tool exists to replace.
+- **Keep it short.** The file is injected in full on every match, so its length is a cost paid every time, forever. A table of replacement ops, the measurement that justified the rule, and stop.
+
+Two constraints on the `match` column, both measured 2026-08-10:
+
+- **The matcher is awk, so `\s`/`\d`/`\w` are not character classes** — macOS ships the one-true-awk, which drops the undefined escape, so `gh\s+pr` compiles to `ghs+pr` and matches nothing. Two of six tool rules were dead this way, both `block`, one of them for however long `merged-is-not-ancestry.md` had existed. Use `[[:space:]]`. `\n` *is* a valid escape and does survive.
+- **`^` anchors the whole command, not each line.** `full_command` is the entire string, so a rule anchored `(^|[;&|] *)` never sees an invocation on the second line of a multi-line script. Put `\n` in the separator class.
+
+A rule that never matches and a rule that never runs look identical everywhere, including the hook's own log, which shows `(none) [shown:0]` for both. After indexing one, run the command it forbids and check it is refused.
 
 ## The defect this codebase keeps having
 

--- a/changelog.d/1254.fixed.md
+++ b/changelog.d/1254.fixed.md
@@ -2,3 +2,4 @@
 - Those rules are additionally anchored on command position, so a rule matches an invocation rather than a mention of the command inside a payload.
 - New rule: `gh pr view` and `gh pr merge` are blocked in favour of `gh-pr`, `gh-pr:N:status`, `gh-pr:N:diff` and `gh-pr-merge`.
 - New rule: raw `git push` is blocked in favour of `git-push`, whose receipt reads the post-push sha back off the remote — a zero exit is not a push. Its separator class includes a newline, because awk anchors `^` at the start of the whole command string, so a push on the second line of a multi-line script was invisible to the earlier anchored rules.
+- Two path rules: `.claude/jit-context/` carries the rule-authoring traps (they now fire when you edit a rule, instead of costing every session in `CLAUDE.md`), and `.claude-plugin/` + `pyproject.toml` carry the five version sites and the unfiltered sweep that the `README.md` badge needed and did not get for fifteen releases.

--- a/changelog.d/1254.fixed.md
+++ b/changelog.d/1254.fixed.md
@@ -1,0 +1,3 @@
+- Two `.claude/jit-context` block rules were written with `\s`, which the one-true-awk that runs the hook does not support — the escape is dropped and `gh\s+pr` compiles to `ghs+pr`, matching nothing. Both read as enforced and had never fired. They now use `[[:space:]]+`.
+- Those rules are additionally anchored on command position, so a rule matches an invocation rather than a mention of the command inside a payload.
+- New rule: `gh pr view` and `gh pr merge` are blocked in favour of `gh-pr`, `gh-pr:N:status`, `gh-pr:N:diff` and `gh-pr-merge`.

--- a/changelog.d/1254.fixed.md
+++ b/changelog.d/1254.fixed.md
@@ -1,3 +1,4 @@
 - Two `.claude/jit-context` block rules were written with `\s`, which the one-true-awk that runs the hook does not support — the escape is dropped and `gh\s+pr` compiles to `ghs+pr`, matching nothing. Both read as enforced and had never fired. They now use `[[:space:]]+`.
 - Those rules are additionally anchored on command position, so a rule matches an invocation rather than a mention of the command inside a payload.
 - New rule: `gh pr view` and `gh pr merge` are blocked in favour of `gh-pr`, `gh-pr:N:status`, `gh-pr:N:diff` and `gh-pr-merge`.
+- New rule: raw `git push` is blocked in favour of `git-push`, whose receipt reads the post-push sha back off the remote — a zero exit is not a push. Its separator class includes a newline, because awk anchors `^` at the start of the whole command string, so a push on the second line of a multi-line script was invisible to the earlier anchored rules.


### PR DESCRIPTION
## What was wrong

The jit-context hook matches with awk (`claude-jit-context/scripts/pre-tool-hook.sh:80`):

    if (match(tolower(full_command), substr(r_match, 2)) == 0) continue

macOS ships the one-true-awk (`awk version 20200816`), where `\s` is not a character class. The
undefined string escape is dropped before the pattern compiles, so `gh\s+pr` becomes the regex
`ghs+pr` and matches nothing at all.

Measured on this machine:

    backslash-s : no
    space-plus  : MATCH
    posix class : MATCH

## How it surfaced

Writing a new rule to block `gh pr view` and `gh pr merge`. The `.md` was correct, the index row
was correct, the mode was `block` — and the command it forbids ran twice and returned normally.

Auditing the rest of the family for the same escape found `merged-is-not-ancestry.md` had it too:
a `block` rule listed in the index, reading as enforced, that had never once fired since it was
written. **Two of the six tool rules were dead, and both were the `block` ones.**

This is the house defect in the enforcement layer: a rule that never matches and a rule that never
runs render identically, including in the hook's own log, which shows `(none) [shown:0]` for both.

## The second defect, found by the fix

The first working version of the new rule **blocked the `append` that was writing its own
documentation**, because the prose quotes the command it forbids. The matcher deliberately tests
the whole command so a rule survives `cd X && ...`; that leaves position as the only thing
separating an invocation from a mention. Both rules are now anchored `(^|[;&|] *)(rtk +)?`.

Verified after the change: the invocation is blocked, and an `append` whose payload quotes it is
not.

## What the new rule points at

`gh-pr:N` (body, linked issues), `gh-pr:N:status` (the summed tally), `gh-pr:N:diff` (blast radius
by filename), and `gh-pr-merge:N:squash|force`, which refuses on the #454 arithmetic, reads
`state`/`mergedAt`/`mergeCommit` back off the remote, and checks every linked issue individually.

Measured in the tick that prompted this: **12** `gh pr view` invocations across four PRs, every one
answered by an op.

## Scope

Config and documentation only — no product code. `Part of #1254`, which is the validator that would
refuse this at write time; the rules themselves are repaired here.

Part of #1254
