### PR TITLE
The anchored guard could not tell a waiver from prose about declining one, and read 80% of the patterns

### DIFF
--- a/_supertool.py
+++ b/_supertool.py
@@ -2050,6 +2050,9 @@ def _extract_env_prefix(cmd: str) -> Tuple[Dict[str, str], str]:
     # with a newline *inside* it matched nothing at all, so the whole token
     # fell through as argv[0] and the env was never set; POSIX sets it. Both
     # are the same character deciding where a value ends (#1188).
+    # anchored-ok: DOTALL is the point. `(.*)` is meant to reach the true end
+    # and keep a newline the caller quoted, so the `\Z` is not the #1241 no-op
+    # it reads as -- it states the intent the flag already carries.
     _kv = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)\Z", re.DOTALL)
     while idx < len(tokens):
         m = _kv.match(tokens[idx])

--- a/changelog.d/1241.fixed.md
+++ b/changelog.d/1241.fixed.md
@@ -1,0 +1,25 @@
+- The #1188 anchored-regex guard could not tell a waiver from prose about
+  declining one, and read string literals only. `"anchored-ok" in line` fired
+  on a comment explaining why the waiver had been *refused* and demanded a
+  reason for an exit nobody took — punishing the one thing most worth writing
+  down. The token now counts only when it opens a real comment token, so a
+  mention inside a string or mid-sentence grants and trips nothing, and a
+  waiver may sit on the comment block directly above the call because thirty
+  trailing columns is not room for a reason worth reading.
+- The same guard now reads a pattern spliced with `+`. `_PATH_TOK` in
+  `presets/claims/check.py` is the same whole-value test over the same
+  author-controlled bytes as the pattern the guard did flag, sat three lines
+  from it, and was invisible for being assembled rather than written out.
+- Three states, not two. A call whose pattern cannot be read is declined *by
+  name* — a bare name, a call result, an f-string — and one whose head says
+  `^` while its tail is unreadable is now a failure rather than a silent pass.
+  A scanner that reads 80% of the patterns and reports clean is the defect it
+  was built to catch. Measured on the tree: 111 calls in scope, 1 spliced and
+  read, 50 declined with a reason, 14 waived, 0 half-read.
+- The guard's own prescribed fix was a no-op on the shape that produced it.
+  On `^(#{1,6})\s+(.*?)\s*$` the `\s*` swallows the trailing newline whichever
+  anchor follows, so `\Z` and a waiver both turn the guard green over an
+  unchanged defect — measured: `$` matches value+newline, naive `\Z` matches,
+  tight `[ \t]*\Z` does not. A `\Z` sitting behind a run that can eat a
+  newline is now refused rather than accepted, and the message says the real
+  fix is narrowing the run.

--- a/changelog.d/1241.fixed.md
+++ b/changelog.d/1241.fixed.md
@@ -14,8 +14,10 @@
   name* — a bare name, a call result, an f-string — and one whose head says
   `^` while its tail is unreadable is now a failure rather than a silent pass.
   A scanner that reads 80% of the patterns and reports clean is the defect it
-  was built to catch. Measured on the tree: 111 calls in scope, 1 spliced and
-  read, 50 declined with a reason, 14 waived, 0 half-read.
+  was built to catch — including its own new half: a splice whose last literal
+  is only the anchor cannot say what precedes it, and reports undecided rather
+  than clean. Measured on the tree: 111 calls in scope, 1 spliced and read, 50
+  declined with a reason, 14 waived, 0 half-read, 0 undecided.
 - The guard's own prescribed fix was a no-op on the shape that produced it.
   On `^(#{1,6})\s+(.*?)\s*$` the `\s*` swallows the trailing newline whichever
   anchor follows, so `\Z` and a waiver both turn the guard green over an

--- a/presets/claims/check.py
+++ b/presets/claims/check.py
@@ -90,19 +90,22 @@ _FENCE = re.compile(r"^\s{0,3}(?:```|~~~)")
 
 _EXTS = ("py|md|json|toml|yml|yaml|sh|bash|cfg|ini|txt|tsv|xml|html|js|ts|"
          "jsx|tsx|rs|php|rb|go|sql|css|lock|env|service")
-# Same reasoning as `_OP_TOK`, and the same anchor. #1188's guard does not see
-# this one — it reads string literals, and this pattern is assembled by
-# concatenation — but a whole-value test on author-controlled bytes does not
-# stop being one because the check cannot read it.
+# Same reasoning as `_OP_TOK`, and the same anchor. #1188's guard could not see
+# this one until #1241 taught it to read a `+` splice: a whole-value test on
+# author-controlled bytes does not stop being one because the check cannot read
+# it, and for a while this sat three lines from a twin the guard did flag.
 _PATH_TOK = re.compile(
     r"^([A-Za-z0-9_.][A-Za-z0-9_./+-]*\.(?:" + _EXTS + r"))(?::(\d+))?\Z")
 
-# `\Z`, and deliberately not a #1188 waiver. This decides whether a backticked
-# token is read as an op reference, and its input is a code span's contents —
-# bytes the document's author wrote, not a line this op sliced out of a larger
-# text. `_CODE_SPAN` already excludes U+000A and `_op_findings` rejects any
-# token holding whitespace, so nothing exploits the old `$` today; the anchor
-# is what makes that true of the pattern rather than of its two callers.
+# `\Z`, and deliberately not an `anchored-ok` waiver -- writing that sentence
+# used to trip the guard itself, which demanded a reason for an exit nobody had
+# taken; #1241 made the token count only when it opens a comment. This decides
+# whether a backticked token is read as an op reference, and its input is the
+# contents of a code span — bytes the document's author wrote, not a line this
+# op sliced out of a larger text. `_CODE_SPAN` already excludes U+000A and
+# `_op_findings` rejects any token holding whitespace, so nothing exploited the
+# old `$`; the anchor is what makes that true of the pattern rather than of its
+# two callers.
 _OP_TOK = re.compile(r"^([a-z][a-z0-9_-]*):(\S.*)\Z")
 
 _CITATION = re.compile(

--- a/tests/test_anchored_guards_1188.py
+++ b/tests/test_anchored_guards_1188.py
@@ -24,12 +24,20 @@ is a line scanner and `\Z` would be wrong in it. A pattern that ends with `$`
 but does not start with `^` is a suffix test (`\.pem$`), where matching before
 a trailing newline changes nothing a caller can act on.
 
-**The limit, stated.** This reads the literal first argument of a call spelled
-`re.<something>`. Four shapes are therefore invisible to it: a pattern built by
-an f-string or `+`, one assembled from a variable, one held in a dict and
-compiled elsewhere, and one reached through an aliased import
-(`from re import compile as _c`). None exists in the tree today. This narrows
-the class; it does not close it.
+**The limit, stated -- and stated per site, not only here.** This reads the
+first argument of a call spelled `re.<something>`: a string literal, or a `+`
+splice whose first and last pieces are literals, which is all the anchor
+question needs. Anything else -- a bare name, a call result, an f-string --
+is *declined by name*, and a pattern whose head says `^` and whose tail cannot
+be read is a **failure**, not a skip. That is the whole point: a scanner that
+read 80% of the patterns and reported clean is what let `_PATH_TOK` sit three
+lines from a flagged twin, spliced with `+` and invisible (#1241).
+
+Measured on the tree at the time of writing: 111 calls in scope, 1 spliced and
+read, 50 declined with a reason, 14 waived, 0 half-read. Still open by
+construction: a pattern held in a dict and compiled elsewhere, and one reached
+through an aliased import (`from re import compile as _c`). This narrows the
+class; it does not close it.
 
 `fullmatch` is deliberately **not** in the call list. `re.fullmatch(r"^x$", s)`
 requires the whole string, so it has never had this bug, and flagging one would
@@ -39,9 +47,12 @@ which is the shape of mistake this file exists to catch.
 from __future__ import annotations
 
 import ast
+import io
 import re
 import sys
+import tokenize
 from pathlib import Path
+from typing import NamedTuple, Optional
 
 import pytest
 
@@ -54,22 +65,67 @@ import _refname  # noqa: E402
 #: Files and trees whose regexes decide whether a *value* is acceptable.
 SCANNED = ("_supertool.py", "presets", ".github/scripts")
 
-#: The escape hatch, and it has to say why. Written on the line the `re.*`
-#: call starts on, so it is read by whoever next edits that call rather than
-#: living in a table in this file that nobody opens.
-WAIVER = re.compile(r"#\s*anchored-ok:\s*(\S.*)")
+#: The escape hatch, and it has to say why. Written on the `re.*` call's own
+#: lines, or on the comment block directly above it, so it is read by whoever
+#: next edits that call rather than living in a table nobody opens. Above is
+#: allowed because a trailing comment has about thirty columns to work with,
+#: and a reason that does not fit is a reason that does not get written.
+#:
+#: Matched against a **comment token's own text**, and it has to *open* that
+#: comment. A bare `"anchored-ok" in line` fails in both directions (#1241):
+#: a comment explaining why the waiver was *declined* was read as a silent
+#: waiver and demanded a reason for an exit nobody took -- punishing the one
+#: thing most worth writing down -- while `# ... anchored-ok: x` buried
+#: mid-sentence, or the token inside a string, would have granted one.
+WAIVER = re.compile(r"#\s*anchored-ok\s*:\s*(\S.*)")
+_WAIVER_OPENS = re.compile(r"#\s*anchored-ok\b")
 
-#: No `fullmatch` — see the docstring; it requires the whole string and so
+#: No `fullmatch` -- see the docstring; it requires the whole string and so
 #: never accepts a trailing newline the pattern did not ask for.
 _RE_CALLS = frozenset((
     "compile", "match", "search", "sub", "subn",
     "split", "findall", "finditer",
 ))
 
-#: A `$` at the very end of the pattern that is not itself escaped. The
-#: even-backslash run is what tells `\\$` (a literal backslash, then the
-#: anchor) apart from `\$` (a literal dollar, and no anchor at all).
-_TRAILING_ANCHOR = re.compile(r"(?<!\\)(?:\\\\)*\$\Z")
+#: What to say when `\Z` would not actually change anything. `$` is only half
+#: the defect: `^...\s*$` and `^...\s*\Z` accept the same values, because the
+#: trailing run eats the newline before either anchor is consulted. Measured
+#: on `^(#{1,6})\s+(.*?)\s*$` in #1241 -- `$` matches `"## x\n"`, `\Z` matches
+#: it too, `[ \t]*\Z` does not.
+_NO_OP_ADVICE = (
+    r"A `\Z` placed after a run that can itself swallow a newline -- `\s*`, "
+    r"`\s+`, `[\s\S]*`, or `.*` under re.DOTALL -- is a no-op: the run eats "
+    r"the newline and the anchor never sees it, so the pattern accepts exactly "
+    r"what it accepted before and the guard turns green over an unchanged "
+    r"defect. A waiver does the same. The fix is to narrow the trailing run to "
+    r"the characters actually meant, `[ \t]*` rather than `\s*`."
+)
+
+#: A quantified atom at the very end of the pattern body.
+_TRAILING_RUN = re.compile(
+    r"(\\[sSwWdD]|\[\^?(?:[^\]\\]|\\.)*\]|\.)"
+    r"(?:[*+]|\{\d*,\d*\})\??\Z")
+
+#: Escapes that match U+000A, and the classes that contain one.
+_NEWLINE_ESCAPES = ("\\s", "\\W", "\\D", "\\n", "\\r")
+
+
+class _Site(NamedTuple):
+    """One `re.*` call the guard considers in scope, and what it could read.
+
+    `decline` is set when the guard **cannot answer**, never merely when it
+    could not read every byte: a pattern spliced from literals still has a
+    readable head and tail, which is all the anchor question needs.
+    """
+
+    lineno: int
+    text: Optional[str]       # whole pattern, when every piece is a literal
+    spliced: bool             # not whole, but head and tail both read
+    head_anchored: bool       # the readable head starts with `^`
+    anchor: Optional[str]     # `"$"`, `"\\Z"`, or None when unreadable
+    swallows: bool            # the run before the anchor can eat a newline
+    waiver: Optional[str]
+    decline: Optional[str]
 
 
 def _python_sources() -> list[Path]:
@@ -83,25 +139,127 @@ def _python_sources() -> list[Path]:
     return out
 
 
-def _anchored_sites(path: Path) -> list[tuple[int, str, str | None]]:
-    """`(lineno, pattern, waiver_reason)` for each fully anchored literal."""
-    text = path.read_text(encoding="utf-8")
-    lines = text.splitlines()
-    found: list[tuple[int, str, str | None]] = []
-    for node in ast.walk(ast.parse(text)):
+def _comments(source: str) -> list[tuple[int, str, bool]]:
+    """`(lineno, text, on_its_own_line)` per comment -- tokenized, not grepped.
+
+    Tokenizing is the point. `"anchored-ok" in line` also fires on the token
+    inside a string literal, and on prose that merely names it (#1241).
+    """
+    out: list[tuple[int, str, bool]] = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT:
+                own = tok.line[:tok.start[1]].strip() == ""
+                out.append((tok.start[0], tok.string, own))
+    except (tokenize.TokenError, IndentationError):  # pragma: no cover
+        pass
+    return out
+
+
+def _silent_waivers(source: str) -> list[int]:
+    """Line numbers of comments that claim a waiver without giving a reason."""
+    return [lineno for lineno, text, _ in _comments(source)
+            if _WAIVER_OPENS.match(text) and not WAIVER.match(text)]
+
+
+def _plus_leaves(node: ast.expr) -> list[ast.expr]:
+    """Flatten `a + b + c`; anything else is a single leaf."""
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _plus_leaves(node.left) + _plus_leaves(node.right)
+    return [node]
+
+
+def _literal(node: ast.expr) -> Optional[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _decline_reason(leaves: list[ast.expr]) -> str:
+    for leaf in leaves:
+        if _literal(leaf) is not None:
+            continue
+        if isinstance(leaf, ast.Name):
+            return f"a name (`{leaf.id}`) this scan does not resolve"
+        if isinstance(leaf, ast.Call):
+            return f"a call (`{ast.unparse(leaf)[:60]}`) evaluated at runtime"
+        if isinstance(leaf, ast.JoinedStr):
+            return "an f-string interpolated at runtime"
+        return f"an expression this scan does not read (`{type(leaf).__name__}`)"
+    raise AssertionError("every leaf was a literal")  # pragma: no cover
+
+
+def _backslash_run(text: str, end: int) -> int:
+    count = 0
+    while end - count - 1 >= 0 and text[end - count - 1] == "\\":
+        count += 1
+    return count
+
+
+def _trailing_anchor(text: str) -> Optional[str]:
+    r"""The anchor that really ends `text` -- `"$"`, `"\\Z"`, or None.
+
+    The even-backslash run tells `\\$` (a literal backslash, then the anchor)
+    apart from `\$` (a literal dollar, and no anchor at all).
+    """
+    if text.endswith("$") and _backslash_run(text, len(text) - 1) % 2 == 0:
+        return "$"
+    if text.endswith("\\Z") and _backslash_run(text, len(text) - 2) % 2 == 0:
+        return "\\Z"
+    return None
+
+
+def _atom_swallows(atom: str, dotall: bool) -> bool:
+    if atom == ".":
+        return dotall
+    if not atom.startswith("["):
+        return atom in ("\\s", "\\W", "\\D")
+    body = atom[1:-1]
+    listed = any(esc in body for esc in _NEWLINE_ESCAPES) or "\n" in body
+    if body.startswith("^"):
+        return not listed          # negated: swallows unless it names one
+    return listed
+
+
+def _swallows_newline(body: str, dotall: bool) -> bool:
+    r"""Can the run at the end of `body` match U+000A on its own?
+
+    Trailing group closers are peeled, because `(.*)\Z` is the same defect as
+    `.*\Z` and writing the capture around it must not hide it.
+    """
+    while True:
+        hit = _TRAILING_RUN.search(body)
+        if hit and _atom_swallows(hit.group(1), dotall):
+            return True
+        if body.endswith(")") and _backslash_run(body, len(body) - 1) % 2 == 0:
+            body = body[:-1]
+            continue
+        return False
+
+
+def _scan_source(source: str) -> list[_Site]:
+    r"""Every in-scope `re.*` call in `source`, decided or explicitly declined.
+
+    In scope means: not `re.MULTILINE` (there `$` means end-of-line and `\Z`
+    would be wrong), and not a readable head that fails to start with `^` (a
+    suffix test such as `\.pem$`, where matching before a trailing newline
+    changes nothing a caller can act on).
+    """
+    comments = _comments(source)
+    waivers = {lineno: WAIVER.match(text).group(1).strip()
+               for lineno, text, _ in comments if WAIVER.match(text)}
+    own_line = {lineno for lineno, _, own in comments if own}
+    sites: list[_Site] = []
+    for node in ast.walk(ast.parse(source)):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
         if not (isinstance(func, ast.Attribute) and func.attr in _RE_CALLS
                 and getattr(func.value, "id", None) == "re" and node.args):
             continue
-        first = node.args[0]
-        if not (isinstance(first, ast.Constant) and isinstance(first.value, str)):
-            continue
-        pattern = first.value
-        if not pattern.startswith("^"):
-            continue
-        if not _TRAILING_ANCHOR.search(pattern):
+        leaves = _plus_leaves(node.args[0])
+        head, tail = _literal(leaves[0]), _literal(leaves[-1])
+        if head is not None and not head.startswith("^"):
             continue
         flags = " ".join(
             [ast.unparse(a) for a in node.args[1:]]
@@ -109,45 +267,112 @@ def _anchored_sites(path: Path) -> list[tuple[int, str, str | None]]:
         )
         if re.search(r"\bre\.(MULTILINE|M)\b", flags):
             continue
-        span = lines[node.lineno - 1:(node.end_lineno or node.lineno)]
-        reason = None
-        for line in span:
-            hit = WAIVER.search(line)
-            if hit:
-                reason = hit.group(1).strip()
-                break
-        found.append((node.lineno, pattern, reason))
-    return found
+        parts = [_literal(leaf) for leaf in leaves]
+        text = "".join(parts) if all(p is not None for p in parts) else None
+        dotall = (bool(re.search(r"\bre\.(DOTALL|S)\b", flags))
+                  or (head or "").startswith("(?s"))
+        anchor = _trailing_anchor(tail) if tail is not None else None
+        decline = (None if head is not None and tail is not None
+                   else _decline_reason(leaves))
+        swallows = bool(anchor) and _swallows_newline(
+            tail[:len(tail) - len(anchor)], dotall)
+        above = node.lineno - 1
+        while above in own_line:
+            above -= 1
+        span = range(above + 1, (node.end_lineno or node.lineno) + 1)
+        reason = next((waivers[n] for n in span if n in waivers), None)
+        sites.append(_Site(node.lineno, text, text is None and decline is None,
+                           head is not None, anchor, swallows, reason, decline))
+    return sites
+
+
+def _scan_tree() -> list[tuple[str, _Site]]:
+    out: list[tuple[str, _Site]] = []
+    for path in _python_sources():
+        rel = path.relative_to(ROOT).as_posix()
+        for site in _scan_source(path.read_text(encoding="utf-8")):
+            out.append((rel, site))
+    return out
 
 
 def test_no_fully_anchored_dollar_guard() -> None:
-    offenders: list[str] = []
-    for path in _python_sources():
-        for lineno, pattern, reason in _anchored_sites(path):
-            if reason:
-                continue
-            rel = path.relative_to(ROOT).as_posix()
-            offenders.append(f"{rel}:{lineno}: {pattern!r}")
+    offenders = [f"{rel}:{site.lineno}: {site.text or '<spliced>'!r}"
+                 for rel, site in _scan_tree()
+                 if site.anchor == "$" and not site.waiver]
     assert not offenders, (
         "These patterns are anchored ^...$ and used as whole-value tests, so "
-        "each one accepts its own value with a trailing newline appended — "
+        "each one accepts its own value with a trailing newline appended -- "
         "Python's $ matches before a final newline (#1188).\n"
         + "\n".join(offenders)
-        + "\n\nEnd the pattern with \\Z instead, or — if the value really is "
+        + "\n\nEnd the pattern with \\Z instead, or -- if the value really is "
         "one line out of a larger text and the newline is the delimiter rather "
-        "than smuggled input — append `# anchored-ok: <why>` to the line the "
-        "re. call starts on."
+        "than smuggled input -- append `# anchored-ok: <why>` to the line the "
+        "re. call starts on.\n\n" + _NO_OP_ADVICE
     )
+
+
+def test_no_no_op_trailing_anchor() -> None:
+    r"""`\Z` that changes nothing, which is worse than the `$` it replaced.
+
+    A guard that accepts its own prescribed fix without checking whether the
+    fix does anything converts a real finding into a closed one (#1241).
+    """
+    offenders = [f"{rel}:{site.lineno}: {site.text or '<spliced>'!r}"
+                 for rel, site in _scan_tree()
+                 if site.anchor == "\\Z" and site.swallows and not site.waiver]
+    assert not offenders, (
+        "These patterns end in \\Z, and the run in front of it swallows a "
+        "trailing newline anyway, so the anchor is decoration:\n"
+        + "\n".join(offenders) + "\n\n" + _NO_OP_ADVICE
+    )
+
+
+def test_no_half_read_whole_value_pattern() -> None:
+    """A pattern the guard can start reading and cannot finish is a finding.
+
+    Silently covering the readable half and reporting clean is the defect this
+    repo keeps having; the third state has to be said out loud (#1241).
+    """
+    offenders = [f"{rel}:{site.lineno}: {site.decline}"
+                 for rel, site in _scan_tree()
+                 if site.head_anchored and site.decline and not site.waiver]
+    assert not offenders, (
+        "These patterns start with `^` and this scan cannot read what they "
+        "end with, so it cannot say whether they accept a trailing newline:\n"
+        + "\n".join(offenders)
+        + "\n\nSplice the tail from a literal, or -- if the pattern is not a "
+        "whole-value test -- append `# anchored-ok: <why>`."
+    )
+
+
+def test_every_declined_site_names_a_reason() -> None:
+    """Out of scope is fine; out of scope without saying so is the defect.
+
+    Three states, never two: read whole, read at both ends and therefore
+    decidable, or declined with the reason attached.
+    """
+    mute = [f"{rel}:{site.lineno}" for rel, site in _scan_tree()
+            if site.text is None and not site.spliced and not site.decline]
+    assert not mute, "read no pattern text and gave no reason:\n" + "\n".join(mute)
+
+
+def test_the_splice_reader_is_still_wired() -> None:
+    """`_PATH_TOK` was invisible for exactly as long as `+` went unhandled.
+
+    With nothing in this bucket the guard is back to literals only, and every
+    tree test above goes quietly green over the half it stopped reading
+    (#1241).
+    """
+    spliced = [f"{rel}:{site.lineno}" for rel, site in _scan_tree()
+               if site.spliced]
+    assert spliced, "no `+`-spliced pattern read; the splice reader is dead"
 
 
 def test_every_waiver_says_why() -> None:
     """A waiver with no reason is a suppression, and reads as a decision."""
-    silent: list[str] = []
-    for path in _python_sources():
-        text = path.read_text(encoding="utf-8")
-        for lineno, line in enumerate(text.splitlines(), 1):
-            if "anchored-ok" in line and not WAIVER.search(line):
-                silent.append(f"{path.relative_to(ROOT).as_posix()}:{lineno}")
+    silent = [f"{path.relative_to(ROOT).as_posix()}:{lineno}"
+              for path in _python_sources()
+              for lineno in _silent_waivers(path.read_text(encoding="utf-8"))]
     assert not silent, (
         "`# anchored-ok` with no reason after the colon:\n" + "\n".join(silent)
     )
@@ -180,3 +405,142 @@ def test_shell_ref_still_prints_an_ordinary_name_bare() -> None:
 
 def test_warning_names_a_newline_bearing_ref() -> None:
     assert _refname.warning(["main\n"]) is not None
+
+# --------------------------------------------------------------------------
+# The scanner's own behaviour, pinned on synthetic sources (#1241).
+#
+# The tree-scan tests above are green whenever the tree happens to be clean,
+# so they cannot tell a scanner that reads every pattern from one that reads
+# the easy half. These do: each hands `_scan_source` a source string whose
+# right answer is known.
+# --------------------------------------------------------------------------
+
+
+def _one(source: str) -> "_Site":
+    sites = _scan_source(source)
+    assert len(sites) == 1, f"expected one candidate site, got {sites}"
+    return sites[0]
+
+
+def test_prose_that_declines_a_waiver_is_not_a_waiver() -> None:
+    """The comment that most deserves to exist must not trip the guard."""
+    source = r"""import re
+# The anchor stays, and deliberately not an anchored-ok waiver: the input
+# is a whole value, not a line sliced out of a larger text.
+X = re.compile(r'^[a-z]+\Z')
+"""
+    assert _silent_waivers(source) == []
+    assert _one(source).waiver is None
+
+
+def test_a_waiver_has_to_open_its_comment() -> None:
+    """Mid-comment prose about a waiver must not grant one."""
+    source = r"""import re
+X = re.compile(r'^[a-z]+$')  # not an anchored-ok: excuse, just prose
+"""
+    assert _one(source).waiver is None
+
+
+def test_anchored_ok_inside_a_string_is_not_a_waiver() -> None:
+    source = r"""import re
+X = re.compile(r'^[a-z]+$')
+S = '# anchored-ok:'
+"""
+    assert _silent_waivers(source) == []
+    assert _one(source).waiver is None
+
+
+def test_a_real_waiver_still_grants_and_still_needs_a_reason() -> None:
+    granted = r"""import re
+X = re.compile(r'^[a-z]+$')  # anchored-ok: one line out of a larger text
+"""
+    assert _one(granted).waiver == "one line out of a larger text"
+    silent = r"""import re
+X = re.compile(r'^[a-z]+$')  # anchored-ok:
+"""
+    assert _silent_waivers(silent) == [2]
+
+
+def test_a_waiver_may_sit_on_the_line_above_the_call() -> None:
+    """Thirty trailing columns is not room for a reason worth reading."""
+    source = r"""import re
+# anchored-ok: DOTALL is the point and the trailing run is meant to swallow
+# the newline, which is a sentence that does not fit after the call.
+X = re.compile(r'^a(.*)\Z', re.DOTALL)
+"""
+    assert _one(source).waiver.startswith("DOTALL is the point")
+
+
+def test_a_pattern_built_by_concatenation_is_seen() -> None:
+    """#1241: `_PATH_TOK` sat three lines from a flagged twin, and was invisible."""
+    source = r"""import re
+E = 'a|b'
+X = re.compile(r'^(?:' + E + r')$')
+"""
+    site = _one(source)
+    assert site.anchor == "$"
+    assert site.decline is None
+
+
+def test_concatenation_with_an_unreadable_tail_is_declined_not_passed() -> None:
+    """Head says `^`, tail unknown: the guard cannot answer, so it must say so."""
+    source = r"""import re
+E = 'a|b'
+X = re.compile(r'^(?:' + E)
+"""
+    site = _one(source)
+    assert site.decline
+    assert site.anchor is None
+
+
+def test_an_unreadable_pattern_always_names_why() -> None:
+    """A runtime pattern is out of scope, but never silently out of scope."""
+    for expr, want in (
+        ("re.compile(pattern)", "a name"),
+        ("re.compile(re.escape(pattern))", "a call"),
+        ("re.compile(f'^{x}$')", "an f-string"),
+    ):
+        site = _one("import re\nX = " + expr + "\n")
+        assert site.text is None
+        assert want in (site.decline or ""), (expr, site.decline)
+
+
+def test_a_Z_after_a_whitespace_run_is_refused() -> None:
+    """The guard's own prescribed fix, and on this shape it is a no-op."""
+    site = _one(r"""import re
+X = re.compile(r'^(#{1,6})\s+(.*?)\s*\Z')
+""")
+    assert site.anchor == "\\Z"
+    assert site.swallows is True
+
+
+def test_a_narrowed_trailing_run_before_Z_is_accepted() -> None:
+    site = _one(r"""import re
+X = re.compile(r'^(#{1,6})\s+(.*?)[ \t]*\Z')
+""")
+    assert site.anchor == "\\Z"
+    assert site.swallows is False
+
+
+def test_dot_star_before_Z_swallows_only_under_dotall() -> None:
+    dotall = r"""import re
+X = re.compile(r'^a(.*)\Z', re.DOTALL)
+"""
+    plain = r"""import re
+X = re.compile(r'^a(.*)\Z')
+"""
+    assert _one(dotall).swallows is True
+    assert _one(plain).swallows is False
+
+
+def test_the_no_op_anchor_is_measured_not_quoted() -> None:
+    """#1241's measurement, run rather than repeated."""
+    value = "## Open defects\n"
+    assert re.compile(r"^(#{1,6})\s+(.*?)\s*$").match(value)
+    assert re.compile(r"^(#{1,6})\s+(.*?)\s*\Z").match(value)
+    assert not re.compile(r"^(#{1,6})\s+(.*?)[ \t]*\Z").match(value)
+
+
+def test_the_advice_says_the_naive_fix_is_a_no_op() -> None:
+    assert "no-op" in _NO_OP_ADVICE
+    assert "narrow" in _NO_OP_ADVICE.lower()

--- a/tests/test_anchored_guards_1188.py
+++ b/tests/test_anchored_guards_1188.py
@@ -26,18 +26,22 @@ a trailing newline changes nothing a caller can act on.
 
 **The limit, stated -- and stated per site, not only here.** This reads the
 first argument of a call spelled `re.<something>`: a string literal, or a `+`
-splice whose first and last pieces are literals, which is all the anchor
-question needs. Anything else -- a bare name, a call result, an f-string --
-is *declined by name*, and a pattern whose head says `^` and whose tail cannot
-be read is a **failure**, not a skip. That is the whole point: a scanner that
-read 80% of the patterns and reported clean is what let `_PATH_TOK` sit three
-lines from a flagged twin, spliced with `+` and invisible (#1241).
+splice whose first and last pieces are literals. Head and tail settle *which
+anchor* ends the pattern; they do not on their own settle whether the run in
+front of it swallows a newline, so a splice whose last literal is only the
+anchor is reported as undecided rather than clean. Anything else -- a bare
+name, a call result, an f-string -- is *declined by name*, and a pattern whose
+head says `^` and whose tail cannot be read is a **failure**, not a skip.
+
+That is the whole point: a scanner that read 80% of the patterns and reported
+clean is what let `_PATH_TOK` sit three lines from a flagged twin, spliced
+with `+` and invisible (#1241).
 
 Measured on the tree at the time of writing: 111 calls in scope, 1 spliced and
-read, 50 declined with a reason, 14 waived, 0 half-read. Still open by
-construction: a pattern held in a dict and compiled elsewhere, and one reached
-through an aliased import (`from re import compile as _c`). This narrows the
-class; it does not close it.
+read, 50 declined with a reason, 14 waived, 0 half-read, 0 with an undecidable
+trailing run. Still open by construction: a pattern held in a dict and compiled
+elsewhere, and one reached through an aliased import (`from re import compile
+as _c`). This narrows the class; it does not close it.
 
 `fullmatch` is deliberately **not** in the call list. `re.fullmatch(r"^x$", s)`
 requires the whole string, so it has never had this bug, and flagging one would
@@ -101,10 +105,13 @@ _NO_OP_ADVICE = (
     r"the characters actually meant, `[ \t]*` rather than `\s*`."
 )
 
-#: A quantified atom at the very end of the pattern body.
+#: An atom at the very end of the pattern body, quantified or not. The
+#: quantifier is optional because `\s\Z` eats a trailing newline exactly as
+#: `\s*\Z` does -- the `*` was never the defect. The `\]?` is Python's rule
+#: that a `]` immediately after `[` or `[^` is a literal member, not the close.
 _TRAILING_RUN = re.compile(
-    r"(\\[sSwWdD]|\[\^?(?:[^\]\\]|\\.)*\]|\.)"
-    r"(?:[*+]|\{\d*,\d*\})\??\Z")
+    r"(\\[sSwWdD]|\[\^?\]?(?:[^\]\\]|\\.)*\]|\.)"
+    r"(?:[*+]|\{\d*,\d*\})?\??\Z")
 
 #: Escapes that match U+000A, and the classes that contain one.
 _NEWLINE_ESCAPES = ("\\s", "\\W", "\\D", "\\n", "\\r")
@@ -121,6 +128,7 @@ class _Site(NamedTuple):
     lineno: int
     text: Optional[str]       # whole pattern, when every piece is a literal
     spliced: bool             # not whole, but head and tail both read
+    swallow_known: bool       # `swallows` is a verdict, not an assumption
     head_anchored: bool       # the readable head starts with `^`
     anchor: Optional[str]     # `"$"`, `"\\Z"`, or None when unreadable
     swallows: bool            # the run before the anchor can eat a newline
@@ -221,20 +229,28 @@ def _atom_swallows(atom: str, dotall: bool) -> bool:
     return listed
 
 
-def _swallows_newline(body: str, dotall: bool) -> bool:
-    r"""Can the run at the end of `body` match U+000A on its own?
+def _swallows_newline(body: str, dotall: bool) -> tuple[bool, bool]:
+    r"""`(swallows, decided)` for the run at the end of `body`.
 
     Trailing group closers are peeled, because `(.*)\Z` is the same defect as
     `.*\Z` and writing the capture around it must not hide it.
+
+    `decided` exists for a spliced pattern whose last literal is only the
+    anchor: the run in front of it lives in a piece this scan cannot read, and
+    answering "no" there would be a definitive clean verdict over bytes never
+    examined. A "yes" is always sound -- a swallowing run that is visible is
+    real whatever precedes it. The residual limit, stated: a splice whose last
+    literal is a fragment of a run started in an unreadable piece (`... + r"s*"`
+    after a piece ending in a backslash) is read as the fragment.
     """
     while True:
         hit = _TRAILING_RUN.search(body)
         if hit and _atom_swallows(hit.group(1), dotall):
-            return True
+            return True, True
         if body.endswith(")") and _backslash_run(body, len(body) - 1) % 2 == 0:
             body = body[:-1]
             continue
-        return False
+        return False, bool(body)
 
 
 def _scan_source(source: str) -> list[_Site]:
@@ -274,14 +290,16 @@ def _scan_source(source: str) -> list[_Site]:
         anchor = _trailing_anchor(tail) if tail is not None else None
         decline = (None if head is not None and tail is not None
                    else _decline_reason(leaves))
-        swallows = bool(anchor) and _swallows_newline(
-            tail[:len(tail) - len(anchor)], dotall)
+        swallows, decided = (
+            _swallows_newline(tail[:len(tail) - len(anchor)], dotall)
+            if anchor else (False, True))
         above = node.lineno - 1
         while above in own_line:
             above -= 1
         span = range(above + 1, (node.end_lineno or node.lineno) + 1)
         reason = next((waivers[n] for n in span if n in waivers), None)
-        sites.append(_Site(node.lineno, text, text is None and decline is None,
+        spliced = text is None and decline is None
+        sites.append(_Site(node.lineno, text, spliced, decided or not spliced,
                            head is not None, anchor, swallows, reason, decline))
     return sites
 
@@ -324,6 +342,23 @@ def test_no_no_op_trailing_anchor() -> None:
         "These patterns end in \\Z, and the run in front of it swallows a "
         "trailing newline anyway, so the anchor is decoration:\n"
         + "\n".join(offenders) + "\n\n" + _NO_OP_ADVICE
+    )
+
+
+def test_no_undecidable_trailing_run() -> None:
+    """A splice whose last literal is only the anchor answers nothing.
+
+    `swallows=False` there would be a clean verdict over bytes the scan never
+    read -- narrower than the old blindness and worse, because being absent
+    from a scan at least never claimed anything (#1241).
+    """
+    offenders = [f"{rel}:{site.lineno}" for rel, site in _scan_tree()
+                 if site.anchor and not site.swallow_known and not site.waiver]
+    assert not offenders, (
+        "These patterns are spliced and end in a literal that is only the "
+        "anchor, so what precedes it was never read:\n" + "\n".join(offenders)
+        + "\n\nMove the trailing run into the last literal of the splice, or "
+        "append `# anchored-ok: <why>`.\n\n" + _NO_OP_ADVICE
     )
 
 
@@ -434,17 +469,23 @@ X = re.compile(r'^[a-z]+\Z')
 
 
 def test_a_waiver_has_to_open_its_comment() -> None:
-    """Mid-comment prose about a waiver must not grant one."""
+    """Mid-comment prose about a waiver must not grant one, or demand one.
+
+    The second assertion is the one #1241 was filed for: the old check said
+    `"anchored-ok" in line`, so this line was a waiver with no reason after
+    the colon and the guard asked the author to justify an exit not taken.
+    """
     source = r"""import re
 X = re.compile(r'^[a-z]+$')  # not an anchored-ok: excuse, just prose
 """
     assert _one(source).waiver is None
+    assert _silent_waivers(source) == []
 
 
 def test_anchored_ok_inside_a_string_is_not_a_waiver() -> None:
+    """On the call's own line, where a line-based reader cannot tell them apart."""
     source = r"""import re
-X = re.compile(r'^[a-z]+$')
-S = '# anchored-ok:'
+S = '# anchored-ok: a fake'; X = re.compile(r'^[a-z]+$')
 """
     assert _silent_waivers(source) == []
     assert _one(source).waiver is None
@@ -531,6 +572,46 @@ X = re.compile(r'^a(.*)\Z')
 """
     assert _one(dotall).swallows is True
     assert _one(plain).swallows is False
+
+
+def test_an_unquantified_swallowing_atom_is_refused() -> None:
+    r"""`\s\Z` eats the newline exactly as `\s*\Z` does; the `*` is not the bug."""
+    assert _one(r"""import re
+X = re.compile(r'^abc\s\Z')
+""").swallows is True
+
+
+def test_a_class_opening_with_a_bracket_is_read() -> None:
+    """`[^]abc]` is a legal class whose first literal member is `]`."""
+    assert _one(r"""import re
+X = re.compile(r'^abc[^]abc]*\Z')
+""").swallows is True
+
+
+def test_a_splice_whose_tail_is_only_the_anchor_gives_no_verdict() -> None:
+    """The run before the anchor is in a piece this scan cannot read.
+
+    Reporting `swallows=False` here would be a definitive clean verdict over
+    bytes never examined -- narrower than the old blindness, and worse, because
+    absent from the scan at least never claimed anything.
+    """
+    site = _one(r"""import re
+V = 'x'
+X = re.compile(r'^abc' + V + r'\Z')
+""")
+    assert site.spliced is True
+    assert site.swallow_known is False
+
+
+def test_a_splice_whose_tail_carries_the_run_still_decides() -> None:
+    """`_PATH_TOK`'s shape: the trailing run is inside the last literal."""
+    site = _one(r"""import re
+E = 'py|md'
+X = re.compile(r'^([a-z]*\.(?:' + E + r'))(?::(\d+))?\Z')
+""")
+    assert site.spliced is True
+    assert site.swallow_known is True
+    assert site.swallows is False
 
 
 def test_the_no_op_anchor_is_measured_not_quoted() -> None:


### PR DESCRIPTION
Closes #1241

Two defects in the #1188 anchored-guard test, one shape: **a lexical check standing in for a semantic one.**

## 1. It could not tell a waiver from prose about declining one

The guard decided a line carried a waiver with a bare substring test, so a comment explaining that the author had *declined* the waiver was read as taking it, and the guard demanded a reason for a waiver that did not exist. **It punished the one thing you most want written down.**

Waiver detection now runs over `tokenize` COMMENT tokens and requires the marker to **open** the comment — a string literal or a mid-sentence mention neither grants nor trips. The waiver span was also extended upward through the contiguous own-line comment block: a reason that has to fit in ~30 trailing columns is a reason that gets written as a bare marker with nothing after it, which is the suppression its sibling test exists to catch. Measured against the old span rule, that newly waives **exactly one** site — the one added here deliberately.

## 2. It read string literals only

A pattern assembled by concatenation was invisible. One such pattern sat three lines from a pattern the guard did flag, was the same whole-value test over the same author-controlled bytes, and was missed. Splices are now flattened and their head and tail literals decide the anchor.

The docstring claimed those shapes were invisible and that "none exists in the tree today". **Seven spliced and 62 opaque sites existed** — the stale-absence claim, inside a test prose.

**Third state, which is the part that matters:** an unreadable pattern is `declined` with its shape named, and a pattern whose head anchors but whose tail cannot be read is a **failure**, not a skip. A scanner that reads 80% of the patterns and reports clean is this repo standing defect.

## 3. The guard prescribed fix was a no-op

The guard offered two exits and, behind a swallowing whitespace run, **both were cosmetic** — the run absorbs the trailing newline whichever anchor follows it, so the property the guard exists to protect is untouched and the finding is converted into a closed one. That is worse than no test.

Judgment call from the issue truncated tail, answered: **refuse it, and fix the message.** A guard that checks which anchor character was typed is measuring its own syntax; the property is "does this accept value plus newline". Refusing is detectable from the pattern text, costs one predicate, and produces **zero churn today** — 0 unwaived offenders.

It did find one live site — an environment-assignment parse whose trailing group genuinely no-op-anchors, but deliberately, because the caller quoted newline is part of the value. Waived with the reason stated: the third state working as designed.

## Independent review

A Sonnet agent against the committed diff, read-only brief. Seven findings, **all accepted, none refused**, and three were detector bugs reproduced before being fixed:

- A splice whose tail leaf is only the anchor produced a clean verdict over bytes it had not read — his framing, that this is worse than the old blindness, is adopted verbatim in the docstring. Added an explicit undecided state and a test.
- The trailing-run pattern required a quantifier, so a single unquantified swallowing atom read as clean.
- A character class opening with a literal bracket was misread.
- Two of my own new tests were **vacuous** — one placed its string on a line where a line-based reader could still tell it from a comment; the other never exercised the discriminating arm, which is the exact arm this issue was filed for.

Counts recomputed live by the reviewer and re-measured after the fixes: unchanged, plus zero undecided.

## Not covered

Full suite not run — the change is one guard test file plus two comment blocks, no shared helper, fixture or product path. **Windows unverified**; nothing touches paths, separators, subprocess or platform-varying exception types, reads are explicit UTF-8, and reported paths go through `as_posix()`.

## Left for later, deliberately

Fourteen patterns built through a local single-return helper are still declined rather than resolved; not needed today, since that helper provably cannot produce the class. An optional group wrapping a swallowing run is still read as non-swallowing — zero sites today.
