### PR TITLE
jit: block `git -C <path>`, which is cwd: plus an op

### DIFF
--- a/.claude/jit-context/tools/00-manual/00-index.tsv
+++ b/.claude/jit-context/tools/00-manual/00-index.tsv
@@ -5,3 +5,4 @@ Bash	~supertool[^|]*\|[^|]*(head|tail|sed|cut|awk)	supertool-no-cut.md	block
 Bash	~(^|[;&|\n] *)(rtk +)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged	merged-is-not-ancestry.md	block	--merged	
 Bash	~(^|[;&|\n] *)(rtk +)?gh[[:space:]]+pr[[:space:]]+(view|merge|create)	gh-pr-view-merge-have-ops.md	block	gh pr	
 Bash	~(^|[;&|\n] *)(rtk +)?(command +)?git[[:space:]]+([^;&|\n]*[[:space:]])?push	git-push-has-an-op.md	block	push	
+Bash	~(^|[;&|\n] *)(rtk +)?(command +)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/	git-C-has-cwd.md	block	git -c	

--- a/.claude/jit-context/tools/00-manual/git-C-has-cwd.md
+++ b/.claude/jit-context/tools/00-manual/git-C-has-cwd.md
@@ -1,0 +1,22 @@
+---
+title: "`git -C <path>` is `cwd:` plus an op"
+tool: Bash
+match: (^|[;&|\n] *)(rtk +)?(command +)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/
+mode: block
+---
+
+**Do not drive another worktree with `git -C`.** `cwd:PATH` is the first op of the call and applies to the whole call, so the path is typed once instead of once per command.
+
+| Instead of | Use |
+| --- | --- |
+| `git -C W status` | `supertool 'cwd:W' 'git-status'` (`:full` uncaps, `:brief` puts the tree first) |
+| `git -C W diff` | `supertool 'cwd:W' 'git-diff'` (`:branch[:BASE]`, `:full` for hunks) |
+| `git -C W log master..HEAD` | `supertool 'cwd:W' 'git-diverge:BRANCH[:BASE]'` |
+| `git -C W status --porcelain` to see if a tree is busy | `supertool 'git-worktrees'` — three states, and `cannot tell` is not `idle` |
+| several trees in a row | one `git-worktrees` call answers all of them |
+
+`cwd:` moves repo paths only: a relative `@payload` reference still resolves against the directory the call was made from, so pass payload paths absolutely.
+
+**Measured.** #850 was filed by Florian, not by me, after I typed `git -C ~/Documents/st-wt/810`, then `842`, then `804` across one afternoon and filed nothing — repetition never *feels* like a workaround, which is why it needs a rule rather than a habit. The ops also carry what the raw command does not: `git-status` names the kind of divergence, `git-worktrees` names each tree's tracker and merge state in four and three states.
+
+A config override (`git -c key=value`) is untouched — the subject is lowercased before matching, so the two spellings are indistinguishable by case, and what separates them is the argument: this fires only when it is a path rather than a `key=value`.


### PR DESCRIPTION
Florian, watching me run `git -C ~/Documents/st-wt/osstrain status` this morning: *"should be forbidden ?"*.

It should. #850 was filed **by him, not by me**, after an afternoon in which I typed `git -C ~/Documents/st-wt/810`, then `842`, then `804` and filed nothing. Typing the same path into three separate commands is the chronic trigger the maintainer skill names, and it never *feels* like a workaround — which is why it wants a rule rather than a habit.

The rule points at `cwd:PATH` plus the op, and at `git-worktrees` for the occupancy question, which is what `git -C W status --porcelain` is usually standing in for.

## The discriminator

It fires only when the argument after `-c` is a **path**. A config override (`git -c key=value`) has no `/` before its `=`, so it is untouched. That case is not hypothetical: #1295 pins `-c status.showUntrackedFiles=normal` at three gates, and a rule that blocked it would make the repo's own fix unrunnable. The subject is lowercased before matching, so `-C` and `-c` are indistinguishable by case and the argument shape is the only discriminator available.

## Verified against the hook, not reasoned

```
git -C ~/Documents/st-wt/1291 status            -> block
git -C ../foo log --oneline                     -> block
git -c status.showUntrackedFiles=normal status  -> {}
git -c core.hooksPath=/dev/null commit -m x     -> {}
git status                                      -> {}
```

Both halves matter: a `block` that never fires and one that fires on commands it was not written for are both live defects here, and the second teaches people to route around the block.
