### PR TITLE
What tool results actually cost, measured off the transcripts — and the two corpora disagree hard

### DIFF
--- a/changelog.d/1252.added.md
+++ b/changelog.d/1252.added.md
@@ -4,6 +4,8 @@
   distribution, repeat reads as both a count and a share of total bytes, and the
   byte cost of errors and empty results. Sessions that could not be parsed are
   named as skipped with a reason rather than dropped from the total, results
-  with no matching `tool_use` are counted under `?`, and a marker is only read
+  with no matching `tool_use` are counted under `?`, non-text result blocks are
+  disclosed as a count per kind rather than having their bytes folded in, and a
+  marker is only read
   as an op when the command line named that op — an echoed `--- branch ---`
   separator otherwise invents ops that never ran. (#1252)

--- a/changelog.d/1252.added.md
+++ b/changelog.d/1252.added.md
@@ -1,0 +1,9 @@
+- `claude-log-cost[:N|:UUID][:raw]` — what tool results actually cost, in bytes,
+  measured off the session transcripts already on disk. Per tool and per
+  supertool op (split on the render's own `--- op ---` markers), plus the size
+  distribution, repeat reads as both a count and a share of total bytes, and the
+  byte cost of errors and empty results. Sessions that could not be parsed are
+  named as skipped with a reason rather than dropped from the total, results
+  with no matching `tool_use` are counted under `?`, and a marker is only read
+  as an op when the command line named that op — an echoed `--- branch ---`
+  separator otherwise invents ops that never ran. (#1252)

--- a/docs/presets/claude-log.md
+++ b/docs/presets/claude-log.md
@@ -49,7 +49,9 @@ Five blocks, all raw numbers:
 - A `tool_result` whose `tool_use_id` matches no `tool_use` is counted under
   tool `?` and disclosed, not discarded.
 - Non-text result blocks (an image's base64 payload) are excluded from the byte
-  total and counted separately — those bytes are not comparable to text bytes.
+  total, because those bytes are not comparable to text bytes. What is reported
+  for them is a count per kind (`image x2`), not a size — their byte cost is not
+  measured at all, and the report says so rather than implying it is in there.
 - A section marker is only believed when the command line it came from named
   that op. Agents write `echo "--- branch ---"` as a shell separator, and
   measured over five live sessions that invented nine ops which do not exist

--- a/docs/presets/claude-log.md
+++ b/docs/presets/claude-log.md
@@ -13,6 +13,55 @@ No external CLIs or tokens. Pure stdlib Python. Reads `~/.claude/projects/<encod
 | `claude-log-list` | `claude-log-list[:N][:raw]` | N most recent sessions for the current project (default 10): UUID, mtime, line count, first user message excerpt |
 | `claude-log-tail` | `claude-log-tail:UUID[:N][:raw]` | Last N events in compact form (default 30): `[role] TOOL name(input)` / `[result] output` / `[result/ERR] msg` |
 | `claude-log-summary` | `claude-log-summary:UUID[:raw]` | Full session digest: model, duration, turn counts, tool calls + errors-by-tool, tokens (input/output/cache read/cache create) + cache hit % |
+| `claude-log-cost` | `claude-log-cost[:N or :UUID][:raw]` | Bytes of tool-result text, per tool and per supertool op, plus size distribution, repeat reads, errors and empties. Default: 10 most recent sessions of this project |
+
+## `claude-log-cost` — what a tool result costs (#1252)
+
+`claude-log-summary` counts tool calls. `claude-log-cost` weighs them, because
+the number that decides whether a result-trimming hook is worth building is
+bytes, not calls.
+
+```bash
+./supertool 'claude-log-cost:40'
+```
+
+Five blocks, all raw numbers:
+
+- **By tool** — calls, bytes, share of total, p50/p95/max. Nearest-rank
+  percentiles, not interpolated: every figure is the size of a result that
+  really happened.
+- **By supertool op** — the same columns, split on the `--- op ---` markers the
+  render already prints. Nested sections (`batch:@-` printing one `edit:` block
+  per sub-op) get their own row.
+- **Concentration** — bytes in the ten largest single results, as a share. A
+  heavy skew means a size cap captures most of the win and nothing clever is
+  needed.
+- **Repeat reads** — paths read more than once, and the subset whose re-read
+  returned byte-identical content. Stated as a count **and** a share of total
+  bytes, because those two disagree and only the second one justifies work.
+- **Failures and empties** — error results and zero-byte results with their
+  byte cost.
+
+### What it declines to claim
+
+- A session that cannot be parsed is listed by name under `Skipped:` with a
+  reason. It is never dropped from the totals silently.
+- A `tool_result` whose `tool_use_id` matches no `tool_use` is counted under
+  tool `?` and disclosed, not discarded.
+- Non-text result blocks (an image's base64 payload) are excluded from the byte
+  total and counted separately — those bytes are not comparable to text bytes.
+- A section marker is only believed when the command line it came from named
+  that op. Agents write `echo "--- branch ---"` as a shell separator, and
+  measured over five live sessions that invented nine ops which do not exist
+  and moved real bytes onto them.
+- Results from commands that never invoked supertool are reported as a count
+  and a byte total under "not attributable to an op", never spread across the
+  ops that did run.
+
+Reads are keyed by one path whichever route produced them: `Read` passes an
+absolute `file_path`, a `read:` op is usually relative, and the session cwd —
+recorded on every transcript event — joins them. Unjoined, one file lands under
+two keys and the headline repeat-read figure reads low.
 
 ## Redaction (#760)
 
@@ -65,4 +114,4 @@ No configuration needed. Windows-friendly cwd encoding (handles `\` and drive co
 
 ## Authoring notes
 
-Preset JSON: `presets/claude-log.json`. Helper scripts: `presets/claude-log/`. Always run `claude-log-list` first to get a UUID — the UUID is required by the other two ops.
+Preset JSON: `presets/claude-log.json`. Helper scripts: `presets/claude-log/`. `claude-log-tail` and `claude-log-summary` require a UUID, so run `claude-log-list` first to get one. `claude-log-cost` does not: with no argument it measures the ten most recent sessions of the current project, and a UUID narrows it to one.

--- a/presets/claude-log.json
+++ b/presets/claude-log.json
@@ -17,6 +17,14 @@
       "syntax": "claude-log-tail:UUID[:N][:raw]",
       "example": "claude-log-tail:84397aff-4925-45fd-afc5-3641e28c993c:50"
     },
+    "claude-log-cost": {
+      "safety": "read-only",
+      "cmd": "{python} {path}claude-log/cost.py {args}",
+      "timeout": 120,
+      "description": "What tool results cost, in bytes: per tool and per supertool op (split on the render's own '--- op ---' markers), size distribution, repeat reads with the share of bytes they re-paid, errors and empties. Sessions that could not be parsed are listed as skipped with a reason, never dropped from the total. Def: 10 most recent sessions of this project; pass a UUID for one",
+      "syntax": "claude-log-cost[:N|:UUID][:raw]",
+      "example": "claude-log-cost:20"
+    },
     "claude-log-summary": {
       "safety": "read-only",
       "cmd": "{python} {path}claude-log/summary.py {args}",

--- a/presets/claude-log/cost.py
+++ b/presets/claude-log/cost.py
@@ -29,7 +29,7 @@ READ_TOOLS = {"Read", "NotebookRead"}
 PATH_KEYS = ("file_path", "notebook_path")
 
 # supertool renders one section per op, headed by this exact line.
-_SECTION_RE = re.compile(r"^--- (.+) ---$")
+_SECTION_RE = re.compile(r"^--- (.+) ---\Z")
 _OP_RE = re.compile(r"^[a-z][a-z0-9_-]*(?::|$)")
 _SUPERTOOL_RE = re.compile(r"\bsupertool(?:\.py)?\b")
 _ARG_RE = re.compile(r"""\s+(?:'([^']*)'|"([^"]*)"|([^\s'"|;&<>()]+))""")
@@ -238,7 +238,7 @@ def normalise_target(cwd, target):
     return cwd.replace("\\", "/").rstrip("/") + "/" + t
 
 
-_READ_ARG_RE = re.compile(r"^(?:|full|-?\d+|\d+-\d+|\d+\+\d+)$")
+_READ_ARG_RE = re.compile(r"^(?:|full|-?\d+|\d+-\d+|\d+\+\d+)\Z")
 
 
 def read_target(rest):

--- a/presets/claude-log/cost.py
+++ b/presets/claude-log/cost.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""What tool results actually cost, measured off the transcripts on disk (#1252).
+
+Every claim this repo makes about batching is reasoning. This op is the
+measurement: bytes of `tool_result` content, grouped by tool and — for
+supertool calls, whose renders carry their own `--- op ---` section markers —
+by op.
+
+Three states, not two. A session that could not be parsed is `skipped` with a
+reason and named on screen; a result whose `tool_use_id` matches no `tool_use`
+is counted under `?` rather than dropped; a non-text result block (an image) is
+excluded from the byte total and disclosed. A cost report that quietly omits
+the expensive sessions is worse than no report.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Redactor, project_dir, session_path, wants_raw  # noqa: E402
+
+# Tools whose result is the content of a file, for the repeat-read question.
+READ_TOOLS = {"Read", "NotebookRead"}
+PATH_KEYS = ("file_path", "notebook_path")
+
+# supertool renders one section per op, headed by this exact line.
+_SECTION_RE = re.compile(r"^--- (.+) ---$")
+_OP_RE = re.compile(r"^[a-z][a-z0-9_-]*(?::|$)")
+_SUPERTOOL_RE = re.compile(r"\bsupertool(?:\.py)?\b")
+_ARG_RE = re.compile(r"""\s+(?:'([^']*)'|"([^"]*)"|([^\s'"|;&<>()]+))""")
+_SECTION_RE_INLINE = re.compile(r"---.*?---")
+
+
+def command_ops(cmd):
+    """The op tokens a Bash command actually passed to supertool.
+
+    The section markers alone are not evidence that an op ran: agents write
+    `echo "--- branch ---"` as a separator in plain shell, and measured over
+    five live sessions that invented nine ops that do not exist and moved real
+    bytes onto them. So a marker is only believed when the command line it came
+    from named that op. Scanning stops at the first shell separator or heredoc
+    after each `supertool` word, so a marker echoed later in the same command
+    is not corroboration.
+    """
+    ops = set()
+    if not isinstance(cmd, str):
+        return ops
+    for m in _SUPERTOOL_RE.finditer(cmd):
+        pos = m.end()
+        while True:
+            m2 = _ARG_RE.match(cmd, pos)
+            if not m2:
+                break
+            token = m2.group(1) or m2.group(2) or m2.group(3) or ""
+            pos = m2.end()
+            if token.startswith("-"):
+                continue  # a flag, not an op
+            ops.add(token.split(":", 1)[0].strip())
+    return ops
+
+
+def command_mentions(cmd, token):
+    """True when the command names `token` somewhere other than in an echoed
+    `--- ... ---` marker.
+
+    This is what admits a nested op — `batch:@-` renders one `--- edit:… ---`
+    section per sub-op, and those really are edits, so folding them into
+    `batch` would hide the op whose render is fat. The marker text itself is
+    removed first, so `echo "--- filing ---"` cannot corroborate itself.
+    """
+    if not isinstance(cmd, str):
+        return False
+    stripped = _SECTION_RE_INLINE.sub(" ", cmd)
+    return re.search(r"(?<![\w-])" + re.escape(token) + r"(?![\w-])", stripped) is not None
+
+
+def split_sections(text):
+    """Split a supertool render into (header, body, header_line) triples.
+
+    `header_line` is the raw marker line, kept so a caller folding a rejected
+    sub-section back into its parent can return those bytes to the op that
+    printed them instead of leaving them in overhead.
+
+    Only a full line of the form `--- <op> ---` whose payload starts with an
+    op-shaped token opens a section: file content is full of dashed lines, and
+    treating one as a section header would move real bytes onto an op that
+    never ran. Bytes before the first header belong to no op and are not
+    returned — the caller reports them as overhead rather than spreading them.
+    """
+    sections = []
+    current = None
+    current_line = ""
+    buf = []
+    for line in text.splitlines(keepends=True):
+        m = _SECTION_RE.match(line.strip())
+        if m and _OP_RE.match(m.group(1)):
+            if current is not None:
+                sections.append((current, "".join(buf), current_line))
+            current = m.group(1)
+            current_line = line
+            buf = []
+        elif current is not None:
+            buf.append(line)
+    if current is not None:
+        sections.append((current, "".join(buf), current_line))
+    return sections
+
+
+def _nbytes(s):
+    return len(s.encode("utf-8", errors="replace"))
+
+
+def _percentile(sorted_sizes, q):
+    """Nearest-rank percentile. No interpolation: these are real result sizes,
+    and an interpolated 45,312.5-byte result never happened."""
+    if not sorted_sizes:
+        return 0
+    idx = max(0, math.ceil(q * len(sorted_sizes)) - 1)
+    return sorted_sizes[min(idx, len(sorted_sizes) - 1)]
+
+
+class Stats:
+    """Running totals for one measurement run.
+
+    A plain class, not a dataclass: this module is loaded out of tree by the
+    test suite's preset loader, and `@dataclass` resolves `cls.__module__`
+    through `sys.modules`, which raises for a module loaded under a synthetic
+    name on 3.14.
+    """
+
+    def __init__(self):
+        self.sessions_measured = 0
+        self.sessions_no_results = 0
+        self.skipped = []            # (name, reason)
+        self.malformed_lines = 0
+
+        self.results = 0
+        self.total_bytes = 0
+        self.all_sizes = []
+
+        self.per_tool = {}           # tool name -> [sizes]
+        self.orphan_results = 0
+        self.orphan_bytes = 0
+
+        self.nontext_blocks = 0
+        self.nontext_kinds = {}
+
+        self.per_op = {}             # op name -> [sizes]
+        self.op_marked_calls = 0
+        self.unattributed_calls = 0
+        self.unattributed_bytes = 0
+        self.section_overhead_bytes = 0
+
+        self.repeat_read_paths = 0
+        self.repeat_read_results = 0
+        self.repeat_read_bytes = 0
+        self.unchanged_repeat_results = 0
+        self.unchanged_repeat_bytes = 0
+        self.top_repeat_paths = []
+
+        self.error_results = 0
+        self.error_bytes = 0
+        self.empty_results = 0
+
+    def add(self, tool, size):
+        self.per_tool.setdefault(tool, []).append(size)
+        self.all_sizes.append(size)
+        self.results += 1
+        self.total_bytes += size
+
+
+def _iter_events(path, st):
+    """Yield decoded events, counting undecodable lines instead of hiding them."""
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                st.malformed_lines += 1
+                continue
+            if isinstance(obj, dict):
+                yield obj
+            else:
+                st.malformed_lines += 1
+
+
+def _result_text(part, st):
+    """Bytes of a tool_result that actually reach the model as text.
+
+    A list-shaped content block can hold an image; its base64 payload is not
+    comparable to text bytes, so it is excluded and counted separately rather
+    than folded into a total that would then be quietly wrong.
+    """
+    content = part.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out = []
+        for b in content:
+            if not isinstance(b, dict):
+                continue
+            if b.get("type") == "text":
+                out.append(b.get("text") or "")
+            else:
+                kind = b.get("type") or "?"
+                st.nontext_blocks += 1
+                st.nontext_kinds[kind] = st.nontext_kinds.get(kind, 0) + 1
+        return "".join(out)
+    return ""
+
+
+_ABS_RE = re.compile(r"^(?:/|[A-Za-z]:[\\/]|~)")
+
+
+def normalise_target(cwd, target):
+    """Key a read by one path string, whichever route produced it.
+
+    `Read` passes an absolute `file_path`; a supertool `read:` op is usually
+    written relative to the session cwd, which the transcript records on every
+    event. Left unjoined the same file lands under two keys and the repeat-read
+    figure — the number this op exists to produce — reads low. String-level on
+    purpose: the separator that matters is the one in the transcript, not the
+    one on the machine running the report.
+    """
+    t = (target or "").replace("\\", "/")
+    if not t or _ABS_RE.match(t):
+        return t
+    if not cwd:
+        return t
+    return cwd.replace("\\", "/").rstrip("/") + "/" + t
+
+
+def _record_read(reads, read_bytes, target, text, size):
+    digest = hashlib.sha1(text.encode("utf-8", errors="replace")).hexdigest()
+    reads.setdefault(target, []).append((digest, size))
+    read_bytes[target] = read_bytes.get(target, 0) + size
+
+
+def measure_sessions(paths):
+    """Measure one or more session transcripts. Returns a populated Stats."""
+    st = Stats()
+    reads = {}       # target path -> [(digest, size), ...]
+    read_bytes = {}  # target path -> total bytes
+
+    for sp in paths:
+        try:
+            events = list(_iter_events(sp, st))
+        except OSError as exc:
+            st.skipped.append((sp.name, f"unreadable: {exc}"))
+            continue
+        if not events:
+            st.skipped.append((sp.name, "no parsable JSON events"))
+            continue
+
+        tool_names = {}
+        session_results = 0
+        cwd = ""
+        for ev in events:
+            if isinstance(ev.get("cwd"), str) and ev["cwd"]:
+                cwd = ev["cwd"]
+            msg = ev.get("message")
+            if not isinstance(msg, dict):
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") == "tool_use":
+                    tool_names[part.get("id")] = (part.get("name") or "?", part.get("input") or {})
+                    continue
+                if part.get("type") != "tool_result":
+                    continue
+
+                session_results += 1
+                known = tool_names.get(part.get("tool_use_id"))
+                text = _result_text(part, st)
+                size = _nbytes(text)
+                if known is None:
+                    tool, inp = "?", {}
+                    st.orphan_results += 1
+                    st.orphan_bytes += size
+                else:
+                    tool, inp = known
+                st.add(tool, size)
+                if part.get("is_error"):
+                    st.error_results += 1
+                    st.error_bytes += size
+                if size == 0:
+                    st.empty_results += 1
+
+                cmd = inp.get("command") if isinstance(inp, dict) else None
+                allowed = command_ops(cmd)
+                kept = []
+                for header, sec, header_line in split_sections(text):
+                    op = header.split(":", 1)[0]
+                    if op in allowed or (kept and command_mentions(cmd, op)):
+                        kept.append([op, header, sec])
+                    elif kept:
+                        # A sub-header inside the render of the op above it. Its
+                        # bytes belong to that op, not to an op of its own name.
+                        kept[-1][2] += header_line + sec
+                if kept:
+                    st.op_marked_calls += 1
+                    body = 0
+                    for op, header, sec in kept:
+                        n = _nbytes(sec)
+                        st.per_op.setdefault(op, []).append(n)
+                        body += n
+                        if op == "read" and ":" in header:
+                            target = header.split(":", 1)[1].split(":", 1)[0]
+                            if target:
+                                _record_read(
+                                    reads, read_bytes, normalise_target(cwd, target), sec, n
+                                )
+                    st.section_overhead_bytes += max(0, size - body)
+                else:
+                    st.unattributed_calls += 1
+                    st.unattributed_bytes += size
+
+                if tool in READ_TOOLS:
+                    for k in PATH_KEYS:
+                        if isinstance(inp.get(k), str) and inp[k]:
+                            _record_read(
+                                reads, read_bytes, normalise_target(cwd, inp[k]), text, size
+                            )
+                            break
+
+        st.sessions_measured += 1
+        if session_results == 0:
+            st.sessions_no_results += 1
+
+    for target, digests in reads.items():
+        if len(digests) < 2:
+            continue
+        st.repeat_read_paths += 1
+        st.repeat_read_results += len(digests)
+        st.repeat_read_bytes += read_bytes[target]
+        seen = set()
+        for digest, size in digests:
+            if digest in seen:
+                st.unchanged_repeat_results += 1
+                st.unchanged_repeat_bytes += size
+            seen.add(digest)
+    st.top_repeat_paths = sorted(
+        ((t, len(d), read_bytes[t]) for t, d in reads.items() if len(d) > 1),
+        key=lambda row: row[2],
+        reverse=True,
+    )[:5]
+    return st
+
+
+def _share(part, whole):
+    return (part / whole * 100) if whole else 0.0
+
+
+def _table(title, rows_src, total, red, first_col):
+    """rows_src: key -> [sizes]. Prints count, bytes, share, p50, p95, max."""
+    if not rows_src:
+        return
+    print(title)
+    print(f"{first_col:<22} {'CALLS':>7} {'BYTES':>12} {'SHARE':>7} {'P50':>8} {'P95':>8} {'MAX':>9}")
+    for name, sizes in sorted(rows_src.items(), key=lambda kv: sum(kv[1]), reverse=True):
+        s = sorted(sizes)
+        print(
+            f"{red(name)[:22]:<22} {len(s):>7} {sum(s):>12} "
+            f"{_share(sum(s), total):>6.1f}% {_percentile(s, 0.5):>8} "
+            f"{_percentile(s, 0.95):>8} {s[-1]:>9}"
+        )
+    print()
+
+
+def render(st, header_lines, red):
+    for line in header_lines:
+        print(line)
+    note = red.note()
+    if note:
+        print(note)
+
+    sess_word = "session" if st.sessions_measured == 1 else "sessions"
+    res_word = "tool result" if st.results == 1 else "tool results"
+    print(
+        f"Measured: {st.sessions_measured} {sess_word}, "
+        f"{st.results} {res_word}, {st.total_bytes} bytes"
+    )
+    if st.skipped:
+        print(f"Skipped:  {len(st.skipped)} sessions — named below, none folded into the total")
+        for name, reason in st.skipped:
+            print(f"  {red(name)} — {reason}")
+    else:
+        print("Skipped:  0 sessions")
+
+    notes = []
+    if st.malformed_lines:
+        notes.append(f"{st.malformed_lines} malformed JSONL lines skipped")
+    if st.orphan_results:
+        notes.append(
+            f"{st.orphan_results} results with no matching tool_use "
+            f"({st.orphan_bytes} bytes) — counted under tool '?', not dropped"
+        )
+    if st.nontext_blocks:
+        kinds = ", ".join(f"{k} x{v}" for k, v in sorted(st.nontext_kinds.items()))
+        notes.append(
+            f"{st.nontext_blocks} non-text result blocks ({kinds}) excluded — "
+            "base64 bytes are not comparable to text bytes"
+        )
+    if st.sessions_no_results:
+        notes.append(f"{st.sessions_no_results} measured sessions contained no tool results")
+    if notes:
+        print("Notes:")
+        for n in notes:
+            print(f"  {n}")
+    print()
+
+    if st.results == 0:
+        print("No tool results to measure.")
+        return
+
+    _table("By tool", st.per_tool, st.total_bytes, red, "TOOL")
+
+    if st.per_op:
+        _table(
+            "By supertool op (split on the '--- op ---' markers in the render)",
+            st.per_op,
+            st.total_bytes,
+            red,
+            "OP",
+        )
+        print(
+            f"  section headers and preamble: {st.section_overhead_bytes} bytes "
+            f"across {st.op_marked_calls} marked calls"
+        )
+    print(
+        f"Results with no op markers: {st.unattributed_calls} calls, "
+        f"{st.unattributed_bytes} bytes ({_share(st.unattributed_bytes, st.total_bytes):.1f}%) "
+        "— not attributable to an op"
+    )
+    print()
+
+    top = sorted(st.all_sizes, reverse=True)[:10]
+    print("Concentration")
+    print(
+        f"  Top 10 results: {sum(top)} bytes "
+        f"({_share(sum(top), st.total_bytes):.1f}% of total, from {st.results} results)"
+    )
+    print()
+
+    print("Repeat reads")
+    print(
+        f"  Paths read more than once: {st.repeat_read_paths} "
+        f"({st.repeat_read_results} reads, {st.repeat_read_bytes} bytes, "
+        f"{_share(st.repeat_read_bytes, st.total_bytes):.1f}% of total)"
+    )
+    print(
+        f"  Re-reads returning identical bytes: {st.unchanged_repeat_results} "
+        f"({st.unchanged_repeat_bytes} bytes, "
+        f"{_share(st.unchanged_repeat_bytes, st.total_bytes):.1f}% of total)"
+    )
+    for target, n, b in st.top_repeat_paths:
+        print(f"    {n:>3}x {b:>10}  {red(target)}")
+    print()
+
+    print("Failures and empties")
+    print(
+        f"  Errors: {st.error_results} results, {st.error_bytes} bytes "
+        f"({_share(st.error_bytes, st.total_bytes):.1f}%)"
+    )
+    print(f"  Empty:  {st.empty_results} results, 0 bytes")
+
+
+def main():
+    args = sys.argv[1:]
+    red = Redactor(enabled=not wants_raw(args))
+    limit = 10
+    uuid = ""
+    for a in args:
+        if str(a).strip().lower() == "raw":
+            continue
+        if str(a).isdigit():
+            limit = int(a)
+        elif a:
+            uuid = a
+
+    if uuid:
+        try:
+            sp = session_path(uuid)
+        except ValueError as exc:
+            print(f"ERROR: {exc}")
+            return 1
+        if not sp.exists():
+            print(f"ERROR: session not found: {sp}")
+            return 1
+        paths = [sp]
+        header = [f"Tool result cost — session {red(uuid)}", f"File: {sp}"]
+    else:
+        pdir = project_dir()
+        if not pdir.exists():
+            print(f"ERROR: no Claude project log dir at {pdir}")
+            return 1
+        found = sorted(pdir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+        if not found:
+            print(f"No sessions found in {pdir}")
+            return 0
+        paths = found[:limit]
+        header = [
+            "Tool result cost",
+            f"Project: {pdir}",
+            f"Selected: {len(paths)} most recent of {len(found)} sessions",
+        ]
+
+    st = measure_sessions(paths)
+    render(st, header, red)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/presets/claude-log/cost.py
+++ b/presets/claude-log/cost.py
@@ -238,6 +238,28 @@ def normalise_target(cwd, target):
     return cwd.replace("\\", "/").rstrip("/") + "/" + t
 
 
+_READ_ARG_RE = re.compile(r"^(?:|full|-?\d+|\d+-\d+|\d+\+\d+)$")
+
+
+def read_target(rest):
+    """The path a `read:` section header names, with the op's own numeric args
+    stripped.
+
+    Splitting once more on ':' to drop `:OFF:LIM` also eats a Windows drive
+    colon, keying every absolute path under `"C"` — unrelated files merged into
+    one fabricated repeat read, and the join with `Read`'s absolute file_path
+    broken, in the very figure this op exists to produce. So trailing tokens are
+    dropped only when they look like arguments, and a leading single letter
+    followed by a separator is put back.
+    """
+    parts = (rest or "").split(":")
+    if len(parts) > 1 and len(parts[0]) == 1 and parts[0].isalpha() and parts[1][:1] in ("/", "\\"):
+        parts = [parts[0] + ":" + parts[1]] + parts[2:]
+    while len(parts) > 1 and _READ_ARG_RE.match(parts[-1]):
+        parts.pop()
+    return ":".join(parts)
+
+
 def _record_read(reads, read_bytes, target, text, size):
     digest = hashlib.sha1(text.encode("utf-8", errors="replace")).hexdigest()
     reads.setdefault(target, []).append((digest, size))
@@ -317,7 +339,7 @@ def measure_sessions(paths):
                         st.per_op.setdefault(op, []).append(n)
                         body += n
                         if op == "read" and ":" in header:
-                            target = header.split(":", 1)[1].split(":", 1)[0]
+                            target = read_target(header.split(":", 1)[1])
                             if target:
                                 _record_read(
                                     reads, read_bytes, normalise_target(cwd, target), sec, n

--- a/tests/test_claude_log_cost_1252.py
+++ b/tests/test_claude_log_cost_1252.py
@@ -335,6 +335,24 @@ class TestRepeatReads:
         assert stats.repeat_read_paths == 1
         assert [t for t, _n, _b in stats.top_repeat_paths] == ["/x/proj/a.py"]
 
+    def test_windows_drive_letter_in_a_read_header_is_not_truncated(self, proj: FakeProject) -> None:
+        # `read:PATH:OFF:LIM` is stripped of its numeric args by splitting on
+        # ':' — which eats a Windows drive colon and keys every absolute path
+        # under "C", merging unrelated files into one fabricated repeat read.
+        body = "--- read:C:\\proj\\a.py ---\ncontent\n"
+        events = [
+            {**_tool_use("a", "Bash", {"command": "supertool 'read:C:\\proj\\a.py'"}),
+             "cwd": "C:\\proj"},
+            _tool_result("a", body),
+        ]
+        proj.add_session("s1", events)
+        stats = cost.measure_sessions([proj.proj_dir / "s1.jsonl"])
+        assert cost.read_target("C:\\proj\\a.py") == "C:\\proj\\a.py"
+        assert cost.read_target("tests/a.py:1:70") == "tests/a.py"
+        assert cost.read_target("tests/a.py:full") == "tests/a.py"
+        assert cost.read_target("tests/a.py:1-70") == "tests/a.py"
+        assert cost.read_target("tests/a.py") == "tests/a.py"
+
     def test_normalise_target_uses_the_transcripts_separators(self) -> None:
         assert cost.normalise_target("/x/proj", "a.py") == "/x/proj/a.py"
         assert cost.normalise_target("/x/proj", "/abs/a.py") == "/abs/a.py"

--- a/tests/test_claude_log_cost_1252.py
+++ b/tests/test_claude_log_cost_1252.py
@@ -1,0 +1,415 @@
+"""claude-log-cost (#1252): measure what tool results actually cost.
+
+The point of the op is a number that decides whether a result-trimming hook is
+worth building. So every test here is about a number being *right* or an
+absence being *disclosed* — never about the table being pretty.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PRESET_DIR = Path(__file__).resolve().parent.parent / "presets" / "claude-log"
+sys.path.insert(0, str(PRESET_DIR))
+
+from _preset_loader import load_preset_module  # noqa: E402
+
+_common = load_preset_module("claude-log", "_common", prefix="claude_log_")
+cost = load_preset_module("claude-log", "cost", prefix="claude_log_")
+
+
+# ---------- helpers ----------------------------------------------------------
+
+
+def _tool_use(uid: str, name: str, inp: dict) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": uid, "name": name, "input": inp}],
+        },
+    }
+
+
+def _tool_result(uid: str, content, is_error: bool = False) -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": uid, "content": content, "is_error": is_error}
+            ],
+        },
+    }
+
+
+def _write_jsonl(path: Path, events: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for ev in events:
+            f.write(json.dumps(ev) + "\n")
+
+
+class FakeProject:
+    def __init__(self, cwd: Path, home: Path, proj_dir: Path) -> None:
+        self.cwd = cwd
+        self.home = home
+        self.proj_dir = proj_dir
+
+    def add_session(self, uuid: str, events: list) -> Path:
+        path = self.proj_dir / f"{uuid}.jsonl"
+        _write_jsonl(path, events)
+        return path
+
+    def run(self, *args: str) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env["HOME"] = str(self.home)
+        env["USERPROFILE"] = str(self.home)
+        return subprocess.run(
+            [sys.executable, str(PRESET_DIR / "cost.py"), *args],
+            capture_output=True,
+            text=True,
+            cwd=self.cwd,
+            env=env,
+            timeout=30,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+
+@pytest.fixture()
+def proj(tmp_path: Path) -> FakeProject:
+    cwd = tmp_path / "work" / "proj"
+    cwd.mkdir(parents=True)
+    home = tmp_path / "fake-home"
+    proj_dir = home / ".claude" / "projects" / _common.encode_cwd(str(cwd))
+    proj_dir.mkdir(parents=True)
+    return FakeProject(cwd, home, proj_dir)
+
+
+# ---------- byte accounting per tool -----------------------------------------
+
+
+class TestPerTool:
+    def test_bytes_and_quantiles_per_tool(self, proj: FakeProject) -> None:
+        events = []
+        for i, n in enumerate((100, 200, 900)):
+            events.append(_tool_use(f"t{i}", "Bash", {"command": "x"}))
+            events.append(_tool_result(f"t{i}", "b" * n))
+        events.append(_tool_use("r0", "Read", {"file_path": "/a.py"}))
+        events.append(_tool_result("r0", "c" * 50))
+        proj.add_session("s1", events)
+
+        r = proj.run()
+        assert r.returncode == 0, r.stderr + r.stdout
+        # 1250 bytes total; Bash is 1200 of them
+        assert "1250" in r.stdout
+        assert "Bash" in r.stdout and "1200" in r.stdout
+        # max and p50 for Bash are real order statistics, not the mean
+        bash_line = [ln for ln in r.stdout.splitlines() if ln.strip().startswith("Bash")][0]
+        assert "900" in bash_line
+        assert "200" in bash_line
+
+    def test_multibyte_counted_in_bytes_not_chars(self, proj: FakeProject) -> None:
+        proj.add_session(
+            "s1",
+            [_tool_use("a", "Bash", {"command": "x"}), _tool_result("a", "é" * 10)],
+        )
+        r = proj.run()
+        assert "20" in r.stdout, r.stdout
+
+
+# ---------- what it could not measure is disclosed, never dropped ------------
+
+
+class TestDisclosure:
+    def test_result_without_matching_tool_use_is_named(self, proj: FakeProject) -> None:
+        proj.add_session("s1", [_tool_result("orphan", "z" * 40)])
+        r = proj.run()
+        assert r.returncode == 0, r.stderr + r.stdout
+        assert "no matching tool_use" in r.stdout
+        # still in the total: an unattributable result is not a free one
+        assert "40" in r.stdout
+
+    def test_unparsable_session_is_skipped_with_a_reason(self, proj: FakeProject) -> None:
+        proj.add_session("good", [_tool_use("a", "Bash", {}), _tool_result("a", "y" * 30)])
+        (proj.proj_dir / "bad.jsonl").write_bytes(b"\xff\xfe not json at all\n")
+        r = proj.run()
+        assert r.returncode == 0, r.stderr + r.stdout
+        assert "skipped" in r.stdout.lower()
+        assert "bad" in r.stdout
+
+    def test_malformed_lines_are_counted(self, proj: FakeProject) -> None:
+        p = proj.add_session("s1", [_tool_use("a", "Bash", {}), _tool_result("a", "y" * 30)])
+        with p.open("a", encoding="utf-8") as f:
+            f.write("{not json\n")
+            f.write("{also not json\n")
+        r = proj.run()
+        assert "2 malformed" in r.stdout, r.stdout
+
+    def test_non_text_result_blocks_are_excluded_and_named(self, proj: FakeProject) -> None:
+        proj.add_session(
+            "s1",
+            [
+                _tool_use("a", "Bash", {}),
+                _tool_result("a", "q" * 10),
+                _tool_use("b", "Bash", {}),
+                _tool_result(
+                    "b",
+                    [
+                        {"type": "text", "text": "w" * 5},
+                        {"type": "image", "source": {"data": "AAAA" * 500}},
+                    ],
+                ),
+            ],
+        )
+        r = proj.run()
+        assert "non-text" in r.stdout.lower()
+        # the image payload is not silently folded into the byte total
+        assert "2000" not in r.stdout
+        assert "15" in r.stdout
+
+    def test_no_sessions_says_so_rather_than_printing_zeroes(self, proj: FakeProject) -> None:
+        r = proj.run()
+        assert "No sessions" in r.stdout or "no sessions" in r.stdout
+
+
+# ---------- per-op attribution ----------------------------------------------
+
+
+class TestPerOp:
+    def test_sections_split_a_batched_supertool_result(self, proj: FakeProject) -> None:
+        body = (
+            "--- read:a.py ---\n"
+            + "x" * 100
+            + "\n--- grep:foo:b ---\n"
+            + "y" * 20
+            + "\n"
+        )
+        proj.add_session(
+            "s1", [_tool_use("a", "Bash", {"command": "supertool 'read:a.py' 'grep:foo:b'"}),
+                   _tool_result("a", body)]
+        )
+        r = proj.run()
+        assert r.returncode == 0, r.stderr + r.stdout
+        lines = r.stdout.splitlines()
+        read_line = [ln for ln in lines if ln.strip().startswith("read")]
+        grep_line = [ln for ln in lines if ln.strip().startswith("grep")]
+        assert read_line and grep_line, r.stdout
+        assert "101" in read_line[0]  # 100 body bytes + the trailing newline
+        assert "21" in grep_line[0]
+
+    def test_results_without_markers_are_reported_as_unattributable(self, proj: FakeProject) -> None:
+        proj.add_session(
+            "s1", [_tool_use("a", "Bash", {"command": "ls"}), _tool_result("a", "n" * 77)]
+        )
+        r = proj.run()
+        assert "not attributable" in r.stdout.lower()
+        assert "77" in r.stdout
+
+    def test_echoed_separator_in_plain_shell_is_not_an_op(self, proj: FakeProject) -> None:
+        # Measured on five live sessions: agents write `echo "--- branch ---"`
+        # as a separator, which invented nine ops that do not exist and moved
+        # real bytes onto them.
+        proj.add_session(
+            "s1",
+            [
+                _tool_use("a", "Bash", {"command": 'git log -3 && echo "--- branch ---" && git branch'}),
+                _tool_result("a", "commits\n--- branch ---\nmaster\n"),
+            ],
+        )
+        stats = cost.measure_sessions([proj.proj_dir / "s1.jsonl"])
+        assert "branch" not in stats.per_op
+        assert stats.per_op == {}
+        assert stats.unattributed_calls == 1
+
+    def test_subsection_bytes_go_to_the_op_that_rendered_them(self, proj: FakeProject) -> None:
+        body = "--- git-status ---\n" + "a" * 10 + "\n--- files ---\n" + "b" * 10 + "\n"
+        proj.add_session(
+            "s1",
+            [
+                _tool_use("a", "Bash", {"command": "supertool 'git-status'"}),
+                _tool_result("a", body),
+            ],
+        )
+        stats = cost.measure_sessions([proj.proj_dir / "s1.jsonl"])
+        assert list(stats.per_op) == ["git-status"]
+        # 11 bytes of the op's own body, plus the sub-section header and its 11
+        assert sum(stats.per_op["git-status"]) == 22 + len("--- files ---\n")
+
+    def test_nested_op_named_in_the_payload_keeps_its_own_row(self, proj: FakeProject) -> None:
+        # batch:@- renders one section per sub-op. Those really are edits, and
+        # folding them into `batch` would hide the op whose render is fat.
+        body = "--- batch:@- ---\nrun\n--- edit:@payload -> a.py ---\n" + "e" * 40 + "\n"
+        proj.add_session(
+            "s1",
+            [
+                _tool_use("a", "Bash", {"command": "supertool 'batch:@-' <<EOF\nop = \"edit\"\nEOF"}),
+                _tool_result("a", body),
+            ],
+        )
+        stats = cost.measure_sessions([proj.proj_dir / "s1.jsonl"])
+        assert sorted(stats.per_op) == ["batch", "edit"]
+        assert sum(stats.per_op["edit"]) == 41
+
+    def test_command_mentions_ignores_the_echoed_marker_itself(self) -> None:
+        assert cost.command_mentions('supertool "paste:@-"; echo "--- filing ---"', "filing") is False
+        assert cost.command_mentions("supertool 'batch:@-' <<EOF\nop = \"edit\"\nEOF", "edit") is True
+
+    def test_command_ops_reads_the_args_supertool_was_given(self) -> None:
+        assert cost.command_ops("supertool 'read:a.py' 'grep:x:y'") == {"read", "grep"}
+        assert cost.command_ops("python3 supertool.py 'gh-pr:12:status'") == {"gh-pr"}
+        assert cost.command_ops('git log && echo "--- branch ---"') == set()
+        # An echoed marker after the op list is not corroboration for itself.
+        assert "filing" not in cost.command_ops(
+            'supertool "paste:@-" <<EOF\nx\nEOF\necho "--- filing ---"'
+        )
+
+    def test_section_splitter_ignores_a_marker_shaped_line_mid_body(self) -> None:
+        # A dashed line inside file content must not open a new op section.
+        text = "--- read:a.py ---\nbefore\n--- not an op line\nafter\n"
+        sections = cost.split_sections(text)
+        assert [s[0] for s in sections] == ["read:a.py"]
+
+
+# ---------- repeat reads ------------------------------------------------------
+
+
+class TestRepeatReads:
+    def test_identical_re_read_counted_as_count_and_byte_share(self, proj: FakeProject) -> None:
+        same = "s" * 100
+        proj.add_session(
+            "s1",
+            [
+                _tool_use("a", "Read", {"file_path": "/x/a.py"}),
+                _tool_result("a", same),
+                _tool_use("b", "Read", {"file_path": "/x/a.py"}),
+                _tool_result("b", same),
+                _tool_use("c", "Read", {"file_path": "/x/b.py"}),
+                _tool_result("c", "o" * 100),
+            ],
+        )
+        r = proj.run()
+        assert r.returncode == 0, r.stderr + r.stdout
+        assert "Repeat reads" in r.stdout
+        block = r.stdout.split("Repeat reads", 1)[1]
+        assert "100" in block          # the re-paid bytes
+        assert "%" in block            # stated as a share too
+
+    def test_changed_file_re_read_is_not_counted_as_unchanged(self, proj: FakeProject) -> None:
+        proj.add_session(
+            "s1",
+            [
+                _tool_use("a", "Read", {"file_path": "/x/a.py"}),
+                _tool_result("a", "1" * 100),
+                _tool_use("b", "Read", {"file_path": "/x/a.py"}),
+                _tool_result("b", "2" * 100),
+            ],
+        )
+        r = proj.run()
+        block = r.stdout.split("Repeat reads", 1)[1]
+        stats = cost.measure_sessions([proj.proj_dir / "s1.jsonl"])
+        assert stats.repeat_read_paths == 1
+        assert stats.unchanged_repeat_results == 0
+        assert stats.unchanged_repeat_bytes == 0
+        assert "0" in block
+
+    def test_relative_and_absolute_routes_to_one_file_are_one_path(self, proj: FakeProject) -> None:
+        # Read passes an absolute file_path; `read:` is written relative to the
+        # session cwd, which every event carries. Unjoined, one file lands under
+        # two keys and the headline repeat-read figure reads low.
+        body = "--- read:a.py ---\ncontent\n"
+        events = [
+            {**_tool_use("a", "Bash", {"command": "supertool 'read:a.py'"}), "cwd": "/x/proj"},
+            _tool_result("a", body),
+            {**_tool_use("b", "Read", {"file_path": "/x/proj/a.py"}), "cwd": "/x/proj"},
+            _tool_result("b", "content\n"),
+        ]
+        proj.add_session("s1", events)
+        stats = cost.measure_sessions([proj.proj_dir / "s1.jsonl"])
+        assert stats.repeat_read_paths == 1
+        assert [t for t, _n, _b in stats.top_repeat_paths] == ["/x/proj/a.py"]
+
+    def test_normalise_target_uses_the_transcripts_separators(self) -> None:
+        assert cost.normalise_target("/x/proj", "a.py") == "/x/proj/a.py"
+        assert cost.normalise_target("/x/proj", "/abs/a.py") == "/abs/a.py"
+        assert cost.normalise_target("C:\\proj", "sub\\a.py") == "C:/proj/sub/a.py"
+        assert cost.normalise_target("C:\\proj", "C:\\other\\a.py") == "C:/other/a.py"
+        assert cost.normalise_target("", "a.py") == "a.py"
+
+    def test_supertool_read_sections_count_as_reads(self, proj: FakeProject) -> None:
+        body = "--- read:a.py ---\n" + "z" * 50 + "\n"
+        proj.add_session(
+            "s1",
+            [
+                _tool_use("a", "Bash", {"command": "supertool 'read:a.py'"}),
+                _tool_result("a", body),
+                _tool_use("b", "Bash", {"command": "supertool 'read:a.py'"}),
+                _tool_result("b", body),
+            ],
+        )
+        stats = cost.measure_sessions([proj.proj_dir / "s1.jsonl"])
+        assert stats.repeat_read_paths == 1
+        assert stats.unchanged_repeat_results == 1
+
+
+# ---------- concentration, errors, empties -----------------------------------
+
+
+class TestSkewAndFailures:
+    def test_top_results_share_is_reported(self, proj: FakeProject) -> None:
+        events = []
+        for i in range(20):
+            events.append(_tool_use(f"t{i}", "Bash", {}))
+            events.append(_tool_result(f"t{i}", "x" * (1000 if i == 0 else 1)))
+        proj.add_session("s1", events)
+        r = proj.run()
+        assert "Top 10" in r.stdout
+        block = r.stdout.split("Top 10", 1)[1]
+        assert "1009" in block  # the 1000-byte result plus nine 1-byte ones
+        assert "99.0%" in block  # 1009 of 1019 total bytes
+
+    def test_errors_and_empties_are_counted_with_their_bytes(self, proj: FakeProject) -> None:
+        proj.add_session(
+            "s1",
+            [
+                _tool_use("a", "Bash", {}),
+                _tool_result("a", "boom" * 5, is_error=True),
+                _tool_use("b", "Bash", {}),
+                _tool_result("b", ""),
+                _tool_use("c", "Bash", {}),
+                _tool_result("c", "fine"),
+            ],
+        )
+        stats = cost.measure_sessions([proj.proj_dir / "s1.jsonl"])
+        assert stats.error_results == 1
+        assert stats.error_bytes == 20
+        assert stats.empty_results == 1
+        r = proj.run()
+        assert "Errors" in r.stdout and "Empty" in r.stdout
+
+
+# ---------- selection ---------------------------------------------------------
+
+
+class TestSelection:
+    def test_single_uuid_argument_measures_only_that_session(self, proj: FakeProject) -> None:
+        proj.add_session("aaaa", [_tool_use("a", "Bash", {}), _tool_result("a", "1" * 10)])
+        proj.add_session("bbbb", [_tool_use("b", "Bash", {}), _tool_result("b", "2" * 500)])
+        r = proj.run("aaaa")
+        assert "aaaa" in r.stdout
+        assert "500" not in r.stdout
+
+    def test_numeric_argument_limits_session_count(self, proj: FakeProject) -> None:
+        a = proj.add_session("aaaa", [_tool_use("a", "Bash", {}), _tool_result("a", "1" * 10)])
+        b = proj.add_session("bbbb", [_tool_use("b", "Bash", {}), _tool_result("b", "2" * 500)])
+        os.utime(a, (1_700_000_000, 1_700_000_000))
+        os.utime(b, (1_700_000_100, 1_700_000_100))
+        r = proj.run("1")
+        assert "1 session" in r.stdout
+        assert "500" in r.stdout


### PR DESCRIPTION
Every claim this repo makes about batching has been reasoning. "37 Reads re-pay the cached prefix 37 times, six batched calls pay it six" is an argument, not a measurement. `claude-log:cost` walks the transcripts already on disk and sums the UTF-8 bytes of tool-result text that actually reached the model, attributed per tool and per op.

## The numbers, and they are the point

| | supertool corpus | dvsi corpus |
| --- | --- | --- |
| sessions / results / bytes | 5 / 882 / 1,104,627 | 40 / 939 / 2,903,119 |
| shape | Bash 93.8% | Bash 51.3%, `Read` 42.1% |
| top ops | `grep` 7.3%, `read` 7.2%, `gh-pr-merge` 7.2%, `edit` 6.8% | — |
| top-10 results | 11.1% of bytes | 18.3% |
| **repeat reads** | **2.3%** of bytes | **37.8%** |
| **unchanged re-reads** | **0.0%** | **8.7%** — 252,851 B, one `portfolio.json` read 16× |
| errors | 11.6% | 7.8% |

A supertool-driven repo re-reads almost nothing. A `Read`-driven one re-pays **8.7% of all result bytes on byte-identical content**. That is the number the tool's own premise rests on, and it is now measurable rather than argued. Whole 40-session corpus in 1.07s.

## What it declines to answer

Unreadable sessions and sessions with zero parsable events are **listed by name with a reason**, never dropped from the denominator. Results whose `tool_use` id joins to nothing land under `?` rather than being attributed to a plausible neighbour. Non-text blocks are counted per kind with their bytes excluded, because an image's byte count is not a token cost this method can speak to.

## The judgment call, found on live data rather than by a test

Attributing bytes by `--- op ---` markers alone was **wrong**: agents write `echo "--- branch ---"` in plain shell, which invented nine ops that do not exist (`branch`, `status`, `files`, `index`, `filing`, `remote`, `milestones`, …) and moved real bytes onto them. A marker is now believed only when the command line named that op; nested sections from `batch:@-` are kept only when the command text mentions them outside a marker.

That was caught by checking the op's own output against the transcripts it had just read — not by a test, and no test would have caught it, because the fabricated ops looked exactly like real ones in the render.

## Review

Independent Sonnet pass on the committed diff — three findings, all real, all accepted:

- `read:C:\\proj\\a.py` was truncated to `"C"`, merging unrelated Windows files into one **fabricated repeat read** — the metric's headline number, wrong on the platform nobody here runs. Fixed with `read_target()`, which strips a trailing `:OFF:LIM` by dropping only argument-shaped tokens so a drive colon survives. Test written first.
- No coverage of the header-parsing branch for Windows paths at all.
- A doc line implying a byte figure for image blocks where only a count exists.

Both reds this PR reports are honest "does not exist" reds rather than "wrong answer" reds, and the report says so — the pin is the assertion set.

## Out of scope, filed separately

`_common.project_dir()`'s longest-common-prefix fallback answers with a **different project's** sessions and says nothing about having done so. Measured from `/Users/floriandavid/Documents/st-wt/1252` it returns `…-st-wt-1024`. That affects every op in the family, not just this one.

Closes #1252
