### PR TITLE
Two of the issue's three layers are false; the real defect is radar reporting delivery it cannot establish

### DIFF
--- a/changelog.d/1309.fixed.md
+++ b/changelog.d/1309.fixed.md
@@ -1,0 +1,19 @@
+- `radar`'s delivery banner no longer lets `accepted` be read as *accepted by
+  the socket this session reads*. Each watcher has published the path it is
+  bound to as `sock_path` since #581 and nothing consumed it, so a second
+  session — one that exported `SUPERTOOL_WATCH_SOCK` but left
+  `SUPERTOOL_WATCH_STATE_DIR` on the default — got `all N watcher state
+  file(s) had their last emit accepted by a listener` while receiving nothing:
+  its `radar` had spawned no pollers, because the first session's already held
+  every `O_CREAT|O_EXCL` slot in the shared `/tmp` and were writing to the
+  first session's socket. The banner now names the count and the other path,
+  and says separately when a watcher emitted and recorded no path at all —
+  which is not agreement. A fleet that all writes here prints neither line, and
+  nothing is stopped, reaped or re-armed on the strength of it.
+  `transport.emit_destinations()` is the read-only survey behind it. ([#1309])
+- Documented the two-session arrangement that already works, in
+  `docs/presets/watch.md` and `presets/watch/README.md`: **both**
+  `SUPERTOOL_WATCH_SOCK` and `SUPERTOOL_WATCH_STATE_DIR`, or neither. Both
+  files previously described the socket override alone as how a second session
+  gets a radar of its own, which is the exact configuration that silently gets
+  no pollers. ([#1309])

--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -1103,6 +1103,73 @@ straggler on the old path after an operator changes the variable is
 something a reader can find rather than something inferred from partial
 delivery.
 
+### Two sessions on one machine: both variables, or neither
+
+([#1309](https://github.com/Digital-Process-Tools/claude-supertool/issues/1309).)
+
+A second session gets a radar of its own, today, with no fan-out anywhere in
+the transport. It takes **two** environment variables, and the failure mode of
+setting only the first is the reason this section exists:
+
+```bash
+export SUPERTOOL_WATCH_SOCK=~/.claude/watch-b.sock
+export SUPERTOOL_WATCH_STATE_DIR=~/.claude/watch-b
+```
+
+`SUPERTOOL_WATCH_SOCK` alone is not enough. The poller slot is a pid file at
+`{SUPERTOOL_WATCH_STATE_DIR}/supertool-watch-{source}__{id}.pid`, claimed
+`O_CREAT|O_EXCL`, and exactly one poller may hold it (#476). Two sessions left
+on the default `/tmp` therefore share **one** set of slots — so the second
+session's `radar` claims nothing and spawns nothing, because the first
+session's pollers already hold every slot, and those pollers captured the
+*other* socket at spawn and keep it for life. Every poller is alive, every
+emit is accepted, and none of it arrives.
+
+Setting the state directory too gives the second session its own slot
+namespace, its own pollers and its own socket. The cost is honest and worth
+stating: each session polls the forge independently, so two sessions are two
+sets of API calls and two sets of rate limit, and neither de-duplicates the
+other's events. That is the trade a per-developer tool makes instead of
+running a broker.
+
+`SUPERTOOL_WATCH_STATE_DIR` travels to the poller through
+`transport.poller_env()` — a fork inherits the environment and an exec does
+not, so it is set explicitly — and `SUPERTOOL_WATCH_SOCK` rides along in the
+same copied environment.
+
+**`radar` says when a fleet is delivering somewhere else.** The delivery
+banner reads each watcher's own `sock_path` and compares it with the socket
+this process is configured for, in the same three states as everything else
+here:
+
+```
+radar: DELIVERY — 6 of 6 watcher state file(s) that emitted last wrote to a
+       socket this session does not read: /tmp/supertool-watch.sock. This
+       session reads /Users/me/.claude/watch-b.sock, so those events reached a
+       consumer that is not this one.
+```
+
+and, when a watcher emitted but published no path at all — an older build, or
+a state file that could not be read — it says *that* rather than assuming
+agreement:
+
+```
+radar: delivery — 1 of 4 watcher state file(s) that emitted do not record
+       which socket they wrote to, so nothing here says whether they reach
+       /tmp/supertool-watch.sock.
+```
+
+A fleet that all writes here prints neither line. Watchers that have never
+emitted are excluded from both counts — they have no destination to disagree
+about, and the header above already reports them. Report-only, like the rest
+of this banner: nothing is stopped, reaped or re-armed on the strength of it.
+
+The two layers underneath this are not gaps and do not need fixing. The wire
+is point-to-point with no broker, deliberately; and `claude-channel` does not
+contend for a socket somebody else owns — it exits `3` naming the path and the
+override rather than unlinking it (#550, pinned end to end by
+`tests/test_notifiers_claude_channel_550.py`).
+
 ### The status file is somebody else's text too, and `watches` renders it
 
 ([#1197](https://github.com/Digital-Process-Tools/claude-supertool/issues/1197),

--- a/docs/presets/watch.md
+++ b/docs/presets/watch.md
@@ -1093,7 +1093,10 @@ side left on the default keeps talking to `/tmp/supertool-watch.sock` while
 the other listens or writes somewhere else entirely. This is the escape
 route `claude-channel` names when it refuses to steal a live socket (#550),
 and the same variable a multi-user machine sets to move the socket under
-`~/.claude/` for per-user isolation.
+`~/.claude/` — for the *socket*. It isolates the consumer and the wire, and
+not the pollers: those are claimed under `SUPERTOOL_WATCH_STATE_DIR`, and
+moving one without the other is the configuration in "Two sessions on one
+machine" below, which gets no pollers at all.
 
 **A poller spawned before the variable changed keeps writing to the path it
 started with**, because `SOCK_PATH` is fixed for the lifetime of the

--- a/presets/watch/README.md
+++ b/presets/watch/README.md
@@ -109,6 +109,16 @@ This is how a second Claude Code session gets a channel of its own after
 multi-user machine gives each session's channel a private path instead of the
 world-traversable default.
 
+**A second session needs `SUPERTOOL_WATCH_STATE_DIR` as well, and setting only
+the socket is worse than setting neither (#1309).** The poller slot is a pid
+file under the state directory, held `O_CREAT|O_EXCL` by exactly one process
+(#476), so two sessions sharing the default `/tmp` share one set of slots: the
+second session spawns no pollers at all, because the first session's already
+hold every slot — and those are bound to the *other* socket for life. The board
+renders healthy from both sides. `radar`'s delivery banner now compares each
+watcher's recorded `sock_path` against the socket this process reads and says
+so; see `docs/presets/watch.md`, "Two sessions on one machine".
+
 A watcher spawned before the variable was changed keeps writing to whatever
 `SOCK_PATH` it started with — that value is fixed for the process's
 lifetime, and cannot migrate mid-run. It is recorded as `sock_path` in the

--- a/presets/watch/README.md
+++ b/presets/watch/README.md
@@ -106,8 +106,9 @@ the *same* path on the Phase 2 consumer for anything to arrive there (see
 [notifiers/claude-channel/README.md](../../notifiers/claude-channel/README.md#start-up-and-socket-ownership)).
 This is how a second Claude Code session gets a channel of its own after
 `claude-channel` refuses to steal a live socket (#550), and it is how a
-multi-user machine gives each session's channel a private path instead of the
-world-traversable default.
+multi-user machine gives each session's *channel* a private path instead of the
+world-traversable default. It does nothing about the pollers, which is the
+next paragraph.
 
 **A second session needs `SUPERTOOL_WATCH_STATE_DIR` as well, and setting only
 the socket is worse than setting neither (#1309).** The poller slot is a pid

--- a/presets/watch/radar.py
+++ b/presets/watch/radar.py
@@ -456,6 +456,13 @@ def _destination_lines(rows: list[tuple[str, str, str]]) -> list[str]:
     Scoped to watchers that have actually emitted: one with nothing to report
     has no destination to disagree about, and `DELIVERY_NO_EMIT` is already
     reported one line up. Report-only, like everything else on this route.
+
+    The two surveys are separate scans of the state directory, so a file that
+    disappears between them lands in the unrecorded bucket rather than being
+    dropped. That is the right side to fall on — the line it produces says
+    only that nothing here establishes where that watcher writes, which is
+    exactly true of a slot whose file has gone — but it is why this must not
+    be read as "these watchers are running an old build".
     """
     emitted = [(source, wid) for source, wid, state in rows
                if state != transport.DELIVERY_NO_EMIT]
@@ -476,8 +483,11 @@ def _destination_lines(rows: list[tuple[str, str, str]]) -> list[str]:
             f"does not read: {', '.join(others)}. This session reads {here}, "
             f"so those events reached a consumer that is not this one.")
     if unrecorded:
+        # Upper-case, like the `unsure` arm above and for its reason: the
+        # convention on this banner is that news is shouted, and an emit whose
+        # destination cannot be established is unresolved rather than fine.
         out.append(
-            f"radar: delivery — {len(unrecorded)} of {len(emitted)} watcher "
+            f"radar: DELIVERY — {len(unrecorded)} of {len(emitted)} watcher "
             f"state file(s) that emitted do not record which socket they "
             f"wrote to, so nothing here says whether they reach {here}.")
     return out

--- a/presets/watch/radar.py
+++ b/presets/watch/radar.py
@@ -430,7 +430,57 @@ def delivery_banner() -> list[str]:
         head = (f"radar: delivery — no watcher has recorded an emit yet across "
                 f"{total} state file(s), so nothing here says whether the socket "
                 f"delivers.")
-    return [head, "       " + _DELIVERY_FOOTNOTE]
+    return [head, "       " + _DELIVERY_FOOTNOTE, *_destination_lines(rows)]
+
+
+def _destination_lines(rows: list[tuple[str, str, str]]) -> list[str]:
+    """Whether `accepted` means accepted by the socket *this* session reads.
+
+    The gap #1309 named. A poller captures `SOCK_PATH` at spawn and keeps it
+    for life, so a second session that exports `SUPERTOOL_WATCH_SOCK` and
+    leaves `SUPERTOOL_WATCH_STATE_DIR` alone shares the first session's poller
+    slots: every slot is held, every emit is accepted, and the header above
+    said so — about a socket this session has never read a byte from. The
+    datum that settles it has been in the state file since #581 and had no
+    reader until here.
+
+    Three states, and the third is what keeps the other two honest:
+
+      * a recorded path that is not this process's — those events reached a
+        consumer, and it is not the one this session is talking to;
+      * a watcher that emitted and recorded no path at all — an older build,
+        or a state file that could not be read. Not agreement. Said so;
+      * everything recorded here — no line, because agreement is not news and
+        a header printed every time is a header nobody reads.
+
+    Scoped to watchers that have actually emitted: one with nothing to report
+    has no destination to disagree about, and `DELIVERY_NO_EMIT` is already
+    reported one line up. Report-only, like everything else on this route.
+    """
+    emitted = [(source, wid) for source, wid, state in rows
+               if state != transport.DELIVERY_NO_EMIT]
+    if not emitted:
+        return []
+    recorded = {(source, wid): path
+                for source, wid, path in transport.emit_destinations()}
+    here = transport.SOCK_PATH
+    elsewhere = [slot for slot in emitted
+                 if recorded.get(slot, "") not in ("", here)]
+    unrecorded = [slot for slot in emitted if not recorded.get(slot, "")]
+    out: list[str] = []
+    if elsewhere:
+        others = sorted({recorded[slot] for slot in elsewhere})
+        out.append(
+            f"radar: DELIVERY — {len(elsewhere)} of {len(emitted)} watcher "
+            f"state file(s) that emitted last wrote to a socket this session "
+            f"does not read: {', '.join(others)}. This session reads {here}, "
+            f"so those events reached a consumer that is not this one.")
+    if unrecorded:
+        out.append(
+            f"radar: delivery — {len(unrecorded)} of {len(emitted)} watcher "
+            f"state file(s) that emitted do not record which socket they "
+            f"wrote to, so nothing here says whether they reach {here}.")
+    return out
 
 
 def state_main(arg: str = "") -> int:

--- a/presets/watch/transport.py
+++ b/presets/watch/transport.py
@@ -1185,6 +1185,32 @@ def delivery_of(last_emit: Any, refusal: str = "") -> str:
     return EMIT_UNKNOWN
 
 
+def _state_file_slots() -> list[tuple[str, str]]:
+    """`(source, id)` for every watcher state file in `STATE_DIR`. Reads only.
+
+    A directory that cannot be listed yields nothing. That is a genuine gap —
+    "no state files" and "could not look" are one answer here — and it is the
+    caller's headers that keep it honest: every one of them is phrased over
+    the files it found, never over the fleet.
+    """
+    prefix = "supertool-watch-"
+    suffix = ".state.json"
+    slots: list[tuple[str, str]] = []
+    try:
+        names = sorted(os.listdir(STATE_DIR))
+    except OSError:
+        return slots
+    for name in names:
+        if not (name.startswith(prefix) and name.endswith(suffix)):
+            continue
+        stem = name[len(prefix):-len(suffix)]
+        if "__" not in stem:
+            continue
+        source, watcher_id = stem.split("__", 1)
+        slots.append((source, watcher_id))
+    return slots
+
+
 def delivery_survey() -> list[tuple[str, str, str]]:
     """`(source, id, delivery state)` per watcher state file. Reads only (#1183).
 
@@ -1199,23 +1225,37 @@ def delivery_survey() -> list[tuple[str, str, str]]:
     wider set than `watches` renders and the header says so, because two counts
     of different things presented as one is how a board starts lying quietly.
     """
-    prefix = "supertool-watch-"
-    suffix = ".state.json"
     out: list[tuple[str, str, str]] = []
-    try:
-        names = sorted(os.listdir(STATE_DIR))
-    except OSError:
-        return out
-    for name in names:
-        if not (name.startswith(prefix) and name.endswith(suffix)):
-            continue
-        stem = name[len(prefix):-len(suffix)]
-        if "__" not in stem:
-            continue
-        source, watcher_id = stem.split("__", 1)
+    for source, watcher_id in _state_file_slots():
         state, refusal = read_state_checked(source, watcher_id)
         out.append((source, watcher_id,
                     delivery_of((state or {}).get("last_emit"), refusal)))
+    return out
+
+
+def emit_destinations() -> list[tuple[str, str, str]]:
+    """`(source, id, the socket that watcher last wrote to)` per state file.
+
+    Same population, same read-only guarantee and same non-mutating scan as
+    `delivery_survey` — kept a separate pass rather than a fourth tuple field
+    because that one's shape is a pinned contract, and two cheap reads of a
+    JSON file cost less than a migration nobody asked for.
+
+    The third element is `""` when this watcher has not published a
+    `sock_path` — it has never emitted, it was spawned by a build older than
+    #581, or its state file could not be read at all. Those are not the same
+    story as each other, but they share the only property the caller may act
+    on: **nothing here says which socket that watcher writes to**, and an
+    empty string is not permission to assume it is this process's. Reporting
+    `SOCK_PATH` as a default would be the absence read as agreement, in the
+    one place whose whole job is telling the two apart.
+    """
+    out: list[tuple[str, str, str]] = []
+    for source, watcher_id in _state_file_slots():
+        state, refusal = read_state_checked(source, watcher_id)
+        recorded = "" if refusal else (state or {}).get("sock_path")
+        out.append((source, watcher_id,
+                    recorded if isinstance(recorded, str) else ""))
     return out
 
 

--- a/tests/test_watch_delivery_elsewhere_1309.py
+++ b/tests/test_watch_delivery_elsewhere_1309.py
@@ -1,0 +1,170 @@
+"""`accepted` is not `accepted by the socket this session reads` (issue #1309).
+
+#1309 asked whether two sessions can both be woken by the radar. Two of its
+three layers do not hold — `claude-channel` refuses to steal a live socket and
+names the override (#550, pinned end to end in
+`tests/test_notifiers_claude_channel_550.py`), and the poller slot is namespaced
+by `SUPERTOOL_WATCH_STATE_DIR`, not by the machine — so a second session already
+gets a radar of its own by exporting both variables.
+
+What does not hold is the render. A session that exports only
+`SUPERTOOL_WATCH_SOCK` shares `/tmp` with the first, so its slots are held by
+pollers that captured the *other* socket at spawn. Those pollers are alive,
+their emits are accepted, and `radar` said `all N watcher state file(s) had
+their last emit accepted by a listener` — true, and read in the second session
+as a statement about a socket nothing had ever written to. The datum that
+settles it (`sock_path`, written beside `last_emit` since #581) had no reader.
+
+Three states here as everywhere in this preset: the recorded path is this
+session's, it is somebody else's, or the watcher emitted and recorded no path
+at all — which is not agreement and must not render as any.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import types
+from pathlib import Path
+
+import pytest
+
+WATCH_DIR = Path(__file__).parent.parent / "presets" / "watch"
+
+
+def _module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+radar = _module("watch_radar_1309", WATCH_DIR / "radar.py")
+transport = radar.transport
+
+ACCEPTED = {"state": "accepted", "ts": "2026-08-11T09:00:00Z"}
+
+#: Two socket paths that differ in the field, never in the separator: these are
+#: compared as opaque strings by the product, and a test that built them with a
+#: hardcoded "/" would assert POSIX rather than the comparison (#1004).
+MINE = str(Path("sock-mine") / "w.sock")
+THEIRS = str(Path("sock-theirs") / "w.sock")
+
+
+@pytest.fixture
+def fleet(tmp_path, monkeypatch):
+    """A state directory of this test's own, and a socket path of its own."""
+    monkeypatch.setattr(transport, "STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(transport, "SOCK_PATH", MINE)
+    monkeypatch.setattr(transport, "scan_poller_pids", lambda: ({}, True))
+    monkeypatch.setattr(transport, "ps_scan_supported", lambda: True)
+    monkeypatch.setattr(transport, "_pid_alive", lambda pid: pid == os.getpid())
+    return tmp_path
+
+
+def _watcher(root: Path, source: str, wid: str, last_emit=None, sock=None) -> None:
+    """One watcher's pair of files. `sock` None means the key is absent."""
+    (root / f"supertool-watch-{source}__{wid}.pid").write_text(f"{os.getpid()}\n")
+    state = {"last_event": {"event": "mr_updated", "ts": "2026-08-11T09:00:00Z"}}
+    if last_emit is not None:
+        state["last_emit"] = last_emit
+    if sock is not None:
+        state["sock_path"] = sock
+    (root / f"supertool-watch-{source}__{wid}.state.json").write_text(
+        json.dumps(state), encoding="utf-8")
+
+
+def _tiers(monkeypatch) -> None:
+    """Radar refuses with no tiers configured; give it one that says nothing."""
+    tier = types.SimpleNamespace(
+        RADAR_OPTIONS=set(), RADAR_QUIET_DEFAULT=True,
+        radar_report=lambda opts: ([], True),
+        radar_state=lambda opts: [])
+    monkeypatch.setenv(radar.TIERS_ENV, '{"fake": {}}')
+    monkeypatch.setattr(radar, "_tier_module", lambda n: tier if n == "fake" else None)
+
+
+# --------------------------------------------------------------------------
+# the survey
+# --------------------------------------------------------------------------
+
+def test_the_survey_reports_the_socket_each_watcher_last_wrote_to(fleet) -> None:
+    _watcher(fleet, "gitlab-mr", "elsewhere", ACCEPTED, sock=THEIRS)
+    assert transport.emit_destinations() == [("gitlab-mr", "elsewhere", THEIRS)]
+
+
+def test_a_watcher_that_recorded_no_socket_reports_an_empty_string(fleet) -> None:
+    """The absence, kept distinct from a path — including from this one's."""
+    _watcher(fleet, "gitlab-mr", "old-build", ACCEPTED, sock=None)
+    assert transport.emit_destinations() == [("gitlab-mr", "old-build", "")]
+
+
+def test_the_survey_neither_prunes_nor_records_a_death(fleet, monkeypatch) -> None:
+    """Same guarantee `delivery_survey` carries: looking must not act (#859)."""
+    def _explode(*a, **k):  # pragma: no cover - the point is that it never runs
+        raise AssertionError("the destination survey must not record a death")
+
+    monkeypatch.setattr(transport, "record_death", _explode)
+    _watcher(fleet, "gitlab-mr", "gone", ACCEPTED, sock=THEIRS)
+    pid_file = fleet / "supertool-watch-gitlab-mr__gone.pid"
+    assert transport.emit_destinations() == [("gitlab-mr", "gone", THEIRS)]
+    assert pid_file.exists()
+
+
+# --------------------------------------------------------------------------
+# the render
+# --------------------------------------------------------------------------
+
+def test_radar_names_a_fleet_delivering_to_another_sessions_socket(
+        fleet, monkeypatch, capsys) -> None:
+    """The defect: `all N accepted`, said to the session receiving none of it."""
+    _tiers(monkeypatch)
+    _watcher(fleet, "gitlab-mr", "a", ACCEPTED, sock=THEIRS)
+    _watcher(fleet, "gitlab-mr", "b", ACCEPTED, sock=THEIRS)
+    assert radar.main(["radar"]) == 0
+    out = capsys.readouterr().out
+    assert "2 of 2" in out
+    assert "this session does not read" in out
+    assert THEIRS in out
+    assert MINE in out
+
+
+def test_radar_says_nothing_extra_when_every_watcher_writes_here(
+        fleet, monkeypatch, capsys) -> None:
+    """Agreement is not news, and a line per healthy fleet is noise."""
+    _tiers(monkeypatch)
+    _watcher(fleet, "gitlab-mr", "a", ACCEPTED, sock=MINE)
+    assert radar.main(["radar"]) == 0
+    out = capsys.readouterr().out
+    assert "all 1" in out
+    assert "this session does not read" not in out
+    assert "do not record" not in out
+
+
+def test_an_emitter_with_no_recorded_socket_is_its_own_answer(
+        fleet, monkeypatch, capsys) -> None:
+    """Not this session's socket, not another's — unsettled, and said so."""
+    _tiers(monkeypatch)
+    _watcher(fleet, "gitlab-mr", "old-build", ACCEPTED, sock=None)
+    assert radar.main(["radar"]) == 0
+    out = capsys.readouterr().out
+    assert "do not record which socket" in out
+    assert "this session does not read" not in out
+
+
+def test_a_fleet_that_never_emitted_gets_no_destination_line(
+        fleet, monkeypatch, capsys) -> None:
+    """A watcher with nothing to report has no destination to disagree about.
+
+    Without this, every quiet fleet on earth would grow a second header saying
+    its sockets were unrecorded — which is true, uninformative, and exactly the
+    kind of line that trains a reader to skip the block (#1183's footnote).
+    """
+    _tiers(monkeypatch)
+    _watcher(fleet, "gitlab-mr", "quiet", None, sock=None)
+    assert radar.main(["radar"]) == 0
+    out = capsys.readouterr().out
+    assert "no watcher has recorded an emit yet" in out
+    assert "do not record which socket" not in out
+    assert "this session does not read" not in out


### PR DESCRIPTION
Closes #1309

The issue claims the radar transport is single-consumer at three independent layers. **Two of the three do not hold**, and the fix is the residual — which is this repo's house defect, not an architecture change.

| Layer | Claim | Verdict |
| --- | --- | --- |
| 1. wire is point-to-point, no fan-out | holds | **True.** `emit_socket` connects, writes, closes. No broker. Deliberate. |
| 2. a second server steals or fails on the socket path, blinding the first | | **False.** #550 removed `channel.ts`'s unconditional `unlinkSync`; the second server exits `3` and its stderr names the socket, names `SUPERTOOL_WATCH_SOCK` and cites #550. Pinned end to end by five assertions in `tests/test_notifiers_claude_channel_550.py`. The issue's "not verified — lives in the Claude dev channel, not this repo" is also wrong: `notifiers/claude-channel/channel.ts` is in this repo and CI runs those tests. |
| 3. one poller per population **per machine**, so a second session gets none | | **False as stated.** The slot is `{STATE_DIR}/supertool-watch-{source}__{id}.pid` and `STATE_DIR` is `SUPERTOOL_WATCH_STATE_DIR`, carried through the exec by `poller_env()`. One poller per population **per state directory**. |

**So multi-consumer is not the target and no broker is warranted.** A second session already gets a full radar of its own by exporting *both* variables. What nobody had written down is that it takes both — and `presets/watch/README.md:107` and `docs/presets/watch.md:1093` both described the socket override **alone** as how a second session gets its own channel. That sentence is what produces layer 3.

## The residual defect, which is the house one

Export only the socket and everything looks healthy: `/tmp` is shared, every slot is already held by session A's pollers, and those captured A's socket at spawn and keep it for life. `radar` then printed

    all N watcher state file(s) had their last emit accepted by a listener

— true, and read in session B as a statement about a socket nothing ever wrote to. `sock_path` has been in the state file since #581 with **zero readers**.

So radar now reads it and says which of three states it is in: the recorded path differs from this process's (`radar: DELIVERY`, with the count and the other path), emitted but no path recorded (`DELIVERY`, unsettled), or all agree (silent). Watchers that never emitted are excluded from both counts — counting them would print a header on every quiet fleet forever, which is how a block trains its reader to skip it. Report-only: nothing spawns, stops or reaps.

## Judgment calls

- **Refused fan-out, a broker and a backlog buffer.** All three of the issue's "what a fix must establish" questions are moot once layers 2 and 3 fall, and a broker replaces a working per-session partition with a component that can die while the pollers stay healthy — the exact failure shape this subsystem's history is made of.
- **Two scans rather than a fourth tuple field.** `delivery_survey`'s 3-tuple is asserted by exact equality in `tests/test_watch_delivery_render_1183.py`; two cheap JSON reads beat a contract migration nobody asked for.

## Tests

RED before the implementation: `5 failed, 2 passed`, including `AttributeError: module 'transport' has no attribute 'emit_destinations'`. GREEN: `24 passed`, and `904 passed, 4 skipped` across `-k "watch or radar or doc"`.

Full suite skipped deliberately — the change is two files in one preset, no shared helper or fixture touched, and the 904-test superset of everything reading this code is green. CI's twelve legs are the authority. Windows: opaque-string equality only, no separator logic, no subprocess, no new exception types, and the test builds its paths with `Path(...) / ...` rather than POSIX literals. Unverified on a Windows box.

## Review

Four findings. Three fixed: two stale doc sentences claiming the socket override gives per-session isolation, sitting three and ten lines above the new paragraphs saying otherwise, and an uncertainty line rendered lower-case against the banner's own shout-when-unsure convention. One **argued down as a code change and accepted as prose**: a state file vanishing between the two scans lands in the unrecorded bucket, which is correct — the line says only that nothing establishes where that watcher writes, exactly true of a vanished slot — so the docstring now says so rather than the code changing.

## Filed rather than fixed

- `notifiers/claude-channel/channel.ts`'s #550 refusal names `SUPERTOOL_WATCH_SOCK` only, so a reader following it exactly lands in the silent-no-pollers state this branch documents. One string, needs `bun` to test.
- `watches` renders per-watcher delivery and still does not show `sock_path` — the same gap the banner had, one surface over.
