### PR TITLE
Four `presets/github/` fixes - and the client-side filters were dead under `iids` for a different reason than the issue I filed said

### DIFF
--- a/changelog.d/1374.fixed.md
+++ b/changelog.d/1374.fixed.md
@@ -1,0 +1,6 @@
+- `gh-branch`'s verdict joins three or more workflow names with `and` instead of
+  a trailing comma. `` `CodeQL`, `changelog`, `tests` `` is the shape a truncated
+  list has, in the one sentence whose job is to say whether the commit is
+  cleared. The list stays uncapped: these names are the verdict's own subject,
+  and a shortened subject inside a not-concluded sentence is the
+  absence-produced-by-the-tool defect. (#1374)

--- a/changelog.d/1387.fixed.md
+++ b/changelog.d/1387.fixed.md
@@ -1,0 +1,6 @@
+- `gh-batch-star` and `gh-batch-follow` can now eat `gh-find-starable` /
+  `gh-find-followable` output directly. A `#` **preceded by whitespace** ends the
+  name and starts an inline annotation; a `#` with no whitespace before it is not
+  a comment, so `evil#tool/x` is refused rather than trimmed to `evil`. Nothing
+  is silent: the receipt counts the annotations it dropped, names every skipped
+  line with its reason, and a run with a skipped line exits 2. (#1387)

--- a/changelog.d/1409.added.md
+++ b/changelog.d/1409.added.md
@@ -1,0 +1,6 @@
+- `gh-branch`'s workflow table names the run: a `Run` column carrying the run id
+  and `attempt N`, with the lifecycle word moved to its own `Phase` column. Both
+  fields were already fetched, so it costs no extra call, and it is the route
+  from the render to `gh-run:<id>` or a re-run that previously needed a raw API
+  call. `attempt` prints on attempt 1 too, and an unreadable id or attempt
+  renders `?` rather than a default. (#1409)

--- a/changelog.d/1439.fixed.md
+++ b/changelog.d/1439.fixed.md
@@ -1,0 +1,6 @@
+- `gh-issues:nomilestone,iids` returned every open issue: the id feed was
+  rendered above the client-side filter block, so `external`, `stale` and
+  `nomilestone` were all inert under `iids` and so were the declines they exist
+  to produce. The feed is now rendered after the filters, carries their
+  narrowing notes as `#` comments, and buys the enrichment call when a filter
+  needs one. (#1439)

--- a/docs/presets/github.md
+++ b/docs/presets/github.md
@@ -292,7 +292,7 @@ Three consequences of the fix:
 
 - the id feed is rendered **after** the filters, so a decline reaches it too. `gh-issues:nomilestone,iids` over a board with one unreadable milestone exits 1 with `cannot filter by nomilestone` and prints no numbers — an id feed is the shape most likely to be piped into another call rather than read, so it is the shape least able to carry a filter that silently did not run;
 - the narrowing note rides the feed as a `#` comment (`# nomilestone excluded 44 of 97 fetched`). The board stated it and the feed stated nothing, so there was no line to disagree with;
-- a filter that reads an **enriched** field (`external`, `stale`) now buys the enrichment call under `iids`, where the bare feed still buys none. That is `gl-mrs`'s rule — it applies `failed` before its own `iids` return and overrides `nopipe` for it — and the sibling had it right first.
+- a filter that reads an **enriched** field (`external`, `stale`) now buys the enrichment call under `iids`, where the bare feed still buys none. That is `gl-mrs`'s rule — it applies `failed` before its own `iids` return and overrides `nopipe` for it — and the sibling had it right first. It holds on **both** routes: `gh-issues:iids=1,2,iids,external` used to decline for want of a field it had chosen not to fetch, while `gh-issues:external,iids` answered, and two spellings of one request must not disagree.
 
 ### Searching the tracker, and saying which engine answered
 

--- a/docs/presets/github.md
+++ b/docs/presets/github.md
@@ -105,6 +105,22 @@ The fix is the convention the rest of the repo already keeps ([#819](https://git
 
 `gh-star`, `gh-follow`, `gh-batch-star` and `gh-batch-follow` flatten too, on a narrower ground: their error arms echo `gh`'s stderr, which quotes back the name it was given, and the batch ops print it as a row in a list a reader skims for exactly the `ERR` lines a forged one imitates.
 
+### The candidates file has one line format, and both ends honour it
+
+The producers write `octo/tool  # 12 stars, a description`; until [#1387](https://github.com/Digital-Process-Tools/claude-supertool/issues/1387) `gh-batch-star` sent all of that as the repository path and `gh-batch-follow` sent `octocat  # stargazer` as the login. Both 404'd, and the pipeline the two op pairs exist to form needed a hand edit in the middle.
+
+The rule, in `presets/github/_candidates.py`, is two lines long:
+
+| Line | Read as |
+|---|---|
+| `# anything` (leading whitespace allowed) | a whole-line comment, skipped — unchanged |
+| `octo/tool  # 12 stars` | name `octo/tool`; everything from the whitespace-preceded `#` is an annotation and is dropped |
+| `evil#tool/x` | **not** a name with a comment. No `#` precedes whitespace, so nothing is stripped — and the guard then refuses the line |
+
+**The whitespace requirement is the whole safety argument.** `evil#tool/x` trimmed at the `#` is `evil`, an account that may well exist and is not the one on the line anybody reviewed. A consumer that silently strips what it does not understand is how a wrong name becomes a starred repo, so the split can only ever remove text no GitHub owner, repository or login could have contained, and anything left over that still cannot be a name — whitespace inside it, or a surviving `#` — is skipped by name rather than sent.
+
+Neither outcome is silent. The receipt says how many lines carried an annotation before the first write happens, names each skipped line with its reason, and ends on `DONE: 3 starred, 0 failed, 2 skipped`. A run with any skipped line exits **2**, not 0: it covered fewer names than the reviewed list held, and a zero there would report a partial run as a complete one.
+
 ## `:fail` on a job that did not fail
 
 `:fail` selects error blocks, which is the right question for a job that **failed** and close to the worst one for a job that was **cancelled**. A cancellation writes exactly one error line — `##[error]The operation was canceled.` — and puts everything diagnostic outside it.
@@ -259,6 +275,24 @@ Two mechanics worth knowing:
 **A listing filter beside `iids=` is refused.** `author`/`assignee`/`label`/`milestone`/`state` narrow a `gh issue list` call that does not happen on this path, so they would have been dropped and the rows printed as though they had been applied — [#864](https://github.com/Digital-Process-Tools/claude-supertool/issues/864)'s defect, one layer up.
 
 Rows also carry `[closed]` now, and `[state:?]` when gh did not answer. A bare board is `state=open` so the marker never showed; `state=all` and `iids=` both render closed issues, and a closed one that looked identical to an open one answered "is this citation still live" wrongly.
+
+**A client-side filter narrows the id feed exactly as it narrows the board.** Until [#1439](https://github.com/Digital-Process-Tools/claude-supertool/issues/1439) it did not, on the live tracker:
+
+```
+$ supertool 'gh-issues:nomilestone,per=100,iids'       -> 95 ids
+$ supertool 'gh-issues:milestone=v0.36.0,per=100,iids' -> 42 ids
+intersection: 42 — every milestoned issue also reported as unmilestoned
+$ supertool 'gh-issues:nomilestone,per=100'
+53 issue(s) | nomilestone excluded 42 of 95 fetched
+```
+
+The cause was **ordering**, not a projection: the `iids` render returned above the client-side filter block, so `external`, `stale` and `nomilestone` were all inert under it — and so were the declines those filters exist to produce. Nothing dropped the `milestone` field; both shapes come from one `gh issue list --json` call with the same fields, and the filter simply never looked at them.
+
+Three consequences of the fix:
+
+- the id feed is rendered **after** the filters, so a decline reaches it too. `gh-issues:nomilestone,iids` over a board with one unreadable milestone exits 1 with `cannot filter by nomilestone` and prints no numbers — an id feed is the shape most likely to be piped into another call rather than read, so it is the shape least able to carry a filter that silently did not run;
+- the narrowing note rides the feed as a `#` comment (`# nomilestone excluded 44 of 97 fetched`). The board stated it and the feed stated nothing, so there was no line to disagree with;
+- a filter that reads an **enriched** field (`external`, `stale`) now buys the enrichment call under `iids`, where the bare feed still buys none. That is `gl-mrs`'s rule — it applies `failed` before its own `iids` return and overrides `nopipe` for it — and the sibling had it right first.
 
 ### Searching the tracker, and saying which engine answered
 
@@ -1170,6 +1204,20 @@ $ gh run list --commit 412375ae98…  --json workflowName # 2 runs  exit 0
 That is the failure the maintainer hit by hand before filing, and passing an
 abbreviation through would have reproduced it inside the op meant to insulate
 against it.
+
+**The table names the run, not only the workflow.** [#1409](https://github.com/Digital-Process-Tools/claude-supertool/issues/1409) was filed asking for a new `gh-runs:REF` op and its own author retracted the body: the ref resolution, the `--commit` exact-match trap and the declared-set comparison all already live here. What was missing was two fields on the render that exists.
+
+```
+Workflow                         Run                        Phase          Outcome        Legs
+CodeQL                           31501780284 attempt 1      concluded      success        2 total: 2 passed, …
+tests                            31507113066 attempt 2      concluded      success        15 total: 15 passed, …
+```
+
+`Run` now names the run and `Phase` carries the lifecycle word it used to hold. Both fields were already fetched — `_run_list` asks for `databaseId` and `attempt` — so this costs no extra call, and it is the route from this render to `gh-run:<id>` or `gh run rerun <id>` that previously needed a raw API call to find.
+
+**`attempt` is printed always, including on attempt 1.** A number that appears only in the interesting case cannot be told from a number the tool failed to read; an unreadable id or attempt renders `?`, never `-1` and never a defaulted `1`.
+
+A note under the table says what the two numbers mean, and it is worth stating precisely because the issue body got it wrong: a re-run is a further **attempt on the same run object**, not a second run object on the same SHA. That is why `_declared_legs.reconcilable` buys a second source exactly when the attempt is not 1 — `filter=all` holds rows the latest attempt dropped — and why the tally beside a row counts the latest attempt only. Only the newest run of each workflow on the commit is listed, so the row count is workflows, never attempts.
 
 **What commit mode does not have, it says.** `--commit` returns one commit's
 runs and no others, so the previous-head comparison — *this workflow ran last

--- a/presets/github/_candidates.py
+++ b/presets/github/_candidates.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""One line format, honoured by both ends of the candidates pipeline (#1387).
+
+`gh-find-starable` and `gh-find-followable` write a reviewable list — one
+candidate per line, with an inline `#` annotation carrying the star count or
+why the account showed up. `gh-batch-star` and `gh-batch-follow` read that same
+file back. Until #1387 they did not agree on what a line was: the producers
+wrote `octo/tool  # 12 stars`, the consumers sent all of it as the repository
+path, and the pipeline the two op pairs exist to form needed a hand edit in the
+middle.
+
+**The decision, of the three the issue laid out.** The consumers learn the
+annotation; the producers keep the readable one-line format; and — the part
+that makes it safe — nothing is *silently* reinterpreted.
+
+Two rules, and the second is the one that matters:
+
+* A `#` **preceded by whitespace** ends the name. Everything from it to the end
+  of the line is an annotation and is dropped.
+* A `#` with nothing but name characters before it is **not** an annotation.
+  `evil#tool/x` stays whole and is then refused by `unusable()`, because
+  trimming it would produce `evil`, a *different* account that may well exist.
+  A consumer that silently strips what it does not understand is how a wrong
+  name becomes a starred repository.
+
+So the split can only ever remove text that no GitHub owner, repository or
+login could have contained, and anything the split leaves behind that still
+cannot be a name is declined by name rather than sent. The callers count both
+outcomes onto their receipt: a batch op that quietly rewrites its input is this
+repository's house defect with a write attached.
+"""
+from __future__ import annotations
+
+#: What starts a comment, at line start or after whitespace.
+COMMENT = "#"
+
+
+def split_annotation(line: str) -> tuple[str, str]:
+    """`(value, annotation)` — the name, and the inline `# ...` that followed it.
+
+    The annotation is returned rather than discarded so a caller can count what
+    it dropped without re-deriving the split. Both halves are stripped; the
+    annotation is `""` when the line carried none.
+    """
+    text = str(line)
+    for i, ch in enumerate(text):
+        if ch == COMMENT and i > 0 and text[i - 1].isspace():
+            return text[:i].strip(), text[i:].strip()
+    return text.strip(), ""
+
+
+def is_comment(line: str) -> bool:
+    """A whole-line comment — `#` first, leading whitespace allowed."""
+    return str(line).strip().startswith(COMMENT)
+
+
+def unusable(value: str) -> str:
+    """Why `value` cannot be a GitHub name, or `""` when it can be one.
+
+    Deliberately not a positive charset test. GitHub's own rules for logins,
+    owners and repository names are theirs to change, and an allowlist written
+    here would reject a legal name on the day they widen one — refusing a name
+    the user reviewed and meant is the *worse* failure of the two. What is
+    asserted is only what the split guarantees: whitespace and `#` cannot
+    appear in any of the three, so their presence means the line was not a
+    name, and sending it would be a guess.
+    """
+    text = str(value)
+    if not text:
+        return "empty after the inline annotation was removed"
+    if any(c.isspace() for c in text):
+        return ("contains whitespace, so it is not one name — an inline "
+                "comment must be introduced by `#`")
+    if COMMENT in text:
+        return ("contains '#', which no GitHub owner, repository or login "
+                "may — an annotation must have whitespace before its '#'")
+    return ""

--- a/presets/github/batch_follow.py
+++ b/presets/github/batch_follow.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
 """gh-batch-follow: gh-batch-follow:FILE — follow each username (one per line).
 
-Lines starting with '#' are skipped (comments). Empty lines skipped.
+A whole line starting with '#' is a comment, and empty lines are skipped. A '#'
+**after whitespace** ends the login and starts an inline annotation, which is
+what `gh-find-followable` writes (`octocat  # stargazer of octo/tool`) — until
+#1387 the annotation was sent as part of the login, so the producer's own output
+could not be handed to this op without a hand edit. The rules, and the reason a
+'#' with no whitespace before it is NOT a comment, are in `_candidates.py`.
+
+This op follows accounts, and it does not require an OWNER/REPO shape, so it is
+the one where a mis-parsed line is a write to somebody's account. Nothing is
+silently reinterpreted: the receipt says how many annotations were dropped, and
+a line that cannot be a login after the split is skipped by name and counted
+rather than sent.
+
 Reports per-user status and a final summary. Sleeps 1s between calls
 to be polite to GitHub's abuse-detection.
 """
@@ -16,6 +28,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from _env import env_float  # noqa: E402  (the one numeric-knob reader)
 import _untrusted  # noqa: E402  (the repo's remote-text convention — #981)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import _candidates  # noqa: E402  (the line format both ends honour — #1387)
 
 #: How much of `gh`'s error text one row may carry, measured on what prints.
 ERROR_MAX = 120
@@ -47,15 +62,34 @@ def main(arg: str) -> int:
         sys.stderr.write(f"ERROR: file not found: {path}\n")
         return 2
     users = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
+    annotated = 0
+    skipped: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip() or _candidates.is_comment(raw):
             continue
-        users.append(line.lstrip("@"))
+        value, annotation = _candidates.split_annotation(raw)
+        if annotation:
+            annotated += 1
+        value = value.lstrip("@")
+        why = _candidates.unusable(value)
+        if why:
+            skipped.append(f"{_untrusted.flat(value or raw.strip())}: {why}")
+            continue
+        users.append(value)
+    for note in skipped:
+        sys.stderr.write(f"WARN: skipping {note}\n")
     if not users:
         sys.stderr.write("ERROR: no usernames in file\n")
         return 2
     print(f"(batch-follow {len(users)} users)")
+    # Stated before the first write, not after the last: this is what the op
+    # decided the file meant, and a reader who disagrees wants to stop now.
+    if annotated:
+        print(f"# {annotated} of these lines carried an inline `# ...` "
+              f"annotation — the text after it was dropped and the login "
+              f"before it used.")
+    for note in skipped:
+        print(f"  SKIP {note}")
     ok = 0
     failed = 0
     delay = env_float("SUPERTOOL_FOLLOW_DELAY", 1.0, minimum=0.0)
@@ -72,8 +106,12 @@ def main(arg: str) -> int:
             ok += 1
         else:
             failed += 1
-    print(f"DONE: {ok} followed, {failed} failed")
-    return 0 if failed == 0 else 1
+    tail = f", {len(skipped)} skipped" if skipped else ""
+    print(f"DONE: {ok} followed, {failed} failed{tail}")
+    if failed:
+        return 1
+    # A skipped line is not a success — see gh-batch-star for the same call.
+    return 2 if skipped else 0
 
 
 if __name__ == "__main__":

--- a/presets/github/batch_star.py
+++ b/presets/github/batch_star.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
 """gh-batch-star: gh-batch-star:FILE — star each repo (one OWNER/REPO per line).
 
-Lines starting with '#' are comments. Sleeps SUPERTOOL_STAR_DELAY (default 1s)
-between calls.
+A whole line starting with '#' is a comment. A '#' **after whitespace** ends the
+name and starts an inline annotation, which is what `gh-find-starable` writes
+(`octo/tool  # 12 stars, a description`) — until #1387 the annotation was sent
+as part of the repository path and every such line 404'd, so the two ops could
+not form the pipeline they exist for. The rules, and the reason a '#' with no
+whitespace before it is NOT a comment, are in `_candidates.py`.
+
+Nothing is silently reinterpreted: the receipt says how many annotations were
+dropped, and a line that cannot be a name after the split is skipped by name
+and counted rather than sent.
+
+Sleeps SUPERTOOL_STAR_DELAY (default 1s) between calls.
 """
 from __future__ import annotations
 
@@ -15,6 +25,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from _env import env_float  # noqa: E402  (the one numeric-knob reader)
 import _untrusted  # noqa: E402  (the repo's remote-text convention — #981)
+
+sys.path.insert(0, str(Path(__file__).parent))
+import _candidates  # noqa: E402  (the line format both ends honour — #1387)
 
 #: How much of `gh`'s error text one row may carry, measured on what prints.
 ERROR_MAX = 120
@@ -47,18 +60,35 @@ def main(arg: str) -> int:
         sys.stderr.write(f"ERROR: file not found: {path}\n")
         return 2
     repos = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip().lstrip("/")
-        if not line or line.startswith("#"):
+    annotated = 0
+    skipped: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip() or _candidates.is_comment(raw):
             continue
-        if "/" not in line:
-            sys.stderr.write(f"WARN: skipping {line!r} (not OWNER/REPO)\n")
+        value, annotation = _candidates.split_annotation(raw)
+        if annotation:
+            annotated += 1
+        value = value.lstrip("/")
+        why = _candidates.unusable(value) or (
+            "" if "/" in value else "is not OWNER/REPO")
+        if why:
+            skipped.append(f"{_untrusted.flat(value or raw.strip())}: {why}")
             continue
-        repos.append(line)
+        repos.append(value)
+    for note in skipped:
+        sys.stderr.write(f"WARN: skipping {note}\n")
     if not repos:
         sys.stderr.write("ERROR: no OWNER/REPO entries in file\n")
         return 2
     print(f"(batch-star {len(repos)} repos)")
+    # Stated before the first write, not after the last: this is what the op
+    # decided the file meant, and a reader who disagrees wants to stop now.
+    if annotated:
+        print(f"# {annotated} of these lines carried an inline `# ...` "
+              f"annotation — the text after it was dropped and the name "
+              f"before it used.")
+    for note in skipped:
+        print(f"  SKIP {note}")
     ok = 0
     failed = 0
     delay = env_float("SUPERTOOL_STAR_DELAY", 1.0, minimum=0.0)
@@ -76,8 +106,15 @@ def main(arg: str) -> int:
             ok += 1
         else:
             failed += 1
-    print(f"DONE: {ok} starred, {failed} failed")
-    return 0 if failed == 0 else 1
+    tail = f", {len(skipped)} skipped" if skipped else ""
+    print(f"DONE: {ok} starred, {failed} failed{tail}")
+    if failed:
+        return 1
+    # A skipped line is not a success. Exit 2 is this op's "the file was not
+    # what it looked like" code — the same one a missing file gets — because a
+    # zero here would report a run that covered fewer repositories than the
+    # reviewed list named.
+    return 2 if skipped else 0
 
 
 if __name__ == "__main__":

--- a/presets/github/branch.py
+++ b/presets/github/branch.py
@@ -585,10 +585,29 @@ def _run_conclusion(run: object) -> str:
 
 
 def _names(names) -> str:
-    items = list(names)
+    """The workflow names as an English list — the last separator is `and`.
+
+    A comma-separated list with no conjunction is the shape a **truncated**
+    list has, and this one is interpolated into the sentence whose whole job is
+    to say whether the commit is cleared (#1374). The reader's question at that
+    moment is "is that all of them"; `` `CodeQL`, `changelog`, `tests` ``
+    answers it wrong for free, and it costs nothing to answer it right.
+
+    **Not capped**, deliberately, and this is the second half of #1374's
+    question. `scope_clause` caps at `_checks.NAMED_CAP` and discloses the
+    remainder, because the names there are a *supplementary* list under a
+    verdict the reader has already got. These names are the verdict's own
+    subject — they are what the reader has to act on — and a shortened subject
+    inside a not-concluded sentence is exactly the absence-produced-by-the-tool
+    defect this repository keeps filing. Eight backticked names on one line is
+    ugly; eight workflows of which three are named is wrong.
+    """
+    items = [f"`{n}`" for n in names]
+    if not items:
+        return ""
     if len(items) == 1:
-        return f"`{items[0]}`"
-    return ", ".join(f"`{n}`" for n in items)
+        return items[0]
+    return f"{', '.join(items[:-1])} and {items[-1]}"
 
 
 def _agrees(n: int, singular: str, plural: str) -> str:
@@ -842,6 +861,67 @@ def _reconcile(repo: str, selected: dict, fetched: dict) -> tuple:
 # render
 # ---------------------------------------------------------------------------
 
+#: Width of the `Run` column — the id plus ` attempt N`. Run ids are 11 digits
+#: today and GitHub allocates them monotonically, so the slack is for the digit
+#: it will grow, not decoration. A column narrower than its content does not
+#: truncate here, it pushes the next one right and un-aligns the table.
+RUN_COL = 26
+PHASE_COL = 14
+
+
+def run_cell(run: object) -> str:
+    """`<id> attempt <n>` — the run this row is about, named so it can be used.
+
+    Until #1409 the table named workflows and never named runs, so there was no
+    route from this render to `gh-run:<id>` or to a re-run without a raw API
+    call. Both fields were already fetched by `_run_list`; only the render was
+    missing.
+
+    `attempt` is printed **always**, including on attempt 1. A number that
+    appears only when it is interesting cannot be told from a number the tool
+    failed to read, and that pair is the defect this repository keeps filing.
+    An unreadable id or attempt is `?` — never `-1` (what `_run_id` answers for
+    an absence) and never a defaulted `1`.
+    """
+    rid = _run_id(run)
+    ident = str(rid) if rid >= 0 else "id ?"
+    attempt = "?"
+    if isinstance(run, dict):
+        try:
+            attempt = str(int(run.get("attempt")))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            attempt = "?"
+    return f"{ident} attempt {attempt}"
+
+
+def table_header() -> str:
+    """The column names. `Run` names the run; `Phase` is what `Run` used to hold.
+
+    Split rather than crammed: the lifecycle word is the answer to "is this
+    still moving" (#615 comment 1) and the id is the answer to "what do I call
+    it next", and one column cannot carry both without a reader parsing it.
+    """
+    return (f"{'Workflow':<32} {'Run':<{RUN_COL}} {'Phase':<{PHASE_COL}} "
+            f"{'Outcome':<14} Legs")
+
+
+def run_id_note() -> str:
+    """What the two new numbers are for, said once under the table.
+
+    The `attempt` half is stated carefully because the issue that asked for it
+    got it wrong: a re-run is a further **attempt on the same run object**, not
+    a second run object on the same SHA — which is why
+    `_declared_legs.reconcilable` pays for a second source exactly when the
+    attempt is not 1, and why the tally on the row is the latest attempt only.
+    """
+    return ("Run ids: `gh-run:<id>` for one run's legs, `gh run rerun <id>` to "
+            "retry it. `attempt N` is GitHub's `run_attempt` — N > 1 means the "
+            "run was re-run and the tally beside it counts the latest attempt "
+            "only, so legs from an earlier attempt are NOT in it. Only the "
+            "newest run of each workflow on this commit is listed, so the row "
+            "count is workflows, never attempts.")
+
+
 def _row(name: str, run: dict, jobs) -> str:
     """One workflow's row. The name is flattened because it is not ours (#851).
 
@@ -870,7 +950,8 @@ def _row(name: str, run: dict, jobs) -> str:
         outcome = "not yet"
     else:
         outcome = "not read"
-    return f"{name:<32} {phase:<14} {outcome:<14} {tally}"
+    return (f"{name:<32} {run_cell(run):<{RUN_COL}} {phase:<{PHASE_COL}} "
+            f"{outcome:<14} {tally}")
 
 
 def main() -> int:
@@ -990,10 +1071,12 @@ def main() -> int:
         # below it — the table and the previous-head list — carries names, and
         # everything above it is this op's own arithmetic.
         print(_untrusted.flat_note("workflow and job names"))
-        print(f"{'Workflow':<32} {'Run':<14} {'Outcome':<14} Legs")
-        print("-" * 96)
+        print(table_header())
+        print("-" * 110)
         for name in sorted(selected):
             print(_row(name, selected[name], fetched.get(name)))
+        print()
+        print(run_id_note())
 
         orphans = orphan_lines(selected, fetched)
         if orphans:

--- a/presets/github/issues.py
+++ b/presets/github/issues.py
@@ -103,6 +103,21 @@ REASON_NOPIPE = "skipped by nopipe"
 # Tokens that are flags, not key=value filters.
 _FLAGS = {"nopipe", "iids", "external", "stale", "nomilestone"}
 
+# The client-side narrowing flags, split by where their field comes from.
+# `external` and `stale` read fields only the GraphQL enrichment sets;
+# `nomilestone` reads one `gh issue list` already returns.
+#
+# The split exists because of #1439: the `iids` id feed used to return before
+# the filter block ran, so all three were inert under it and so were their
+# declines — `gh-issues:nomilestone,iids` answered 95 ids on a board where the
+# same filter without `iids` excluded 42 of them. The cause was ordering, not
+# the projection: both shapes come from one `gh issue list --json` call with
+# the same `_LIST_FIELDS`, and `milestone` was on every row the filter never
+# looked at. `gl-mrs` had the shape right already — it applies `failed` before
+# its own `iids_only` return and overrides `nopipe` for it — and this is the
+# same rule: a filter that needs enrichment buys it, whatever the output shape.
+_ENRICHED_FLAGS = {"external", "stale"}
+
 # Filter keys this op forwards. Anything else is refused rather than dropped:
 # `_build_list_cmd` ignores a key it does not know, so `milestne=v0.26.0` used
 # to render the entire queue as the contents of one milestone (#864). A filter
@@ -1244,38 +1259,6 @@ def main_with_args(arg_str: str) -> int:
         # the --limit disclosure is a statement about this number.
         fetched = len(rows)
 
-    # Bare number list — on the listing path no enrichment is paid for at all.
-    #
-    # The disclosures ride along as `#` comments rather than being dropped: a
-    # truncated list stops being the same bytes as a complete one. This early
-    # return is why `iids` was the one shape that said nothing about the page
-    # boundary (#1067) — and under `iids=` a requested number that resolved to
-    # nothing is named here too, because the consumer of this shape is another
-    # tool and a shorter list is indistinguishable from a clean one.
-    #
-    # Not stderr — `_run_custom_op` returns a successful op's stdout and drops
-    # its stderr, so a note there is a note nobody receives (#654).
-    if numbers_only:
-        # The search disclosure rides the piped shape too. This stream becomes
-        # another tool's input, and a list of numbers produced by a search that
-        # covered title/body/comments is not the same population as one from a
-        # search over titles — a consumer that cannot see which it got will
-        # read the shorter one as the tracker being emptier (#1067's shape).
-        if search is not None:
-            print(f"# {_search_note(search)}")
-        for note in lookup_notes:
-            print(f"# {note}")
-        cap = _cap_note(per_page, fetched)
-        if cap:
-            print(f"# {cap}")
-        for row in unresolved:
-            print(f"# {row['number']} {row['_unresolved_note']}")
-        for row in rows:
-            number = row.get("number")
-            if number is not None:
-                print(number)
-        return 0
-
     # **The listing route's enrichment only** — `iids=` has already done its own,
     # in the same GraphQL call that fetched the rows, and `_lookup_iids` has
     # already set `reason` to None, REASON_NOPIPE or the fault it hit. Running
@@ -1288,7 +1271,13 @@ def main_with_args(arg_str: str) -> int:
     # `reason` is NOT re-declared here. It is initialised once above, because
     # the two routes now both set it and a fresh `= None` at this point would
     # silently discard whatever the lookup route established.
-    if iids_spec is None:
+    # A bare `iids` feed pays for no enrichment — that is what makes it the
+    # cheap shape — *unless* a filter that reads an enriched field was asked
+    # for. Then the call is what the caller bought, and skipping it would leave
+    # the filter with a field nobody read, which is a decline at best and the
+    # #1439 answer at worst.
+    if iids_spec is None and (
+            not numbers_only or (flags & _ENRICHED_FLAGS)):
         if "nopipe" in flags:
             reason = REASON_NOPIPE
         elif rows:
@@ -1344,6 +1333,53 @@ def main_with_args(arg_str: str) -> int:
             return 1
         rows = _narrow("nomilestone", rows,
                        [r for r in rows if not _milestone_of(r)])
+
+    # Bare number list, rendered AFTER the client-side filters rather than
+    # instead of them (#1439). Placed here and not thirty lines up because the
+    # id feed is the shape most likely to be consumed by a script rather than
+    # read by a person, so it is the shape least able to carry a filter that
+    # silently did not run — and every decline above it now reaches it too.
+    #
+    # The disclosures ride along as `#` comments rather than being dropped: a
+    # truncated list stops being the same bytes as a complete one. That is why
+    # `iids` was the one shape that said nothing about the page boundary
+    # (#1067) — and under `iids=` a requested number that resolved to nothing
+    # is named here too, because the consumer of this shape is another tool and
+    # a shorter list is indistinguishable from a clean one.
+    #
+    # `notes` rather than `lookup_notes`: it is the same list plus what each
+    # client-side filter removed, and the missing half of #1439 was that the
+    # board said `nomilestone excluded 42 of 95 fetched` and the id feed said
+    # nothing, so there was no line to disagree with.
+    #
+    # Not stderr — `_run_custom_op` returns a successful op's stdout and drops
+    # its stderr, so a note there is a note nobody receives (#654).
+    if numbers_only:
+        # The search disclosure rides the piped shape too. This stream becomes
+        # another tool's input, and a list of numbers produced by a search that
+        # covered title/body/comments is not the same population as one from a
+        # search over titles — a consumer that cannot see which it got will
+        # read the shorter one as the tracker being emptier (#1067's shape).
+        if search is not None:
+            print(f"# {_search_note(search)}")
+        for note in notes:
+            print(f"# {note}")
+        cap = _cap_note(per_page, fetched)
+        if cap:
+            print(f"# {cap}")
+        # `rows` now carries the unresolved rows too — they were appended
+        # before the filters so a decline could see them — so the two groups
+        # are told apart by the marker rather than by which list they are in.
+        for row in rows:
+            if row.get("_unresolved_note"):
+                print(f"# {row['number']} {row['_unresolved_note']}")
+        for row in rows:
+            if row.get("_unresolved_note"):
+                continue
+            number = row.get("number")
+            if number is not None:
+                print(number)
+        return 0
 
     # `flat_note` rather than `banner()` (#819). This render fences nothing —
     # titles and labels are one-line fields and are flattened — so the banner

--- a/presets/github/issues.py
+++ b/presets/github/issues.py
@@ -1158,8 +1158,15 @@ def _lookup_iids(
         return 1
 
     # Under the numbers-only render nothing derived is printed, so the
-    # enrichment half of the query is not paid for.
-    enrich = "nopipe" not in flags and not numbers_only
+    # enrichment half of the query is not paid for — unless a client-side
+    # filter reads one of those fields, which is the same rule the listing
+    # route applies (#1439). Without the second clause this route skipped the
+    # fetch and then declined for want of the field it had chosen not to get,
+    # so `iids=1,2,iids,external` refused what `external,iids` answered: two
+    # spellings of one request disagreeing, which is the asymmetry #1439 asks
+    # to be closed where the projection and the filter set are reconciled.
+    enrich = "nopipe" not in flags and (
+        not numbers_only or bool(flags & _ENRICHED_FLAGS))
     results, reason = _fetch_lookup(pair[0], pair[1], numbers, cfg["chunk"], enrich)
 
     rows: list[dict] = []

--- a/tests/test_batch_candidate_annotation_1387.py
+++ b/tests/test_batch_candidate_annotation_1387.py
@@ -1,0 +1,231 @@
+"""#1387 — the batch ops could not eat their own producers' output.
+
+`gh-find-starable` and `gh-find-followable` write one candidate per line with an
+inline annotation, because that is what makes the list reviewable:
+
+    octo/tool  # 12 stars, a description
+    octocat    # stargazer of X
+
+Neither `gh-batch-star` nor `gh-batch-follow` stripped it, so
+`octo/tool  # 12 desc` went out as the repository path and `octocat  # stargazer`
+as the login. The two ops are each other's obvious pipeline and it did not
+connect without a hand edit.
+
+**The contract, which is the decision the issue asked for.** A `#` **preceded by
+whitespace** ends the name and starts an annotation; the rest of the line is
+dropped. A `#` with no whitespace before it is *not* a comment — `foo#bar` stays
+`foo#bar` and is then refused, because no GitHub owner, repository or login may
+contain one, so a line that still holds a `#` after the split was never a name.
+
+The refusal is the half that matters. "A consumer that silently strips whatever
+it does not understand is how a wrong name becomes a starred repo" — so nothing
+here guesses: the value after the split must contain no whitespace and no `#`,
+or the line is skipped by name, counted, and reported. And the count of lines
+whose annotation was dropped is disclosed on the receipt, because a batch op
+that silently reinterprets its input is this repository's house defect with a
+write attached.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+
+
+def _load(rel: str, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, _ROOT / rel)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+candidates = _load("presets/github/_candidates.py", "gh_candidates_1387")
+batch_star = _load("presets/github/batch_star.py", "gh_batch_star_1387")
+batch_follow = _load("presets/github/batch_follow.py", "gh_batch_follow_1387")
+
+
+def _run(monkeypatch: Any, mod: Any, attr: str, text: str,
+         tmp_path: Path) -> tuple[list[str], int]:
+    """`(targets, exit code)` for one candidates file. stdout via capsys."""
+    seen: list[str] = []
+
+    def _fake(name: str) -> tuple[bool, str]:
+        seen.append(name)
+        return True, "ok"
+
+    monkeypatch.setattr(mod, attr, _fake)
+    monkeypatch.setattr(mod, "time", types.SimpleNamespace(sleep=lambda _: None))
+    path = tmp_path / "candidates.txt"
+    path.write_text(text, encoding="utf-8")
+    return seen, mod.main(str(path))
+
+
+# ---------------------------------------------------------------------------
+# the split, on its own
+# ---------------------------------------------------------------------------
+
+class TestSplit:
+
+    def test_a_whitespace_preceded_hash_ends_the_name(self) -> None:
+        assert candidates.split_annotation("octo/tool  # 12 desc") == (
+            "octo/tool", "# 12 desc")
+
+    def test_a_tab_counts_as_whitespace(self) -> None:
+        assert candidates.split_annotation("octocat\t# stargazer") == (
+            "octocat", "# stargazer")
+
+    def test_a_line_with_no_annotation_is_unchanged_and_says_so(self) -> None:
+        assert candidates.split_annotation("octo/tool") == ("octo/tool", "")
+
+    def test_a_hash_with_no_space_before_it_is_not_an_annotation(self) -> None:
+        """`foo#bar` is not a name with a comment — it is not a name at all.
+
+        Splitting it would hand `foo` to the API, which is a *different*
+        account that may well exist. The line is kept whole so the guard
+        below refuses it.
+        """
+        assert candidates.split_annotation("evil#tool") == ("evil#tool", "")
+
+    def test_the_first_annotating_hash_wins(self) -> None:
+        assert candidates.split_annotation("a/b # one # two") == (
+            "a/b", "# one # two")
+
+
+class TestGuard:
+
+    @pytest.mark.parametrize("value,token", [
+        ("", "empty"),
+        ("evil#tool", "#"),
+        ("octo/tool 12", "whitespace"),
+    ])
+    def test_a_value_that_cannot_be_a_github_name_is_named(
+            self, value: str, token: str) -> None:
+        why = candidates.unusable(value)
+        assert why, f"{value!r} was accepted as a name"
+        assert token in why, why
+
+    @pytest.mark.parametrize("value", [
+        "octo/tool", "octocat", "a-b.c/d_e.f", "Octo/Tool-2",
+    ])
+    def test_an_ordinary_name_is_not_refused(self, value: str) -> None:
+        assert candidates.unusable(value) == ""
+
+
+# ---------------------------------------------------------------------------
+# the pipeline the issue is about
+# ---------------------------------------------------------------------------
+
+PRODUCED_STAR = (
+    "# 2 repos for topic 'cli' (sorted by stars)\n"
+    "# Review, delete those you do not want, then:\n"
+    "\n"
+    "octo/tool  # 12  a small tool\n"
+    "other/thing  # 4  something else\n"
+)
+
+PRODUCED_FOLLOW = (
+    "# 2 candidates from octo/tool (stargazers + contributors)\n"
+    "\n"
+    "octocat  # stargazer of octo/tool\n"
+    "hubber  # contributor to octo/tool\n"
+)
+
+
+def test_batch_star_eats_gh_find_starable_output(
+        monkeypatch: Any, capsys: Any, tmp_path: Path) -> None:
+    seen, code = _run(monkeypatch, batch_star, "star", PRODUCED_STAR, tmp_path)
+    out = capsys.readouterr().out
+    assert seen == ["octo/tool", "other/thing"], out
+    assert code == 0, out
+
+
+def test_batch_follow_eats_gh_find_followable_output(
+        monkeypatch: Any, capsys: Any, tmp_path: Path) -> None:
+    seen, code = _run(monkeypatch, batch_follow, "follow", PRODUCED_FOLLOW,
+                      tmp_path)
+    out = capsys.readouterr().out
+    assert seen == ["octocat", "hubber"], out
+    assert code == 0, out
+
+
+@pytest.mark.parametrize("mod,attr,text", [
+    ("star", "star", "octo/tool  # 12  a small tool\n"),
+    ("follow", "follow", "octocat  # stargazer\n"),
+])
+def test_the_receipt_says_how_many_annotations_it_dropped(
+        monkeypatch: Any, capsys: Any, tmp_path: Path,
+        mod: str, attr: str, text: str) -> None:
+    """Silent reinterpretation is the defect; the count is the disclosure."""
+    target = batch_star if mod == "star" else batch_follow
+    _run(monkeypatch, target, attr, text, tmp_path)
+    out = capsys.readouterr().out
+    assert "annotation" in out, out
+    assert "1" in out, out
+
+
+@pytest.mark.parametrize("mod,attr", [("star", "star"), ("follow", "follow")])
+def test_no_disclosure_when_nothing_was_rewritten(
+        monkeypatch: Any, capsys: Any, tmp_path: Path,
+        mod: str, attr: str) -> None:
+    """A qualifier on every run is one nobody reads on the run that matters."""
+    target = batch_star if mod == "star" else batch_follow
+    text = "octo/tool\n" if mod == "star" else "octocat\n"
+    _run(monkeypatch, target, attr, text, tmp_path)
+    assert "annotation" not in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# what must NOT be stripped
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod,attr,line", [
+    ("star", "star", "evil#tool/x"),
+    ("follow", "follow", "evil#tool"),
+])
+def test_a_name_holding_a_hash_is_refused_not_trimmed(
+        monkeypatch: Any, capsys: Any, tmp_path: Path,
+        mod: str, attr: str, line: str) -> None:
+    """The whole reason the split requires whitespace.
+
+    `evil#tool/x` trimmed at the `#` is `evil`, a different account. Nothing is
+    sent; the line is named and counted.
+    """
+    target = batch_star if mod == "star" else batch_follow
+    seen, code = _run(monkeypatch, target, attr, line + "\n", tmp_path)
+    out = capsys.readouterr().out
+    assert seen == [], f"a refused line was sent anyway: {seen!r}"
+    assert code == 2, out
+
+
+@pytest.mark.parametrize("mod,attr", [("star", "star"), ("follow", "follow")])
+def test_a_skipped_line_is_counted_on_the_receipt(
+        monkeypatch: Any, capsys: Any, tmp_path: Path,
+        mod: str, attr: str) -> None:
+    """A line that vanishes between the file and the run is an absence the tool made."""
+    target = batch_star if mod == "star" else batch_follow
+    good = "octo/tool\n" if mod == "star" else "octocat\n"
+    seen, code = _run(monkeypatch, target, attr, good + "evil#x/y\n", tmp_path)
+    out = capsys.readouterr().out
+    assert len(seen) == 1, out
+    assert "1 skipped" in out, out
+
+
+@pytest.mark.parametrize("mod,attr", [("star", "star"), ("follow", "follow")])
+def test_a_full_line_comment_is_still_a_comment(
+        monkeypatch: Any, capsys: Any, tmp_path: Path,
+        mod: str, attr: str) -> None:
+    target = batch_star if mod == "star" else batch_follow
+    good = "octo/tool\n" if mod == "star" else "octocat\n"
+    seen, code = _run(monkeypatch, target, attr,
+                      "  # a leading-space comment\n" + good, tmp_path)
+    out = capsys.readouterr().out
+    assert len(seen) == 1, out
+    assert "skipped" not in out, out

--- a/tests/test_gh_branch_orphaned_leg_1408.py
+++ b/tests/test_gh_branch_orphaned_leg_1408.py
@@ -147,6 +147,12 @@ def _rows(out: str) -> list[str]:
     return rows
 
 
+#: The `Run` cell #1409 added between the workflow name and the phase word:
+#: `31501780284 attempt 2`, or `id ? attempt ?` when either field was unreadable.
+#: Dropped here rather than asserted — this file is about the phase/outcome pair.
+_RUN_CELL = re.compile(r"^(?:\d+|id \?) attempt (?:\d+|\?)\s+")
+
+
 def _cells(out: str, name: str) -> tuple[str, str]:
     """`(phase, outcome)` for one workflow row, located by position not width."""
     for row in _rows(out):
@@ -154,6 +160,8 @@ def _cells(out: str, name: str) -> tuple[str, str]:
             m = _TALLY.search(row)
             assert m, "no leg tally in row: " + row
             left = row[len(name):m.start()].strip()
+            left, n = _RUN_CELL.subn("", left)
+            assert n == 1, "no `<id> attempt <n>` cell in row (#1409): " + row
             phase, _, outcome = left.partition(" ")
             return phase.strip(), outcome.strip()
     raise AssertionError("no row for " + repr(name) + " in output:\n" + out)

--- a/tests/test_gh_branch_run_ids_1409.py
+++ b/tests/test_gh_branch_run_ids_1409.py
@@ -1,0 +1,141 @@
+"""#1409 — `gh-branch` named workflows and never named runs.
+
+The table's `Run` column held a lifecycle word (`concluded` / `running` /
+`unestablished`) and nothing else, so the render carried no run id at all. Two
+consequences, both measured while diagnosing an orphaned check-run on #1406:
+
+* **No route onward.** `gh-run:<id>` and `gh run rerun <id>` both need the id,
+  and getting one meant a raw API call — which is the standing tell that an op
+  is missing a field, not that the caller should reach past it.
+* **A re-run was invisible.** GitHub's `run_attempt` is already fetched by
+  `_run_list` and was already read by `_declared_legs.reconcilable`, which
+  exists precisely because attempt 2 puts legs in `filter=all` that
+  `filter=latest` has dropped. The reader of the table had no way to know the
+  tally beside a row was one attempt of several.
+
+The issue body asked for a new op and its own author retracted that: the
+resolution, the `--commit` exact-match trap and the declared-set comparison all
+already live here (#1083, #846). This is two fields on the render that exists.
+
+`attempt` is rendered **always**, never only when it is greater than one: a
+number that appears only in the interesting case cannot be told from a number
+the tool failed to read, which is this repository's house defect in miniature.
+An unreadable id or attempt renders `?`, never a default.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).parent.parent
+
+
+def _load(rel: str, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, _ROOT / rel)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+branch = _load("presets/github/branch.py", "github_branch_1409")
+
+
+def _run(**over: Any) -> dict:
+    base = {"status": "completed", "conclusion": "success",
+            "databaseId": 31501780284, "attempt": 1,
+            "createdAt": "2026-08-11T00:00:00Z"}
+    base.update(over)
+    return base
+
+
+_PASS = [{"name": "leg", "status": "completed", "conclusion": "SUCCESS"}]
+
+
+# ---------------------------------------------------------------------------
+# the cell
+# ---------------------------------------------------------------------------
+
+class TestRunCell:
+
+    def test_the_run_id_is_rendered(self) -> None:
+        assert "31501780284" in branch.run_cell(_run())
+
+    def test_attempt_one_is_stated_rather_than_implied(self) -> None:
+        """An absent number and an unread number must not look alike."""
+        assert "attempt 1" in branch.run_cell(_run(attempt=1))
+
+    def test_a_rerun_is_visible_and_differs_from_the_first_attempt(self) -> None:
+        first = branch.run_cell(_run(attempt=1))
+        again = branch.run_cell(_run(attempt=2))
+        assert first != again
+        assert "attempt 2" in again
+
+    def test_an_absent_attempt_is_a_question_mark_not_a_one(self) -> None:
+        cell = branch.run_cell(_run(attempt=None))
+        assert "attempt ?" in cell, cell
+        assert "attempt 1" not in cell, cell
+
+    def test_an_unreadable_attempt_is_a_question_mark(self) -> None:
+        assert "attempt ?" in branch.run_cell(_run(attempt="two"))
+
+    def test_an_absent_run_id_never_renders_as_minus_one(self) -> None:
+        """`_run_id` answers -1 for an unreadable id. -1 is not a run."""
+        cell = branch.run_cell(_run(databaseId=None))
+        assert "-1" not in cell, cell
+        assert "?" in cell, cell
+
+    def test_a_non_dict_run_is_declined_not_crashed(self) -> None:
+        assert "?" in branch.run_cell(None)
+
+
+# ---------------------------------------------------------------------------
+# the row, which is what a reader sees
+# ---------------------------------------------------------------------------
+
+class TestRow:
+
+    def test_the_row_carries_the_id_and_the_attempt(self) -> None:
+        row = branch._row("tests", _run(attempt=3), _PASS)
+        assert "31501780284" in row, row
+        assert "attempt 3" in row, row
+
+    def test_the_row_still_carries_the_lifecycle_phase(self) -> None:
+        """The column split must not cost the word #615 comment 1 asked for."""
+        assert branch.PHASE_CONCLUDED in branch._row("tests", _run(), _PASS)
+        assert branch.PHASE_RUNNING in branch._row(
+            "tests", _run(status="in_progress", conclusion=""), _PASS)
+
+    def test_the_row_still_carries_the_outcome_and_the_tally(self) -> None:
+        row = branch._row("tests", _run(), _PASS)
+        assert "success" in row, row
+        assert "1 total" in row, row
+
+
+# ---------------------------------------------------------------------------
+# the header and the note, so the numbers are readable as what they are
+# ---------------------------------------------------------------------------
+
+class TestDisclosure:
+
+    def test_the_header_names_both_new_columns(self) -> None:
+        head = branch.table_header()
+        assert "Run" in head and "Phase" in head, head
+
+    def test_the_header_is_wide_enough_for_the_widest_cell(self) -> None:
+        """A column narrower than its content silently runs into its neighbour."""
+        cell = branch.run_cell(_run(databaseId=31501780284, attempt=12))
+        assert len(cell) <= branch.RUN_COL, (cell, branch.RUN_COL)
+
+    def test_the_note_says_what_an_id_is_for_and_what_an_attempt_means(
+            self) -> None:
+        note = branch.run_id_note()
+        assert "gh-run:" in note, note
+        assert "attempt" in note, note
+        # The correction the issue body got wrong: a re-run is a further
+        # attempt on the same run object, not a second run object, so the row
+        # count is workflows and the tally is the latest attempt only.
+        assert "latest attempt" in note, note

--- a/tests/test_gh_issues_iids_client_filters_1439.py
+++ b/tests/test_gh_issues_iids_client_filters_1439.py
@@ -1,0 +1,219 @@
+"""#1439 — `iids` turned every client-side filter off, decline included.
+
+Measured on the live board before the fix:
+
+    $ supertool 'gh-issues:nomilestone,per=100,iids'       -> 95 ids
+    $ supertool 'gh-issues:milestone=v0.36.0,per=100,iids' ->  42 ids
+    intersection: 42 — every milestoned issue also reported as unmilestoned
+    $ supertool 'gh-issues:nomilestone,per=100'
+    53 issue(s) | nomilestone excluded 42 of 95 fetched
+
+**The mechanism is not the one the issue body proposed.** The body's hypothesis
+was that the `iids` projection drops the `milestone` field before the filter
+reads it. It does not: both shapes come from the same `gh issue list --json`
+call with the same `_LIST_FIELDS`, and the field is present on every row. The
+cause is **ordering** — the `numbers_only` early return sat *above* the whole
+client-side filter block, so `external`, `stale` and `nomilestone` were all
+inert under `iids`, and so were their declines. Nothing was dropped; the filter
+simply never ran.
+
+That also settles the class question the issue asks: it is not per-filter, it is
+every flag in the block, and the sibling op had already got it right. `gl-mrs`
+applies `failed` *before* its own `iids_only` return, and sets
+`show_pipe = failed_only or "nopipe" not in flags` so a filter that needs
+enrichment pays for it. `gh-issues` now has the same shape.
+
+Three properties, and the third is the one the issue was really about:
+
+* a client-side filter applies to the number list exactly as it applies to the
+  board;
+* a filter whose field is unknown **declines** under `iids` too — an id feed is
+  the shape most likely to be consumed by a script rather than read, so it is
+  the shape least able to carry a wrong answer;
+* the narrowing note rides the id feed as a `#` comment, because the non-`iids`
+  render states `nomilestone excluded 42 of 95 fetched` and the id feed stated
+  nothing at all — there was no line to disagree with.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+
+
+def _load(rel: str, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, _ROOT / rel)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+issues = _load("presets/github/issues.py", "github_issues_1439")
+
+REPO = "https://github.com/Digital-Process-Tools/claude-supertool"
+
+
+def _row(number: int, milestone: object = None, **over: Any) -> dict:
+    row = {
+        "number": number,
+        "title": f"issue {number}",
+        "state": "OPEN",
+        "author": {"login": "someone"},
+        "labels": [],
+        "assignees": [],
+        "milestone": milestone,
+        "createdAt": "2026-08-01T00:00:00Z",
+        "updatedAt": "2026-08-01T00:00:00Z",
+        # One comment, not zero: `_annotate` can settle `_stale` from the list
+        # data alone when an issue has no comments at all, so a zero-comment
+        # fixture makes the `stale` decline unreachable and the test vacuous.
+        "comments": [{"createdAt": "2026-08-02T00:00:00Z"}],
+        "url": f"{REPO}/issues/{number}",
+    }
+    row.update(over)
+    return row
+
+
+def _board(monkeypatch: Any, rows: list[dict], enrichment: object = "none"):
+    """Stub `gh issue list`. `enrichment` mocks the GraphQL half."""
+    calls: dict[str, int] = {"list": 0, "enrich": 0}
+
+    def _run(argv, **kwargs):
+        calls["list"] += 1
+        return types.SimpleNamespace(
+            returncode=0, stdout=json.dumps(rows), stderr="")
+
+    monkeypatch.setattr(issues.subprocess, "run", _run)
+
+    def _enrich(owner, name, numbers, chunk=20):
+        calls["enrich"] += 1
+        if enrichment == "none":
+            return {}, "the enrichment call was not stubbed"
+        return {n: dict(enrichment) for n in numbers}, None
+
+    monkeypatch.setattr(issues, "_fetch_enrichment", _enrich)
+    return calls
+
+
+def _out(capsys: Any) -> tuple[list[str], str]:
+    cap = capsys.readouterr()
+    return cap.out.splitlines(), cap.err
+
+
+def _numbers(lines: list[str]) -> list[int]:
+    return [int(ln) for ln in lines if ln.strip().isdigit()]
+
+
+# ---------------------------------------------------------------------------
+# the reported pair
+# ---------------------------------------------------------------------------
+
+MIXED = [
+    _row(1, milestone={"title": "v0.36.0"}),
+    _row(2, milestone=None),
+    _row(3, milestone={"title": "v0.36.0"}),
+    _row(4, milestone=None),
+]
+
+
+def test_nomilestone_narrows_the_id_feed(monkeypatch: Any, capsys: Any) -> None:
+    _board(monkeypatch, MIXED)
+    assert issues.main_with_args("nomilestone,iids") == 0
+    lines, _err = _out(capsys)
+    assert _numbers(lines) == [2, 4], lines
+
+
+def test_the_same_filter_gives_the_same_population_with_and_without_iids(
+        monkeypatch: Any, capsys: Any) -> None:
+    """The property the live reproduction measured: the two must not disagree."""
+    _board(monkeypatch, MIXED)
+    assert issues.main_with_args("nomilestone,iids") == 0
+    ids, _ = _out(capsys)
+    piped = set(_numbers(ids))
+
+    _board(monkeypatch, MIXED)
+    assert issues.main_with_args("nomilestone") == 0
+    board, _ = _out(capsys)
+    rendered = {n for n in (1, 2, 3, 4)
+                if any(f"#{n}" in ln for ln in board)}
+    assert piped == rendered, (sorted(piped), sorted(rendered), board)
+
+
+def test_the_narrowing_note_rides_the_id_feed(
+        monkeypatch: Any, capsys: Any) -> None:
+    """The tell that was missing: no line to disagree with is why it passed."""
+    _board(monkeypatch, MIXED)
+    assert issues.main_with_args("nomilestone,iids") == 0
+    lines, _err = _out(capsys)
+    notes = [ln for ln in lines if ln.startswith("#")]
+    assert any("nomilestone excluded 2 of 4 fetched" in ln for ln in notes), lines
+
+
+# ---------------------------------------------------------------------------
+# the decline, which `iids` must be able to carry
+# ---------------------------------------------------------------------------
+
+def test_an_unknown_milestone_declines_under_iids(
+        monkeypatch: Any, capsys: Any) -> None:
+    """A row whose `milestone` key never came back cannot be placed.
+
+    Filtering it in reports a scheduled issue as unscheduled; filtering it out
+    drops exactly the gap the query exists to find. The board already declined
+    here and the id feed did not.
+    """
+    rows = [_row(1, milestone=None), dict(_row(2))]
+    del rows[1]["milestone"]
+    _board(monkeypatch, rows)
+    assert issues.main_with_args("nomilestone,iids") == 1
+    lines, err = _out(capsys)
+    assert "cannot filter by nomilestone" in err, err
+    assert _numbers(lines) == [], lines
+
+
+@pytest.mark.parametrize("flag,field", [
+    ("external", "author association"),
+    ("stale", "body-edit time"),
+])
+def test_an_unenriched_field_declines_under_iids(
+        monkeypatch: Any, capsys: Any, flag: str, field: str) -> None:
+    """`nopipe` makes the field unknown by construction; the feed must not lie."""
+    _board(monkeypatch, MIXED)
+    assert issues.main_with_args(f"{flag},nopipe,iids") == 1
+    lines, err = _out(capsys)
+    assert f"cannot filter by {flag}" in err, err
+    assert _numbers(lines) == [], lines
+
+
+# ---------------------------------------------------------------------------
+# a filter that needs enrichment pays for it — `gl-mrs`'s rule
+# ---------------------------------------------------------------------------
+
+def test_external_under_iids_buys_the_enrichment_it_needs(
+        monkeypatch: Any, capsys: Any) -> None:
+    calls = _board(monkeypatch, MIXED, enrichment={
+        "authorAssociation": "NONE", "lastEditedAt": None,
+        "timelineItems": {"nodes": []},
+    })
+    assert issues.main_with_args("external,iids") == 0
+    lines, err = _out(capsys)
+    assert calls["enrich"] == 1, (calls, err)
+    assert _numbers(lines) == [1, 2, 3, 4], lines
+
+
+def test_a_bare_id_feed_still_pays_for_no_enrichment_at_all(
+        monkeypatch: Any, capsys: Any) -> None:
+    """The control. `iids` alone is the cheap shape and must stay cheap."""
+    calls = _board(monkeypatch, MIXED)
+    assert issues.main_with_args("iids") == 0
+    lines, _err = _out(capsys)
+    assert calls["enrich"] == 0, calls
+    assert _numbers(lines) == [1, 2, 3, 4], lines

--- a/tests/test_gh_issues_iids_client_filters_1439.py
+++ b/tests/test_gh_issues_iids_client_filters_1439.py
@@ -209,6 +209,44 @@ def test_external_under_iids_buys_the_enrichment_it_needs(
     assert _numbers(lines) == [1, 2, 3, 4], lines
 
 
+def test_the_named_population_route_buys_it_too(
+        monkeypatch: Any, capsys: Any) -> None:
+    """`iids=N,N,N,iids,external` must not decline what `external,iids` answers.
+
+    Found by the review of this change. `_lookup_iids` gates its half of the
+    GraphQL query on `not numbers_only` alone, so the named-population route
+    skipped enrichment even when a filter that reads an enriched field was
+    asked for, and then declined for want of the field it had chosen not to
+    fetch. A decline is honest and is still the wrong answer here: the op can
+    answer, and the two spellings of one request disagreed. #1439 asks for the
+    rule at the point the projection and the filter set are reconciled, not a
+    special case per route.
+    """
+    calls: dict[str, int] = {"n": 0}
+
+    def _lookup(owner, name, numbers, chunk, enrich):
+        calls["n"] += 1
+        assert enrich, "the lookup was asked for rows without the field the filter needs"
+        return ({n: ("issue", {
+            "number": n, "title": f"issue {n}", "state": "OPEN",
+            "author": {"login": "someone"}, "labels": {"nodes": []},
+            "assignees": {"nodes": []}, "milestone": None,
+            "createdAt": "2026-08-01T00:00:00Z",
+            "updatedAt": "2026-08-01T00:00:00Z",
+            "comments": {"totalCount": 0, "nodes": []},
+            "url": f"{REPO}/issues/{n}",
+            "authorAssociation": "NONE", "lastEditedAt": None,
+            "timelineItems": {"nodes": []},
+        }) for n in numbers}, None)
+
+    monkeypatch.setattr(issues, "_fetch_lookup", _lookup)
+    monkeypatch.setattr(issues, "_lookup_repo", lambda: (("o", "r"), None))
+    assert issues.main_with_args("iids=1,2,external,iids") == 0
+    lines, err = _out(capsys)
+    assert calls["n"] == 1, (calls, err)
+    assert _numbers(lines) == [1, 2], (lines, err)
+
+
 def test_a_bare_id_feed_still_pays_for_no_enrichment_at_all(
         monkeypatch: Any, capsys: Any) -> None:
     """The control. `iids` alone is the cheap shape and must stay cheap."""

--- a/tests/test_security_github.py
+++ b/tests/test_security_github.py
@@ -276,6 +276,16 @@ class TestBatchFollowShellSpecialUsernames:
         "user\x00null",
     ]
 
+    #: Since #1387 a candidate line holding whitespace is refused rather than
+    #: sent — it cannot be one login, and the file is now also the output of
+    #: `gh-find-followable`, whose lines carry an inline `# ...` annotation. So
+    #: this class asserts two things where it used to assert one: what still
+    #: goes out goes out literally, and what does not go out is not *trimmed*
+    #: into something that does. A prefix of an attacker-chosen string is a
+    #: different account, and following it would be the worse outcome of the two.
+    REFUSED = [u for u in EVIL_USERNAMES if any(c.isspace() for c in u)]
+    SENT = [u for u in EVIL_USERNAMES if not any(c.isspace() for c in u)]
+
     def test_evil_usernames_passed_as_literal_args(self, monkeypatch, tmp_path):
         evil_file = tmp_path / "evil_users.txt"
         evil_file.write_text("\n".join(self.EVIL_USERNAMES) + "\n")
@@ -292,17 +302,36 @@ class TestBatchFollowShellSpecialUsernames:
         monkeypatch.setenv("SUPERTOOL_FOLLOW_DELAY", "0")
         rc = batch_follow.main(str(evil_file))
 
-        # Every call must be list form — already asserted in spy
-        assert len(calls) == len(self.EVIL_USERNAMES), \
-            f"Expected {len(self.EVIL_USERNAMES)} calls, got {len(calls)}"
-        # Each username must appear verbatim as a list element in the gh call
-        for i, (call, evil) in enumerate(zip(calls, self.EVIL_USERNAMES)):
+        assert rc == 2, "a refused line must not leave a clean exit"
+        assert len(calls) == len(self.SENT), \
+            f"Expected {len(self.SENT)} calls, got {len(calls)}"
+        # Each username that IS sent must appear verbatim as a list element
+        for i, (call, evil) in enumerate(zip(calls, self.SENT)):
             username = evil.lstrip("@")
             # The username is embedded in the endpoint "user/following/<username>"
             endpoint_args = [a for a in call if "user/following" in str(a)]
             assert endpoint_args, f"Call {i}: no user/following arg found in {call}"
             assert username in endpoint_args[0], \
                 f"Call {i}: username {username!r} not literal in endpoint {endpoint_args[0]!r}"
+
+    def test_a_refused_username_is_not_trimmed_into_a_reachable_one(
+            self, monkeypatch, tmp_path):
+        """The failure mode a silent stripper would have: `foo; touch x` -> `foo`.
+
+        `foo` is an account that may well exist and is not the one on the line
+        anybody reviewed. Nothing derived from a refused line may reach `gh`.
+        """
+        evil_file = tmp_path / "evil_users.txt"
+        evil_file.write_text("\n".join(self.REFUSED) + "\n")
+
+        calls: list[list] = []
+        monkeypatch.setattr(batch_follow.subprocess, "run",
+                            lambda args, **k: calls.append(args) or _ok())
+        monkeypatch.setenv("SUPERTOOL_FOLLOW_DELAY", "0")
+
+        assert self.REFUSED, "fixture no longer exercises the refusal"
+        assert batch_follow.main(str(evil_file)) == 2
+        assert calls == [], f"a refused line reached gh: {calls!r}"
 
 
 # ===========================================================================

--- a/tests/test_verdict_name_conjunction_1374.py
+++ b/tests/test_verdict_name_conjunction_1374.py
@@ -1,0 +1,124 @@
+"""#1374 — a list of workflow names with no conjunction reads as truncated.
+
+Live on master before this:
+
+    Verdict: NOT GREEN — nothing has failed, but `CodeQL`, `changelog`, `tests`
+    have not concluded on d6cf7a4 ...
+
+A trailing comma-separated list with no `and` is the shape a *truncated* list
+has, in the one sentence whose job is to say whether the commit is cleared. The
+reader's question at that moment is "is that all of them", and the punctuation
+answers it wrong for free.
+
+`_names()` is the single place every such list is assembled (#841), so every
+`verdict()` branch that interpolates one is pinned here at two names and at
+three — the one-name control passes against the pre-#1374 code, so neither
+assertion stands alone as proof.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).parent.parent
+
+
+def _load(rel: str, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, _ROOT / rel)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+branch = _load("presets/github/branch.py", "github_branch_1374")
+
+SHA = "d6cf7a4e1f4c0d2f7b9e8a3d5c1b0e2f4a6c8d09"
+
+_DONE = {"status": "completed", "conclusion": "success",
+         "databaseId": 1, "createdAt": "2026-01-01T00:00:00Z"}
+_MOVING = {"status": "in_progress", "conclusion": "",
+           "databaseId": 2, "createdAt": "2026-01-01T00:00:00Z"}
+
+
+def _say(selected, legs, missing=(), age=0, unreconciled=""):
+    return branch.verdict(selected, legs, set(missing), SHA, age,
+                          unreconciled=unreconciled, scope="")[1]
+
+
+# ---------------------------------------------------------------------------
+# the joiner itself
+# ---------------------------------------------------------------------------
+
+def test_one_name_is_the_name() -> None:
+    assert branch._names(["tests"]) == "`tests`"
+
+
+def test_two_names_are_joined_by_a_conjunction_not_a_comma() -> None:
+    assert branch._names(["CodeQL", "tests"]) == "`CodeQL` and `tests`"
+
+
+def test_three_names_end_on_a_conjunction() -> None:
+    assert (branch._names(["CodeQL", "changelog", "tests"])
+            == "`CodeQL`, `changelog` and `tests`")
+
+
+def test_no_rendered_list_ever_ends_on_a_bare_name_after_a_comma() -> None:
+    """The property, not the three cases: the last separator is never a comma.
+
+    A list ending `..., `tests`` is indistinguishable from one that was cut, and
+    that is the whole defect. Asserted over 1..6 names so a future cap or a
+    re-write of the joiner cannot reintroduce the shape at some other length.
+    """
+    for n in range(1, 7):
+        rendered = branch._names([f"w{i}" for i in range(n)])
+        assert " and " in rendered or n == 1, rendered
+        assert not rendered.endswith("`, `w%d`" % (n - 1)) or n == 1, rendered
+
+
+def test_the_empty_list_is_not_silently_a_name() -> None:
+    """Nothing calls it with zero today. It must not render as a name if one does."""
+    assert branch._names([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# every verdict branch that interpolates one
+# ---------------------------------------------------------------------------
+
+def test_the_unconcluded_branch_carries_the_conjunction() -> None:
+    one = _say({"tests": _MOVING}, {"tests": ["IN_PROGRESS"]})
+    three = _say({"tests": _MOVING, "CodeQL": _MOVING, "changelog": _MOVING},
+                 {"tests": ["IN_PROGRESS"], "CodeQL": ["QUEUED"],
+                  "changelog": ["QUEUED"]})
+    assert "`tests` has not concluded" in one
+    assert "`CodeQL`, `changelog` and `tests` have not concluded" in three
+
+
+def test_the_red_branch_carries_the_conjunction() -> None:
+    red = {"status": "completed", "conclusion": "failure", "databaseId": 3,
+           "createdAt": "2026-01-01T00:00:00Z"}
+    one = _say({"tests": red}, {"tests": ["FAILURE"]})
+    three = _say({"tests": red, "CodeQL": red, "changelog": red},
+                 {"tests": ["FAILURE"], "CodeQL": ["FAILURE"],
+                  "changelog": ["FAILURE"]})
+    assert "in `tests`." in one
+    assert "in `CodeQL`, `changelog` and `tests`." in three
+
+
+def test_the_unread_job_list_branch_carries_the_conjunction() -> None:
+    one = _say({"tests": _DONE}, {"tests": None})
+    three = _say({"tests": _DONE, "CodeQL": _DONE, "changelog": _DONE},
+                 {"tests": None, "CodeQL": None, "changelog": None})
+    assert "for `tests` did" in one
+    assert "for `CodeQL`, `changelog` and `tests` did" in three
+
+
+def test_the_previous_head_branch_carries_the_conjunction() -> None:
+    one = _say({"tests": _DONE}, {"tests": ["SUCCESS"]}, missing=["docs"])
+    three = _say({"tests": _DONE}, {"tests": ["SUCCESS"]},
+                 missing=["docs", "lint", "spell"])
+    assert "`docs` ran on the previous head" in one
+    assert "`docs`, `lint` and `spell` ran on the previous head" in three

--- a/tests/test_verdict_plural_agreement_841.py
+++ b/tests/test_verdict_plural_agreement_841.py
@@ -58,7 +58,7 @@ def test_unconcluded_workflows_take_a_plural_verb_and_a_plural_pronoun() -> None
                {"tests": ["IN_PROGRESS"], "CodeQL": ["QUEUED"]})
     assert "`tests` has not concluded" in one
     assert "so it is neither a pass nor a fail" in one
-    assert "`CodeQL`, `tests` have not concluded" in two
+    assert "`CodeQL` and `tests` have not concluded" in two
     assert "so they are neither a pass nor a fail" in two
 
 
@@ -84,7 +84,7 @@ def test_workflows_with_no_run_on_this_head_take_a_plural_verb() -> None:
     two = _say({"tests": _DONE}, {"tests": ["SUCCESS"]},
                missing=["CodeQL", "lint"])
     assert "`CodeQL` ran on the previous head and has no run" in one
-    assert "`CodeQL`, `lint` ran on the previous head and have no run" in two
+    assert "`CodeQL` and `lint` ran on the previous head and have no run" in two
 
 
 def test_an_unread_job_list_pluralises_the_thing_that_did_not_come_back() -> None:
@@ -92,7 +92,7 @@ def test_an_unread_job_list_pluralises_the_thing_that_did_not_come_back() -> Non
     two = _say({"tests": _DONE, "CodeQL": _DONE},
                {"tests": None, "CodeQL": None})
     assert "the job list for `tests` did not come back" in one
-    assert "the job lists for `CodeQL`, `tests` did not come back" in two
+    assert "the job lists for `CodeQL` and `tests` did not come back" in two
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1374
Closes #1387
Closes #1409
Closes #1439

Four issues in one lane — `presets/github/` — one worktree, one context load.

## #1439, and the issue body's stated mechanism is wrong

I filed #1439 guessing that the `iids` projection dropped the `milestone` field before the filter read it. **There is no projection.** Both shapes come from one `gh issue list --json _LIST_FIELDS` call, `milestone` is on every row, and `_milestone_of` would have read it correctly. The `if numbers_only:` early return simply sat about thirty lines **above** the client-filter block, so `nomilestone`, `external` and `stale` — and all of their declines — were inert under `iids`.

That distinction decides the fix. Under my theory you repair a projection and `nomilestone` is the only casualty; under the real one all three client-side flags are dead under `iids`, which is what the issue's own "what to check beyond this pair" section asks about. It also explains the symptom exactly: rows looked *unmilestoned* rather than *unknown* because nothing evaluated them, where a dropped field would have hit `_milestone_of`'s missing-key arm and produced the decline the issue says never fired.

The sibling had the right shape already — `gl-mrs` applies `failed` before its own `iids_only` return. `gh-issues` now matches it.

Live, on the real board, with the branch binary:

```
$ python3 supertool.py 'gh-issues:nomilestone,per=100,iids'        -> 53 ids, "# nomilestone excluded 44 of 97 fetched"
$ python3 supertool.py 'gh-issues:milestone=v0.36.0,per=100,iids'  -> 44 ids
intersection: 0        (was 42)
```

## #1387: the consumer strips, and the guard is what makes that safe

Option one, and the issue's own middle option rejected: moving comments to their own line leaves the batch ops taking any line they do not understand and sending it.

`split_annotation` cuts at a `#` **preceded by whitespace**; `unusable` then refuses any value still holding whitespace or a `#`. The split can therefore only remove text no GitHub owner, repository or login could have contained, and anything left that still cannot be a name is refused rather than sent. `evil#tool/x` is the case that decides it — the issue's third option (first whitespace-delimited token) trims it to `evil`, an account that may well exist and is not the one anybody reviewed.

## #1409: a field on the existing op, and the body's remaining claim is also wrong

`run_cell` / `table_header` / `run_id_note` in `branch.py`; `Run` renders `<id> attempt <n>`, `Phase` the lifecycle word. The fields were already in `_run_list`'s `--json`, so this costs zero extra calls.

The body still asserts a re-run is a second run object on the same sha and nothing distinguishes attempt 1 from attempt 2. `POST /runs/{id}/rerun` increments `run_attempt` on the **same** run object, and this repo already depends on that: `_declared_legs.reconcilable` buys the `filter=all` second source precisely when the attempt is not 1. A re-run never doubles the row count. The field is still worth rendering for a different reason — the tally beside the row counts the latest attempt only — and that is what the note under the table now says.

## #1374

`_names()` joined with `", "` everywhere; now `a, b and c`, and two names get `and` too, since it is the same defect at n=2. Left uncapped deliberately, argued in the docstring: these names are the verdict's own subject, unlike `scope_clause`'s supplementary list.

## Three existing test files adapted — read this as intent, not collateral

- `test_gh_branch_orphaned_leg_1408.py` — its `_cells()` helper parsed by `partition(" ")` and now hits the run id. Taught the new cell, and the strip **asserts** it found one so the helper cannot go vacuous.
- `test_verdict_plural_agreement_841.py` — three wording assertions, comma to `and`. #1374 predicted this.
- `test_security_github.py::TestBatchFollowShellSpecialUsernames` — **a real contract change.** It asserted every line of the evil-usernames file becomes a `gh` call; under #1387 the four containing whitespace are refused, so 4 of 7 go out. The literal-argument property is kept for what is still sent, `rc == 2` added, plus a new test that nothing *derived* from a refused line reaches `gh` — the `foo; touch x` to `foo` failure a silent stripper would have had. Strictly stronger, but it is a deliberate weakening of a stated count in a security test.

## Adjacent, fixed

- `issues.py:1162` — found by the reviewer: the `iids=N,N,N` named-population route gated enrichment on `not numbers_only` alone, so `gh-issues:iids=1,2,iids,external` skipped the fetch and then declined for want of the field it chose not to get, while `gh-issues:external,iids` answered. Two spellings of one request disagreeing — the per-route special case #1439 asks to avoid. Red first.
- `batch_star` / `batch_follow` receipts gained `, N skipped` and exit 2 on a skipped line. Previously a `WARN` to stderr and nothing in `DONE:` — a line vanishing between the reviewed file and the run, with a clean exit.

## Left for filing

- `gh-issues`' `iids` notes go to stdout while `gl-mrs`' equivalent goes to **stderr**, which #654 says `_run_custom_op` drops on success — a disclosure nobody receives, same class as #1067, in the sibling.
- `test_gh_branch_orphaned_leg_1408.py`'s `_rows()` stops at the first blank line, so the new note sits outside the row scan by luck rather than by design.

## Tests

Red first on all four, verbatim in the commit trail. Green: 138 across the `gh-branch` family, 24 / 13 / 9 in the new files, 1447 passed 21 skipped across `-k "issues or iids or batch or branch or security"`.

Full suite ran in a disposable clone: **3 failed, 11158 passed, 93 skipped**. All three accounted for: `test_mcp_stop_crash_574` and `test_tsc_check` fail identically at base `042c6a9`; `test_git_timeout_disclosure_650` passes in isolation on this branch and failed only in the full run with `not inside a git repository`, the known non-hermetic worktree case.

Windows unverified — no path, subprocess or exception-type surface added, but that is reasoning, not a run.
