### PR TITLE
Git runs pre-push with zero ref lines when there is nothing to push, and the hook read that as 'I could not read stdin' and ran 296s of tests against a 300s budget

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -99,12 +99,36 @@ while read -r _local_ref _local_sha remote_ref _remote_sha; do
     esac
 done
 
-# Three states, not two. No refs on stdin means the question was never answered
-# — some callers invoke the hook with stdin closed — and an unanswered question
-# must not read as "feature branch, skip it". Say so, then run the suite: the
-# cost of being wrong that way is three minutes, and the other way is master.
+# Three states, not two — and zero ref lines is two different things (#1242).
+#
+# Git invokes this hook with `<remote-name> <remote-url>` in argv, always. So
+# when there are no ref lines AND git is the caller, the refs were read fine
+# and there are none: that is what an already-up-to-date `git push` looks like,
+# and git runs the hook for it anyway. Nothing is being updated, so there is
+# nothing to gate — and gating it cost the full suite. Measured 2026-08-12 with
+# this hook's branches marked: a second `git-push` on a pushed feature branch
+# took the "could not read" arm and went on to ~296s of pytest, against
+# `_PUSH_TIMEOUT = 300` in presets/git/push.py. That four-second margin is the
+# coin flip #1242 was filed about, and the suite was authorising a transfer of
+# nothing. An absence the tool produced, read as an absence in the world.
+#
+# With no argv, the caller is not git and the question really was never
+# answered — some callers invoke the hook with stdin closed. That is the case
+# the fallback below was written for and it keeps it: say so, then run the
+# suite, because the cost of being wrong that way is three minutes and the
+# other way is master.
 if [ "$saw_ref" -eq 0 ]; then
-    echo "── pre-push: could not read the push refs from stdin — running the suite ──"
+    if [ "$#" -lt 2 ]; then
+        echo "── pre-push: could not read the push refs from stdin — running the suite ──"
+    elif [ -n "${PREPUSH_FULL:-}" ]; then
+        echo "── pre-push: no refs to update, but PREPUSH_FULL=1 — running the suite ──"
+    else
+        echo "── pre-push: no refs to update — nothing to push, suite NOT run here ──"
+        echo "   git ran this hook for remote '$1' and sent no ref lines, which is"
+        echo "   what an up-to-date push looks like. Nothing moves, so nothing is gated."
+        echo "   Force it locally with: PREPUSH_FULL=1 git push"
+        exit 0
+    fi
 elif [ "$target_protected" -eq 0 ] && [ -z "${PREPUSH_FULL:-}" ]; then
     echo "── pre-push: feature branch — suite NOT run here ──"
     echo "   The PR's checks are the gate, and they run in parallel while you work."

--- a/changelog.d/1242.fixed.md
+++ b/changelog.d/1242.fixed.md
@@ -1,0 +1,16 @@
+- `.githooks/pre-push` no longer runs the full test suite for a push that
+  updates nothing (#1242). Git invokes the hook even when everything is already
+  up to date, and legitimately hands it zero ref lines; the hook read that as
+  "I could not read the refs" and fell through to the ~296s suite — against
+  `git-push`'s own 300s budget, which is what made a legitimate push look like
+  a coin flip. The two cases are told apart by argv, which git always fills
+  with the remote name and URL, so a hook run by something that is not git
+  still runs the suite. The skip is disclosed, like the feature-branch one.
+
+- `git-push`'s timeout receipt now says whether a local pre-push hook was in
+  play (#1242), in three states — it names the hook path, says no hook ran, or
+  declines when git did not answer where the hook lives. A timeout whose budget
+  went to a local suite and one that went to a hanging network were previously
+  indistinguishable, and the receipt's advice ("the push may still be in
+  flight") reads as the second. The verdict, the remote read-back, both shas
+  and the do-not-force-push advice are unchanged.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -799,11 +799,25 @@ red PR branch is what PRs are for and the PR's checks run in parallel on
 somebody else's machine. The measured cost it removes from a feature push is
 **176.66s**, serial and blocking.
 
-Three states, not two, and each announces itself: destination is master → run;
-destination is a feature branch → skip, and say so; **stdin unreadable → run
-the suite**, because "the question was never answered" must not render as
-"feature branch, skip it". Being wrong that way costs three minutes; being
-wrong the other way costs master.
+Four states, and each announces itself: destination is master → run;
+destination is a feature branch → skip, and say so; **git handed us no refs at
+all → skip, and say so**; **something that is not git ran the hook and stdin
+was unreadable → run the suite**, because "the question was never answered"
+must not render as "feature branch, skip it". Being wrong that way costs three
+minutes; being wrong the other way costs master.
+
+The third and fourth used to be one state, and merging them was the bug
+([#1242](https://github.com/Digital-Process-Tools/claude-supertool/issues/1242)).
+Git runs this hook even when there is nothing to update — an already-up-to-date
+`git push` is the common case — and it legitimately sends zero ref lines. The
+hook read that as "I could not tell what is being pushed" and ran the whole
+suite to authorise a transfer of nothing: measured 2026-08-12 with the hook's
+branches marked, **~296s against `git-push`'s own 300s budget**, four seconds
+apart, which is the coin flip #1242 was filed about. They are distinguishable
+without guessing, and not by counting lines: **git always invokes `pre-push`
+with `<remote-name> <remote-url>` in argv**, so two args and no ref lines means
+git asked and there is nothing to gate, while no args at all means the caller
+was not git and the question really is open.
 
 - `PREPUSH_FULL=1 git push` — force the suite on a feature branch.
 - `git push --no-verify` — the blunt instrument: skips this hook and every

--- a/presets/git/push.py
+++ b/presets/git/push.py
@@ -1410,6 +1410,15 @@ def _report_push_timeout(branch: str, head_before: str,
     not do. Only a remote that did not move gets a failing verdict, and even
     then it is reported as *unverified*, not rejected — the push may still be
     in flight server-side.
+
+    The failing arm additionally names where the budget probably went, via
+    `_prepush_hook_state` (#1242): a local pre-push hook and a hanging network
+    are indistinguishable from a clock, and this repo's own hook can spend
+    ~296s of a 300s budget. That disclosure never edits the verdict, and it
+    never retracts the in-flight caution below it — the timeout kills the whole
+    `git push`, so a hook that finished at 290s and a transfer that then began
+    are still on the table, and inferring otherwise from "a hook exists" would
+    be the same guess this op refuses everywhere else.
     """
     head_after, _head_why = _local_head()
     live, live_why = _live_remote_sha(remote, ref)

--- a/presets/git/push.py
+++ b/presets/git/push.py
@@ -792,6 +792,46 @@ def _watch_target(mr: Optional[dict]) -> Optional[tuple[str, str]]:
     return source, str(mr["iid"])
 
 
+def _prepush_hook_state(flags: set[str]) -> tuple[str, str]:
+    """Would `git push` have run a local pre-push hook here? `(state, detail)`.
+
+    Three states, and the third is the one that matters (#1242). A push that
+    outlasts its budget has two causes that look identical from outside — the
+    network, and a local hook that was still running — and the receipt used to
+    name only the first. A lookup that could not answer must therefore not
+    render as "no hook", which is precisely the reading that sends someone to
+    check their connection for a suite that was running on their own laptop.
+
+    * `runs`    — detail is the hook path git resolved.
+    * `none`    — detail says why: the flag, or nothing executable there.
+    * `unknown` — detail is the git call that did not answer.
+
+    `--git-path` is asked rather than `.git/hooks` assumed: it honours
+    `core.hooksPath`, which is how this repo installs its own hook, and it
+    resolves per worktree. Nothing here changes the verdict; it changes where
+    the reader looks for the four seconds.
+    """
+    if "no-verify" in flags:
+        return "none", "--no-verify was passed, so git skipped the local hook"
+    r, why = _checked_git(["rev-parse", "--git-path", "hooks/pre-push"],
+                          "git rev-parse --git-path hooks/pre-push")
+    if r is None:
+        return "unknown", why
+    path = r.stdout.strip()
+    if not path:
+        return "unknown", ("`git rev-parse --git-path hooks/pre-push` "
+                           "answered with nothing")
+    # `os.access(X_OK)` is True for any existing file on Windows — there is no
+    # execute bit — so this reads `runs` there for a hook that is merely
+    # present. That is the right answer on that platform rather than a vacuous
+    # one: git runs hooks through sh, which does not consult a bit that does
+    # not exist. Erring toward `runs` is also the safe direction here, because
+    # this line only redirects where the reader looks; it decides no verdict.
+    if os.path.isfile(path) and os.access(path, os.X_OK):
+        return "runs", path
+    return "none", f"no executable pre-push hook at {path}"
+
+
 def _repo_root() -> str:
     """Directory holding the `supertool` wrapper and `supertool.py`."""
     return install_dir()
@@ -1402,6 +1442,19 @@ def _report_push_timeout(branch: str, head_before: str,
     print(f"local HEAD {head_after[:7] or 'unknown'} | "
           f"remote {remote}/{ref} at {live[:7] or 'unknown'}"
           + (f" ({live_why})" if not live and live_why else ""))
+    hook_state, hook_detail = _prepush_hook_state(flags)
+    if hook_state == "runs":
+        print(f"A local pre-push hook runs before anything is sent "
+              f"({hook_detail}), so some or all of that {_PUSH_TIMEOUT}s may "
+              "have been local — a remote that has not moved is exactly what a "
+              "push still inside its own hook looks like. This repo's hook "
+              "runs the full suite when the destination is master/main (#1242).")
+    elif hook_state == "none":
+        print(f"No local pre-push hook ran ({hook_detail}), so the "
+              f"{_PUSH_TIMEOUT}s was the push itself.")
+    else:
+        print(f"Whether a local pre-push hook ran is UNKNOWN — {hook_detail}. "
+              "This receipt is not saying none did.")
     print("The push may still be in flight — `git fetch` and re-check before "
           "retrying; do NOT force-push on a timeout alone.")
     _result(f"NOT PUSHED - UNVERIFIED  {branch} -> {remote}/{ref} - push timed "

--- a/tests/test_git_push_timeout_names_the_hook_1242.py
+++ b/tests/test_git_push_timeout_names_the_hook_1242.py
@@ -1,0 +1,190 @@
+"""A push timeout must say whether the clock was the network or the hook (#1242).
+
+`_report_push_timeout` is the receipt this issue explicitly did not want
+weakened: it refuses to infer success, asks the remote, names both shas, and
+tells the reader not to force-push. All of that stays.
+
+What it never said is *where the time went*. The success arm already hedges —
+"slow pre-push hook or transfer" — but the failing arm, the one a reader acts
+on, offers only "the push may still be in flight". For a push whose local
+pre-push hook was still running the suite when the budget expired, nothing was
+ever in flight, and "in flight" is the reading that sends someone to check the
+network.
+
+`.githooks/pre-push` runs the full suite (~296s measured) when the destination
+is `master`/`main`, against a 300s budget. So the two causes are four seconds
+apart and the receipt could not tell them apart.
+
+Three states, per docs/validators.md §"Declining instead of guessing" — the
+point is that `unknown` is a real answer and must never render as `none`:
+
+* `runs` — an executable pre-push hook is what `git push` would run here;
+* `none` — `--no-verify` was passed, or there is no executable hook;
+* `unknown` — git did not answer where the hook lives.
+
+The verdict itself is untouched by all three. This changes where the reader
+looks, not what the receipt concludes.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import stat
+import subprocess
+import types
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+PRESET = Path(__file__).parent.parent / "presets" / "git" / "push.py"
+_spec = importlib.util.spec_from_file_location("git_push_1242", PRESET)
+assert _spec is not None and _spec.loader is not None
+push = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(push)
+
+
+def _repo(tmp_path: Path) -> Path:
+    work = tmp_path / "repo"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q", str(work)], check=True,
+                   capture_output=True)
+    return work
+
+
+def _install_hook(work: Path, hooks_dir: str = ".githooks") -> Path:
+    subprocess.run(["git", "config", "core.hooksPath", hooks_dir], cwd=work,
+                   check=True, capture_output=True)
+    d = work / hooks_dir
+    d.mkdir(parents=True, exist_ok=True)
+    hook = d / "pre-push"
+    hook.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+    return hook
+
+
+# ---------------------------------------------------------------------------
+# the state helper
+# ---------------------------------------------------------------------------
+
+def test_an_executable_hook_reads_as_runs(tmp_path: Path,
+                                          monkeypatch: pytest.MonkeyPatch) -> None:
+    work = _repo(tmp_path)
+    _install_hook(work)
+    monkeypatch.chdir(work)
+    state, detail = push._prepush_hook_state(set())
+    assert state == "runs", detail
+    assert "pre-push" in detail
+
+
+def test_no_hook_reads_as_none(tmp_path: Path,
+                               monkeypatch: pytest.MonkeyPatch) -> None:
+    work = _repo(tmp_path)
+    monkeypatch.chdir(work)
+    state, _detail = push._prepush_hook_state(set())
+    assert state == "none"
+
+
+def test_no_verify_reads_as_none_without_asking_git(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The flag settles it — a hook on disk that git was told to skip did not
+    run, and reporting `runs` there would point the reader at the wrong cause."""
+    work = _repo(tmp_path)
+    _install_hook(work)
+    monkeypatch.chdir(work)
+    state, detail = push._prepush_hook_state({"no-verify"})
+    assert state == "none"
+    assert "no-verify" in detail
+
+
+def test_git_not_answering_is_unknown_not_none(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """The defect class. A lookup that could not run must not render as `no
+    hook ran`, which is the reading that blames the network."""
+    monkeypatch.setattr(push, "_checked_git",
+                        lambda *a, **k: (None, "`git rev-parse` exited 128"))
+    state, detail = push._prepush_hook_state(set())
+    assert state == "unknown", detail
+    assert "rev-parse" in detail
+
+
+# ---------------------------------------------------------------------------
+# the receipt
+# ---------------------------------------------------------------------------
+
+def _timeout_receipt(monkeypatch: pytest.MonkeyPatch,
+                     hook_state: tuple[str, str]) -> tuple[str, int]:
+    """The failing arm: local HEAD and remote disagree, so the push is
+    UNVERIFIED. That is the arm a reader acts on."""
+    monkeypatch.setattr(push, "_local_head", lambda: ("a" * 40, ""))
+    monkeypatch.setattr(push, "_live_remote_sha", lambda *a, **k: ("b" * 40, ""))
+    monkeypatch.setattr(push, "_prepush_hook_state", lambda flags: hook_state)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = push._report_push_timeout("fix/1", "c" * 40, "origin",
+                                       "refs/heads/fix/1", set())
+    return buf.getvalue(), rc
+
+
+def test_timeout_receipt_names_a_hook_that_would_have_run(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    out, _rc = _timeout_receipt(monkeypatch, ("runs", ".githooks/pre-push"))
+    assert ".githooks/pre-push" in out
+    assert "pre-push hook" in out
+
+
+def test_timeout_receipt_says_so_when_no_hook_ran(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """The useful half of the disclosure: ruling the hook out is what confirms
+    the network diagnosis the rest of the receipt implies."""
+    out, _rc = _timeout_receipt(
+        monkeypatch, ("none", "no executable pre-push hook"))
+    assert "no executable pre-push hook" in out.lower()
+
+
+def test_timeout_receipt_declines_rather_than_claiming_no_hook(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    out, _rc = _timeout_receipt(
+        monkeypatch, ("unknown", "`git rev-parse` exited 128"))
+    assert "UNKNOWN" in out
+    assert "rev-parse" in out
+
+
+# ---------------------------------------------------------------------------
+# what must not weaken — the receipt #1242 asked to keep intact
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("state", [
+    ("runs", ".githooks/pre-push"),
+    ("none", "no executable pre-push hook"),
+    ("unknown", "`git rev-parse` exited 128"),
+])
+def test_the_verdict_and_its_advice_survive_every_hook_state(
+        monkeypatch: pytest.MonkeyPatch, state: tuple[str, str]) -> None:
+    out, rc = _timeout_receipt(monkeypatch, state)
+    assert rc == 1
+    assert "PUSH TIMED OUT" in out
+    assert "aaaaaaa" in out and "bbbbbbb" in out, "both shas must still be named"
+    assert "do NOT force-push" in out
+    assert "NOT PUSHED - UNVERIFIED" in out
+
+
+def test_a_landed_push_is_still_reported_as_pushed(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    """The other arm: the remote matches HEAD, so the timeout is not a failure
+    and no hook disclosure may turn it into one."""
+    monkeypatch.setattr(push, "_local_head", lambda: ("a" * 40, ""))
+    monkeypatch.setattr(push, "_live_remote_sha", lambda *a, **k: ("a" * 40, ""))
+    monkeypatch.setattr(push, "_mr_lookup",
+                        lambda *a, **k: types.SimpleNamespace(mr=None,
+                                                              answered=True))
+    monkeypatch.setattr(push, "_open_mr_line", lambda *a, **k: "")
+    monkeypatch.setattr(push, "_post_push_advisories", lambda *a, **k: None)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = push._report_push_timeout("fix/1", "c" * 40, "origin",
+                                       "refs/heads/fix/1", set())
+    out = buf.getvalue()
+    assert rc == 0
+    assert "PUSHED" in out
+    assert "PUSH TIMED OUT" not in out

--- a/tests/test_prepush_nothing_to_push_1242.py
+++ b/tests/test_prepush_nothing_to_push_1242.py
@@ -30,7 +30,7 @@ Three states, and the middle one stops being answered by the wrong arm.
 """
 from __future__ import annotations
 
-import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -72,7 +72,15 @@ class _Box:
         self.log.write_text("", encoding="utf-8")
         git = shutil.which("git")
         assert git is not None, "git is required to run the hook at all"
-        os.symlink(git, self.bin / "git")
+        # A shim rather than a symlink. The hook only needs *a* `git` on this
+        # PATH, and a symlink would add a call site to the register in
+        # tests/test_symlink_gating_register_1232.py — a capability this file
+        # does not otherwise need, gated for a platform it already skips.
+        shim = self.bin / "git"
+        shim.write_text(
+            '#!/bin/bash\nexec ' + shlex.quote(git) + ' "$@"\n',
+            encoding="utf-8")
+        shim.chmod(0o755)
         python = self.bin / "python3.13"
         python.write_text(_STUB, encoding="utf-8")
         python.chmod(0o755)

--- a/tests/test_prepush_nothing_to_push_1242.py
+++ b/tests/test_prepush_nothing_to_push_1242.py
@@ -1,0 +1,176 @@
+"""Zero ref lines from git means nothing to push, not "I could not read" (#1242).
+
+`.githooks/pre-push` reads one line per ref off stdin and, since #894, runs the
+suite only when the destination is `master`/`main`. Its third state — no lines
+at all — was written for "some callers invoke the hook with stdin closed" and
+resolves to *run the suite*, on the reasoning that being wrong that way costs
+three minutes and the other way costs master.
+
+That fallback fires on a case it was not written for and gets it backwards.
+**`git push` with nothing to update still invokes the hook, and legitimately
+sends zero ref lines.** Measured 2026-08-12 in a disposable clone, with the
+hook's branches marked: a second `git-push` on an already-pushed feature branch
+reached `could not read the push refs from stdin` and went on to the full
+~296s suite — to decide whether to permit a push that transfers nothing. Under
+`_PUSH_TIMEOUT = 300` in `presets/git/push.py` that is the coin flip #1242 was
+filed about, and it is this repo's own defect class: an absence produced by the
+tool (git had no refs to send) read as an absence in the world (the refs could
+not be read).
+
+The two are distinguishable, and not by counting lines. **Git always invokes
+`pre-push` with two arguments** — the remote name and its URL. So:
+
+* two args and no ref lines — git ran us and there is nothing to update. There
+  is nothing to gate. Skip, and say so.
+* no args and no ref lines — something that is not git ran the hook, and the
+  question of what is being pushed really is unanswered. Run the suite; that is
+  the case the original fallback was written for and it keeps it.
+
+Three states, and the middle one stops being answered by the wrong arm.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+HOOK = REPO / ".githooks" / "pre-push"
+BASH = shutil.which("bash") or "/bin/bash"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason=".githooks/pre-push is a bash script"
+)
+
+# Logs every invocation, so "did the suite run" is answered by what the
+# interpreter was asked to do, never by parsing the hook's prose.
+_STUB = """#!/bin/bash
+echo "$*" >> "$STUB_LOG"
+exit 0
+"""
+
+# What git actually passes: `pre-push <remote-name> <remote-url>`.
+GIT_ARGV = ("origin", "https://example.invalid/repo.git")
+
+MASTER_REF = "refs/heads/master abc123 refs/heads/master def456\n"
+FEATURE_REF = "refs/heads/fix/1 abc123 refs/heads/fix/1 def456\n"
+
+
+class _Box:
+    """A git repo, a stub interpreter, and a way to feed the hook stdin."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.bin = tmp_path / "bin"
+        self.bin.mkdir()
+        self.work = tmp_path / "work"
+        self.work.mkdir()
+        self.log = tmp_path / "invocations.log"
+        self.log.write_text("", encoding="utf-8")
+        git = shutil.which("git")
+        assert git is not None, "git is required to run the hook at all"
+        os.symlink(git, self.bin / "git")
+        python = self.bin / "python3.13"
+        python.write_text(_STUB, encoding="utf-8")
+        python.chmod(0o755)
+        self.python = python
+        subprocess.run(["git", "init", "-q", str(self.work)], check=True,
+                       capture_output=True)
+
+    def run(self, stdin: str = "",
+            argv: tuple[str, ...] = GIT_ARGV,
+            prepush_full: bool = False) -> subprocess.CompletedProcess[str]:
+        env = {
+            "PATH": str(self.bin),
+            "HOME": str(self.work),
+            "STUB_LOG": str(self.log),
+            # Named explicitly: the interpreter ladder is #572's subject, not
+            # this file's, and resolving it here would couple the two.
+            "PYTHON": str(self.python),
+        }
+        if prepush_full:
+            env["PREPUSH_FULL"] = "1"
+        return subprocess.run(
+            [BASH, str(HOOK), *argv], cwd=str(self.work), env=env,
+            input=stdin, capture_output=True, encoding="utf-8",
+            errors="replace", timeout=60,
+        )
+
+    def ran_the_suite(self) -> bool:
+        return "-m pytest" in self.log.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def box(tmp_path: Path) -> _Box:
+    return _Box(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# the defect
+# ---------------------------------------------------------------------------
+
+def test_git_with_nothing_to_push_does_not_run_the_suite(box: _Box) -> None:
+    """The whole issue. An up-to-date `git push` still runs the hook and sends
+    no ref lines; ~296s of pytest to authorise moving nothing."""
+    r = box.run(stdin="", argv=GIT_ARGV)
+    assert not box.ran_the_suite(), (
+        "the suite ran for a push that updates no ref: " + r.stdout + r.stderr)
+    assert r.returncode == 0
+
+
+def test_nothing_to_push_is_disclosed_not_silent(box: _Box) -> None:
+    """A gate that stops gating has to say so — same rule as #894's skip."""
+    r = box.run(stdin="", argv=GIT_ARGV)
+    out = r.stdout + r.stderr
+    assert "pre-push" in out
+    assert "no refs" in out or "nothing to push" in out, out
+
+
+# ---------------------------------------------------------------------------
+# what must not weaken
+# ---------------------------------------------------------------------------
+
+def test_no_argv_and_no_refs_still_runs_the_suite(box: _Box) -> None:
+    """The case the original fallback was written for: a caller that is not
+    git, with stdin closed. The destination is genuinely unknown, so the
+    three-minute answer is the right one and stays."""
+    r = box.run(stdin="", argv=())
+    assert box.ran_the_suite(), r.stdout + r.stderr
+
+
+def test_a_push_to_master_still_runs_the_suite(box: _Box) -> None:
+    r = box.run(stdin=MASTER_REF)
+    assert box.ran_the_suite(), r.stdout + r.stderr
+
+
+def test_a_feature_branch_still_skips(box: _Box) -> None:
+    r = box.run(stdin=FEATURE_REF)
+    assert not box.ran_the_suite(), r.stdout + r.stderr
+    assert r.returncode == 0
+
+
+def test_prepush_full_still_forces_the_suite_on_a_feature_branch(
+        box: _Box) -> None:
+    r = box.run(stdin=FEATURE_REF, prepush_full=True)
+    assert box.ran_the_suite(), r.stdout + r.stderr
+
+
+def test_prepush_full_forces_the_suite_even_with_nothing_to_push(
+        box: _Box) -> None:
+    """The override keeps meaning "run it anyway" in every state, and the
+    banner has to say which state it overrode — a message about refs that
+    could not be read, printed for refs that were read and were empty, is the
+    same conflation one layer up."""
+    r = box.run(stdin="", argv=GIT_ARGV, prepush_full=True)
+    out = r.stdout + r.stderr
+    assert box.ran_the_suite(), out
+    assert "could not read" not in out, out
+
+
+def test_master_among_several_refs_still_runs_the_suite(box: _Box) -> None:
+    """Zero lines is the new case; more than one line was always handled."""
+    r = box.run(stdin=FEATURE_REF + MASTER_REF)
+    assert box.ran_the_suite(), r.stdout + r.stderr


### PR DESCRIPTION
Closes #1242

## The issue's premise was already dead when it was filed

#1242 cites `.githooks/pre-push:132` as if the full suite ran before every push. **#894 (`654d410`, 2026-08-06) gated it on the destination ref**; the issue was filed on 2026-08-09. Six pushes through `git-push` this morning returned in 6.5–8.1s each, which is impossible if a ~296s suite ran first — that observation is what sent this back for re-derivation rather than for a timeout bump.

Measured against a scratch clone with a local bare remote and a marker-instrumented hook, so each branch reports which arm it took:

| probe | markers | time |
| --- | --- | --- |
| feature branch, real commit, main clone | `HOOK-RAN`, `SKIP-FEATURE` | 1.12s |
| feature branch, real commit, **worktree** | `WT-HOOK-RAN`, `WT-SKIP-FEATURE` | 1.33s |
| **up-to-date push** (nothing to push), worktree | `WT-HOOK-RAN`, **`WT-NO-REFS`**, **`WT-SUITE-WOULD-RUN`** | — |

The four candidates I offered are all answered: the hook **does** fire from a worktree; `core.hooksPath=.githooks` is relative and resolves per worktree; it was not uninstalled; and `git-push` passes `--no-verify` nowhere unbidden (`push.py:1600,1821` gate it on the flag).

**Not reconstructed, and not invented:** the issue's own 274s and 302s pushes. Both `fix/1220` and `fix/1159` contain #894, so the stale-hook route does not explain them either. There is no measurement from that night and no story is offered to cover it.

## What survives, and it is the house defect

**Git invokes `pre-push` even when nothing is being updated, and legitimately sends zero ref lines.** The hook's third state read that as *"could not read the push refs from stdin"* and ran the whole ~296s suite — to authorise a transfer of nothing — against `_PUSH_TIMEOUT = 300`. Four seconds of margin, on the most common push there is.

The fail-safe itself was reasoned correctly ("three minutes beats pushing a red master") and then applied to a case it was never written for, where the safe direction is provably wrong. An absence produced by the tool, read as an absence in the world.

Discriminated without guessing: **git always passes `<remote-name> <remote-url>` in argv.** Two args and zero refs means git asked and there is nothing to gate. Zero args and zero refs means the caller is not git, the question is genuinely open, and the suite runs exactly as before.

## The options, and why two were refused

- **Option 2's message: built.** The timeout arm now names the hook's state.
- **Option 2's separate budget: refused.** The op runs `git push` as one subprocess; budgeting the hook separately means knowing when the hook ended and transport began, and the only available signal is the hook's own stdout. Parsing a hook's prose to decide a timeout is the inference this op exists to refuse. The message needs no such guess.
- **Option 3 (`-x`, `-n auto`): declined.** Neither addresses the conflation, and after this fix the suite runs only for master or `PREPUSH_FULL`.
- **The timeout constant is untouched.**
- **`no-verify` as the documented answer: no.** The hook's cost now lands only where it was designed to.
- **The in-flight caution is not retracted.** The timeout kills the whole `git push`, so a hook finishing at 290s and a transfer then beginning are both live. Concluding "nothing was sent" from "a hook exists" would weaken the one receipt #1242 explicitly protects. Pinned across all three hook states.

## Tests

Red first, verbatim:

```
AssertionError: the suite ran for a push that updates no ref: ── pre-push: could not read the push refs from stdin — running the suite ──
2 failed, 5 passed in 2.71s
```

The five passing are the guards — master runs, feature skips, `PREPUSH_FULL`, no-argv — so the discriminator is real rather than a blanket skip. Green: 53 passed across the new files plus `test_symlink_gating_register_1232`, `test_pre_push_interpreter_572`, `test_git_env_scrub_692`. End-to-end after the fix: `NEW-ARM-NOTHING-TO-PUSH`, suite arm never reached, 0.89s.

Full suite, disposable clone with `set-url`: **2 failed, 11251 passed, 93 skipped**. Both are the known pre-existing pair (`test_mcp_stop_crash_574`, `test_tsc_check`). Windows unverified.

## What the review caught, and what it could not

An `Explore` reviewer accepted one finding (a stale `_report_push_timeout` docstring, fixed in `5dce2a8`) and had one refused: that the "may still be in flight" line should be conditioned on `hook_state`. It is literally true in all three states, and gating it converts a hedge into an inference.

**The red that mattered came from the full suite, not the review** — the new sandbox's `os.symlink` was an unregistered call site in `test_symlink_gating_register_1232`. A missing register entry is an absence, and it sits on no line the diff touches. Diff review cannot see that by construction.

## Left for filing

- `tests/test_gh_pr_merge_cleanup_1256.py:13` claims `git push --delete` "runs the whole suite per deletion… about three hours of pytest". **Stale since #894** — measured, the delete refspec takes the feature-branch arm and the suite never runs. #1256's conclusion still stands on #1281's ref-safety grounds; only its stated reason is false. Left alone as another test's file.
- **`git-push` swallows the pre-push hook's stdout**, so `feature branch — suite NOT run here` and the new `no refs to update` never reach the operator through the op. A gate announcing that it is not gating, into a void.
- **Relative `core.hooksPath` resolves per worktree**, so a worktree cut from a stale master silently runs that master's hook, with no warning anywhere.
