### PR TITLE
The JIT rule stops firing on what the guard already claims - and the test derives its commands from the registry so the coupling cannot rot quietly

### DIFF
--- a/.claude/jit-context/tools/00-manual/00-index.tsv
+++ b/.claude/jit-context/tools/00-manual/00-index.tsv
@@ -2,4 +2,4 @@ Edit|Write|Read|Grep|Glob|MultiEdit|NotebookEdit	~.	harness-tools-blocked.md	blo
 Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(python3?[[:space:]]+(-m[[:space:]]+)?)?([^[:space:]]*/)?supertool(\.py)?[[:space:]][^|]*'(gh-prs|gl-mrs|gh-issues|gl-issues|radar|watches)	op-defaults-that-narrow.md	remind		
 Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(python3?[[:space:]]+(-m[[:space:]]+)?)?([^[:space:]]*/)?supertool(\.py)?[[:space:]][^\n]*[[:space:]'"]\|[[:space:]]*(head|tail|sed|cut|awk)	supertool-no-cut.md	block		
 Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged	merged-is-not-ancestry.md	block	--merged	
-Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(command[[:space:]]+)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/	git-C-has-cwd.md	block	git -c	
+Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(command[[:space:]]+)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/[^[:space:]]*[[:space:]]+(diff|log|status[^;&|\n]*--porcelain)	git-C-has-cwd.md	block	git -c	

--- a/.claude/jit-context/tools/00-manual/00-index.tsv
+++ b/.claude/jit-context/tools/00-manual/00-index.tsv
@@ -2,4 +2,4 @@ Edit|Write|Read|Grep|Glob|MultiEdit|NotebookEdit	~.	harness-tools-blocked.md	blo
 Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(python3?[[:space:]]+(-m[[:space:]]+)?)?([^[:space:]]*/)?supertool(\.py)?[[:space:]][^|]*'(gh-prs|gl-mrs|gh-issues|gl-issues|radar|watches)	op-defaults-that-narrow.md	remind		
 Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(python3?[[:space:]]+(-m[[:space:]]+)?)?([^[:space:]]*/)?supertool(\.py)?[[:space:]][^\n]*[[:space:]'"]\|[[:space:]]*(head|tail|sed|cut|awk)	supertool-no-cut.md	block		
 Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?git[[:space:]]+(branch|for-each-ref)[^|]*--merged	merged-is-not-ancestry.md	block	--merged	
-Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(command[[:space:]]+)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/[^[:space:]]*[[:space:]]+(diff|log|status[^;&|\n]*--porcelain)	git-C-has-cwd.md	block	git -c	
+Bash	~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(command[[:space:]]+)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/[^[:space:]]*[[:space:]]+(diff|log|status[^;&|\n]*[[:space:]]-)	git-C-has-cwd.md	block	git -c	

--- a/.claude/jit-context/tools/00-manual/git-C-has-cwd.md
+++ b/.claude/jit-context/tools/00-manual/git-C-has-cwd.md
@@ -1,7 +1,7 @@
 ---
 title: "`git -C <path>` is `cwd:` plus an op"
 tool: Bash
-match: ~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(command[[:space:]]+)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/[^[:space:]]*[[:space:]]+(diff|log|status[^;&|\n]*--porcelain)
+match: ~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(command[[:space:]]+)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/[^[:space:]]*[[:space:]]+(diff|log|status[^;&|\n]*[[:space:]]-)
 mode: block
 ---
 
@@ -14,7 +14,7 @@ mode: block
 | `git -C W status --porcelain` to see if a tree is busy | `supertool 'git-worktrees'` — three states, and `cannot tell` is not `idle` |
 | several trees in a row | one `git-worktrees` call answers all of them |
 
-**Only the subcommands no `replaces` entry claims.** `git -C W status`, `commit`, `push` and `worktree list` are the shipped guard's, which answers them with the op — this rule fired on them too until #1438, so every one was refused twice with two different messages. The coupling that creates is held by `tests/test_jit_rule_retirement_1376.py`: a subcommand the registry claims *and* this `match` still fires on is a red test naming both.
+**Only what no `replaces` entry claims.** Bare `git -C W status`, `commit`, `push` and `worktree list` are the shipped guard's — this rule fired on them too until #1438, so each was refused twice with two different messages. A flagged `status` is still here, because the guard's `unless_flag` declines all four spellings; a flagged `push`/`commit`/`worktree list` is refused by neither, deliberately, since there is no row above to offer. The coupling that creates is held by `tests/test_jit_rule_retirement_1376.py`: a command the registry claims *and* this `match` still fires on is a red test naming both.
 
 `cwd:` moves repo paths only: a relative `@payload` reference still resolves against the directory the call was made from, so pass payload paths absolutely.
 

--- a/.claude/jit-context/tools/00-manual/git-C-has-cwd.md
+++ b/.claude/jit-context/tools/00-manual/git-C-has-cwd.md
@@ -1,7 +1,7 @@
 ---
 title: "`git -C <path>` is `cwd:` plus an op"
 tool: Bash
-match: ~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(command[[:space:]]+)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/
+match: ~(^|[;&|\n])[[:space:]]*(rtk[[:space:]]+)?(command[[:space:]]+)?git[[:space:]]+-c[[:space:]]+[^=[:space:]]*/[^[:space:]]*[[:space:]]+(diff|log|status[^;&|\n]*--porcelain)
 mode: block
 ---
 
@@ -9,11 +9,12 @@ mode: block
 
 | Instead of | Use |
 | --- | --- |
-| `git -C W status` | `supertool 'cwd:W' 'git-status'` (`:full` uncaps, `:brief` puts the tree first) |
 | `git -C W diff` | `supertool 'cwd:W' 'git-diff'` (`:branch[:BASE]`, `:full` for hunks) |
 | `git -C W log master..HEAD` | `supertool 'cwd:W' 'git-diverge:BRANCH[:BASE]'` |
 | `git -C W status --porcelain` to see if a tree is busy | `supertool 'git-worktrees'` — three states, and `cannot tell` is not `idle` |
 | several trees in a row | one `git-worktrees` call answers all of them |
+
+**Only the subcommands no `replaces` entry claims.** `git -C W status`, `commit`, `push` and `worktree list` are the shipped guard's, which answers them with the op — this rule fired on them too until #1438, so every one was refused twice with two different messages. The coupling that creates is held by `tests/test_jit_rule_retirement_1376.py`: a subcommand the registry claims *and* this `match` still fires on is a red test naming both.
 
 `cwd:` moves repo paths only: a relative `@payload` reference still resolves against the directory the call was made from, so pass payload paths absolutely.
 

--- a/docs/presets/git.md
+++ b/docs/presets/git.md
@@ -89,11 +89,11 @@ It is worse on a refspec. `git push --dry-run origin feature:refs/heads/other` p
 
 **The cost, which is real:** a short flag carrying a clustered *value* is expanded too, so `git push -ofoo` reads as carrying `-f` and is no longer claimed (while `git push -oci.skip`, spelling no excluded letter, is still claimed — which is the arbitrariness, not a mitigation). Telling that from `-sb` needs per-flag arity the guard does not have. It errs toward allowing, and `git-push` forwards no push options anyway, so that particular block was already a dead end.
 
-### `git -C <path> <subcommand>` reaches none of these mappings
+### `git -C <path> <subcommand>` reaches these mappings — since #1421, not before
 
-`argv` is matched **token-for-token against the start of a simple command**, and `-C`'s value sits between the command word and the subcommand — so `{"argv": "git status"}` cannot see `git -C /tmp/x status`. The same holds for `git -c key=value`, `--git-dir` and `--work-tree`.
+This section said the opposite until #1438, and said it four sections below the paragraph recording the fix. `argv` is matched **token-for-token against the start of a simple command**, and `-C`'s value sits between the command word and the subcommand, so `{"argv": "git status"}` could not see `git -C /tmp/x status` — the answer was the matcher stripping git's own global options before scoring, not an entry here. Same for `git -c key=value`, `--git-dir` and `--work-tree`.
 
-That is a limit of the matcher, not of this preset, and it is deliberately not papered over here: an entry of `{"argv": "git -C"}` is the only spelling `replaces` offers, and it would block `git -C W tag` and `git -C W push origin v1.2.3` alike, neither of which any op answers. The op-side answer to driving another tree is `cwd:PATH` as the first op of the call.
+The entries are unchanged, and deliberately: `{"argv": "git -C"}` was the only spelling `replaces` offered, and it would have blocked `git -C W tag` too, which no op answers. What still reaches nothing is `git -C W <sub>` for a subcommand nothing maps, and the flagged spellings each `unless_flag` declines. The op-side answer to driving another tree is `cwd:PATH` as the first op of the call, and `.claude/jit-context/tools/00-manual/git-C-has-cwd.md` says so for the shapes above that the guard does not claim.
 
 ### Nine ops declare nothing
 

--- a/tests/test_jit_block_match_anchored_1415.py
+++ b/tests/test_jit_block_match_anchored_1415.py
@@ -183,8 +183,10 @@ OTHER_RULES = [
     ("merged-is-not-ancestry.md",
      "cd /tmp &&\n\tgit branch --merged master",
      "git commit -m " + APOS + "docs: --merged is not ancestry for git branch" + APOS),
+    # `status` here until #1438, which narrowed this rule to the subcommands no
+    # `replaces` entry claims -- `git -C W status` is the shipped guard's now.
     ("git-C-has-cwd.md",
-     "cd /tmp &&\n\tgit -C /Users/x/repo status",
+     "cd /tmp &&\n\tgit -C /Users/x/repo diff",
      "echo " + APOS + "git -C /tmp is not a cwd" + APOS),
     ("op-defaults-that-narrow.md",
      "cd /tmp &&\n\tsupertool " + APOS + "gh-prs:state=open" + APOS,

--- a/tests/test_jit_rule_retirement_1376.py
+++ b/tests/test_jit_rule_retirement_1376.py
@@ -332,6 +332,13 @@ def test_no_command_is_blocked_by_both_the_guard_and_the_rule(
     Read the failure as: the registry now claims this subcommand, so
     `git-C-has-cwd.md`'s `match` has to stop firing on it -- not as a bug in
     the mapping.
+
+    The guard-CLEAN half of these cases -- every `unless_flag` spelling -- is
+    VACUOUS today and is here for the day it stops being: `not (blocked and
+    fires)` holds whatever the rule does when the guard says nothing. What
+    stops that reading as coverage is `test_the_double_block_gate_is_not_
+    vacuous` below, and `_RULE_STILL_FIRES`, which asserts the flagged shapes
+    positively.
     """
     blocked = supertool.guard_command(command).state == "blocked"
     fires = _awk_matches(_pattern_for("git-C-has-cwd.md"), command)
@@ -343,13 +350,34 @@ def test_no_command_is_blocked_by_both_the_guard_and_the_rule(
 
 # The other direction, without which narrowing the pattern to nothing at all
 # would satisfy every case above. Each is guard-clean because `git diff` and
-# `git log` are recorded ABSENCES in presets/git.json, and because
-# `--porcelain` sits in git-status's `unless_flag`.
+# `git log` are recorded ABSENCES in presets/git.json, and because every flag
+# below sits in git-status's `unless_flag` -- the guard declines a flagged
+# `status` outright, so those shapes are this rule's or nobody's.
 _RULE_STILL_FIRES = [
     ("git -C /tmp/wt diff", "git-diff answers a narrower question"),
     ("git -C /tmp/wt log master..HEAD", "git-diverge answers a range"),
+    # Every `unless_flag` git-status carries, not just the one the rule's table
+    # happens to name: the guard declines all four, so all four are this rule's
+    # or nobody's, and the first draft of the narrowing left three unrefused.
     ("git -C /tmp/wt status --porcelain", "git-worktrees answers busy-ness"),
+    ("git -C /tmp/wt status --short", "same question, shorter flag"),
+    ("git -C /tmp/wt status -s", "same question, shortest flag"),
+    ("git -C /tmp/wt status -z", "same question, NUL-separated"),
 ]
+
+
+@needs_awk
+def test_the_double_block_gate_is_not_vacuous(shipped_registry):
+    """At least one derived command must actually reach the guard.
+
+    Without this, a registry that claimed no git command at all -- or a
+    `guard_command` that stopped answering -- would satisfy every case above
+    by making `blocked` false everywhere, and the gate would read as green
+    while checking nothing.
+    """
+    blocked = [c for _, c in _git_commands_the_registry_claims()
+               if supertool.guard_command(c).state == "blocked"]
+    assert len(blocked) >= 4, blocked
 
 
 @needs_awk

--- a/tests/test_jit_rule_retirement_1376.py
+++ b/tests/test_jit_rule_retirement_1376.py
@@ -29,6 +29,9 @@ the retirement decision is forced rather than forgotten.
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -41,6 +44,39 @@ INDEX = MANUAL / "00-index.tsv"
 SETTINGS = REPO / ".claude" / "settings.json"
 GUARD = "hooks/pre-bash-guard.sh"
 TAB = "\t"
+
+
+needs_awk = pytest.mark.skipif(
+    shutil.which("awk") is None,
+    reason="awk absent: no verdict is available, which is not the same as a pass")
+
+
+def _pattern_for(rule_file):
+    """Column 2 of the live row naming RULE_FILE, tilde stripped."""
+    for raw in INDEX.read_text(encoding="utf-8").splitlines():
+        fields = raw.split(TAB)
+        if len(fields) >= 3 and fields[2] == rule_file:
+            assert fields[1].startswith("~"), rule_file
+            return fields[1][1:]
+    raise AssertionError("no row for {0} in {1}".format(rule_file, INDEX))
+
+
+def _awk_matches(pattern, subject):
+    """Exactly what pre-tool-hook.sh:137 does: match(tolower(cmd), pat).
+
+    Through awk rather than `re` because awk is what compiles these and the
+    two disagree; via ENVIRON rather than `-v` so escapes arrive intact.
+    """
+    env = dict(os.environ, JIT_PAT=pattern, JIT_SUBJ=subject)
+    proc = subprocess.run(
+        ["awk", 'BEGIN { if (match(tolower(ENVIRON["JIT_SUBJ"]), '
+                'ENVIRON["JIT_PAT"])) print "MATCH"; else print "NO" }'],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        env=env)
+    assert proc.returncode == 0, "awk refused the pattern: " + proc.stderr
+    out = proc.stdout.strip()
+    assert out in ("MATCH", "NO"), "awk said {0!r}".format(out)
+    return out == "MATCH"
 
 
 def _indexed_files():
@@ -187,6 +223,11 @@ _KEPT_UNCOVERED = {
     # it also covers `git -C W diff` and `git -C W log`, and `git diff` /
     # `git log` are recorded ABSENCES in presets/git.json (the ops answer
     # narrower questions), so no mapping will ever claim them.
+    # #1438 then narrowed the `match` itself to those shapes, so `status`,
+    # `commit`, `push` and `worktree list` under `-C` are the guard's alone.
+    # This row asserting `clean` is no longer the whole gate -- the section at
+    # the foot of this file asserts the other side, that nothing the registry
+    # claims is still matched by the rule.
     "git-C-has-cwd.md": (
         "git -C /tmp/x diff",
         "git-diff answers a narrower question than raw git diff and is a "
@@ -241,3 +282,80 @@ def test_the_index_and_the_directory_still_agree():
     on_disk = {p.name for p in MANUAL.glob("*.md")}
     assert indexed == on_disk, {"indexed only": sorted(indexed - on_disk),
                                 "on disk only": sorted(on_disk - indexed)}
+
+
+# --------------------------------------------------------------------------
+# Nothing may be refused twice (#1438)
+# --------------------------------------------------------------------------
+#
+# `git-C-has-cwd.md` is kept for the shapes no `replaces` entry claims, which
+# means its `match` is now coupled to the registry: the moment a mapping grows
+# to cover a subcommand the regex still fires on, that command is refused twice
+# with two different messages -- #1376's option 3, which #1428 and #1437 were
+# supposed to have ended. Nothing about adding a `replaces` entry makes anyone
+# open the TSV, so the coupling is enforced here instead of remembered.
+#
+# The commands are DERIVED from the shipped registry rather than listed, so a
+# new git mapping enters this test by existing. `unless_flag` spellings are
+# derived too: they are the half that is guard-clean today and the half most
+# likely to flip.
+
+GIT_C = "git -C /tmp/wt "
+
+
+def _git_commands_the_registry_claims():
+    """(op, `git -C PATH ...` form) for every git `replaces` argv shipped."""
+    out = set()
+    for path in sorted((REPO / "presets").glob("*.json")):
+        ops = json.loads(path.read_text(encoding="utf-8")).get("ops") or {}
+        for op, spec in ops.items():
+            for entry in spec.get("replaces") or []:
+                argv = entry.get("argv") or ""
+                if not argv.startswith("git "):
+                    continue
+                tail = argv[len("git "):]
+                out.add((op, GIT_C + tail))
+                if entry.get("flag"):
+                    out.add((op, GIT_C + tail + " " + entry["flag"]))
+                for flag in entry.get("unless_flag") or []:
+                    out.add((op, GIT_C + tail + " " + flag))
+    assert out, "no git `replaces` entry found -- this test proved nothing"
+    return sorted(out)
+
+
+@needs_awk
+@pytest.mark.parametrize("op,command", _git_commands_the_registry_claims())
+def test_no_command_is_blocked_by_both_the_guard_and_the_rule(
+        shipped_registry, op, command):
+    """The coupling, made loud.
+
+    Read the failure as: the registry now claims this subcommand, so
+    `git-C-has-cwd.md`'s `match` has to stop firing on it -- not as a bug in
+    the mapping.
+    """
+    blocked = supertool.guard_command(command).state == "blocked"
+    fires = _awk_matches(_pattern_for("git-C-has-cwd.md"), command)
+    assert not (blocked and fires), (
+        "{0!r} is refused twice: the shipped guard (op {1}) and "
+        "git-C-has-cwd.md both answer it with different messages. Narrow the "
+        "rule's match in 00-index.tsv.".format(command, op))
+
+
+# The other direction, without which narrowing the pattern to nothing at all
+# would satisfy every case above. Each is guard-clean because `git diff` and
+# `git log` are recorded ABSENCES in presets/git.json, and because
+# `--porcelain` sits in git-status's `unless_flag`.
+_RULE_STILL_FIRES = [
+    ("git -C /tmp/wt diff", "git-diff answers a narrower question"),
+    ("git -C /tmp/wt log master..HEAD", "git-diverge answers a range"),
+    ("git -C /tmp/wt status --porcelain", "git-worktrees answers busy-ness"),
+]
+
+
+@needs_awk
+@pytest.mark.parametrize("command,why", _RULE_STILL_FIRES)
+def test_the_rule_still_fires_on_what_no_mapping_claims(
+        shipped_registry, command, why):
+    assert supertool.guard_command(command).state == "clean", (command, why)
+    assert _awk_matches(_pattern_for("git-C-has-cwd.md"), command), (
+        command, why)


### PR DESCRIPTION
Closes #1438

Since #1421 the shipped guard blocks `git -C W status`, and `git-C-has-cwd.md` fired on it too — two hooks, two different messages, on one command. #1376 named that shape as its own defect and accepted it only for a release window.

## Option 1, and why the deliverable is the test rather than the regex

The issue offered three. Retiring the rule loses real coverage (`git -C W diff` and `git -C W log` are recorded absences, not mappings), and adding `replaces` entries for `git diff` / `git log` would start refusing two of the commonest read commands there are.

So: narrow the `match` to what no mapping claims. **The honest cost of that is coupling a hand-written rule to the registry, where nothing fails when somebody forgets** — so `test_no_command_is_blocked_by_both_the_guard_and_the_rule` derives its commands **from the shipped registry itself** (`argv`, plus each `flag` and `unless_flag`) and reddens on guard-blocked ∧ rule-matches, naming both. A new git mapping enters that test by existing.

Two tests hold the other directions: one that the rule still fires on what nothing claims (narrowing the pattern to nothing would satisfy the first test alone), and one that at least four derived commands actually reach the guard, or the gate is green while checking nothing.

## What the review caught, and it was strictly worse than the double block

The first narrowing keyed the `status` branch on `--porcelain`. `git-status`'s `unless_flag` declines **all four** flagged spellings, so the `-s`, `--short` and `-z` forms came out refused by *nobody* — a hole where there had been a duplicate. The branch is now any flagged `status`, which is also simpler and survives `unless_flag` growing.

Red for that, verbatim:

```
FAILED test_the_rule_still_fires_on_what_no_mapping_claims[... status -s-...]
FAILED test_the_rule_still_fires_on_what_no_mapping_claims[... status --short-...]
FAILED test_the_rule_still_fires_on_what_no_mapping_claims[... status -z-...]
```

## Verified by running the hook, not by reading the regex

`claude-jit-context/scripts/pre-tool-hook.sh` with `CLAUDE_PROJECT_DIR` pointed at the worktree, reading the **rule-name** field of the log rather than `[shown:0]`:

```
$ git -C /tmp/x status               JIT: (none)   guard: BLOCKED (git-status)
$ git -C /tmp/x commit -m y          JIT: (none)   guard: BLOCKED (git-commit)
$ git -C /tmp/x worktree list        JIT: (none)   guard: BLOCKED (git-worktrees)
$ git -C /tmp/x diff                 JIT: block
$ git -C /tmp/x log master..HEAD     JIT: block
$ git -C /tmp/x status -s            JIT: block
$ git -c core.hooksPath=/tmp/h diff  JIT: (none)   (config override untouched)
$ echo 'not a cwd'                   JIT: (none)
```

## One thing deliberately left refused by neither

The flagged forms — a forced push, an amended commit, a porcelain worktree listing — are guard-clean by `unless_flag`, and the rule's table has no row that answers them. Firing there injects `git-diff` advice at a force-push, which is the wrong-block shape #1433 shrank this file for. Stated in the rule body rather than left to be rediscovered, and **filed**: nothing anywhere refuses a force-push through another worktree. That predates this change for the plain spelling.

## Adjacent, fixed

`docs/presets/git.md:92` was headed as though that whole invocation shape reaches none of these mappings — false since #1421, and contradicted by line 43 of the same file. A stated absence would have argued a reader out of the mapping that exists.

## Tests

Red first: 8 failed / 48 passed, then 3 failed / 57 passed for the review finding. Green: 197 across `test_jit_rule_retirement_1376`, `test_jit_block_match_anchored_1415`, `test_jit_index_dead_match_1254`, `test_jit_rule_body_budget_1433` and `test_git_replaces_1384`.

Full suite skipped deliberately — the change is `.claude/jit-context/`, two test files and one doc line; no core, no shared fixture, no rename. Rule body is 2,313 bytes against #1433's 3,200 ceiling.

**No changelog fragment**, and that is a decision rather than an omission: `.github/workflows/changelog.yml` requires one only from PRs touching `supertool.py`, `_supertool.py`, `presets/`, `validators/`, `formatters/`, `notifiers/` or `.claude-plugin/`. The jit rules are this checkout's own and ship to nobody.

## Filed from writing this PR body

The rule **blocked this very description** on its way to GitHub, because the transcript above contains lines that begin with the invocation it matches. `^`-alternation cannot tell a payload body from a command — bullet three of #1433, hit while shipping its sibling. Prefixing each line with a `$` prompt was the workaround.
