### PR TITLE
Two child-stream sinks #1555 opened in git-status, measured against a census #1556 wrote on an older base (#1562)

### DIFF
--- a/changelog.d/1562.fixed.md
+++ b/changelog.d/1562.fixed.md
@@ -1,0 +1,5 @@
+- `git-status` no longer relays a failed `git diff`'s stderr into its own
+  `Staged provenance UNKNOWN` line unmarked — a separator in that text could
+  start a line at column 0 in a receipt the tool owns. Routed through
+  `_untrusted.flat`, and the no-HEAD probe's stderr is now weighed as a
+  predicate rather than read as text, so the #1475 census holds again (#1562).

--- a/presets/git/status.py
+++ b/presets/git/status.py
@@ -182,9 +182,12 @@ def _unborn_head() -> bool:
     established there is no HEAD, and returns False so the caller discloses.
     """
     probe = _git(["rev-parse", "--verify", "--quiet", "HEAD"])
+    # `bool` because this is a predicate, not a relay: the stderr is weighed for
+    # emptiness and never rendered, so the taint stops at the type (#1562).
+    said = bool(probe.stderr.strip())
     return (probe.returncode != 0
             and probe.returncode != TIMEOUT_RC
-            and not probe.stderr.strip())
+            and not said)
 
 
 def _staged_path(line: str) -> str:
@@ -609,7 +612,7 @@ def main() -> int:
                     _note_failed(diff_cmd, diff_head)
                     print(f"⚠ {STAGED_PROVENANCE_UNKNOWN} — `git "
                           f"{' '.join(diff_cmd)}` did not answer "
-                          f"({_reason(diff_head.returncode, diff_head.stderr)}). "
+                          f"({_reason(diff_head.returncode, _untrusted.flat(diff_head.stderr))}). "
                           f"This run did not check whether the staged content "
                           f"exists in any file here.")
                 else:


### PR DESCRIPTION
`master` is red on three ubuntu legs at `1c92672` (run 31679333715):

```
FAILED tests/test_forged_child_stream_line_1475.py::test_no_new_child_stream_reaches_a_receipt_raw
    presets/git/status.py: 16 -> 18
```

Neither PR that produced it is wrong on its own base, and neither CI run could
have seen the combination: #1555 added two `stderr` sites to
`presets/git/status.py`, and #1556 introduced the census with
`"presets/git/status.py": 16` measured against a master that predated them.
Each blob extracted with `git show`: `f3602bd` (#1556 head) measures 16 against
its own 16; `1c92672` measures 18 against the same number.

Two sites, two different answers:

- `presets/git/status.py:610` genuinely relayed a failed `git diff` stderr into
  the `Staged provenance UNKNOWN` line the tool owns. `_reason` collapses
  whitespace with `" ".join(stderr.split())`, which absorbs U+2028 only because
  Python counts it as whitespace — an accident of `str.split()`, not a guard.
  Routed through `_untrusted.flat`.
- `presets/git/status.py:185` reads `probe.stderr.strip()` inside a boolean
  `return`. It is a predicate and is never rendered, so `bool()` stops the taint
  at the type — which is what the census own `NOT_TEXT` set exists for.

No census number is raised.

Verified locally on the branch: `tests/test_forged_child_stream_line_1475.py`
10 passed (red before the change with the assertion above), plus 84 passed
across the five `git-status` suites.

Closes #1562