### PR TITLE
A test read a declining `git status` as a disagreeing one, so an environmental timeout rendered as a product verdict

### DIFF
--- a/tests/_git_decline.py
+++ b/tests/_git_decline.py
@@ -1,0 +1,109 @@
+"""One decline decision for `read`'s git marker, read off the suffix (#705).
+
+`_path_meta_suffix` asks git for a path's working-tree state under a 2s budget
+and, when that query cannot answer, says so: the marker is
+``supertool.PATH_META_UNKNOWN`` -- state unknown, not clean. That is the product
+behaving correctly (#705, ``docs/validators.md`` "Declining instead of
+guessing").
+
+A test that compares two such answers to each other cannot tell a decline from
+a disagreement. On 2026-08-13 that reddened master's
+``pytest (windows-latest, 3.12)`` leg and nothing else, at ac1b3e4:
+
+    {'sub/clean.txt': ' git?'} != {'sub/clean.txt': ''}
+
+That test spawns `git status` fourteen times, measured: thirteen per-path
+queries and one repo-wide. One of the thirteen blew the 2s budget on a loaded
+runner, so the route under comparison declined and the parity assertion read an
+environment condition as the two routes disagreeing about the file. Reproduced
+deterministically on macOS by raising ``TimeoutExpired`` from the 13th -- the
+one the coalesced pass makes -- which prints the failure above byte for byte.
+
+Same token, same leg and same shape as #1364 (a docs-only PR reddened by the
+parallel receipts), the same budget class one layer over as #1360, and the same
+defect this repo files against itself: an absence produced by the tooling, read
+as an absence in the world (#1205, #1218).
+
+``suffix()`` sits in front of every assertion about the marker and does one of
+two things:
+
+  * **returns** the suffix, when git answered. The caller asserts as before.
+    That is the only green -- this is a gate, not a tolerance.
+  * **skips**, carrying ``TOKEN``, when the suffix carries the decline. Nothing
+    is asserted about a lookup that did not happen, and ``conftest`` prints the
+    count, its denominator and its population every run, zero included.
+
+**Residual, stated rather than waved away.** ``PATH_META_UNKNOWN`` is one token
+for two causes -- the 2s timeout, and a non-zero git exit whose stderr is not
+"not a git repository" (a held index lock, a dubious-ownership refusal). Both
+are environment conditions here, and the product does not distinguish them in
+the suffix, so this gate cannot either: a product bug that made git exit
+non-zero would skip rather than red *in this file*. It stays red in
+``tests/test_status_swallowed_705.py``, which pins the decline itself against
+shimmed gits and is deliberately not routed through here.
+
+**The count is a subset and says so** (#1274). Only a call routed through
+``suffix`` can produce a token skip. The spawn-count tests call the product
+directly because they read the counter and never the string;
+``test_every_marker_assertion_is_decline_gated`` derives that population from
+the AST rather than trusting this sentence.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import supertool
+
+#: Grep handle. Appears in every skip this module produces, so `N skipped` on a
+#: Windows leg can be resolved to `N did not get an answer out of git here`.
+TOKEN = "git-status-decline(#705)"
+
+
+def require_answer(out: str, subject: str) -> None:
+    """Skip, countably, when `out` says the lookup declined. Never tolerate.
+
+    Token-wise and not a substring test: the suffix is a space-joined token
+    list, and a symlink target renders into it verbatim.
+    """
+    if supertool.PATH_META_UNKNOWN not in out.split():
+        return
+    pytest.skip(
+        "{0}: the working-tree lookup for {1!r} declined ({2!r}), so this "
+        "runner never produced a marker to compare. The decline itself is "
+        "pinned by tests/test_status_swallowed_705.py; do NOT raise the 2s "
+        "budget, and do NOT compare a decline against an answer -- that is "
+        "what reddened windows-latest at ac1b3e4.".format(TOKEN, subject, out))
+
+
+def suffix(path, sample: bytes = b"x\n") -> str:
+    """`_path_meta_suffix`, gated. The only route this file asserts through.
+
+    Takes a `Path` as readily as a `str` -- the callers hold `tmp_path`
+    objects, and `str(...)` at twenty call sites is twenty chances to convert
+    the wrong one.
+    """
+    path = os.fspath(path)
+    out = supertool._path_meta_suffix(path, sample)
+    require_answer(out, path)
+    return out
+
+
+#: One line for the terminal summary, printed whether the count is zero or not.
+POPULATION = (
+    "  ^ counts skips carrying that token only, not every test that reads a "
+    "git marker: the spawn-count tests call the product directly and never "
+    "look at the string, and a decline outside this gate (the shimmed-git "
+    "pins in tests/test_status_swallowed_705.py) stays red rather than "
+    "skipping. Full population, derived from the AST: "
+    "tests/test_path_meta_bulk_1126.py")
+
+
+def verdict_line(n: int, total: int) -> str:
+    """``N of M skipped``, never a bare ``N`` (#1274)."""
+    return (
+        "{0}: {1} of {2} skipped tests did NOT get a working-tree answer out "
+        "of git -- the 2s budget ran out, or git exited non-zero for a reason "
+        "other than 'not a repository' (expect 0; a non-zero count is a "
+        "runner too loaded to answer, not a finding)".format(TOKEN, n, total))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,13 +359,17 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     `688 skipped` is a number. `N of 688 skipped, because this runner has no
     create-symlink privilege` is a fact somebody can act on -- it is the
     difference between an absence in the world and an absence the tooling
-    produced. Two reasons are broken out that way, each in its own helper below:
-    the create-symlink privilege (#1143) and the post-edit lint budget (#1360).
+    produced. Four reasons are broken out that way, each in its own helper
+    below: the create-symlink privilege (#1143), the post-edit lint budget
+    (#1360), the live GitHub API (#1568) and a `git status` that would not
+    answer about a path's working-tree state (#705). This sentence said "two"
+    for as long as there were three -- the count is the thing that goes stale,
+    so it is derived nowhere and stated here once.
 
-    Both print whether the count is zero or not -- silence would be
+    All of them print whether the count is zero or not -- silence would be
     indistinguishable from not having looked -- and each prints its denominator
     and its population next to the number, so a non-zero count is not read as a
-    total either (#1274). Neither is reached through the other: this hook used to
+    total either (#1274). None is reached through another: this hook used to
     return early when `_symlink` was absent from the tree, which would now omit
     the lint line silently -- the same absence, one layer up (#1360).
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,13 @@ try:
 except ImportError:  # pragma: no cover - only in the synthetic-repo suites
     _live_gh = None
 
+# Same tolerance, same reason: the `git status` decline gate behind read's
+# working-tree marker, and its countable skip.
+try:
+    import _git_decline  # noqa: E402
+except ImportError:  # pragma: no cover - only in the synthetic-repo suites
+    _git_decline = None
+
 # Same tolerance, same reason (#1523). This one is registered as a plugin rather
 # than called from the hooks below: it needs `pytest_runtest_makereport`,
 # `pytest_runtest_logreport` and `pytest_sessionfinish` as well as a summary
@@ -366,6 +373,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     _symlink_summary(terminalreporter, skipped)
     _lint_budget_summary(terminalreporter, skipped)
     _live_gh_summary(terminalreporter, skipped)
+    _git_decline_summary(terminalreporter, skipped)
 
 
 def _token_skips(skipped, token: str) -> int:
@@ -436,6 +444,27 @@ def _live_gh_summary(terminalreporter, skipped):
     terminalreporter.write_line(
         _live_gh.verdict_line(n, unconfigured, len(skipped)))
     terminalreporter.write_line(_live_gh.POPULATION)
+
+
+def _git_decline_summary(terminalreporter, skipped):
+    """Count the skips where git would not answer about a path's state.
+
+    Same shape as the three above, same reason. `_path_meta_suffix` declines
+    under a 2s budget and says so (#705); a test that compares two markers
+    cannot tell that decline from a disagreement, and one such comparison
+    reddened master's windows-latest leg alone at ac1b3e4. The gate turns it
+    into a skip, and a skip nobody counts is the same absence one layer up --
+    so this prints at zero too, with its denominator and its population
+    (#1274).
+    """
+    if _git_decline is None:
+        terminalreporter.write_line(
+            "git-status decline: NOT CHECKED -- tests/_git_decline.py is not "
+            "in this tree")
+        return
+    n = _token_skips(skipped, _git_decline.TOKEN)
+    terminalreporter.write_line(_git_decline.verdict_line(n, len(skipped)))
+    terminalreporter.write_line(_git_decline.POPULATION)
 
 
 def _lint_budget_summary(terminalreporter, skipped):

--- a/tests/test_path_meta_bulk_1126.py
+++ b/tests/test_path_meta_bulk_1126.py
@@ -17,6 +17,7 @@ things that invalidate it.
 
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
 import time
@@ -24,6 +25,8 @@ from pathlib import Path
 
 import pytest
 import supertool
+import _git_decline
+from _git_decline import suffix as _suffix
 from _symlink import require_symlink
 
 
@@ -117,11 +120,10 @@ def test_coalesced_markers_match_the_per_path_answer(repo: Path) -> None:
     per_path = {}
     for name in _PATHS:
         _reset_bulk()                              # force the single-path route
-        per_path[name] = supertool._path_meta_suffix(str(repo / name), b"x\n")
+        per_path[name] = _suffix(repo / name)
 
     _reset_bulk()
-    coalesced = {n: supertool._path_meta_suffix(str(repo / n), b"x\n")
-                 for n in _PATHS}
+    coalesced = {n: _suffix(repo / n) for n in _PATHS}
 
     assert coalesced == per_path
     # and the answers are the real ones, not uniformly empty
@@ -151,9 +153,9 @@ def test_a_relative_path_with_a_directory_answers_like_an_absolute_one(
 
     for name in _SUB_PATHS:
         _reset_bulk()                              # force the single-path route
-        relative = supertool._path_meta_suffix(name, b"x\n")
+        relative = _suffix(name)
         _reset_bulk()
-        absolute = supertool._path_meta_suffix(str(repo / name), b"x\n")
+        absolute = _suffix(repo / name)
         assert relative == absolute, (
             f"{name}: written relative -> {relative!r}, written absolute -> "
             f"{absolute!r}; the pathspec is being resolved against the wrong "
@@ -163,10 +165,10 @@ def test_a_relative_path_with_a_directory_answers_like_an_absolute_one(
     per_path = {}
     for name in _SUB_PATHS:
         _reset_bulk()
-        per_path[name] = supertool._path_meta_suffix(name, b"x\n")
+        per_path[name] = _suffix(name)
 
     _reset_bulk()
-    coalesced = {n: supertool._path_meta_suffix(n, b"x\n") for n in _SUB_PATHS}
+    coalesced = {n: _suffix(n) for n in _SUB_PATHS}
 
     assert coalesced == per_path
     # and the answers are the real ones, not uniformly empty
@@ -200,19 +202,18 @@ def test_a_filename_that_looks_like_a_glob_is_not_matched_against_a_sibling(
 
     literal = os.path.join("sub", "t[a].txt")
     _reset_bulk()
-    alone = supertool._path_meta_suffix(literal, b"x\n")
+    alone = _suffix(literal)
     _reset_bulk()
     for name in _SUB_PATHS[:2]:
         supertool._path_meta_suffix(name, b"x\n")   # build the snapshot
-    with_snapshot = supertool._path_meta_suffix(literal, b"x\n")
+    with_snapshot = _suffix(literal)
 
     assert " m" not in alone, (
         "t[a].txt is committed and unmodified; the ' m' belongs to ta.txt"
     )
     assert alone == with_snapshot
     # the fixture is doing what it claims - the sibling really is modified
-    assert " m" in supertool._path_meta_suffix(os.path.join("sub", "ta.txt"),
-                                               b"x\n")
+    assert " m" in _suffix(os.path.join("sub", "ta.txt"))
 
 
 def test_a_relative_symlink_is_still_answered_about_its_own_repo(
@@ -235,8 +236,8 @@ def test_a_relative_symlink_is_still_answered_about_its_own_repo(
     link = here / "sub" / "points_away.txt"
     link.symlink_to(elsewhere / "clean.txt")
 
-    assert " ?" in supertool._path_meta_suffix(
-        os.path.join("sub", "points_away.txt"), b"x\n"
+    assert " ?" in _suffix(
+        os.path.join("sub", "points_away.txt")
     ), "an untracked link is untracked in the repo it sits in, not its target's"
 
 
@@ -259,7 +260,7 @@ def test_a_write_through_supertool_drops_the_snapshot(repo: Path) -> None:
     assert not supertool._PATH_META_BULK, (
         "_atomic_write left a stale git snapshot in place"
     )
-    assert " m" in supertool._path_meta_suffix(str(repo / "clean.txt"), b"x\n")
+    assert " m" in _suffix(repo / "clean.txt")
 
 
 def test_a_file_touched_after_the_snapshot_is_not_served_from_it(repo: Path) -> None:
@@ -279,7 +280,7 @@ def test_a_file_touched_after_the_snapshot_is_not_served_from_it(repo: Path) -> 
     an_hour_ahead = (time.time() + 3600)
     os.utime(target, (an_hour_ahead, an_hour_ahead))
 
-    assert " m" in supertool._path_meta_suffix(str(target), b"x\n")
+    assert " m" in _suffix(target)
 
 
 def test_a_path_outside_any_repo_still_declines_rather_than_guessing(
@@ -289,7 +290,7 @@ def test_a_path_outside_any_repo_still_declines_rather_than_guessing(
     _reset_bulk()
     loose = tmp_path / "loose.txt"
     loose.write_bytes(b"x\n")
-    out = supertool._path_meta_suffix(str(loose), b"x\n")
+    out = _suffix(loose)
     assert " ?" not in out and " m" not in out and " !" not in out
 
 
@@ -305,8 +306,8 @@ def test_two_repos_in_one_call_do_not_answer_for_each_other(tmp_path: Path) -> N
     for name in _PATHS:
         supertool._path_meta_suffix(str(a / name), b"x\n")
     (b / "also_clean.txt").write_bytes(b"only dirty in b\n")
-    assert " m" in supertool._path_meta_suffix(str(b / "also_clean.txt"), b"x\n")
-    assert " m" not in supertool._path_meta_suffix(str(a / "also_clean.txt"), b"x\n")
+    assert " m" in _suffix(b / "also_clean.txt")
+    assert " m" not in _suffix(a / "also_clean.txt")
 
 
 def test_a_symlink_gets_the_same_marker_from_either_route(repo: Path) -> None:
@@ -325,12 +326,12 @@ def test_a_symlink_gets_the_same_marker_from_either_route(repo: Path) -> None:
     link.symlink_to(Path("real") / "target.txt")
 
     _reset_bulk()
-    alone = supertool._path_meta_suffix(str(link), b"x\n")
+    alone = _suffix(link)
     # Now with a snapshot already built for this repo by earlier paths.
     _reset_bulk()
     for name in _PATHS[:3]:
         supertool._path_meta_suffix(str(repo / name), b"x\n")
-    with_snapshot = supertool._path_meta_suffix(str(link), b"x\n")
+    with_snapshot = _suffix(link)
 
     assert " ?" in alone, "an untracked symlink is untracked"
     assert with_snapshot == alone
@@ -352,7 +353,7 @@ def test_a_symlink_is_never_answered_from_another_repo(tmp_path: Path) -> None:
     for name in _PATHS[:3]:
         supertool._path_meta_suffix(str(here / name), b"x\n")
 
-    assert " ?" in supertool._path_meta_suffix(str(link), b"x\n")
+    assert " ?" in _suffix(link)
 
 
 def test_a_file_deep_under_an_untracked_directory_keeps_its_marker(
@@ -367,11 +368,11 @@ def test_a_file_deep_under_an_untracked_directory_keeps_its_marker(
     target.write_bytes(b"new\n")
 
     _reset_bulk()
-    alone = supertool._path_meta_suffix(str(target), b"x\n")
+    alone = _suffix(target)
     _reset_bulk()
     for name in _PATHS[:3]:
         supertool._path_meta_suffix(str(repo / name), b"x\n")
-    with_snapshot = supertool._path_meta_suffix(str(target), b"x\n")
+    with_snapshot = _suffix(target)
 
     assert " ?" in alone
     assert with_snapshot == alone
@@ -392,7 +393,7 @@ def test_a_repo_whose_query_declines_falls_back_and_stays_fallen_back(
     assert supertool._PATH_META_BULK[root] == "declined"
     # Every path fell back, so every path was really asked about.
     assert counter.status == len(_PATHS)
-    assert " m" in supertool._path_meta_suffix(str(repo / "dirty.txt"), b"x\n")
+    assert " m" in _suffix(repo / "dirty.txt")
 
     supertool._path_meta_bulk_drop()
     assert supertool._PATH_META_BULK.get(root) == "declined", (
@@ -423,3 +424,114 @@ def test_the_snapshot_globals_are_registered_for_reset() -> None:
 
     assert "_PATH_META_BULK" in conftest.RESET_GLOBALS
     assert "_PATH_META_ROOT_CACHE" in conftest.RESET_GLOBALS
+
+
+# ===========================================================================
+# A lookup that DECLINED is not a route that disagreed (tests/_git_decline.py)
+# ===========================================================================
+
+
+def _decline_every_per_path_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Blow the per-path query's 2s budget; leave the repo-wide one answering.
+
+    `-z` is what tells the two apart, and it is the bulk query's own flag
+    rather than a name this helper invents - a shim that killed both would
+    prove nothing about which route declined.
+    """
+    real = subprocess.run
+
+    def run(cmd, *a, **kw):
+        if isinstance(cmd, (list, tuple)) and "status" in cmd and "-z" not in cmd:
+            raise subprocess.TimeoutExpired(list(cmd), 2)
+        return real(cmd, *a, **kw)
+
+    monkeypatch.setattr(supertool.subprocess, "run", run)
+
+
+def test_a_declined_lookup_skips_rather_than_reading_as_a_disagreement(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The windows-latest red at ac1b3e4, made deterministic.
+
+    One per-path `git status` blew its budget on a loaded runner, the product
+    correctly said `git?` - state unknown, not clean (#705) - and the parity
+    assertion above read ` git?` against `` as the two routes disagreeing about
+    `sub/clean.txt`. It is an environment condition rendered as a product
+    verdict, which is this repo's own defect class relocated into the harness
+    (#1205, #1218, #1360, #1364).
+
+    The first assertion pins the exact string CI printed, so this test fails if
+    the product ever stops declining here; the second pins that the gate turns
+    it into a countable skip instead of a red.
+    """
+    monkeypatch.chdir(repo)
+    _reset_bulk()
+    _decline_every_per_path_status(monkeypatch)
+
+    raw = supertool._path_meta_suffix("sub/clean.txt", b"x\n")
+    assert raw == " " + supertool.PATH_META_UNKNOWN, raw
+
+    _reset_bulk()
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        _suffix("sub/clean.txt")
+    assert _git_decline.TOKEN in str(excinfo.value)
+
+
+def test_the_gate_stays_out_of_the_way_when_git_answers(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anti-vacuity. A gate that skipped unconditionally would satisfy the test
+    above and silently delete every assertion in this file."""
+    monkeypatch.chdir(repo)
+    _reset_bulk()
+    assert " m" in _suffix("sub/dirty.txt")
+    _reset_bulk()
+    assert _suffix("sub/clean.txt") == ""
+
+
+#: The one call in this module that reads a bare suffix on purpose - it is the
+#: test that pins what the product returns when it declines, so gating it would
+#: be gating the thing under test.
+_UNGATED_BY_DESIGN = {
+    "test_a_declined_lookup_skips_rather_than_reading_as_a_disagreement",
+}
+
+
+def test_the_census_line_carries_its_denominator_and_its_population() -> None:
+    """#1274: a bare `N skipped` is a number nobody can act on, and a count
+    with no stated population gets read as a total."""
+    line = _git_decline.verdict_line(2, 97)
+    assert _git_decline.TOKEN in line, line
+    assert "2 of 97" in line, line
+    assert "tests/test_path_meta_bulk_1126.py" in _git_decline.POPULATION
+
+
+def test_every_marker_assertion_in_this_module_is_decline_gated() -> None:
+    """`_git_decline.POPULATION` names this module. Derive it, do not trust it.
+
+    A bare `supertool._path_meta_suffix(...)` whose result is *used* is a
+    marker assertion that can read a decline as a verdict. One whose result is
+    discarded is a priming call - it builds the snapshot and asserts nothing -
+    so it stays bare on purpose, and that is also why this cannot be a grep for
+    the name.
+    """
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    offenders = []
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if func.name in _UNGATED_BY_DESIGN:
+            continue
+        discarded = {id(n.value) for n in ast.walk(func) if isinstance(n, ast.Expr)}
+        for node in ast.walk(func):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "_path_meta_suffix"
+                    and id(node) not in discarded):
+                offenders.append("{0} (line {1})".format(func.name, node.lineno))
+    assert not offenders, (
+        "these read a suffix without the decline gate, so a `git?` on a loaded "
+        "runner reds them instead of skipping - route them through "
+        "_git_decline.suffix or add them to _UNGATED_BY_DESIGN with a reason: "
+        + ", ".join(offenders)
+    )


### PR DESCRIPTION
`pytest (windows-latest, 3.12)` went red on `master` at `ac1b3e4` in `test_path_meta_bulk_1126`, reporting a clean file in a subdirectory as ` git?`. It cleared on a re-run, which is what makes it worth a PR rather than a shrug — a re-run destroys the evidence and the exposure stays.

## The maintainer's hypothesis was wrong, and here is what disproved it

I briefed this as the #1257 shape: two PRs each green on disjoint files, meeting for the first time on the merge commit. It is not.

- `git diff 99688d4 ac1b3e4 -- _supertool.py` is 24 hunks and **none** of them mention `_path_meta*` or `subprocess.run`. The hunk contexts are `_shipped_preset_ops`, `_near_miss_ops`, `_cwd_retargets_note`, `render_file`, `_read_window_note`, `_split_arg`, `_parse_grep_args`, `_dispatch_impl`.
- Both PRs did touch `tests/conftest.py`, but only to add `_SHIPPED_PRESET_SYNTAX` and `_MAX_COLON_SLOTS` to the reset lists. Neither is in the path-meta lane.
- The test and its exposure both predate those PRs — last touched in `c5c7f4a` (#1226).

## The actual mechanism, reproduced byte-for-byte

`_path_meta_suffix`'s per-path query has a 2s budget and emits ` git?` when it declines — state unknown, not clean, which is #705's correct behaviour. That test spawns `git status` **fourteen** times: thirteen per-path plus one repo-wide. Spawn #13 is the coalesced pass's lookup of `sub/clean.txt`. Raising `TimeoutExpired` from exactly that one, on macOS:

```
E         Differing items:
E         {'sub/clean.txt': ' git?'} != {'sub/clean.txt': ''}
tests/test_path_meta_bulk_1126.py:171: AssertionError
```

Character-for-character the CI line. The test was comparing a `git status` that **declined** against one that **answered**, and reading the difference as the two code routes disagreeing.

This is the **fourth** instance of the class — #1205, #1218, #1360, #1364 — the test harness rendering an environment limit as a product verdict, which is this repo's own defect class relocated into the thing meant to detect it.

## The fix, and why it is a gate rather than a normalisation

#1364 handled its instance by erasing the token from both sides of a byte comparison. That is wrong here: the token **is** the value under test, so erasing it turns a decline into a false agreement for a clean file. A skip asserts nothing about a lookup that did not happen.

| Mechanism | Where |
| --- | --- |
| Gate: `suffix()` returns when git answered, `pytest.skip` carrying a token when it declined | `tests/_git_decline.py` (new) |
| 20 result-using call sites routed onto it; priming calls that discard their result stay bare | `tests/test_path_meta_bulk_1126.py` |
| Countable census line, printing at zero, with denominator and population (#1274) | `tests/conftest.py` |
| AST pin: any bare `_path_meta_suffix` whose result is *used* is a finding, one named exemption | `test_every_marker_assertion_in_this_module_is_decline_gated` |

The skip is **counted**, not silent — a skip nobody counts is the same absence one layer up, and it is what keeps a silently-degrading Windows leg visible:

```
git-status-decline(#705): 1 of 1 skipped tests did NOT get a working-tree answer out of git
```

## Tests

Red first, with the gate neutered so `require_answer` returns immediately:

```
>       with pytest.raises(pytest.skip.Exception) as excinfo:
E       Failed: DID NOT RAISE <class 'Skipped'>
1 failed, 18 passed in 4.32s
```

Green: `20 passed in 8.41s`. Full suite, run because `tests/conftest.py` is touched: `12512 passed, 97 skipped, 2 subtests passed in 341.03s`.

**Windows unverified** — the reproduction is macOS with a shim, and a local green says nothing about the leg this started on. CI is the authority.

## Residual, stated rather than hidden

` git?` is one token for two causes: a blown budget, and a non-zero exit whose stderr is not "not a repository". Both are environmental and the product does not distinguish them, so the gate cannot either — meaning a product bug that made `git` exit non-zero would skip rather than red **in that file**. `test_status_swallowed_705.py` is deliberately left ungated for the same reason it exists: it pins the decline against shimmed gits, and gating it would go vacuous.

## Review

Sonnet reviewer against the committed diff, from inside the worktree. One finding accepted: `pytest_terminal_summary`'s docstring claimed "Two reasons are broken out" while printing four — wrong since #1568 made it three, and this PR's line made it four. Fixed. It also raised that Windows coverage could silently drop if the gate fires there, which is answered by the census line printing on every leg, zero included.

## Left for filing

- `tests/test_status_swallowed_705.py:231-234` has the same exposure, but line 233 asserts the token's *absence* as its anti-vacuity control, so gating it needs a skip-vs-stay-red design call.
- **#1397 carries a false claim, and it is load-bearing.** Its body says the doomed spawn outside a repository is "the sole source" of the spurious ` git?` token that made #1364 look like a product defect. This red disproves it: the declining call was a legitimate per-path query for a *tracked* file inside a real repository. Closing #1397 would not have prevented `ac1b3e4`.
