### PR TITLE
The {arg} census was one op stale the moment gh-run took {args} (#1715)

### DIFF
--- a/_supertool.py
+++ b/_supertool.py
@@ -3054,11 +3054,11 @@ _SYNTAX_TOKEN_RE = re.compile(r"[^A-Za-z0-9_]+")
 #: than a prose `syntax` string, and the one #1350 was filed about.
 #:
 #: `{arg}` is deliberately absent even though it substitutes the very same
-#: `parts[1]`. Twenty-one shipped ops carry `{arg}` (24 until #873 moved three
-#: multi-token ops to `{args}`); 8 of them name a path in `syntax` and are
-#: already held by `_syntax_names_a_path`, leaving 13 that pass a handle, a
-#: ref, a tag, an ID or a repo slug and take no path at all.
-#: Promoting `{arg}` would refuse those 13 and gate nothing. `{file}` and
+#: `parts[1]`. Twenty shipped ops carry `{arg}` (24 until #873 moved three
+#: multi-token ops to `{args}`, then `gh-run` for #1715); 8 of them name a path
+#: in `syntax` and are already held by `_syntax_names_a_path`, leaving 12 that
+#: pass a handle, a ref, a tag, an ID or a repo slug and take no path at all.
+#: Promoting `{arg}` would refuse those 12 and gate nothing. `{file}` and
 #: `{dir}` are the placeholders whose NAME is the claim; `{arg}` is the one
 #: that declines to make it. An op that means a path and writes `{arg}` is
 #: still ungated, and that is a naming problem in the op rather than a hole


### PR DESCRIPTION
The comment above `_PATH_PLACEHOLDERS` in `_supertool.py` states a count that #1719 invalidated in the same merge: `gh-run` moved from `{arg}` to `{args}` to carry `:attempt=K`, so the census is one lower in both of its numbers.

Re-derived rather than decremented — counted off `presets/*.json` at `ed755a5`:

```
$ python3 -c "...json load presets/*.json, count ops whose cmd contains {arg}..."
20 ops carry {arg}
```

Of those 20, the 8 whose `syntax` names a path (`git-investigate:PATH`, `gh-batch-follow:FILE`, `gh-batch-star:FILE`, `gh-issue-create:@FILE`, `gh-pr-create:@FILE`, `gl-issue-create:@FILE`, and the two `MD_FILE` publishers) are already held by `_syntax_names_a_path`, leaving 12.

The parenthetical is amended rather than left to sum wrong: `24 until #873 moved three multi-token ops to {args}` no longer reaches 20 on its own, so it now names the fourth departure.

Comment-only. No behaviour change, no test change.
