### PR TITLE
ESC survives splitlines() into a receipt supertool owns, and "five callers share one answer" was three callers and a different function (#1660, #1701)

### DIFF
--- a/changelog.d/1660.fixed.md
+++ b/changelog.d/1660.fixed.md
@@ -1,0 +1,19 @@
+- A cursor-control sequence in `gh`'s stdout reached six lines of the receipt
+  `gh-pr-create` writes, including its own `[result]` verdict
+  ([#1660](https://github.com/Digital-Process-Tools/claude-supertool/issues/1660)).
+  `str.splitlines()` consumes every line *separator*, so the URL line selected
+  out of `gh pr create` cannot be forged — that half holds. It does not consume
+  ESC. The selected line was printed raw at column 0 as `URL:`, and `number` is
+  derived from it, so it also reached `PR:`, all three `## Next` commands and
+  the `[result]` line, two lines under a `title` that was already flattened.
+  The value is now `_untrusted.flat()`ed at the seam where it is extracted
+  rather than at each print, so the escape is disclosed as `␛` instead of
+  moving the cursor, and a clean URL is untouched. This is the ESC half of
+  [#851](https://github.com/Digital-Process-Tools/claude-supertool/issues/851)
+  arriving at a site that sweep did not cover.
+
+  The register entry in `tests/test_preset_twin_splitlines_register_1119.py`
+  read "the extracted value is printed, not parsed", which answers
+  forgery-by-separator and is silent on control characters — an entry that
+  answers one question reads as though it answered the other. Corrected to say
+  which question it answers and which it does not.

--- a/changelog.d/1701.changed.md
+++ b/changelog.d/1701.changed.md
@@ -1,0 +1,34 @@
+- Three hand-rolled copies of `gh repo view --json nameWithOwner` now share
+  `_repo_target.effective_slug()`, and the two that were counted as copies turn
+  out not to be
+  ([#1701](https://github.com/Digital-Process-Tools/claude-supertool/issues/1701)).
+  The issue named five sites and `cwd_slug()` (#1700) as the shared answer none
+  of them used. Re-derived, both halves were different. `cwd_slug()` answers
+  `""` under a `repo:` target on purpose — its caller substitutes the target
+  itself — while all five callers are target-*first*, so adopting it would have
+  printed the cwd's repository in a header for a call made about another one.
+  And `github/branch.py` and `github/pr_merge.py` read
+  `nameWithOwner,defaultBranchRef` in one call and return a third element
+  carrying the error their `main()` aborts on: they already tell *could not
+  ask* from *asked, got nothing*, and folding them in would have traded a
+  three-state answer for a two-state one. They keep their own reader.
+
+  `effective_slug()` is `target()` first, then the cwd's clone, then `""`. Two
+  states rather than three because no caller of it consumes a reason: each
+  keeps its own sentinel at its own boundary, so `gh-labels` still renders `""`
+  (`— repository UNKNOWN (gh could not name it)`), the `gh_prs` radar tier
+  still renders `"?"`, and `claims` still returns `None`. Nothing any of the
+  three prints on failure changed.
+
+  One site was actually wrong. `presets/claims/check.py` read
+  `os.environ["SUPERTOOL_REPO"]` directly instead of through `target()`, so it
+  skipped the rule that a blank export is absence rather than an empty target:
+  a whitespace-only value became the slug, reached `gh issue view --repo "   "`,
+  and every issue citation in the document rendered "couldn't check" against
+  gh's complaint — while the cwd, which could have answered, was never asked.
+
+  A sweep for the subcommand found seven calls across four distinct questions,
+  two of which the issue never counted (`--json owner,name` in `issues.py`,
+  `--json defaultBranchRef` in `pr_create.py`). The regression pin is keyed on
+  the exact single-field argv rather than on `gh repo view`, because a guard
+  that refused all four would be worked around rather than obeyed.

--- a/presets/_repo_target.py
+++ b/presets/_repo_target.py
@@ -125,10 +125,12 @@ def cwd_slug(timeout: int = 15) -> str:
 
     A subprocess in a module that had none: this is where the question "which
     repository is this call about" already lives, and the alternative was a
-    sixth hand-rolled copy of `gh repo view --json nameWithOwner`. There are
-    five today (`github/labels.py`, `github/branch.py`, `github/pr_merge.py`,
-    `watch/tiers/gh_prs.py`, `claims/check.py`), returning three different
-    absence sentinels between them.
+    sixth hand-rolled copy of `gh repo view --json nameWithOwner`.
+
+    **Not the function a caller printing a header wants** — see
+    :func:`effective_slug`, which #1701 added after re-deriving the five copies
+    this docstring used to list. Three of them were migrated there; the other
+    two ask for a second field in the same call and are not copies of this.
     """
     if target():
         # The target is the answer, and reading the cwd would not improve it.
@@ -150,6 +152,39 @@ def cwd_slug(timeout: int = 15) -> str:
     if not isinstance(data, dict):
         return ""
     return str(data.get("nameWithOwner") or "")
+
+
+def effective_slug(timeout: int = 15) -> str:
+    """``OWNER/NAME`` this call is *about* — the target, else the cwd's, else ``""``.
+
+    The target-first sibling of :func:`cwd_slug`, and the difference between
+    them is the whole of #1701. `cwd_slug` answers *which repository is this
+    directory*, and under a `repo:` target it deliberately answers ``""``: its
+    caller :func:`api_path_for_display` substitutes the target itself, so
+    reading the cwd there would put the wrong repository into a command printed
+    for a human to paste. A caller that wants a slug for a **header** wants the
+    opposite precedence, because the target is the repository the call was made
+    about. So #1701 could not be closed by adopting `cwd_slug` at the five
+    sites it named; it needed this.
+
+    Three sites use it — `github/labels.py`, `watch/tiers/gh_prs.py` and
+    `claims/check.py` — and all three had already spelled it by hand as
+    `target() or <gh repo view>`. The other two the issue counted are not this
+    question: `github/branch.py::_repo_identity` and
+    `github/pr_merge.py::_repo_identity` read `nameWithOwner,defaultBranchRef`
+    in one call and return a third element carrying the error their `main()`
+    aborts on, so they already tell *could not ask* from *asked, got nothing*.
+    Handing them a two-state slug would trade a three-state answer for a
+    two-state one, which is this repo's own defect class arriving through a
+    cleanup. They keep their own reader, and that is why the count is three.
+
+    Two states here, not three, on evidence rather than on brevity: **no caller
+    of this consumes a reason.** Each keeps its own absence sentinel at its own
+    boundary — ``""``, ``"?"``, ``None`` — which is what each rendered before
+    #1701 and after it. A third state nobody reads is a render decision made in
+    the wrong module.
+    """
+    return target() or cwd_slug(timeout)
 
 
 def api_path_printable(suffix: str, timeout: int = 15) -> str:

--- a/presets/claims/check.py
+++ b/presets/claims/check.py
@@ -58,6 +58,9 @@ import sys
 from pathlib import Path
 from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import _repo_target  # noqa: E402  (the repo this call is about, when not cwd's)
+
 HOLDS = "holds"
 CONTRADICTED = "contradicted"
 UNCHECKED = "couldn't check"
@@ -652,19 +655,22 @@ def _memo(thunk: Callable[[], Optional[str]]) -> Callable[[], Optional[str]]:
 
 
 def _repo_slug(root: Path) -> Optional[str]:
-    env = os.environ.get("SUPERTOOL_REPO")
-    if env:
-        return env
-    try:
-        proc = _run(["gh", "repo", "view", "--json", "nameWithOwner"], timeout=15)
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if proc.returncode != 0:
-        return None
-    try:
-        return str(json.loads(proc.stdout).get("nameWithOwner") or "") or None
-    except ValueError:
-        return None
+    """`OWNER/NAME` for the repo an issue citation should be looked up in.
+
+    `None`, not `""`, and that is preserved rather than defended: every
+    consumer here tests it with `if slug:`, so the two were already the same
+    answer at this site — which is why #1701's two-state
+    `_repo_target.effective_slug` loses nothing by arriving underneath it.
+
+    The hand-rolled version this replaced read `os.environ["SUPERTOOL_REPO"]`
+    directly and so skipped `target()`'s rule that a blank export is absence,
+    not an empty target. A whitespace-only value became the slug, reached
+    `gh issue view --repo "   "`, and every issue citation in the document
+    rendered "couldn't check" against gh's complaint — while the cwd, which
+    could have answered, was never asked. `root` is unused and kept: two test
+    files monkeypatch this as a one-argument callable.
+    """
+    return _repo_target.effective_slug(timeout=15) or None
 
 
 def _root() -> Path:

--- a/presets/github/labels.py
+++ b/presets/github/labels.py
@@ -421,20 +421,7 @@ def repo_name() -> str:
     a header that does not say which repo it came from is the same trap one
     layer out, and the `repo:OWNER/NAME` form makes the cwd a bad default guess.
     """
-    target = _repo_target.target()
-    if target:
-        return target
-    try:
-        r = _gh(["gh", "repo", "view", "--json", "nameWithOwner"], timeout=15)
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return ""
-    if r.returncode != 0:
-        return ""
-    try:
-        d = json.loads(r.stdout)
-    except json.JSONDecodeError:
-        return ""
-    return str(d.get("nameWithOwner") or "") if isinstance(d, dict) else ""
+    return _repo_target.effective_slug(timeout=15)
 
 
 def group_of(name: str) -> str:

--- a/presets/github/pr_create.py
+++ b/presets/github/pr_create.py
@@ -365,7 +365,14 @@ def main() -> int:  # noqa: C901
     url = ""
     for line in (result.stdout or "").splitlines():
         if "/pull/" in line:
-            url = line.strip()
+            # Flattened at the seam, not at each print. `str.splitlines()`
+            # consumes every line SEPARATOR, so no line here can be forged and
+            # #1652's argument holds — but it does not consume ESC, and this
+            # value is written at column 0 six times: `URL:`, `PR:` and the
+            # three `## Next` commands via `number`, and this op's own
+            # `[result]` verdict. That last one is the line #851/#853 exist to
+            # protect, and `number` inherits whatever the URL carried (#1660).
+            url = _untrusted.flat(line.strip())
             break
     number = url.rstrip("/").split("/")[-1] if url else "?"
 

--- a/presets/watch/tiers/gh_prs.py
+++ b/presets/watch/tiers/gh_prs.py
@@ -410,21 +410,7 @@ def scope_label(filters: dict[str, str], repo: str) -> str:
 
 def repo_name() -> str:
     """`owner/name` this board is about — the target, or the cwd's clone."""
-    target = _repo_target.target()
-    if target:
-        return str(target)
-    try:
-        r = subprocess.run(["gh", "repo", "view", "--json", "nameWithOwner"],
-                           capture_output=True, text=True, timeout=20,
-                           encoding="utf-8", errors="replace")
-    except (OSError, subprocess.SubprocessError):
-        return "?"
-    if r.returncode != 0:
-        return "?"
-    try:
-        return str(json.loads(r.stdout).get("nameWithOwner") or "?")
-    except (json.JSONDecodeError, AttributeError):
-        return "?"
+    return _repo_target.effective_slug(timeout=20) or "?"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gh_pr_create_url_control_chars_1660.py
+++ b/tests/test_gh_pr_create_url_control_chars_1660.py
@@ -1,0 +1,113 @@
+"""#1660 - gh's stdout reaches a receipt supertool owns, and ESC survives.
+
+`str.splitlines()` consumes every line SEPARATOR, so no line selected out of
+`gh pr create`'s stdout can be forged - that half of #1652's argument holds
+here. What it does not consume is ESC, and the selected line is printed at
+column 0 as `URL:`, feeds `number`, and `number` reaches this op's own
+`[result]` line. That is #851's question (closed by #853 for `check.py` and
+`branch.py`) arriving at a site #851 did not cover.
+
+The register entry in `tests/test_preset_twin_splitlines_register_1119.py` said
+"the extracted value is printed, not parsed", which answers forgery and is
+silent on control characters. Corrected in the same change.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MOD_PATH = Path(__file__).parent.parent / "presets" / "github" / "pr_create.py"
+_spec = importlib.util.spec_from_file_location("github_pr_create_1660", MOD_PATH)
+assert _spec is not None and _spec.loader is not None
+m = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(m)
+
+REPO = "Digital-Process-Tools/claude-supertool"
+ESC = chr(27)
+
+#: What a hostile or proxied `gh` can put on the line this op selects. `[2K`
+#: erases the line the cursor is on and `[1A` moves it up one - together they
+#: rub out the receipt line above, which is `PR:   #N  <title>`.
+HOSTILE_URL = "https://github.com/o/r/pull/957" + ESC + "[1A" + ESC + "[2K"
+
+
+class _Harness:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+
+    def gh(self, args, timeout=30):
+        if args[:2] == ["pr", "create"]:
+            return subprocess.CompletedProcess(args, 0, self.stdout, "")
+        raise AssertionError("unexpected gh call: %r" % (args,))
+
+    def gh_json(self, args, timeout=30):
+        if args[:2] == ["repo", "view"]:
+            return ({"defaultBranchRef": {"name": "master"}}, "")
+        if args[:2] == ["pr", "view"]:
+            return ({"statusCheckRollup": [], "headRefOid": "a" * 40,
+                     "createdAt": "2999-01-01T00:00:00Z"}, "")
+        raise AssertionError("unexpected gh_json call: %r" % (args,))
+
+
+def _run(monkeypatch, tmp_path, stdout: str) -> str:
+    payload = tmp_path / "pr.json"
+    payload.write_text(json.dumps(
+        {"repo": REPO, "title": "a change", "base": "master",
+         "body": "Closes #1660"}), encoding="utf-8")
+    h = _Harness(stdout)
+    monkeypatch.setattr(m, "_gh", h.gh)
+    monkeypatch.setattr(m, "_gh_json", h.gh_json)
+    monkeypatch.setattr(m, "_current_branch", lambda: ("fix/1660", ""))
+    monkeypatch.setattr(sys, "argv", ["pr_create.py", str(payload)])
+    return m.main()
+
+
+def test_esc_in_ghs_url_line_never_reaches_the_receipt(monkeypatch, capsys,
+                                                       tmp_path):
+    """The whole of #1660: not one raw ESC anywhere in a receipt this op wrote."""
+    assert _run(monkeypatch, tmp_path, HOSTILE_URL + chr(10)) == 0
+    out = capsys.readouterr().out
+    assert ESC not in out, (
+        "a cursor-control sequence out of gh's stdout reached the receipt at "
+        "column 0 (#1660): %r" % out)
+
+
+def test_the_escape_is_disclosed_rather_than_stripped(monkeypatch, capsys,
+                                                      tmp_path):
+    """Removing the bytes silently would be the absence-produced-by-the-tool
+    defect one layer along - the reader could not tell a mangled URL from a
+    clean one. `_untrusted.flat` shows the character instead."""
+    assert _run(monkeypatch, tmp_path, HOSTILE_URL + chr(10)) == 0
+    out = capsys.readouterr().out
+    assert ("␛" in out or "[U+001B]" in out), (
+        "the ESC was dropped rather than disclosed: %r" % out)
+    # The part of the URL that is real still reads as itself.
+    assert "https://github.com/o/r/pull/957" in out
+
+
+def test_the_number_derived_from_that_line_is_clean_too(monkeypatch, capsys,
+                                                        tmp_path):
+    """`number` is `url.rstrip("/").split("/")[-1]`, so it inherits whatever the
+    URL carried - and it is printed four more times, including inside this op's
+    own `[result]` verdict, which is the line #851 exists to protect."""
+    assert _run(monkeypatch, tmp_path, HOSTILE_URL + chr(10)) == 0
+    lines = capsys.readouterr().out.splitlines()
+    result = [ln for ln in lines if ln.startswith("[result]")]
+    assert result, lines
+    assert ESC not in result[0], result[0]
+    assert not any(ln.startswith("[1A") or ln.startswith("[2K")
+                   for ln in lines), (
+        "a receipt line begins with the tail of an escape sequence: %r" % lines)
+
+
+def test_an_ordinary_url_is_left_exactly_as_it_came(monkeypatch, capsys,
+                                                    tmp_path):
+    """The guard must be invisible on the path everyone actually takes."""
+    url = "https://github.com/%s/pull/1660" % REPO
+    assert _run(monkeypatch, tmp_path, url + chr(10)) == 0
+    out = capsys.readouterr().out
+    assert ("URL:  " + url) in out
+    assert "PR:   #1660" in out

--- a/tests/test_preset_twin_splitlines_register_1119.py
+++ b/tests/test_preset_twin_splitlines_register_1119.py
@@ -55,8 +55,13 @@ REGISTER: dict[str, str] = {
     # by the tool. split_lines decides the boundary, _untrusted.flat spells the
     # separator, and neither happens.
     "presets/github/pr_create.py::main":
-        "gh's stdout, scanned for a URL. The extracted value is printed, not "
-        "parsed.",
+        "gh's stdout, scanned for a URL. splitlines() consumes the separators, "
+        "so no line here can be forged and that half still holds. It does not "
+        "consume ESC — and 'printed, not parsed' answered only the forgery "
+        "question while the value went to column 0 six times (URL:, PR: and "
+        "the three ## Next commands via `number`, and this op's own [result]). "
+        "Narrowed by #1660: the split stays, the value is _untrusted.flat()ed "
+        "at the seam, pinned by test_gh_pr_create_url_control_chars_1660.py.",
     "presets/github/batch_follow.py::main":
         "a local file the caller passed in. A stray separator yields a "
         "username that 404s visibly rather than a forged record.",

--- a/tests/test_repo_target_effective_slug_1701.py
+++ b/tests/test_repo_target_effective_slug_1701.py
@@ -1,0 +1,263 @@
+"""#1701 - one `gh repo view --json nameWithOwner`, and what the count really was.
+
+The issue counted five hand-rolled copies and named `_repo_target.cwd_slug()`
+(#1700) as the shared answer none of them used. Re-derived here, both halves
+came out different:
+
+**It was three, not five.** `github/branch.py::_repo_identity` and
+`github/pr_merge.py::_repo_identity` ask a different question - they read
+`nameWithOwner,defaultBranchRef` in ONE call and return a third element holding
+the error message their `main()` aborts on. So they already distinguish *could
+not ask* (abort with a sentence) from *asked, got nothing* (`"?"` / `""`), and
+folding them into a slug helper would lose the default branch AND the reason.
+They are deliberately not migrated.
+
+**`cwd_slug` could not have served any of the three anyway.** It answers ``""``
+when a `repo:` target is set - on purpose, because its caller
+`api_path_for_display` substitutes the target itself. The three callers want
+the opposite precedence: the target FIRST, because that is the repository the
+call is about. Adopting `cwd_slug` at any of them would have printed the cwd's
+repo in a header for a call made about another one. So closing #1701 needed a
+new function, `effective_slug()`, not an adoption.
+
+Two states there, not three, and the reason is measured rather than assumed:
+no caller of it consumes a reason. Each keeps its own absence sentinel at its
+own boundary - `""` (labels), `"?"` (the radar board), `None` (claims) - which
+is exactly what each rendered before this change and after it.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).parent.parent
+
+
+def _load(rel: str, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, _ROOT / rel)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Bound under its real name FIRST, so every preset loaded below imports this
+# object rather than a second copy - one `monkeypatch.setattr` then reaches all
+# four call sites, which is the whole claim being tested.
+rt = _load("presets/_repo_target.py", "_repo_target")
+
+labels = _load("presets/github/labels.py", "gh_labels_1701")
+board = _load("presets/watch/tiers/gh_prs.py", "radar_gh_prs_1701")
+claims = _load("presets/claims/check.py", "claims_check_1701")
+
+SLUG = "Digital-Process-Tools/claude-supertool"
+OTHER = "someone-else/their-repo"
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: str) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _fake_subprocess(calls: list, returncode: int = 0, stdout: str = ""):
+    """A stand-in for the `subprocess` module `_repo_target` holds."""
+
+    class _Mod:
+        TimeoutExpired = subprocess.TimeoutExpired
+        CalledProcessError = subprocess.CalledProcessError
+
+        @staticmethod
+        def run(argv, **kw):
+            calls.append(list(argv))
+            return _FakeProc(returncode, stdout)
+
+    return _Mod
+
+
+# ===========================================================================
+# effective_slug: the target wins, and costs nothing
+# ===========================================================================
+
+def test_the_target_is_the_answer_and_no_subprocess_runs(monkeypatch):
+    calls: list = []
+    monkeypatch.setenv("SUPERTOOL_REPO", OTHER)
+    monkeypatch.setattr(rt, "subprocess", _fake_subprocess(calls))
+    assert rt.effective_slug() == OTHER
+    assert calls == [], "a repo target was named and gh was still asked"
+
+
+def test_without_a_target_the_cwds_clone_answers(monkeypatch):
+    calls: list = []
+    monkeypatch.delenv("SUPERTOOL_REPO", raising=False)
+    monkeypatch.setattr(rt, "subprocess",
+                        _fake_subprocess(calls, 0,
+                                         json.dumps({"nameWithOwner": SLUG})))
+    assert rt.effective_slug() == SLUG
+    assert calls and calls[0][:3] == ["gh", "repo", "view"]
+
+
+def test_every_failure_is_the_empty_string(monkeypatch):
+    monkeypatch.delenv("SUPERTOOL_REPO", raising=False)
+    for rc, out in ((1, ""), (0, "not json"), (0, "[]"), (0, "{}")):
+        monkeypatch.setattr(rt, "subprocess",
+                            _fake_subprocess([], rc, out))
+        assert rt.effective_slug() == "", (rc, out)
+
+
+def test_a_blank_env_var_is_absence_not_a_target(monkeypatch):
+    """An exported-but-empty variable is how a shell accident looks, and
+    `target()` has said so since #673. A second hand-rolled reader that skips
+    the check is a second place the answer can differ - #1411's argument, which
+    is the class this issue asked whoever took it to rule on."""
+    calls: list = []
+    monkeypatch.setenv("SUPERTOOL_REPO", "   ")
+    monkeypatch.setattr(rt, "subprocess",
+                        _fake_subprocess(calls, 0,
+                                         json.dumps({"nameWithOwner": SLUG})))
+    assert rt.effective_slug() == SLUG
+    assert calls, "a whitespace-only target was taken as a repository name"
+
+
+def test_cwd_slug_still_declines_under_a_target(monkeypatch):
+    """The distinction `effective_slug` exists for, pinned so nobody collapses
+    the two functions later. `cwd_slug` is for `api_path_for_display`, which
+    substitutes the target itself; answering the cwd there would name the wrong
+    repository in a command printed for a human to paste (#1670)."""
+    monkeypatch.setenv("SUPERTOOL_REPO", OTHER)
+    monkeypatch.setattr(rt, "subprocess", _fake_subprocess([]))
+    assert rt.cwd_slug() == ""
+    assert rt.effective_slug() == OTHER
+
+
+# ===========================================================================
+# the three migrated sites keep the sentinel they always rendered
+# ===========================================================================
+
+def _no_repo(monkeypatch):
+    monkeypatch.delenv("SUPERTOOL_REPO", raising=False)
+    monkeypatch.setattr(rt, "cwd_slug", lambda timeout=15: "")
+
+
+def _cwd_answers(monkeypatch):
+    monkeypatch.delenv("SUPERTOOL_REPO", raising=False)
+    monkeypatch.setattr(rt, "cwd_slug", lambda timeout=15: SLUG)
+
+
+def test_labels_renders_empty_string_when_nothing_answers(monkeypatch):
+    """Before: `""`. After: `""`. `main()` turns it into
+    ` — repository UNKNOWN (gh could not name it)`, unchanged."""
+    _no_repo(monkeypatch)
+    assert labels.repo_name() == ""
+
+
+def test_labels_prefers_the_target(monkeypatch):
+    monkeypatch.setenv("SUPERTOOL_REPO", OTHER)
+    monkeypatch.setattr(rt, "cwd_slug", lambda timeout=15: SLUG)
+    assert labels.repo_name() == OTHER
+
+
+def test_the_radar_board_renders_question_mark_when_nothing_answers(monkeypatch):
+    """Before: `"?"`. After: `"?"`. The sentinel stays at this boundary because
+    it is a decision about THIS line's rendering, not about the read."""
+    _no_repo(monkeypatch)
+    assert board.repo_name() == "?"
+
+
+def test_the_radar_board_prefers_the_target(monkeypatch):
+    monkeypatch.setenv("SUPERTOOL_REPO", OTHER)
+    monkeypatch.setattr(rt, "cwd_slug", lambda timeout=15: SLUG)
+    assert board.repo_name() == OTHER
+
+
+def test_claims_renders_none_when_nothing_answers(monkeypatch, tmp_path):
+    """Before: `None`. After: `None`. `_issue_state_reader` tests it with
+    `if slug:`, so `""` and `None` were already indistinguishable there - which
+    is why collapsing to two states loses nothing at this site."""
+    _no_repo(monkeypatch)
+    assert claims._repo_slug(tmp_path) is None
+
+
+def test_claims_prefers_the_target(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUPERTOOL_REPO", OTHER)
+    monkeypatch.setattr(rt, "cwd_slug", lambda timeout=15: SLUG)
+    assert claims._repo_slug(tmp_path) == OTHER
+
+
+def test_claims_no_longer_reads_the_env_var_by_hand(monkeypatch, tmp_path):
+    """The one thing that was actually WRONG at any of the five sites.
+
+    `_repo_slug` read `os.environ["SUPERTOOL_REPO"]` directly, so it skipped
+    `target()`'s strip-and-blank-is-absence rule. A whitespace-only export
+    became the slug, went to `gh issue view --repo "   "`, and every issue
+    citation in the document rendered "couldn't check" with gh's complaint -
+    while the cwd, which could have answered, was never asked.
+    """
+    monkeypatch.setenv("SUPERTOOL_REPO", "   ")
+    monkeypatch.setattr(rt, "cwd_slug", lambda timeout=15: SLUG)
+    assert claims._repo_slug(tmp_path) == SLUG
+
+
+# ===========================================================================
+# the two that are NOT the same question stay where they are
+# ===========================================================================
+
+def test_the_two_identity_readers_are_left_alone() -> None:
+    """A register, in the shape #1119 uses: the count is written down so the
+    next reader does not re-derive "five copies" off the issue title.
+
+    Both read a SECOND field in the same call and both return an error string
+    their `main()` prints before returning 1. `effective_slug` has neither, so
+    migrating them would trade a three-state answer for a two-state one - this
+    repo's own defect class, arriving through a cleanup.
+    """
+    for rel in ("presets/github/branch.py", "presets/github/pr_merge.py"):
+        text = (_ROOT / rel).read_text(encoding="utf-8")
+        assert "nameWithOwner,defaultBranchRef" in text, (
+            rel + " no longer reads the default branch in the same call, so "
+            "the reason it was excluded from #1701 may no longer hold")
+
+
+def test_no_sixth_hand_rolled_copy_of_the_single_field_read() -> None:
+    """The defect #1701 was actually filed for: not that any site is wrong, but
+    that the next person writes a sixth copy.
+
+    Keyed on the exact single-field argv, NOT on `gh repo view`, and the
+    difference is a finding rather than a nicety. Sweeping for the subcommand
+    turned up SEVEN calls across FOUR distinct questions, two of which the
+    issue never counted:
+
+      * `--json nameWithOwner`              this one - three sites, migrated
+      * `--json nameWithOwner,defaultBranchRef`
+                                            branch.py / pr_merge.py, which
+                                            return an error string their
+                                            `main()` aborts on
+      * `--json owner,name`                 issues.py, which wants the PAIR and
+                                            classifies gh's failure three ways
+      * `--json defaultBranchRef`           pr_create.py, hinting a base
+
+    A guard that refused all four would push the next author to work around it,
+    which is worse than no guard. So the pin is narrow enough to be true.
+    """
+    offenders = []
+    for path in sorted((_ROOT / "presets").rglob("*.py")):
+        rel = path.relative_to(_ROOT).as_posix()
+        if rel == "presets/_repo_target.py":   # the one implementation
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, (ast.List, ast.Tuple)):
+                continue
+            words = [e.value for e in node.elts
+                     if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+            if "repo" in words and "view" in words and "nameWithOwner" in words:
+                offenders.append("%s:%d" % (rel, node.lineno))
+    assert not offenders, (
+        "a hand-rolled single-field `gh repo view --json nameWithOwner` is "
+        "back. Use _repo_target.effective_slug() (#1701): " + repr(offenders))


### PR DESCRIPTION
Closes #1660
Closes #1701

Two `lane-tracker-ops` issues, one context load. The second one's premise did not survive contact and the disagreement is recorded below rather than resolved silently.

## #1660 — `forges`

`pr_create.py` selected the PR URL out of `gh`'s stdout with `splitlines()` and printed it at column 0. `splitlines()` consumes separators but not ESC, so a cursor sequence in that line reached a receipt supertool owns, two lines under a `title` that **is** flattened.

The issue said one line. Writing the test first showed **six**: `URL:`, `PR:`, the three `## Next` commands, and the op's own `[result]` — because `number = url.rstrip("/").split("/")[-1]` inherits the bytes. `\\x1b[1A` plus `\\x1b[2K` together erase the line above.

```
[result] PR #957<ESC>[1A<ESC>[2K opened; check state unknown (not read) — links #1660
```

Fixed at the **extraction seam** — `url = _untrusted.flat(line.strip())` — not at each print, so one edit covers all six and a future print cannot reintroduce the raw value. `splitlines()` is kept: #1648 retired the consumes-the-separator argument for *error-message extraction*, where discarding a line is the harm; here discarding non-URL lines is the intent.

The register entry in `tests/test_preset_twin_splitlines_register_1119.py` gave a reason that answered forgery-by-separator and was silent on control characters — which is why the #1652 sweep passed over this site. Corrected to state which question it answers, which it does not, and to name the pin.

## #1701 — the issue was wrong twice, and the second one changes the deliverable

**The shared answer could not have been adopted.** `cwd_slug()` is the cwd's identity, and `_repo_target.py:99` says so in its own words: *"which repository the call is about. `slug` is the cwd's identity and is not that answer."* All five named callers are target-first. Adopting `cwd_slug` at any of them prints the cwd's repository in a header for a call made about another one. Closing #1701 therefore required a **new** function, not a migration: `effective_slug() = target() or cwd_slug()`.

**It was three sites, not five.** `branch.py::_repo_identity` and `pr_merge.py::_repo_identity` read `nameWithOwner,defaultBranchRef` in one request and return a third tuple element carrying the error their `main()` prints. They already separate *could not ask* from *asked, got nothing* — in that third element, not in the sentinel — so a slug helper cannot carry it and migrating them would trade three states for two. Left alone. (The issue's `branch.py:985` also points at `_format_error`; the real site is `:1032`.)

**Shape chosen: two-state helper, sentinels stay at the callers**, measured at each consumer rather than assumed — `labels.py:650` has one arm for both cases, `gh_prs` interpolates without branching, and `claims/check.py:611` tests `if slug:`, so `""` and `None` were already the same value there. The distinction #1701 predicted is real and lives in the two sites not migrated.

| Site | Sentinel | Failure rendered BEFORE | AFTER |
| --- | --- | --- | --- |
| `github/labels.py:416` | `""` | `# Labels — repository UNKNOWN (gh could not name it)` | identical |
| `watch/tiers/gh_prs.py:411` | `"?"` | `scope every author (default) on ?` | identical |
| `claims/check.py:654` | `None` | `gh issue view N` with no `--repo` | identical |
| `github/branch.py:1032` | `("","",err)` | `main()` prints `err`, exits 1 | **untouched** |
| `github/pr_merge.py:1181` | `("","",err)` | same shape | **untouched** |

## Adjacent, fixed in the same commit

- **`claims/check.py` read `os.environ["SUPERTOOL_REPO"]` raw**, bypassing `target()`'s blank-is-absence rule. `SUPERTOOL_REPO="   "` became the slug and reached `gh issue view --repo "   "`, so every issue citation rendered "couldn't check" against gh's complaint while the cwd — which could have answered — was never asked. This is the one thing that was actually wrong at any of the five, and it is #1411's class literally: a second reading of one value that disagrees with the canonical one.
- **A latent crash beside it.** The old code caught `ValueError` around `json.loads(...).get(...)`; a valid non-object payload raises `AttributeError`, uncaught — `json.loads('[]').get('x')`. `cwd_slug`'s `isinstance(data, dict)` guard removes it.

## Test

```
3 failed, 1 passed     # #1660 targeted, before the fix
10 failed, 4 passed    # #1701 targeted, before the fix
18 passed              # both after
246 passed             # neighbouring suites
13454 passed, 98 skipped   # full suite, disposable clone, 390s
```

Windows unverified locally; the diff adds no paths, no subprocess and no POSIX literals in either test, and CI is the authority.

## Review

One `Explore`/Sonnet pass against the committed diff returned **NO FINDINGS naming its coverage** — the evidence-shaped zero rather than a silent one. It independently reproduced the exception-set comparison and counted 29 presets carrying the identical `sys.path.insert` where the author had estimated ~15. Working tree clean afterwards; it wrote nothing.
