### PR TITLE
`description` is rendered whole by `ops`, so a maintainer changelog in it is a per-session tax (#1774)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -119,6 +119,30 @@ This is not a rule invented for one field. Measured across every shipped preset:
 
 **A second invocation form goes after ` | `, and starts with the op's own name.** `gh-check:CHECK_RUN_ID | gh-check:pr:NUMBER` is the shape, shared by `bluesky_list`, `devto_list`, `hashnode_list` and (since #1590) `gh-prs`. A bare `|` inside a form is an alternation between *values* and means something different — 34 fields use it that way.
 
+**`description` is not the long form — there is no long form** ([#1774](https://github.com/Digital-Process-Tools/claude-supertool/issues/1774)). The note above sends provenance and rationale here, and that is still the right destination relative to `syntax`. What it does not say, and what a writer needs before adding a paragraph, is that `ops` and `help:OP` render this field **byte for byte the same**. On 0.46.0 `gh-prs` carries 4,512 characters of `description`; its `ops` row is 4,706 bytes and `help:gh-prs` is 4,721 — the difference is the syntax line and the payload-route footer. So a clause written for the maintainer record is not filed somewhere a reader can opt into. It is injected into every reader of the roster, on every call, forever.
+
+Measured across the 128 documented ops in the shipped tree:
+
+| | |
+|---|---|
+| total | 76,795 chars |
+| median | 151 |
+| p90 | 1,868 |
+| max | 6,578 (`channel`) |
+| top 10 rows | 37,739 = **49% of the corpus, in 8% of the ops** |
+
+The assembled `ops` render is 74,838 bytes against `_HOOK_OUTPUT_CAP_BYTES` = 7,168, which is why this repo's own SessionStart injection has fallen back to a bare alphabetical list of op names carrying no signatures at all.
+
+**The line to draw.** A `description` says what the op does, what it will refuse, and what it declines to tell you — the three things a caller cannot get from the `syntax` field and cannot afford to learn from a failed call. What it is *not* is the record of how the op got here. These, from one entry, are all true and none of them belong on a line printed to every reader of the roster:
+
+- "It defaulted to `author=@me` until #1207 — disclosing that filter (#1072) was not enough, and three PRs nobody on the team wrote sat unseen for 5h to 1 day behind a footer read past every time."
+- "radar's `gh-prs` tier does NOT narrow by author … this line claimed the opposite until #1411."
+- "Resolving one has three outcomes and this line used to say a filter has only two."
+
+Those have homes that a reader pays for only when they ask: the issue, the changelog fragment, the docstring of the test that pins the behaviour. The behaviour itself — *bare `gh-prs` is every open PR on the repo; a role filter beside `anyauthor` is refused* — stays.
+
+**A ratchet, not a rewrite.** `tests/test_description_is_not_a_changelog_1774.py` caps a new op at 2,000 characters (p90, rounded up — nine ops in ten already fit) and carries the twelve that are over it in a ledger with their exact size. Those may shrink and may not grow, and an op that comes under the cap is deleted from the ledger rather than left at a stale number. Nothing asks for the twelve to be rewritten in one PR; the point is that the direction is one-way while #1774 decides whether the roster keeps carrying prose at all.
+
 ### `replaces` — the raw command this op supersedes
 
 If your op exists because a raw command was the wrong way to get the answer, say so **in the op**, and the shipped guard enforces it for every plugin user:

--- a/tests/test_description_is_not_a_changelog_1774.py
+++ b/tests/test_description_is_not_a_changelog_1774.py
@@ -1,0 +1,137 @@
+"""#1774 — `description` is rendered whole by `ops`, so its length is a per-session tax.
+
+`ops` and `help:OP` print the **same** `description` field, byte for byte: there
+is no long form today. Measured on 0.46.0, `gh-prs` carries 4,512 characters of
+`description`, its `ops` row is 4,706 bytes and its `help:gh-prs` render is
+4,721 — the difference is the syntax line and the payload-route footer, nothing
+else. So a clause added "for the maintainer record" is not filed somewhere
+cheaper; it is injected into every reader of the roster, forever.
+
+What that costs, over the whole shipped tree (128 documented ops):
+
+    total 76,795   median 151   p90 1,868   max 6,578 (`channel`)
+    top 10 rows    37,739 = 49% of the corpus, in 8% of the ops
+
+`_HOOK_OUTPUT_CAP_BYTES` is 7,168 and the assembled `ops` render is 74,838 —
+over the SessionStart cap by 10x, which is why this repo's own session
+injection has fallen back to a bare list of op names carrying no signatures.
+
+This file is a **ratchet, not a style rule.** Every entry in `_OVER_BUDGET` is a
+description that is already over `MAX_DESCRIPTION`; each may shrink and none may
+grow, and an op absent from the ledger must come in under the cap. Nothing here
+asks for a rewrite in one PR — it makes the direction one-way while #1774
+decides the shape.
+
+The cap is p90 rounded up, deliberately: nine ops in ten already fit under it,
+so it is the corpus's own habit written down rather than a budget invented for
+the twelve that broke it.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_ROOT = Path(__file__).parent.parent
+
+# p90 of the corpus, rounded up. A new op needing more than this is telling you
+# the extra is provenance, and provenance has homes that are not paid for on
+# every `ops` call: the issue, the changelog fragment, the test's own docstring.
+MAX_DESCRIPTION = 2000
+
+# The twelve over budget at 0.46.0, with their exact size. Sizes may only fall.
+# An op that drops under MAX_DESCRIPTION comes **out** of this ledger — that is
+# how the burn-down stays visible rather than sitting here at a stale number.
+_OVER_BUDGET = {
+    "channel": 6578,
+    "git-worktrees": 4832,
+    "gh-prs": 4512,
+    "git-push": 3991,
+    "gh-pr-merge": 3589,
+    "git-commit": 3463,
+    "gh-issues": 2866,
+    "gh-branch": 2784,
+    "gh-labels": 2723,
+    "dashboard": 2401,
+    "guard": 2166,
+    "radar": 2141,
+}
+
+
+def _descriptions() -> list[tuple[str, str, int]]:
+    """`(source_file, op_name, length)` for every documented op in the tree.
+
+    Both halves of the roster, because both are rendered by the same `ops` call:
+    the shipped presets and this repo's own `builtin-ops` block.
+    """
+    out: list[tuple[str, str, int]] = []
+    for path in sorted((_ROOT / "presets").glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for name, entry in (data.get("ops") or {}).items():
+            desc = (entry or {}).get("description")
+            if desc:
+                out.append((path.name, name, len(desc)))
+    root = json.loads((_ROOT / ".supertool.json").read_text(encoding="utf-8"))
+    for name, entry in (root.get("builtin-ops") or {}).items():
+        if isinstance(entry, dict) and entry.get("description"):
+            out.append((".supertool.json", name, len(entry["description"])))
+    return out
+
+
+def test_the_corpus_is_the_whole_documented_tree() -> None:
+    """A ratchet whose population silently shrank to nothing passes forever."""
+    rows = _descriptions()
+    assert len(rows) >= 120, len(rows)
+    names = {name for _f, name, _n in rows}
+    assert "gh-prs" in names and "read" in names
+
+
+def test_no_new_op_is_over_the_roster_budget() -> None:
+    """An op absent from the ledger fits, or the ledger is the wrong answer.
+
+    If you are here because a new op needs more room: it does not. Split the
+    provenance out. If you are here because an *existing* op grew past the cap,
+    that op is one of the twelve and the failure below is the other test.
+    """
+    bad = [
+        (name, size)
+        for _f, name, size in _descriptions()
+        if name not in _OVER_BUDGET and size > MAX_DESCRIPTION
+    ]
+    assert not bad, (
+        f"description over {MAX_DESCRIPTION} chars and not in the #1774 "
+        f"ledger: {bad}. The roster prints this field whole on every call."
+    )
+
+
+def test_the_over_budget_ledger_only_ever_falls() -> None:
+    """The ratchet itself. Grow one of the twelve and this is what says so."""
+    sizes = {name: size for _f, name, size in _descriptions()}
+    grew = [
+        (name, recorded, sizes[name])
+        for name, recorded in _OVER_BUDGET.items()
+        if name in sizes and sizes[name] > recorded
+    ]
+    assert not grew, (
+        f"description grew on an op already over budget (name, was, now): "
+        f"{grew}. #1774 — this field is paid for by every reader of `ops`."
+    )
+
+
+def test_a_shrunk_entry_leaves_the_ledger_rather_than_going_stale() -> None:
+    """Two ways the ledger lies if nothing checks it.
+
+    An entry recorded above its real size quietly buys headroom back, and an
+    entry that has come under the cap keeps claiming a debt that is paid. Both
+    read as progress and neither is; the remedy in each case is one line.
+    """
+    sizes = {name: size for _f, name, size in _descriptions()}
+    stale = [
+        (name, recorded, sizes.get(name))
+        for name, recorded in _OVER_BUDGET.items()
+        if name not in sizes or sizes[name] != recorded
+    ]
+    assert not stale, (
+        f"#1774 ledger out of date (name, recorded, actual): {stale}. "
+        f"Update the number, or delete the row if the op is now under "
+        f"{MAX_DESCRIPTION}."
+    )


### PR DESCRIPTION
Part of #1774, and deliberately only part of it: this settles the **writing rule** and puts a ratchet under it. It does not touch the shape question (signature-only default, `ops:FAMILY` filtering, an explicit split), which is what the SessionStart cap actually needs and what #1774 stays open for.

## The fact that changes the advice

`docs/contributing.md` already tells a writer that provenance and rationale go in `description` ([#1590](https://github.com/Digital-Process-Tools/claude-supertool/issues/1590)). Correct relative to `syntax`, and incomplete: **`ops` and `help:OP` print `description` byte for byte the same.** There is no long form to move prose into.

```
gh-prs description   4,512 chars
gh-prs `ops` row     4,706 bytes
`help:gh-prs`        4,721 bytes
```

The difference is the syntax line and the payload-route footer. So a clause written for the maintainer record is not filed somewhere a reader opts into — it is injected into every reader of the roster, on every call.

## Measured, 128 documented ops in the shipped tree

| | |
|---|---|
| total | 76,795 chars |
| median | 151 |
| p90 | 1,868 |
| max | 6,578 (`channel`) |
| top 10 rows | 37,739 = **49% of the corpus, in 8% of the ops** |

The assembled `ops` render is 74,838 bytes against `_HOOK_OUTPUT_CAP_BYTES` = 7,168, which is why this repo's own SessionStart injection has fallen back to a bare alphabetical list of op names with no signatures.

This is not a listing that grew evenly. It is one where ten entries became reference manuals and a hundred and eighteen stayed one-liners.

## What the rule says

A `description` is what the op does, what it will refuse, and what it declines to tell you. What it is not is the record of how the op got here. Three clauses from one entry, all true, none of them payable by every reader of the roster:

- "It defaulted to `author=@me` until #1207 — disclosing that filter (#1072) was not enough, and three PRs nobody on the team wrote sat unseen for 5h to 1 day behind a footer read past every time."
- "radar's `gh-prs` tier does NOT narrow by author … this line claimed the opposite until #1411."
- "Resolving one has three outcomes and this line used to say a filter has only two."

Their homes — paid only by a reader who asks — are the issue, the changelog fragment, and the docstring of the test that pins the behaviour. The behaviour itself stays: *bare `gh-prs` is every open PR on the repo; a role filter beside `anyauthor` is refused.*

## The ratchet, and why it is not a rewrite

`tests/test_description_is_not_a_changelog_1774.py`:

- **2,000 chars for an op not in the ledger** — p90 rounded up, so nine ops in ten already fit. The cap is the corpus's own habit written down, not a budget invented for the twelve that broke it.
- **A ledger of the twelve currently over it, with exact sizes.** They may shrink; they may not grow.
- **An entry that falls under the cap must leave the ledger** rather than sit at a stale number, and a recorded size that no longer matches the file is a failure too — an entry recorded above its real size quietly buys headroom back, and one still claiming a paid debt reads as progress that is not there.
- **The corpus is asserted non-empty** (≥120 rows, `gh-prs` and `read` present), because a ratchet whose population silently shrank to nothing passes forever.

No existing description is edited here. The direction is one-way while #1774 decides whether the roster keeps carrying prose at all.

## Proven red

Padding `gh-prs` by 8 characters and `gh-pr` past the cap:

```
E  AssertionError: description grew on an op already over budget (name, was, now): [('gh-prs', 4512, 4520)]
E  AssertionError: description over 2000 chars and not in the #1774 ledger: [('gh-pr', 4705)]
E  AssertionError: #1774 ledger out of date (name, recorded, actual): [('gh-prs', 4512, 4520)]
3 failed, 1 passed
```

Reverted, and green with `tests/test_syntax_is_grammar_not_prose_1590.py` alongside it: `11 passed`.

## Changelog

Docs and tests only, which `.github/workflows/changelog.yml` exempts by design; `no-changelog` applied so the state is stated rather than inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
