### PR TITLE
.oss.json's milestones list names five milestones, all of them closed on the forge

### DIFF
--- a/.oss.json
+++ b/.oss.json
@@ -32,11 +32,7 @@
     ]
   },
   "milestones": [
-    "v0.37.0",
-    "backlog",
-    "v0.38.0",
-    "v0.39.0",
-    "v0.42.0"
+    "backlog"
   ],
   "release": {
     "tag_pattern": "v{version}",


### PR DESCRIPTION
Board furniture, not product code. Found by this tick's triage sweep and verified against the forge before changing anything.

## Symptom

`.oss.json`'s `milestones` key listed `v0.37.0`, `backlog`, `v0.38.0`, `v0.39.0`, `v0.42.0`. Every `v*` entry is a closed milestone, and the one that was actually current — `v0.48.0`, which two open issues were sitting on — was not in the list at all. A run that trusted the file would have had no milestone to assign those two to, or would have invented one.

## Measured

```
$ gh api repos/Digital-Process-Tools/claude-supertool/milestones
v0.37.0 state=open open=0 closed=15
backlog state=open open=108 closed=89
v0.38.0 state=open open=0 closed=26
v0.39.0 state=open open=0 closed=14
v0.42.0 state=open open=0 closed=2
v0.48.0 state=open open=2 closed=5
```

`v0.48.0` tagged on 2026-08-18 (`gh release list` reports `v0.48.0  Latest  2026-08-18T15:02:51Z`) and was still open on the tracker holding #1802 and #1804. A shipped milestone should end at zero.

## What was done on the forge, outside this diff

- #1802 and #1804 moved to `backlog`.
- All five `v*` milestones closed. `backlog` is now the only open one, which is why it is the only entry left in the file.
- `cohort-22`'s label description gained the wording every earlier frozen cohort carries — it read `Open at the v0.48.0 tag` and now reads `Open at the v0.48.0 tag, 2026-08-18 — frozen set, nothing joins it`.

## Why the list went stale, which is the part worth keeping

This is the same list #1767 was about. A `_milestones_note` key recorded which entries were already closed; the maintainer plugin's config validator rejects unknown keys, so `/oss:scaffold` refused outright and `/oss:doctor` called maintainer prose a typo. The note was removed to satisfy the validator — and with it the record. This loop then re-derived exactly that fact by hand this morning, which is the second time somebody has paid for it.

So both halves of #1767 are settled and it is closed: the local half by removal, and the format half filed upstream as `Digital-Process-Tools/claude-oss#355` — a sanctioned comment slot in the config schema, with this recurrence as its evidence. `oss` is the loop's own repository, so filing there is part of finishing this rather than a favour to another project.

## No changelog fragment

`.oss.json` is not in `changelog.yml`'s user-visible path set at line 189, which matches `_supertool.py`, `presets/`, `validators/`, `formatters/`, `notifiers/` and `.claude-plugin/`. That leg reports `skipped (no user-visible paths changed — nothing to announce)`. Read from the workflow, not assumed.

## Not claimed

- Not that any test covers this. `grep` over `tests/` for the filename returns `0 results in 0 files, scanned 818 files` — nothing in the suite reads it, so nothing here is guarded by CI. It is config the maintainer loop reads.
- Not that the merged config was invalid. `oss_config.validate()` over `.oss.json` plus `.oss.local.json` returns `[]` both before and after this change; the list was wrong, not malformed.

Closes #1767.
