### PR TITLE
#1841 is a duplicate of #1845: two timing assertions with a one-second budget, and a contended git call read as a product verdict

### DIFF
--- a/tests/test_git_status_untracked_mtime_1724.py
+++ b/tests/test_git_status_untracked_mtime_1724.py
@@ -99,6 +99,17 @@ def test_fresh_and_stale_untracked_paths_both_carry_a_time(tmp_path, monkeypatch
     two_hours_ago = time.time() - 7200
     os.utime(repo / "old_scratch", (two_hours_ago, two_hours_ago))
     (repo / "fresh_stray").write_text("dropped just now" + NL)
+    # Pinned, not left at "now". `_age` renders whole seconds, so `written 0s
+    # ago` is an assertion with a ONE-SECOND budget: a loaded machine that
+    # takes two seconds to get from here to the render fails it, and the
+    # failure reads as a verdict about the product (#1845). Five minutes is
+    # inside the 15m activity window with 3x margin, and `_age`'s minute
+    # bucket holds it at `5m` for a full 60 seconds of drift -- a 60x wider
+    # budget. It is also a STRONGER assertion than the old disjunction: `5m`
+    # can only come from the mtime set here, where `0s` is equally what a
+    # render that had lost the mtime and formatted `_age(0)` would print.
+    five_minutes_ago = time.time() - 300
+    os.utime(repo / "fresh_stray", (five_minutes_ago, five_minutes_ago))
 
     _stub_no_mr(monkeypatch)
     out = _run_main(repo, monkeypatch, "full")
@@ -108,7 +119,7 @@ def test_fresh_and_stale_untracked_paths_both_carry_a_time(tmp_path, monkeypatch
 
     # Marker present.
     assert "activity window" in fresh, fresh
-    assert "written 0s ago" in fresh or "written 1s ago" in fresh, fresh
+    assert "written 5m ago" in fresh, fresh
     # Marker absent — on a line that provably rendered, and that still carries
     # the field, so this cannot pass by the whole column being missing.
     assert "activity window" not in old, old
@@ -194,6 +205,13 @@ def test_truncated_default_view_still_reports_the_newest_hidden_write(tmp_path, 
         p.write_text("x" + NL)
         os.utime(p, (old, old))
     (repo / "zz_stray").write_text("dropped just now" + NL)
+    # Pinned for the same reason as the sibling case above (#1845): `newest of
+    # them written 0s ago` is a one-second budget, and the delay a loaded
+    # machine adds between this write and the render is read as a product
+    # verdict. `5m` still sorts as the newest of the fifteen -- the other
+    # fourteen are a day old -- and survives 60 seconds of drift.
+    five_minutes_ago = time.time() - 300
+    os.utime(repo / "zz_stray", (five_minutes_ago, five_minutes_ago))
 
     _stub_no_mr(monkeypatch)
     out = _run_main(repo, monkeypatch)
@@ -201,8 +219,7 @@ def test_truncated_default_view_still_reports_the_newest_hidden_write(tmp_path, 
     assert "### Untracked (15)" in out
     assert "zz_stray" not in out          # genuinely hidden by the cap
     more = next(l for l in out.splitlines() if l.strip().startswith("... (5 more"))
-    assert ("newest of them written 0s ago" in more
-            or "newest of them written 1s ago" in more), more
+    assert "newest of them written 5m ago" in more, more
     assert "unreadable" not in more, more
 
 

--- a/tests/test_git_timeout_disclosure_650.py
+++ b/tests/test_git_timeout_disclosure_650.py
@@ -71,12 +71,6 @@ merge = _load_preset("merge")
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX /bin/sh shim")
 
-#: Resolved at import, while PATH is still the real one. Every fixture below
-#: replaces PATH with a directory holding nothing but a shim, so a
-#: `shutil.which("git")` evaluated INSIDE a test returns that shim -- and the
-#: shim is precisely what a contention check must not ask.
-_REAL_GIT_AT_IMPORT = shutil.which("git")
-
 
 # ---------------------------------------------------------------------------
 # A real git that really hangs, for one subcommand only
@@ -586,60 +580,56 @@ def _conflicted_repo(tmp_path: Path) -> Path:
     return repo
 
 
-#: What `git-conflicts` prints when its own `rev-parse --git-dir` probe does
-#: not come back 0 -- including when it merely TIMED OUT (conflicts.py:160).
-_NOT_A_REPO = "ERROR: not inside a git repository."
+def _run_conflicts(repo: Path, monkeypatch, stalled: str | None = None) -> tuple[str, int]:
+    """Run `git-conflicts`. STALLED names the one subcommand the shim hangs.
 
+    The contention guard needs the same evidence the `git-status` one has: that
+    a call ACTUALLY timed out. `conflicts.py` keeps no unanswered-call list, so
+    one is recorded here by wrapping its `_git` -- a `TIMEOUT_RC` seen with our
+    own eyes, not inferred from the sentence the product printed.
 
-def _run_conflicts(repo: Path, monkeypatch) -> tuple[str, int]:
-    """Run `git-conflicts`, declining rather than lying when the machine is loaded.
+    The first cut of this did infer it, and both reviewers of the commit caught
+    it: it skipped whenever the output held `not inside a git repository` and
+    the directory really was a repository. Those two facts are equally true of
+    a deterministic regression that prints the refusal unconditionally, with no
+    timing involved -- and because
+    `test_conflicts_still_reports_a_genuinely_clean_tree` runs through here
+    too, the mutant that guard's own docstring claimed was killed would have
+    been skipped instead. A guard that greens a real regression is the exact
+    defect this repository is named for, so the string match is gone.
 
-    The contention guard here cannot read an unanswered-call list the way the
-    `git-status` one does -- `conflicts.py` keeps none. What it has instead is
-    an unambiguous signal: the fixture has just BUILT this repository with real
-    git, so `not inside a git repository` cannot be true of it. Under
-    contention the unshimmed `rev-parse --git-dir` loses the 1s budget,
-    `conflicts.py:160` reads `returncode != 0` without excluding `TIMEOUT_RC`,
-    and the refusal is printed about a repository that is demonstrably there
-    (#1845). The repository is re-checked here on an UNBUDGETED call before
-    anything is skipped, so a genuine refusal still fails.
-
-    This does not paper over an unconditional-decline regression: that mutant
-    is killed by `test_conflicts_still_reports_a_genuinely_clean_tree`, which
-    runs real git with no shim and demands the honest answer.
+    What is left cannot fire without a real stall: no timeout recorded, no
+    skip, whatever the product printed.
     """
     monkeypatch.chdir(repo)
     monkeypatch.setattr(conflicts.sys, "argv", ["conflicts.py"])
+
+    stalls: list[str] = []
+    real_git = conflicts._git
+
+    def recording_git(args, timeout=None):
+        res = real_git(args, timeout)
+        if res.returncode == status.TIMEOUT_RC:
+            stalls.append("git " + " ".join(args))
+        return res
+
+    monkeypatch.setattr(conflicts, "_git", recording_git)
     buf = io.StringIO()
     with redirect_stdout(buf):
         rc = conflicts.main()
-    out = buf.getvalue()
-    if _NOT_A_REPO in out and _is_really_a_repo(repo):
+
+    unexpected = [c for c in stalls
+                  if stalled is None or _subcommand_of(c) != stalled]
+    if unexpected:
         pytest.skip(
-            "contended-git(#1845): `git-conflicts` refused with "
-            + repr(_NOT_A_REPO) + " for a repository that IS one -- its "
-            "unshimmed `rev-parse --git-dir` did not answer inside the 1s "
-            "budget, so nothing is claimed about the product here"
+            "contended-git(#1845): a git call this fixture needs to ANSWER did "
+            "not -- " + "; ".join(f"`{c}`" for c in unexpected)
+            + (f" (only `git {stalled} ...` was meant to stall)" if stalled
+               else " (no call was meant to stall)")
+            + ". `conflicts.py:160` reads a TIMEOUT_RC as `not inside a git "
+            "repository`, so nothing is claimed about the product here"
         )
-    return out, rc
-
-
-def _is_really_a_repo(repo: Path) -> bool:
-    """Unbudgeted, unshimmed second opinion, so the skip above needs evidence.
-
-    Uses the real binary by absolute path rather than whatever `PATH` the test
-    installed -- the shim on `PATH` is the thing under suspicion, and asking it
-    would be asking the suspect.
-    """
-    if not _REAL_GIT_AT_IMPORT:
-        return False          # cannot corroborate -> do not skip, fail loudly
-    try:
-        done = subprocess.run(
-            [_REAL_GIT_AT_IMPORT, "-C", str(repo), "rev-parse", "--git-dir"],
-            capture_output=True, text=True, timeout=60)
-    except (subprocess.TimeoutExpired, OSError):
-        return False
-    return done.returncode == 0
+    return buf.getvalue(), rc
 
 
 def test_a_failed_conflict_list_does_not_read_as_no_conflicts(
@@ -673,13 +663,59 @@ def test_a_stalled_conflict_list_declines_instead_of_crashing(
     monkeypatch.setenv("SUPERTOOL_GIT_TIMEOUT", "1")
 
     started = time.monotonic()
-    out, rc = _run_conflicts(repo, monkeypatch)
+    out, rc = _run_conflicts(repo, monkeypatch, stalled="diff")
     elapsed = time.monotonic() - started
 
     assert "No conflicted files." not in out, out
     assert "UNKNOWN" in out, out
     assert rc != 0
     assert elapsed < 60, elapsed
+
+
+def test_the_conflicts_contention_guard_needs_a_real_stall_to_fire(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The guard must not fire on a product that simply says the wrong thing.
+
+    This is the regression both reviewers of the first commit reproduced: a
+    guard keyed on `git-conflicts` printing `not inside a git repository` for a
+    directory that IS one skips for a DETERMINISTIC wrong answer just as
+    readily as for a contended stall -- and since the clean-tree test below
+    runs through the same helper, the unconditional-decline mutant it exists to
+    kill would have been skipped rather than failed.
+
+    So: a `main` that prints the refusal with no git call stalling must reach
+    the caller as output, never as a skip.
+    """
+    repo = _repo(tmp_path)
+    monkeypatch.setenv("PATH", _git_only_path(tmp_path))
+    monkeypatch.setattr(
+        conflicts, "main",
+        lambda: (print("ERROR: not inside a git repository."), 1)[1])
+
+    out, rc = _run_conflicts(repo, monkeypatch)
+
+    assert "not inside a git repository" in out, out
+    assert rc == 1
+
+
+def test_the_conflicts_contention_guard_does_fire_on_a_real_stall(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The other half -- a guard that never fires reads exactly like no guard.
+
+    `rev-parse` is stalled rather than `diff`, so the call that loses the
+    budget is the repository probe at `conflicts.py:160` itself: the real #1845
+    shape, not a simulation of it.
+    """
+    repo = _conflicted_repo(tmp_path)
+    monkeypatch.setenv("PATH", _slow_git_path(tmp_path, "rev-parse"))
+    monkeypatch.setenv("SUPERTOOL_GIT_TIMEOUT", "1")
+
+    with pytest.raises(pytest.skip.Exception) as exc:
+        _run_conflicts(repo, monkeypatch, stalled="diff")
+    assert "contended-git(#1845)" in str(exc.value)
+    assert "rev-parse" in str(exc.value)
 
 
 def test_conflicts_still_reports_a_genuinely_clean_tree(

--- a/tests/test_git_timeout_disclosure_650.py
+++ b/tests/test_git_timeout_disclosure_650.py
@@ -41,7 +41,7 @@ from pathlib import Path
 import pytest
 
 import supertool
-from _gitshim import dispatch_on_subcommand
+from _gitshim import TAKES_A_SEPARATE_ARGUMENT, dispatch_on_subcommand
 
 _ROOT = Path(__file__).parent.parent
 _STATUS_PATH = _ROOT / "presets" / "git" / "status.py"
@@ -70,6 +70,12 @@ resolve = _load_preset("resolve")
 merge = _load_preset("merge")
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX /bin/sh shim")
+
+#: Resolved at import, while PATH is still the real one. Every fixture below
+#: replaces PATH with a directory holding nothing but a shim, so a
+#: `shutil.which("git")` evaluated INSIDE a test returns that shim -- and the
+#: shim is precisely what a contention check must not ask.
+_REAL_GIT_AT_IMPORT = shutil.which("git")
 
 
 # ---------------------------------------------------------------------------
@@ -150,12 +156,74 @@ def _repo(tmp_path: Path) -> Path:
     return repo
 
 
-def _run_status(repo: Path, monkeypatch) -> str:
+def _subcommand_of(rendered: str) -> str:
+    """The git subcommand in an `_UNANSWERED` entry like `git -C /x status -s`.
+
+    Same rule as the PATH shim in `_gitshim`, and deliberately so: the shim is
+    what decides which call stalls, so anything that disagrees with it here
+    would classify a stall as expected when the shim never fired on it. Global
+    flags are skipped, and the ones taking a separate argument consume it.
+    """
+    argv = rendered.split()[1:]          # drop the leading "git"
+    i = 0
+    while i < len(argv):
+        if argv[i] in TAKES_A_SEPARATE_ARGUMENT:
+            i += 2
+        elif argv[i].startswith("-"):
+            i += 1
+        else:
+            return argv[i]
+    return ""
+
+
+def _skip_if_an_unshimmed_git_call_stalled(stalled: str | None) -> None:
+    """Third state for a timing assertion: the machine could not meet the premise.
+
+    Every fixture here stalls ONE subcommand on purpose and needs every other
+    git call to answer inside the budget. That premise is not free: the budget
+    these tests set is 1s, and the file's own docstring measured a worst real
+    git latency of 0.76s under 96 CPU burners -- 1.3x of headroom. When a
+    contended machine spends it, `presets/git/status.py` treats the unanswered
+    `branch -vv` as a git FAILURE and returns 1 with no report at all, so the
+    assertions below read a machine limit as a verdict about the product. That
+    is #1845, and the product half of it is filed separately -- this guard does
+    not fix it, it stops the suite from mis-attributing it.
+
+    The cost, stated rather than hidden: on a leg loaded enough to trip this,
+    the test does not run. A skip carrying a token is visible; a false red that
+    trains people to re-run is not.
+    """
+    unexpected = [
+        (cmd, why) for cmd, why in status._UNANSWERED
+        if cmd.startswith("git ")
+        and why.startswith("timed out after")
+        and (stalled is None or _subcommand_of(cmd) != stalled)
+    ]
+    if unexpected:
+        pytest.skip(
+            "contended-git(#1845): a git call this fixture needs to ANSWER did "
+            "not, so nothing is claimed about the product here -- "
+            + "; ".join(f"`{cmd}` ({why})" for cmd, why in unexpected)
+            + (f" (only `git {stalled} ...` was meant to stall)" if stalled
+               else " (no call was meant to stall)")
+        )
+
+
+def _run_status(repo: Path, monkeypatch, stalled: str | None = None) -> str:
+    """Run `git-status`. STALLED names the one subcommand the shim hangs.
+
+    The return code is checked AFTER the premise guard on purpose: when an
+    unshimmed call times out the product returns 1 and prints no report, so
+    asserting the code first would turn a machine limit into a bare
+    `assert 1 == 0` naming nothing.
+    """
     monkeypatch.chdir(repo)
     monkeypatch.setattr(status.sys, "argv", ["status.py"])
     buf = io.StringIO()
     with redirect_stdout(buf):
-        assert status.main() == 0
+        rc = status.main()
+    _skip_if_an_unshimmed_git_call_stalled(stalled)
+    assert rc == 0
     return buf.getvalue()
 
 
@@ -172,7 +240,7 @@ def test_a_stalled_git_call_does_not_kill_the_whole_report(
     monkeypatch.setenv("SUPERTOOL_GIT_TIMEOUT", "1")
 
     started = time.monotonic()
-    out = _run_status(repo, monkeypatch)
+    out = _run_status(repo, monkeypatch, stalled="rev-list")
     elapsed = time.monotonic() - started
 
     assert "# git-status" in out
@@ -196,7 +264,7 @@ def test_the_report_says_which_git_call_went_unanswered(
     repo = _repo(tmp_path)
     monkeypatch.setenv("PATH", _slow_git_path(tmp_path, "rev-list"))
     monkeypatch.setenv("SUPERTOOL_GIT_TIMEOUT", "1")
-    out = _run_status(repo, monkeypatch)
+    out = _run_status(repo, monkeypatch, stalled="rev-list")
 
     assert status.INCOMPLETE_MARKER in out
     note = next(l for l in out.splitlines() if status.INCOMPLETE_MARKER in l)
@@ -238,7 +306,7 @@ def test_a_stalled_call_is_never_rendered_as_a_git_success(
     repo = _repo(tmp_path)
     monkeypatch.setenv("PATH", _slow_git_path(tmp_path, "rev-list"))
     monkeypatch.setenv("SUPERTOOL_GIT_TIMEOUT", "1")
-    out = _run_status(repo, monkeypatch)
+    out = _run_status(repo, monkeypatch, stalled="rev-list")
 
     assert "no own commits" not in out
     assert "vs master:" not in out
@@ -274,12 +342,67 @@ def test_a_stalled_branch_name_reads_unknown_not_blank(
     repo = _repo(tmp_path)
     monkeypatch.setenv("PATH", _slow_git_path(tmp_path, "rev-parse"))
     monkeypatch.setenv("SUPERTOOL_GIT_TIMEOUT", "1")
-    out = _run_status(repo, monkeypatch)
+    out = _run_status(repo, monkeypatch, stalled="rev-parse")
 
     branch_line = next(l for l in out.splitlines() if l.startswith("Branch:"))
     assert branch_line.strip() != "Branch:", "a stall rendered as an empty branch name"
     assert "?" in branch_line, branch_line
     assert status.INCOMPLETE_MARKER in out
+
+
+def test_the_contention_guard_fires_on_an_unshimmed_stall_and_only_on_one(
+    monkeypatch,
+) -> None:
+    """Both halves, because a guard that never fires reads exactly like no guard.
+
+    #1845's flake is an unshimmed `branch -vv` losing the 1s budget on a loaded
+    machine; the product then returns 1 with no report and the assertions blame
+    it. The guard turns that into a skip. Each case below is paired with one
+    that must NOT skip, so a guard stuck in the "always decline" position --
+    which would quietly green the whole file -- fails here.
+    """
+    def unanswered(entries):
+        monkeypatch.setattr(status, "_UNANSWERED", list(entries))
+
+    # Fires: a real call this fixture needed an ANSWER from did not give one.
+    unanswered([("git branch -vv --no-color", "timed out after 1s")])
+    with pytest.raises(pytest.skip.Exception) as exc:
+        _skip_if_an_unshimmed_git_call_stalled("rev-parse")
+    assert "contended-git(#1845)" in str(exc.value)
+    assert "branch" in str(exc.value)
+
+    # Silent: the shimmed call stalling IS the premise, not a broken one.
+    unanswered([("git rev-parse --abbrev-ref HEAD", "timed out after 1s")])
+    _skip_if_an_unshimmed_git_call_stalled("rev-parse")
+
+    # Silent: nothing stalled at all.
+    unanswered([])
+    _skip_if_an_unshimmed_git_call_stalled("rev-parse")
+    _skip_if_an_unshimmed_git_call_stalled(None)
+
+    # Silent: a git call that FAILED rather than timed out is a real finding
+    # and must stay red, not be laundered into a skip.
+    unanswered([("git branch -vv --no-color", "exit 128: fatal: bad object")])
+    _skip_if_an_unshimmed_git_call_stalled("rev-parse")
+
+    # Fires with no subcommand shimmed: this fixture expected every call to
+    # answer, so any stall breaks the premise.
+    unanswered([("git status --porcelain", "timed out after 1s")])
+    with pytest.raises(pytest.skip.Exception):
+        _skip_if_an_unshimmed_git_call_stalled(None)
+
+
+def test_the_guard_reads_the_subcommand_the_way_the_shim_does() -> None:
+    """A disagreement here classifies a stall the shim never caused as expected.
+
+    Global flags are skipped and `-C <path>` consumes its value -- the exact
+    trap `_gitshim`'s own docstring was written for.
+    """
+    assert _subcommand_of("git rev-parse --abbrev-ref HEAD") == "rev-parse"
+    assert _subcommand_of("git -C /tmp/x status --porcelain") == "status"
+    assert _subcommand_of("git --no-pager branch -vv") == "branch"
+    assert _subcommand_of("git -c core.abbrev=8 rev-list --count HEAD") == "rev-list"
+    assert _subcommand_of("git") == ""
 
 
 # ---------------------------------------------------------------------------
@@ -463,13 +586,60 @@ def _conflicted_repo(tmp_path: Path) -> Path:
     return repo
 
 
+#: What `git-conflicts` prints when its own `rev-parse --git-dir` probe does
+#: not come back 0 -- including when it merely TIMED OUT (conflicts.py:160).
+_NOT_A_REPO = "ERROR: not inside a git repository."
+
+
 def _run_conflicts(repo: Path, monkeypatch) -> tuple[str, int]:
+    """Run `git-conflicts`, declining rather than lying when the machine is loaded.
+
+    The contention guard here cannot read an unanswered-call list the way the
+    `git-status` one does -- `conflicts.py` keeps none. What it has instead is
+    an unambiguous signal: the fixture has just BUILT this repository with real
+    git, so `not inside a git repository` cannot be true of it. Under
+    contention the unshimmed `rev-parse --git-dir` loses the 1s budget,
+    `conflicts.py:160` reads `returncode != 0` without excluding `TIMEOUT_RC`,
+    and the refusal is printed about a repository that is demonstrably there
+    (#1845). The repository is re-checked here on an UNBUDGETED call before
+    anything is skipped, so a genuine refusal still fails.
+
+    This does not paper over an unconditional-decline regression: that mutant
+    is killed by `test_conflicts_still_reports_a_genuinely_clean_tree`, which
+    runs real git with no shim and demands the honest answer.
+    """
     monkeypatch.chdir(repo)
     monkeypatch.setattr(conflicts.sys, "argv", ["conflicts.py"])
     buf = io.StringIO()
     with redirect_stdout(buf):
         rc = conflicts.main()
-    return buf.getvalue(), rc
+    out = buf.getvalue()
+    if _NOT_A_REPO in out and _is_really_a_repo(repo):
+        pytest.skip(
+            "contended-git(#1845): `git-conflicts` refused with "
+            + repr(_NOT_A_REPO) + " for a repository that IS one -- its "
+            "unshimmed `rev-parse --git-dir` did not answer inside the 1s "
+            "budget, so nothing is claimed about the product here"
+        )
+    return out, rc
+
+
+def _is_really_a_repo(repo: Path) -> bool:
+    """Unbudgeted, unshimmed second opinion, so the skip above needs evidence.
+
+    Uses the real binary by absolute path rather than whatever `PATH` the test
+    installed -- the shim on `PATH` is the thing under suspicion, and asking it
+    would be asking the suspect.
+    """
+    if not _REAL_GIT_AT_IMPORT:
+        return False          # cannot corroborate -> do not skip, fail loudly
+    try:
+        done = subprocess.run(
+            [_REAL_GIT_AT_IMPORT, "-C", str(repo), "rev-parse", "--git-dir"],
+            capture_output=True, text=True, timeout=60)
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return done.returncode == 0
 
 
 def test_a_failed_conflict_list_does_not_read_as_no_conflicts(


### PR DESCRIPTION
Closes #1845. Closes #1841 — **as a duplicate, with evidence**: its stated mechanism is not what the code does.

## #1841's diagnosis does not survive contact with the file

#1841 says `tests/test_git_status_untracked_mtime_1724.py` reads the **real** working tree's untracked list. It does not. `_init_repo(tmp_path)` builds a hermetic repo under pytest's `tmp_path` and `_run_main` chdirs into it. With a canary file left untracked in the real worktree, the canary is absent from the render and the report says `### Untracked (2)` — the fixture's own two files. On master, with **25** untracked entries present (a changelog fragment, a new test file, an untracked directory, 20 scratch files), the file passes **6/6**.

So both remedies #1841 proposes are built on a premise that is not true: a hermetic fixture is what the file already has, and there is no real-tree surface to filter.

## What actually fails

`_age()` renders whole seconds below 90s. Two assertions pin a file written **now**:

```
assert "written 0s ago" in fresh or "written 1s ago" in fresh
assert ("newest of them written 0s ago" in more or "... 1s ago" in more)
```

Those are the only two age assertions in the file not sitting in a bucket with an hour of slack — every other one is `os.utime`d to 1h, 2h or 24h. They are **exactly** the two tests #1841 names, and two of the three #1845 names. Injecting a 2s delay reproduces `2 failed, 4 passed`, byte-identical to the count #1841 measured after `git stash pop`. The stash correlation was coincidence; the machine was loaded, which is #1845.

Both are now pinned with `os.utime` to five minutes, the way the file already pins its stale paths: inside the 15m activity window with 3x margin, held at `5m` by `_age`'s minute bucket across 60 seconds of drift. Observed green at a **30s** delay — 15x the delay that broke it.

**The assertion gets stronger, not looser.** Against a mutant that loses the mtime and formats `_age(0)`:

| | result |
|---|---|
| old disjunction vs mutant | **6 passed** — vacuous |
| new exact `5m` vs mutant | **2 failed**, 4 passed |

`0s` is what a correct render of a just-written file prints *and* what a render with no mtime at all prints. `5m` can only come from the mtime the fixture set.

## The 650 flake is a product defect — reported, not fixed

Product code was out of this lane's bounds, so these are handed over rather than patched. Both reproduced by making one real git call exceed the 1s budget these tests set (1.3x of headroom over the 0.76s worst latency this file's own docstring measured under load):

* **`presets/git/status.py:563-575`** — `branch_result.returncode != 0` does not exclude `TIMEOUT_RC` (124), so an unanswered `branch -vv` is read as a git **failure** and returns 1 with **no report at all**. That is the defect #650 was filed to close, surviving at the first git call of the run. `_unborn_head()` 350 lines above already has the `!= TIMEOUT_RC` guard — the pattern is known and applied inconsistently.
* **`presets/git/conflicts.py:160`** — same shape, worse sentence: a stalled `rev-parse --git-dir` makes `git-conflicts` print `ERROR: not inside a git repository.` about a repository mid-merge with live conflict markers. A positive false claim about the world, not merely a missing section.

## The tests now carry the third state

`_run_status` and `_run_conflicts` decline with a `contended-git(#1845)` token when a call the fixture needed an **answer** from did not give one, instead of rendering a machine limit as a verdict about the product. Both guards key on a `TIMEOUT_RC` **observed** — `status`'s own `_UNANSWERED` list, and a recording wrapper around `conflicts._git` — never on the sentence the product printed.

**The cost, not hidden:** on a leg loaded enough to trip a guard, that test does not run. A skip carrying a token is visible in `-rs`; a false red that trains people to re-run is not.

## Measured under real contention

Six agents running suites concurrently on this machine. Same two files, same selection, minutes apart:

```
master    : 6 failed, 21 passed  in 52.00s
fix/1841  : 27 passed, 2 skipped in 53.55s
```

Master's six include all three tests #1845 names. The skip names the call:

```
contended-git(#1845): a git call this fixture needs to ANSWER did not, so nothing is
claimed about the product here -- `git branch -vv --no-color` (timed out after 1s)
(only `git rev-parse ...` was meant to stall)
```

## Second commit: a defect both reviewers caught in the first

Worth reading as its own commit (`9739c871`). The first cut of the conflicts guard inferred the stall from the output string — it skipped whenever `git-conflicts` printed `not inside a git repository` for a directory that really was one. Both reviewers independently **reproduced** the consequence: those two facts are equally true of a deterministic regression that prints the refusal unconditionally, and because `test_conflicts_still_reports_a_genuinely_clean_tree` runs through the same helper, the unconditional-decline mutant that test exists to kill would have been **skipped rather than failed** — while the guard's own docstring claimed the opposite. A guard that greens a real regression is this repository's named defect class, introduced inside the guard written to prevent one.

Fixed by recording an observed `TIMEOUT_RC` instead. Verified against the reviewers' own mutant: **4 failed, 21 passed**, where the previous guard skipped. Both halves are now pinned by tests of their own, as is the `status.py` guard — including that a git call which **failed** rather than timed out stays red.

## Suite

`tests/ -k git` — **2647 passed**, 2 subtests passed, 774s. The three coupled files (`test_git_shim_subcommand_1206.py` imports this module; `test_symlink_gating_register_1232.py` names one of its helpers in a register) run green. No full-suite run: test-only change in two files, nothing shared moved, no rebase — and six agents were already running suites, so a 26-minute full run would have added the contention #1845 is about.

## Notes for the maintainer

* **No changelog fragment.** `.github/workflows/changelog.yml:186-189` excludes `tests/` from the user-visible set, with the reason in the file: *"requiring a fragment for a typo fix is how the discipline decays into a reflex-added empty file."* A `tests/`-only diff reports `skipped (no user-visible paths changed)`.
* **`tests/conftest.py` untouched** (held by PR #1843). So the `contended-git(#1845)` token is **not** wired into the suite's token-tally register, which lives there. The skips are visible under `-rs` but are not counted in the tally block the other tokens print. That is the one piece of this change that wants a conftest edit and could not have it — a small follow-up once #1843 lands.
* **`_subcommand_of` blind spot, stated rather than guarded.** It splits on whitespace, so a `-C <path>` containing a space would have the path's second half read as the subcommand. Unreachable today: every `_git` call site in `status.py` and `conflicts.py` passes a fixed argv with no path at all. Guarding an input that cannot arrive would be a coverage claim that is not true.
