### PR TITLE
bash-check: label the nearest unclosed quote when far from bash -n's own line (#1810)

### DIFF
--- a/_supertool.py
+++ b/_supertool.py
@@ -21260,6 +21260,30 @@ def _flat_cell(value: Any, limit: Optional[int] = None) -> str:
     return text
 
 
+def _quote_open_guess_line(e: Dict[str, Any]) -> Optional[str]:
+    """One short receipt line for `quote_open_guess` (#1810), or None.
+
+    Unlike `source_context`/`context_unavailable` -- several lines, shown only
+    in `verbose` mode -- this is a single short line, so it is not gated the
+    same way: the incident it exists for is read from the receipt an edit's
+    own rollback prints, which never carries `verbose` at all
+    (`_validator_render_diff` takes no such parameter). Gating it behind an
+    explicit `validate:PATH:verbose` re-run would build the hint and then hide
+    it from the one moment it is for.
+
+    Adapter-supplied text, `_flat_cell`-ed like every other string these
+    renderers put on a line of its own (#895).
+    """
+    guess = e.get("quote_open_guess")
+    if not isinstance(guess, dict):
+        return None
+    gl = guess.get("line")
+    if gl is None:
+        return None
+    note = _flat_cell(str(guess.get("note") or ""), 100)
+    return f"      ↳ maybe opened at L{gl}" + (f": {note}" if note else "")
+
+
 def _validator_render_row(data: Dict[str, Any], verbose: bool = False) -> list:
     """Render a single validator result as a list of display lines.
 
@@ -21305,6 +21329,9 @@ def _validator_render_row(data: Dict[str, Any], verbose: bool = False) -> list:
             code = e.get("code") or ""
             msg = _flat_cell(e.get("msg") or "")
             out.append(f"  {line_n} {code}  {msg}")
+            guess_line = _quote_open_guess_line(e)
+            if guess_line:
+                out.append(guess_line)
             for ctx_line in (e.get("source_context") or []):
                 out.append(f"    {_flat_cell(ctx_line)}")
             # An empty `source_context` used to mean either "no lines to show"
@@ -21334,6 +21361,9 @@ def _validator_render_row(data: Dict[str, Any], verbose: bool = False) -> list:
             code = e.get("code") or ""
             msg = _flat_cell(e.get("msg") or "", 120)
             out.append(f"  {line_n} {code}  {msg}")
+            guess_line = _quote_open_guess_line(e)
+            if guess_line:
+                out.append(guess_line)
         if len(errors) > 5:
             out.append(f"  ... +{len(errors) - 5} more")
     return out
@@ -21785,6 +21815,9 @@ def _validator_render_diff(before: Optional[Dict[str, Any]], after: Dict[str, An
                 code = e.get("code") or ""
                 msg = _flat_cell(e.get("msg") or "", 120)
                 out.append(f"  {line_n} {code}  {msg}")
+                guess_line = _quote_open_guess_line(e)
+                if guess_line:
+                    out.append(guess_line)
             if len(after.get("errors") or []) > 5:
                 out.append(f"  ... +{len(after['errors']) - 5} more")
         return out
@@ -21828,6 +21861,9 @@ def _validator_render_diff(before: Optional[Dict[str, Any]], after: Dict[str, An
             msg = _flat_cell(e.get("msg") or "", 120)
             out.append(f"  {' ' if code == 'adapter' else bullet} "
                        f"{line_n} {code}  {msg}")
+            guess_line = _quote_open_guess_line(e)
+            if guess_line:
+                out.append(guess_line)
         if len(new) > 5:
             out.append(f"  {bullet} ... +{len(new) - 5} more"
                        f"{'' if b_unknown else ' new'}")

--- a/changelog.d/1810.fixed.md
+++ b/changelog.d/1810.fixed.md
@@ -1,0 +1,10 @@
+- **`bash-check` named the line `bash -n` gave up on, five lines past the quote that actually broke it** ([#1810](https://github.com/Digital-Process-Tools/claude-supertool/issues/1810)). An edit that leaves a `'` or `"` unclosed still parses fine right up until the shell hits EOF or the next syntactic wall, so the reported line is exact about where `bash -n` stopped and says nothing about where the mistake is -- on a ~1,900-line file of awk embedded in shell quoting, that put a whole indented `function` block between the two, and every neighbouring line was also full of quotes.
+
+  Each finding now also carries a `quote_open_guess` when a small dedicated state-machine scan (`validators/common/quote_balance.py`) finds a quote still open by the time it reaches the reported line:
+
+  ```json
+  {"line": 8, "msg": "syntax error: unexpected end of file",
+   "quote_open_guess": {"line": 2, "note": "best-effort: ..."}}
+  ```
+
+  `line`, `col` and `msg` stay exactly what `bash -n` said. The guess is explicitly labelled and never folded into them: the tracker has no model of here-docs, command substitution or nested quoting, so it can be wrong, and a report naming the true open line already gets nothing extra.

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -562,6 +562,34 @@ file (`validate:hooks.d/after_save/50-git-backup`) and shellcheck reads the
 shebang. A repo of extensionless hooks should add a second entry globbing the
 directory.
 
+### bash-check — a second line, always labelled a guess
+
+`bash -n`'s own `line` is exact about where its parser gave up, and an
+unterminated quote can leave that a long way from the line that actually
+opened it -- reported at five lines and a whole indented `function` block
+past the apostrophe, on a ~1,900-line file of awk embedded in shell quoting,
+where every neighbouring line is also full of quotes ([#1810](https://github.com/Digital-Process-Tools/claude-supertool/issues/1810)).
+The message alone sent the reader to a correct, innocent line in a file where
+every line looks equally guilty.
+
+`bash-check` now also runs a small, dedicated state-machine scan
+(`validators/common/quote_balance.py`) over the file up to the reported line,
+and adds a **second**, explicitly labelled field when it finds a quote still
+open there:
+
+```json
+{"line": 8, "col": null, "severity": "error", "code": "syntax",
+ "msg": "syntax error: unexpected end of file",
+ "quote_open_guess": {"line": 2, "note": "best-effort: a quote opened here ..."}}
+```
+
+`line`, `col` and `msg` are untouched -- they are `bash -n`'s own output and
+stay exact. `quote_open_guess` is not a diagnostic in its own right: the
+tracker has no model of here-docs, command substitution or nested quoting, so
+it can be wrong, and it says as much in its own `note`. It is present only
+when it differs from `line` -- a report that already names the true open line
+gets nothing extra.
+
 ### eslint — declining beats inventing a config
 
 JS/TS coverage was `node-check` (syntax), `tsc-check` (types, TS only),

--- a/tests/test_bash_check_render_guess_1810.py
+++ b/tests/test_bash_check_render_guess_1810.py
@@ -1,0 +1,52 @@
+"""quote_open_guess reaches the receipt a caller actually reads (#1810).
+
+The adapter can compute the right hint, but nothing was worth building if the
+renderer that turns a validator payload into what a human or agent sees never
+walks the new key -- `_validator_render_row` and `_validator_render_diff` are
+the only two places that do that, and neither knew about `quote_open_guess`
+before this. `_validator_render_diff` in particular is the one shown at the
+exact moment #1810 is about: right after an edit gets rolled back.
+"""
+from __future__ import annotations
+
+import supertool
+
+
+ERR = {"line": 8, "code": "syntax", "msg": "syntax error: unexpected end of file",
+       "quote_open_guess": {"line": 2, "note": "best-effort: a quote opened here."}}
+
+
+def test_render_row_verbose_shows_the_guess():
+    data = {"tool": "bash-check", "ok": False, "count": 1, "duration_ms": 1,
+            "errors": [dict(ERR)]}
+    lines = supertool._validator_render_row(data, verbose=True)
+    body = "\n".join(lines)
+    assert "L2" in body and "opened" in body, body
+
+
+def test_render_diff_shows_the_guess_on_a_fresh_failure():
+    """No baseline (`before=None`) -- the shape an edit's own post-write
+    validator pass produces, and the one #1810's own incident went through."""
+    after = {"tool": "bash-check", "ok": False, "count": 1, "duration_ms": 1,
+             "errors": [dict(ERR)]}
+    lines = supertool._validator_render_diff(None, after)
+    body = "\n".join(lines)
+    assert "L2" in body and "opened" in body, body
+
+
+def test_render_diff_shows_the_guess_on_a_regression():
+    """A baselined run that regressed -- the other branch of the same function."""
+    before = {"tool": "bash-check", "ok": True, "count": 0, "duration_ms": 1, "errors": []}
+    after = {"tool": "bash-check", "ok": False, "count": 1, "duration_ms": 1,
+              "errors": [dict(ERR)]}
+    lines = supertool._validator_render_diff(before, after)
+    body = "\n".join(lines)
+    assert "L2" in body and "opened" in body, body
+
+
+def test_no_guess_key_adds_nothing():
+    """No `quote_open_guess` on the error -- no extra line, no crash."""
+    err = {"line": 8, "code": "syntax", "msg": "m"}
+    lines = supertool._validator_render_diff(
+        None, {"tool": "t", "ok": False, "count": 1, "duration_ms": 1, "errors": [err]})
+    assert not any("opened" in l for l in lines), lines

--- a/tests/test_bash_check_unbalanced_quote_guess_1810.py
+++ b/tests/test_bash_check_unbalanced_quote_guess_1810.py
@@ -61,8 +61,12 @@ FIXTURE = (
 
 
 def test_far_diagnostic_line_carries_a_labelled_guess_at_the_true_open(tmp_path):
-    """The `line: 8` finding -- bash's own EOF report, six lines past the
-    apostrophe -- also names line 2 as a guess. `line` itself is untouched."""
+    """The `line: 8` finding -- bash's own EOF report, five lines past the
+    `function` block and six past the apostrophe -- also names line 2 as a
+    guess. `line` itself is untouched. This is the positive case: it is the
+    one thing in this file that fails if `unbalanced_quote_open` is deleted or
+    made a no-op, which the two tests below are deliberately NOT (see their
+    own docstrings)."""
     mod = adapter("bash-check")
     f = tmp_path / "unterm.sh"
     f.write_text(FIXTURE, encoding="utf-8")
@@ -78,21 +82,36 @@ def test_far_diagnostic_line_carries_a_labelled_guess_at_the_true_open(tmp_path)
     assert "note" in guess and guess["note"], "the guess must say it is a guess"
 
 
-def test_diagnostic_line_that_is_itself_the_open_carries_no_guess():
+def test_diagnostic_line_that_is_itself_the_open_carries_no_guess(tmp_path):
     """bash's `line 2` report already IS where the quote opened -- nothing to
-    add, so no `quote_open_guess` key at all (never one pointing at itself)."""
+    add, so no `quote_open_guess` key (never one pointing at itself).
+
+    Reads a REAL, existing file (unlike a stale earlier version of this test,
+    which pointed at a nonexistent path and so passed on the file-unreadable
+    short-circuit rather than on the de-duplication check this test names --
+    a positive control on THIS test, run once by hand: with the `guess_line
+    != ln` check in `parse_diagnostics` removed, this test fails, correctly,
+    on a self-referential guess.)"""
     mod = adapter("bash-check")
+    f = tmp_path / "unterm.sh"
+    f.write_text(FIXTURE, encoding="utf-8")
     errors = mod.parse_diagnostics(
-        UNTERMINATED_QUOTE_STDERR.format(file="x.sh"), "x.sh")
-    # parse_diagnostics reads the file for context/guessing; x.sh does not
-    # exist here, so nothing can be read and no guess is fabricated either.
+        UNTERMINATED_QUOTE_STDERR.format(file=str(f)), str(f))
     by_line = {e["line"]: e for e in errors}
     assert "quote_open_guess" not in by_line[2]
 
 
 def test_balanced_file_gets_no_guess(tmp_path):
     """A real syntax error with no unbalanced quote anywhere before it must not
-    manufacture a guess -- the positive control for the two tests above."""
+    manufacture a guess.
+
+    This is a negative test, not a positive control on its own -- it passes
+    identically whether `unbalanced_quote_open` runs correctly or has been
+    deleted outright, since both produce "no guess" here. What proves the
+    machinery is live is `test_far_diagnostic_line_...` above (parse_diagnostics
+    driven end to end) and `tests/test_quote_balance_1810.py` (the tracker
+    itself, driven directly on cases built to have a real answer). This test's
+    only job is to confirm those two don't fire everywhere."""
     mod = adapter("bash-check")
     f = tmp_path / "brace.sh"
     f.write_text("#!/bin/bash\nif [ 1 ]; then\n  echo hi\n", encoding="utf-8")

--- a/tests/test_bash_check_unbalanced_quote_guess_1810.py
+++ b/tests/test_bash_check_unbalanced_quote_guess_1810.py
@@ -1,0 +1,101 @@
+"""bash-check names bash -n's own line; a reader also needs where it began (#1810).
+
+`bash -n` reports a syntax finding at the line where parsing gave up, not at the
+line that broke it. An apostrophe left open by an edit is a common cause, and
+the line it reports can sit several lines -- in the reported incident, five, on
+a ~1,900-line file of awk embedded in shell quoting -- past the apostrophe that
+actually opened the string. The reported line is correct about where `bash -n`
+stopped; it is not where the mistake is, and from it alone the file reads as
+broken everywhere, because every neighbouring line is also full of quotes.
+
+This does not replace `bash -n`'s own line -- that is exact, and rewriting it
+would misattribute a real diagnostic. It adds a *second*, explicitly labelled
+guess: the nearest quote that a plain state-machine scan finds still open by
+the time execution reaches the reported line. Only a guess -- the tracker knows
+nothing of here-docs, command substitution or nested quoting -- so it is never
+folded into `line`, `col` or `msg`, all of which stay exactly what `bash -n`
+said.
+
+No subprocess: `parse_diagnostics` is driven directly against a **real**
+`bash -n` transcript captured once (below), so the test is exercised on every
+platform without depending on the bash on PATH agreeing about wording.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+VALIDATORS = REPO / "validators"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def adapter(name: str):
+    return _load(VALIDATORS / name / f"{name}.py", "_v1810_" + name.replace("-", "_"))
+
+
+# Captured once, from GNU bash, against the fixture written below:
+#   bash -n <file>  ->  exit 2
+UNTERMINATED_QUOTE_STDERR = (
+    "{file}: line 2: unexpected EOF while looking for matching `''\n"
+    "{file}: line 8: syntax error: unexpected end of file\n"
+)
+
+FIXTURE = (
+    "#!/bin/bash\n"
+    "FOO='unterminated\n"
+    "BAR=baz\n"
+    "QUX=qux\n"
+    "function foo() {\n"
+    "    echo hi\n"
+    "}\n"
+)
+
+
+def test_far_diagnostic_line_carries_a_labelled_guess_at_the_true_open(tmp_path):
+    """The `line: 8` finding -- bash's own EOF report, six lines past the
+    apostrophe -- also names line 2 as a guess. `line` itself is untouched."""
+    mod = adapter("bash-check")
+    f = tmp_path / "unterm.sh"
+    f.write_text(FIXTURE, encoding="utf-8")
+    out = UNTERMINATED_QUOTE_STDERR.format(file=str(f))
+    errors = mod.parse_diagnostics(out, str(f))
+    by_line = {e["line"]: e for e in errors}
+    assert 8 in by_line and 2 in by_line
+    far = by_line[8]
+    assert far["line"] == 8, "bash's own line must not be rewritten"
+    guess = far.get("quote_open_guess")
+    assert guess is not None, "a finding far from an open quote must carry a guess"
+    assert guess["line"] == 2
+    assert "note" in guess and guess["note"], "the guess must say it is a guess"
+
+
+def test_diagnostic_line_that_is_itself_the_open_carries_no_guess():
+    """bash's `line 2` report already IS where the quote opened -- nothing to
+    add, so no `quote_open_guess` key at all (never one pointing at itself)."""
+    mod = adapter("bash-check")
+    errors = mod.parse_diagnostics(
+        UNTERMINATED_QUOTE_STDERR.format(file="x.sh"), "x.sh")
+    # parse_diagnostics reads the file for context/guessing; x.sh does not
+    # exist here, so nothing can be read and no guess is fabricated either.
+    by_line = {e["line"]: e for e in errors}
+    assert "quote_open_guess" not in by_line[2]
+
+
+def test_balanced_file_gets_no_guess(tmp_path):
+    """A real syntax error with no unbalanced quote anywhere before it must not
+    manufacture a guess -- the positive control for the two tests above."""
+    mod = adapter("bash-check")
+    f = tmp_path / "brace.sh"
+    f.write_text("#!/bin/bash\nif [ 1 ]; then\n  echo hi\n", encoding="utf-8")
+    out = f"{f}: line 4: syntax error: unexpected end of file\n"
+    errors = mod.parse_diagnostics(out, str(f))
+    assert errors and errors[0].get("quote_open_guess") is None

--- a/tests/test_quote_balance_1810.py
+++ b/tests/test_quote_balance_1810.py
@@ -1,0 +1,104 @@
+"""Direct unit coverage for the bash quote-balance tracker (#1810).
+
+`unbalanced_quote_open` is a small, deliberately non-authoritative
+state machine -- validators/common/quote_balance.py's own docstring lists
+what it does not model (here-docs, command substitution, ANSI-C `$'...'`
+quoting, nested constructs). These tests exercise the part it DOES claim:
+single- and double-quote balance, `#` comments, and backslash escapes,
+plus the boundary conditions a hand-rolled scanner like this one is most
+likely to get wrong (empty input, a request past the end of the file, a
+quote that opens on the very last scanned line).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+COMMON = REPO / "validators" / "common"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def qb():
+    if str(COMMON) not in sys.path:
+        sys.path.insert(0, str(COMMON))
+    return _load(COMMON / "quote_balance.py", "_v1810_quote_balance")
+
+
+def test_empty_text_has_nothing_open():
+    assert qb().unbalanced_quote_open("", 1) is None
+
+
+def test_no_quotes_at_all():
+    assert qb().unbalanced_quote_open("echo hi\necho bye\n", 2) is None
+
+
+def test_single_quote_open_and_closed_same_line():
+    assert qb().unbalanced_quote_open("FOO='bar'\necho done\n", 2) is None
+
+
+def test_single_quote_left_open():
+    text = "FOO='bar\necho done\n"
+    assert qb().unbalanced_quote_open(text, 2) == 1
+
+
+def test_double_quote_left_open():
+    text = 'FOO="bar\necho done\n'
+    assert qb().unbalanced_quote_open(text, 2) == 1
+
+
+def test_backslash_escapes_a_double_quote_so_it_does_not_close():
+    # \" inside a double-quoted string does not close it -- still open.
+    text = 'FOO="a\\"b\necho done\n'
+    assert qb().unbalanced_quote_open(text, 2) == 1
+
+
+def test_backslash_has_no_special_meaning_inside_single_quotes():
+    # A single-quoted string cannot contain a single quote at all, escaped
+    # or not -- bash's own rule, and this scanner's `state == "'"` branch
+    # never consumes two characters for a backslash. The quote right after
+    # the backslash still closes the string.
+    text = "FOO='a\\'\necho done\n"
+    assert qb().unbalanced_quote_open(text, 2) is None
+
+
+def test_comment_hides_a_quote_after_the_hash():
+    text = "echo hi # a dangling ' quote in a comment\necho done\n"
+    assert qb().unbalanced_quote_open(text, 2) is None
+
+
+def test_quote_reopened_after_being_closed_is_the_new_open_line():
+    text = "FOO='closed'\nBAR='open\necho x\n"
+    assert qb().unbalanced_quote_open(text, 3) == 2
+
+
+def test_upto_line_stops_the_scan_there():
+    # The quote on line 2 is still open at line 2 itself...
+    text = "echo hi\nFOO='open\necho x\n"
+    assert qb().unbalanced_quote_open(text, 2) == 2
+    # ...and reported the same way three lines further into the same
+    # unterminated string, since nothing closes it.
+    assert qb().unbalanced_quote_open(text, 3) == 2
+
+
+def test_upto_line_past_the_end_of_a_short_file_does_not_crash():
+    text = "FOO='open\n"
+    assert qb().unbalanced_quote_open(text, 500) == 1
+
+
+def test_documented_false_negative_hash_not_at_a_word_boundary():
+    """A `#` immediately after non-whitespace is NOT a comment in real bash,
+    but this tracker treats every unquoted `#` as one -- a documented gap
+    (validators/common/quote_balance.py's own docstring). Pinned here so a
+    change to that behavior is a decision, not an accident: real bash reads
+    the apostrophe in `foo#bar'baz` as unterminated; this tracker, having
+    treated `#bar'baz` as a comment, does not."""
+    assert qb().unbalanced_quote_open("a=foo#bar'baz\n", 1) is None

--- a/validators/bash-check/bash-check.py
+++ b/validators/bash-check/bash-check.py
@@ -48,6 +48,14 @@ def _read_for_guess(file: str) -> str:
     `context_unavailable` state for exactly that case. This one just gives up
     on the guess quietly, by returning "", which `unbalanced_quote_open`
     treats as an empty file (no quote open anywhere).
+
+    Known and left as-is: this duplicates the read `source_context()`
+    (validators/common/source_context.py) already does for the same
+    diagnostic, so a run producing at least one finding opens the file twice.
+    Sharing one read between two independently-designed helper modules is a
+    real fix, but it is not this one -- it would mean touching
+    `source_context`'s own contract for a cost that only matters on files
+    large enough for a second full read to register at all (#1810 review).
     """
     try:
         return pathlib.Path(file).read_text(errors="replace", encoding="utf-8")

--- a/validators/bash-check/bash-check.py
+++ b/validators/bash-check/bash-check.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "common"
 from source_context import context_fields
 from refusal import guard_main, tool_fault
 from linebreaks import split_lines
+from quote_balance import unbalanced_quote_open
 
 # `bash -n` reports a syntax finding as `file: line N: message`. Its other
 # non-zero exits are the shell failing to get as far as parsing:
@@ -39,17 +40,56 @@ from linebreaks import split_lines
 DIAGNOSTIC = re.compile(r":\s*line\s+(\d+):\s*(.+)")
 
 
+def _read_for_guess(file: str) -> str:
+    """Best-effort read for `unbalanced_quote_open`, never a diagnostic path.
+
+    An unreadable file is not this function's failure to report -- the
+    diagnostic itself still stands on `context_fields`, which has its own
+    `context_unavailable` state for exactly that case. This one just gives up
+    on the guess quietly, by returning "", which `unbalanced_quote_open`
+    treats as an empty file (no quote open anywhere).
+    """
+    try:
+        return pathlib.Path(file).read_text(errors="replace", encoding="utf-8")
+    except OSError:
+        return ""
+
+
 def parse_diagnostics(out: str, file: str) -> list[dict]:
     """Every located diagnostic in bash's stderr. Empty means the shell never
-    got as far as parsing."""
+    got as far as parsing.
+
+    `bash -n`'s own `line` is exact about where its parser gave up, and stays
+    untouched. An unterminated quote can leave that line far from the one that
+    actually broke -- five lines and an indented `function` block, in the
+    incident this exists for (#1810) -- so each finding also carries a
+    `quote_open_guess` when a plain state-machine scan finds a quote still
+    open by the time it reaches `line`. It is a GUESS, explicitly labelled:
+    the scan knows nothing of here-docs or command substitution, so it can be
+    wrong, and it is never folded into `line`, `col` or `msg`.
+    """
     errors = []
+    text = None
     for line in split_lines(out):
         m = DIAGNOSTIC.search(line)
         if m:
             ln = int(m.group(1))
-            errors.append({"line": ln, "col": None, "severity": "error",
-                           "code": "syntax", "msg": m.group(2).strip()[:200],
-                           **context_fields(file, ln)})
+            err = {"line": ln, "col": None, "severity": "error",
+                   "code": "syntax", "msg": m.group(2).strip()[:200],
+                   **context_fields(file, ln)}
+            if text is None:
+                text = _read_for_guess(file)
+            if text:
+                guess_line = unbalanced_quote_open(text, ln)
+                if guess_line is not None and guess_line != ln:
+                    err["quote_open_guess"] = {
+                        "line": guess_line,
+                        "note": ("best-effort: a quote opened here looks still "
+                                 "unclosed by the reported line. Not itself a "
+                                 "diagnostic -- `line` above is bash's own and "
+                                 "exact, this is a guess (#1810)."),
+                    }
+            errors.append(err)
     return errors
 
 

--- a/validators/common/quote_balance.py
+++ b/validators/common/quote_balance.py
@@ -2,7 +2,7 @@
 
 `bash -n` reports a syntax finding at the line where its parser gave up, which
 for an unterminated `'` or `"` is not the line that opened it -- the reported
-incident put six lines and a whole indented `function` block between the two,
+incident put five lines and a whole indented `function` block between the two,
 in a ~1,900-line file where every neighbouring line is also full of quotes.
 This module answers a narrower, checkable question instead of trying to be
 `bash -n`: **is a quote still open by the time execution reaches line N, and
@@ -10,9 +10,13 @@ if so, where did it start?**
 
 This is NOT a bash parser and does not try to be one. It has no model of
 here-docs, command substitution, ANSI-C $'...' quoting, or nested
-constructs -- any of those can make its answer wrong. That is exactly why its
-result must never be folded into `line`, `col` or `msg` (bash's own, and
-exact): callers surface it as a separately labelled guess, never as a second
+constructs -- any of those can make its answer wrong. Nor does it require a
+`#` to sit at a word boundary the way real bash does, so `foo#bar'baz` reads
+as a comment starting at the `#` here and would not in a real shell -- a false
+negative (no guess where one exists), never a false positive, so it degrades
+to silence rather than to a wrong pointer. That is exactly why its result
+must never be folded into `line`, `col` or `msg` (bash's own, and exact):
+callers surface it as a separately labelled guess, never as a second
 diagnostic.
 """
 from __future__ import annotations

--- a/validators/common/quote_balance.py
+++ b/validators/common/quote_balance.py
@@ -1,0 +1,69 @@
+"""Best-effort bash quote-balance tracker (#1810).
+
+`bash -n` reports a syntax finding at the line where its parser gave up, which
+for an unterminated `'` or `"` is not the line that opened it -- the reported
+incident put six lines and a whole indented `function` block between the two,
+in a ~1,900-line file where every neighbouring line is also full of quotes.
+This module answers a narrower, checkable question instead of trying to be
+`bash -n`: **is a quote still open by the time execution reaches line N, and
+if so, where did it start?**
+
+This is NOT a bash parser and does not try to be one. It has no model of
+here-docs, command substitution, ANSI-C $'...' quoting, or nested
+constructs -- any of those can make its answer wrong. That is exactly why its
+result must never be folded into `line`, `col` or `msg` (bash's own, and
+exact): callers surface it as a separately labelled guess, never as a second
+diagnostic.
+"""
+from __future__ import annotations
+
+from linebreaks import split_lines
+
+
+def unbalanced_quote_open(text: str, upto_line: int) -> int | None:
+    """1-based line where a quote still open at `upto_line` began, or None.
+
+    Walks `text` from its first line through `upto_line` (inclusive) tracking
+    quote state character by character: `#` starts a comment when unquoted (to
+    end of line), a backslash escapes the next character when unquoted or
+    inside a double-quoted string (never inside a single-quoted one, matching
+    bash), and a matching quote character closes the string it opened.
+
+    Returns None when nothing is open at `upto_line` -- either no quote was
+    ever opened, or every one seen was closed again before that point.
+    """
+    lines = split_lines(text)
+    state: str | None = None
+    open_line: int | None = None
+    for i, line in enumerate(lines, start=1):
+        if i > upto_line:
+            break
+        j = 0
+        n = len(line)
+        while j < n:
+            ch = line[j]
+            if state is None:
+                if ch == "#":
+                    break
+                if ch == "\\":
+                    j += 2
+                    continue
+                if ch == "'":
+                    state, open_line = "'", i
+                elif ch == '"':
+                    state, open_line = '"', i
+                j += 1
+                continue
+            if state == "'":
+                if ch == "'":
+                    state, open_line = None, None
+                j += 1
+                continue
+            # state == '"'
+            if ch == "\\":
+                j += 2
+                continue
+            if ch == '"':
+                state, open_line = None, None
+            j += 1
+    return open_line


### PR DESCRIPTION
## Summary

Closes #1810.

`bash-check` (the validator that runs `bash -n <file>` after an edit) reported an unterminated-quote syntax error at the line bash's own parser gave up on -- which for an unterminated quote can be several lines past the line that actually broke it. The reported incident put a whole indented `function` block between the reported line and the real one, on a ~1,900-line file where every neighbouring line is also full of quotes.

Adds `validators/common/quote_balance.py`, a small best-effort state-machine scan tracking bash quote state up to the reported line, wired into `bash-check`'s `parse_diagnostics`. A finding whose line differs from where a quote is still open now carries a labelled `quote_open_guess: {"line": N, "note": "..."}`. `line`, `col` and `msg` stay exactly what `bash -n` said.

A first-pass version of this fix computed `quote_open_guess` but never rendered it anywhere a caller would actually see it -- caught by a spawned reviewer's self-review before this PR was opened, and fixed in the second commit, along with several test-quality issues the same review found. See `review.findings` in the machine report for the full list and disposition of each.

### #1809 and #1819 -- investigated, found already fixed, no code change

This lane also carried #1809 (a payload value ending in a quote colliding with the `'''` literal-block terminator) and #1819 (a backslash refusal costing a re-send because it didn't name occurrences or support per-field opt-out). Both were reproduced directly against the live parser rather than assumed from the issue text, and both are substantially already fixed:

- **#1809**: `_toml_multiline_close` (fixed by #834) already lets a literal block end in 1 or 2 surplus quotes (`'''hello world''''` -> `hello world'`), and `_toml_delimiter_hint`/`_toml_delimiter_early_close` (fixed by #1830) already refuse, at parse time, any run that closes a value early -- naming the payload line and column. Both are documented at length in `docs/input-forms.md` under "When the content itself contains `'''`" and "Ending a block with a quote", with the exact worked examples the issue describes. The one case that remains unfixable -- a caller writes exactly 3 trailing quotes when they meant 4, silently producing a value missing its trailing quote -- cannot be detected: `tests/test_payload_literal_backslash_834.py::the_issue_spelled_right` explicitly requires the opposite behaviour (a value legitimately ending in a quote must parse, not be refused), so a blanket refusal on "ends in a quote" would revert #834. Recommend closing #1809 with this as the evidence.
- **#1819**: `_dbs_occurrences` (fixed by #1808/#1814) already names every occurrence's payload line and column via `finditer`, not just the first, and `_payload_literal_backslashes_scope` (fixed by #1839) already supports `literal_backslashes = ["field"]` for a per-field opt-out. Verified live against the current parser. Recommend closing #1819 with this as the evidence.

No code was written for either issue in this diff -- they are reported for closure rather than built on top of an expired premise, per this lane's own brief.

## Test plan

- [x] `tests/test_bash_check_unbalanced_quote_guess_1810.py` -- red before the fix (no `quote_open_guess` key), green after
- [x] `tests/test_quote_balance_1810.py` -- direct unit coverage of the tracker (open/closed quotes, comment handling, escapes, quote type, file-length boundaries, a documented false-negative)
- [x] `tests/test_bash_check_render_guess_1810.py` -- red before the render fix (guess computed but never shown), green after
- [x] Full suite run twice in a disposable clone (once per commit): same 8 pre-existing, environment-caused failures both times (`tree_sitter_language_pack` download errors, one `git_mr_lookup` test), confirmed present on bare `master` before this branch. 14973 passed after the second commit.
- [x] `python3 .../assemble_changelog.py --check` on `changelog.d/1810.fixed.md` -- clean

## Below-bar finding

One reviewer finding is real but left unfixed: `bash-check.py`'s `_read_for_guess` re-reads the target file with its own `Path(file).read_text(...)` call, duplicating the read `source_context()` (in `validators/common/source_context.py`) already makes for the same diagnostic -- so a run producing at least one finding now opens the file twice instead of once. This is below the bar for this PR: it is a real, measurable inefficiency, but fixing it would mean touching `source_context.py`'s own read contract to share a cache between two independently-designed helper modules, for a cost that only matters on the large files this feature specifically targets, not on an ordinary edit. Left as a comment in `_read_for_guess`'s own docstring rather than acted on.

Co-Authored-By: Max <noreply>


## Verified by the maintainer

**The red re-run, taken independently: 16 failed, 3 passed — and only 4 of the 16 are behavioural.** All three new test files copied onto a disposable clone of `master` at `5bfa56f`, the implementation absent.

Twelve of the failures are every case in `tests/test_quote_balance_1810.py`, and they fail with `FileNotFoundError` because `validators/common/quote_balance.py` does not exist there. For a new module that is the only red available and it demonstrates nothing about whether the assertions bite. The four that do are the ones worth quoting:

```
FAILED tests/test_bash_check_unbalanced_quote_guess_1810.py::test_far_diagnostic_line_carries_a_labelled_guess_at_the_true_open
FAILED tests/test_bash_check_render_guess_1810.py::test_render_row_verbose_shows_the_guess
FAILED tests/test_bash_check_render_guess_1810.py::test_render_diff_shows_the_guess_on_a_fresh_failure
FAILED tests/test_bash_check_render_guess_1810.py::test_render_diff_shows_the_guess_on_a_regression
```

The **3 passed** are the controls that are supposed to pass without the fix. A run where everything went red would mean the fixtures were measuring the missing module rather than the behaviour.

**The three render failures are the interesting ones, and they exist because the first pass shipped the defect this repository is named after.** `quote_open_guess` was computed and never rendered anywhere a caller could see it — a checker that had the answer and returned the shape of one that did not. The lane's own spawned reviewer caught it before this pull request existed. Those three tests are the guard against it coming back, and they are the reason the render path is asserted separately from the computation.

**I re-derived the two issues this lane closed rather than accepting the recommendation**, because closing an issue on a lane's say-so is the cheap direction:

```
$ supertool 'paste:@-' <<'EOF'
path = "q1809.txt"
content = '''hello world''''
EOF
created q1809.txt (1 lines, 0 → 13 bytes)
$ supertool 'read:q1809.txt'
1 │ hello world'
```

and an early-closing run is refused at parse time naming payload line and column. #1809 and #1819 are closed with those receipts on the issues themselves, not here.

**The below-bar finding is correctly below the bar and correctly recorded.** `_read_for_guess` opening the file a second time is real; sharing a cache with `source_context()` means touching a contract two independent helpers rely on, for a cost that only bites on the large files this feature targets. Left in the docstring where the next reader meets it.
