### PR TITLE
docs(readme): name the three sibling plugins near the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ supertool 'read:src/Module.py' 'read:src/Auth.py' 'grep:TODO:src/:20' 'map:src/'
 
 ---
 
+## From the same workshop
+
+Four plugins, one team, each does one thing. This one and three siblings:
+
+- [claude-remember](https://github.com/Digital-Process-Tools/claude-remember): memory across sessions. Saves, compresses through Haiku, reloads at the next start.
+- [claude-jit-context](https://github.com/Digital-Process-Tools/claude-jit-context): project knowledge that loads only when the prompt, the file or the tool matches it.
+- [claude-oss](https://github.com/Digital-Process-Tools/claude-oss): the maintainer loop that runs these four repos. Triage, build, review, merge, release.
+
+All four install from one marketplace: `/plugin marketplace add Digital-Process-Tools/claude-marketplace`.
+
 ## Why
 
 **Hammer in 2026.** Claude Code's default toolbelt is 1995 unix: `cat` one file, `grep` one pattern, `git status` returns 200 bytes of porcelain. Every tool call re-sends the entire conversation cache — system prompt, CLAUDE.md, rules, every prior turn — at 10% of input price. Read 7 files? Pay that prefix 7 times. Run `git status` then realize you needed `ahead/behind` too? Pay it twice for one decision. The bill compounds turn over turn.

--- a/changelog.d/2142.added.workshop.md
+++ b/changelog.d/2142.added.workshop.md
@@ -1,0 +1,3 @@
+- **The README names its three sibling plugins near the top** (#2142). One block, three
+  links, one marketplace command. Before this each README named the others once or not
+  at all, and the repo strangers reach first (claude-remember) pointed nowhere.


### PR DESCRIPTION
One block under the pitch: the three sibling plugins, one line each, and the one marketplace command that installs all four.

Why: claude-remember has 163 stars and its README named the other three tools once in 934 lines. supertool named remember 5 times. The traffic went the wrong way. Same block on all four repos tonight.

Part of #2142 (the README rewrite), which this does not close.

https://claude.ai/code/session_01UqogxB9dfRZaWefk6SkXqL
