### PR TITLE
validate:@- footer parity, around_line containment, retraction spelling

### DIFF
--- a/_supertool.py
+++ b/_supertool.py
@@ -6601,7 +6601,18 @@ def _op_around(pattern: str, path: str, n: int = 10) -> str:
         # here (the cwd was fine), so name the actual mistake instead —
         # never redirect the call itself, only the advice.
         suggest = None
-        if _is_ascii_int(path):
+        # `pattern` becomes the PATH slot of the suggested `around_line:`
+        # call, and this route reaches an unresolved `pattern` no colon-CLI
+        # caller could: dispatch's own `_PATH_ARG_POSITIONS` gate refuses
+        # `around:/etc/hosts:3` before `op_around` ever runs, but the
+        # `@payload`/`batch` route applies no containment to `pattern` (it
+        # is a regex there, not a declared path). Printing the suggestion
+        # unconditionally advertised a call the colon route itself refuses
+        # for containment (#1146) -- the same shape as the `git-checkout`
+        # hint in #850: never prescribe a command the tool's own sibling
+        # rejects. `_containment_error` mirrors the gate `_swap_suggest`
+        # (#1711) already applies to its own candidate below.
+        if _is_ascii_int(path) and _containment_error([pattern]) is None:
             suggest = (
                 "`around` takes PATTERN:PATH[:N] — "
                 f"'{path}' was read as the path. Did you mean: "
@@ -10445,6 +10456,38 @@ def _write_target(path: str) -> str:
     identity on an object the writer never touched. One expression, two callers.
     """
     return os.path.realpath(path) if os.path.islink(path) else path
+
+
+def _write_target_display(path: str) -> str:
+    """`_write_target(path)`, spelled the way `path` itself is displayed (#1146).
+
+    `_write_target` uses `os.path.realpath`, which canonicalises every
+    symlinked ANCESTOR directory along the way, not only the leaf symlink —
+    macOS routes every `/tmp` path through `/private/tmp`. The receipt lines
+    that quote `path` back (the success line `_receipt_head` retracts, the
+    `[rolled back]`/`[left on disk]` subject) never canonicalise ancestors —
+    they use `os.path.abspath`. So a retraction of a write through a symlink
+    named the SAME directory two different ways: `/private/var/…/target.py`
+    for the resolved target, `/var/…/link.py` for the link the success line
+    named, and a reader had to work out the two prefixes were one place.
+
+    Rewritten to agree with `path`'s own spelling wherever the divergence is
+    ONLY that ancestor-canonicalisation — i.e. the write target and `path`'s
+    directory resolve (via realpath) to the very same directory, and differ
+    only in which of the two equivalent spellings was used for it. A target
+    that genuinely lives elsewhere (chained symlinks pointing well outside
+    `path`'s own directory) is returned exactly as `_write_target` found it —
+    this only removes a cosmetic mismatch, never the disclosure that the
+    write landed somewhere else.
+    """
+    target = _write_target(path)
+    if target == path:
+        return target
+    path_dir = os.path.dirname(os.path.abspath(path))
+    target_dir = os.path.dirname(target)
+    if path_dir != target_dir and os.path.realpath(path_dir) == os.path.realpath(target_dir):
+        return os.path.join(path_dir, os.path.basename(target))
+    return target
 
 
 def _process_umask() -> int:
@@ -24797,7 +24840,15 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
     # Every rollback arm reports on the object it acted on, refuse included: a
     # refusal that names the link while the restore beside it names the target
     # would describe two different files as one.
-    _target_cell = _flat_cell(_target)
+    #
+    # Displayed via `_write_target_display`, not `_target` itself (#1146):
+    # `_write_target`'s `os.path.realpath` canonicalises a symlinked ANCESTOR
+    # directory as well as the leaf link, while every OTHER path in this
+    # receipt (`path` itself, via `os.path.abspath`) does not — so the same
+    # directory was spelled two different ways across one sentence. The
+    # functional `_target` below is untouched; only what gets printed changes.
+    _target_display = _write_target_display(path)
+    _target_cell = _flat_cell(_target_display)
     if os.path.abspath(_target) != os.path.abspath(path):
         _target_cell += f" (which the symlink {_flat_cell(path)} resolves to)"
     applicable_fmt = _applicable_formatters(op, path)
@@ -24954,7 +25005,7 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
                             fmt_rows.append(_retraction_line(
                                 result_name, "failed", path, body,
                                 created=fmt_action == "unlink",
-                                target=_target))
+                                target=_target_display))
                         except OSError as e:
                             fmt_rows.append(f"[ROLLBACK FAILED] {result_name}: {e}")
                 else:
@@ -25037,7 +25088,7 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
                 _retract_write(path)
                 diff_out += ("\n" + _retraction_line(
                     name, "regressed", path, body,
-                    created=action == "unlink", target=_target) + "\n")
+                    created=action == "unlink", target=_target_display) + "\n")
             except OSError as e:
                 diff_out += f"\n[ROLLBACK FAILED] {name}: {e}\n"
             already_undone = True
@@ -25062,7 +25113,7 @@ def _run_with_validators(op: str, parts: Any, do_op: Any) -> str:
         if refused_by and os.path.exists(_target):
             _note_left_on_disk()
             diff_out += ("\n" + _left_on_disk_line(
-                refused_by, path, body, target=_target) + "\n")
+                refused_by, path, body, target=_target_display) + "\n")
 
     suffix = ""
     if fmt_rows:  # silent when all formatters are no-op
@@ -28656,6 +28707,57 @@ def dispatch_verdict(
     return out, _call_failed()
 
 
+def _depth1_call_footer(op: str, body: str,
+                        attempts_before: int, writes_before: int,
+                        skips_before: int, reapplies_before: int,
+                        rollbacks_before: int, left_on_disk_before: int) -> str:
+    """`[result]`/`[branch: X]` footer for a depth<=1 call (#381, #990).
+
+    Factored out of the tail of `_dispatch_impl` so the `op:@-` payload route
+    can carry it too (#1158): that route used to `return` its body directly,
+    before dispatch ever reached this block, so `validate:@-` silently
+    dropped the summary line `validate:PATH` prints for the identical file
+    and identical config. Same computation either way — the six `*_before`
+    counters are deltas taken at whichever call site snapshotted them, and a
+    read-only route (nothing in `_READ_OP_AT_FIELDS` mutates) can snapshot
+    them immediately before the op runs without losing anything.
+    """
+    if getattr(_DISPATCH_STATE, "depth", 1) > 1:
+        return body
+    # This frame's own rows (#1109), not a slice of the process-global.
+    # `dispatch` installed them before `_dispatch_impl` ran, so the lists
+    # are always present here; `or ()` declines to fall back to the global,
+    # because a footer built from every op's rows is the defect, not a
+    # degraded reading of it.
+    _not_checked_slice = list(
+        getattr(_DISPATCH_STATE, "acc_not_checked", None) or ())
+    _validated_slice = list(
+        getattr(_DISPATCH_STATE, "acc_validated", None) or ())
+    if not (op in _OP_TARGETS or _MUTATION_ATTEMPTS[0] > attempts_before
+            or _not_checked_slice or _validated_slice):
+        return body
+    _result = _result_line(_MUTATION_ATTEMPTS[0] - attempts_before,
+                           _WRITE_COUNT[0] - writes_before,
+                           _SKIP_COUNT[0] - skips_before,
+                           _REAPPLY_COUNT[0] - reapplies_before,
+                           _not_checked_slice,
+                           _ROLLBACK_COUNT[0] - rollbacks_before,
+                           _validated_slice,
+                           _LEFT_ON_DISK_COUNT[0] - left_on_disk_before)
+    # A batch says its count twice, and the leading copy is the load-bearing
+    # one. The footer is separated from the per-op results by a validators
+    # block long enough that `tail` lands on `git-status : ok` and reads as
+    # success -- the exact half of #984 that #1018 marked `Part of` and did
+    # not build. Only `batch`: a single op's receipt is three lines with the
+    # footer already adjacent, and a duplicate there is noise rather than a
+    # signal.
+    if op == "batch":
+        body = _result + body
+    body += _result
+    body += _branch_line()
+    return body
+
+
 def _dispatch_impl(arg: str, pre_parsed: "Optional[Tuple[List[str], bool]]" = None) -> str:
     """Body of dispatch — separated so the recursion guard stays minimal."""
     # Strip :::no-exclude before splitting so it doesn't interfere with arg parsing
@@ -28753,10 +28855,26 @@ def _dispatch_impl(arg: str, pre_parsed: "Optional[Tuple[List[str], bool]]" = No
         # The warnings lead the body, so the verdict is taken from the op's
         # own answer rather than from whatever ends up first on the line.
         _read_warnings = _take_payload_warnings()
+        # Snapshotted immediately before the op runs (#1158): nothing in
+        # `_READ_OP_AT_FIELDS` mutates, so a footer built from a delta against
+        # this point is exact -- and without it, `validate:@-` printed
+        # neither `[result]` nor `[branch: X]`, the two lines `validate:PATH`
+        # ends on, because this branch returned before dispatch ever reached
+        # the footer block.
+        _read_attempts_before = _MUTATION_ATTEMPTS[0]
+        _read_writes_before = _WRITE_COUNT[0]
+        _read_skips_before = _SKIP_COUNT[0]
+        _read_reapplies_before = _REAPPLY_COUNT[0]
+        _read_rollbacks_before = _ROLLBACK_COUNT[0]
+        _read_left_on_disk_before = _LEFT_ON_DISK_COUNT[0]
         _read_body = _read_op_from_payload(
             op, _read_payload, no_exclude=no_exclude)
         if _op_body_failed(_read_body):
             _mark_op_failure()
+        _read_body = _depth1_call_footer(
+            op, _read_body, _read_attempts_before, _read_writes_before,
+            _read_skips_before, _read_reapplies_before,
+            _read_rollbacks_before, _read_left_on_disk_before)
         return header + _read_warnings + _read_body
 
     # @file route — 'op:@path' or 'op:@-' (stdin).
@@ -29670,41 +29788,15 @@ def _dispatch_impl(arg: str, pre_parsed: "Optional[Tuple[List[str], bool]]" = No
     # must stay the last line (#381's tests assert `endswith`), and a footer
     # that only appears when a branch happens to exist would go missing outside
     # a repo — which is the exact shape #621 is about.
-    if getattr(_DISPATCH_STATE, "depth", 1) <= 1:
-        # A read-only op that ran validators can still carry the one thing the
-        # footer exists to carry: a checker that did not check (#969).
-        # `validate` is not in `_OP_TARGETS` and mutates nothing, so it was
-        # gated out of the summary line entirely.
-        # This frame's own rows (#1109), not a slice of the process-global.
-        # `dispatch` installed them before `_dispatch_impl` ran, so the lists
-        # are always present here; `or ()` declines to fall back to the global,
-        # because a footer built from every op's rows is the defect, not a
-        # degraded reading of it.
-        _not_checked_slice = list(
-            getattr(_DISPATCH_STATE, "acc_not_checked", None) or ())
-        _validated_slice = list(
-            getattr(_DISPATCH_STATE, "acc_validated", None) or ())
-        if (op in _OP_TARGETS or _MUTATION_ATTEMPTS[0] > _attempts_before
-                or _not_checked_slice or _validated_slice):
-            _result = _result_line(_MUTATION_ATTEMPTS[0] - _attempts_before,
-                                   _WRITE_COUNT[0] - _writes_before,
-                                   _SKIP_COUNT[0] - _skips_before,
-                                   _REAPPLY_COUNT[0] - _reapplies_before,
-                                   _not_checked_slice,
-                                   _ROLLBACK_COUNT[0] - _rollbacks_before,
-                                   _validated_slice,
-                                   _LEFT_ON_DISK_COUNT[0] - _left_on_disk_before)
-            # A batch says its count twice, and the leading copy is the load-
-            # bearing one. The footer is separated from the per-op results by a
-            # validators block long enough that `tail` lands on `git-status :
-            # ok` and reads as success -- the exact half of #984 that #1018
-            # marked `Part of` and did not build. Only `batch`: a single op's
-            # receipt is three lines with the footer already adjacent, and a
-            # duplicate there is noise rather than a signal.
-            if op == "batch":
-                body = _result + body
-            body += _result
-            body += _branch_line()
+    # A read-only op that ran validators can still carry the one thing the
+    # footer exists to carry: a checker that did not check (#969). `validate`
+    # is not in `_OP_TARGETS` and mutates nothing, so it was gated out of the
+    # summary line entirely -- `_depth1_call_footer` (factored out for #1158,
+    # so the `validate:@-` payload route could carry the identical footer)
+    # applies the same gate.
+    body = _depth1_call_footer(op, body, _attempts_before, _writes_before,
+                               _skips_before, _reapplies_before,
+                               _rollbacks_before, _left_on_disk_before)
 
     return header + body
 

--- a/_supertool.py
+++ b/_supertool.py
@@ -6603,15 +6603,19 @@ def _op_around(pattern: str, path: str, n: int = 10) -> str:
         suggest = None
         # `pattern` becomes the PATH slot of the suggested `around_line:`
         # call, and this route reaches an unresolved `pattern` no colon-CLI
-        # caller could: dispatch's own `_PATH_ARG_POSITIONS` gate refuses
-        # `around:/etc/hosts:3` before `op_around` ever runs, but the
-        # `@payload`/`batch` route applies no containment to `pattern` (it
-        # is a regex there, not a declared path). Printing the suggestion
-        # unconditionally advertised a call the colon route itself refuses
-        # for containment (#1146) -- the same shape as the `git-checkout`
-        # hint in #850: never prescribe a command the tool's own sibling
-        # rejects. `_containment_error` mirrors the gate `_swap_suggest`
-        # (#1711) already applies to its own candidate below.
+        # caller could: `around` was dropped from `_PATH_ARG_POSITIONS`
+        # entirely (#1166 -- see `_around_line_delegation`'s own comment),
+        # and the colon route's actual gate for this exact swapped-argument
+        # shape is `_around_line_delegation`'s `_gate_paths([pattern])`,
+        # which refuses `around:/etc/hosts:3` before `op_around` ever runs.
+        # The `@payload`/`batch` route applies no containment to `pattern`
+        # at all (it is a regex there, not a declared path), so it could
+        # reach this branch with an out-of-bounds `pattern` and print a
+        # suggestion the colon route's own gate refuses (#1146) -- the same
+        # shape as the `git-checkout` hint in #850: never prescribe a
+        # command the tool's own sibling rejects. `_containment_error`
+        # mirrors the gate `_swap_suggest` (#1711) already applies to its
+        # own candidate below.
         if _is_ascii_int(path) and _containment_error([pattern]) is None:
             suggest = (
                 "`around` takes PATTERN:PATH[:N] — "

--- a/changelog.d/1146.fixed.md
+++ b/changelog.d/1146.fixed.md
@@ -1,0 +1,12 @@
+- Two cosmetic misreports left by the #1135/#1136 fix, both found by a release audit (#1146).
+  `around`'s `around_line:` delegation hint (#734) is built from the raw `pattern` string with no
+  containment check, so the `@payload`/`batch` route -- which applies no containment to `pattern`,
+  a regex there rather than a declared path -- could print a suggestion that the colon route's own
+  `_PATH_ARG_POSITIONS` gate refuses for containment. The hint now only fires when the suggested
+  call would actually pass containment, the same gate `_swap_suggest` (#1711) already applies to
+  its own candidate. Separately, the retraction subject a rollback prints for a write through a
+  symlink used `_write_target`'s `os.path.realpath`, which canonicalises a symlinked ANCESTOR
+  directory as well as the leaf link -- so the same directory was spelled two different ways
+  across one sentence (`/private/var/...` for the resolved target, `/var/...` for the success line
+  it retracts). `_write_target_display` now rewrites the display copy to agree with the success
+  line's own spelling wherever the divergence is purely that ancestor canonicalisation.

--- a/changelog.d/1158.fixed.md
+++ b/changelog.d/1158.fixed.md
@@ -1,0 +1,6 @@
+- `validate:@-` now prints the same `[result]`/`[branch: X]` footer `validate:PATH` does (#1158).
+  The `@payload`/`@-` route (`_read_op_from_payload`, in `_dispatch_impl`) returned its body
+  directly, before dispatch ever reached the footer block #990 and #381 built for the colon route
+  -- so the same op, on the same file, with the same config, printed a different verdict depending
+  on which route carried the call. The footer logic is now factored into `_depth1_call_footer`,
+  shared by both routes.

--- a/tests/test_around_line_hint_containment_1146.py
+++ b/tests/test_around_line_hint_containment_1146.py
@@ -1,0 +1,69 @@
+"""The `around_line:` delegation hint must not advertise a call dispatch refuses (#1146).
+
+`_op_around`'s int-path branch (#734) builds
+
+    Did you mean: around_line:{pattern}:{path}[:N]
+
+straight from the raw `pattern` string, with no containment check. The colon
+route never reaches this branch with an out-of-bounds `pattern` -- dispatch's
+own `_PATH_ARG_POSITIONS` gate refuses `around:/etc/hosts:3` before `op_around`
+ever runs. The `@payload`/`batch` route does not delegate that gate onto the
+`pattern` field (it is a regex, not a declared path there), so it reaches this
+branch with `pattern="/etc/hosts"` and happily prints a suggestion that running
+it -- on the colon route, the very thing being suggested -- gets refused for
+containment. Same defect class as the `git-checkout:<branch>` hint in #850: a
+prescribed command the tool's own sibling refuses.
+
+`_swap_suggest` (#1711) already gates its own candidate through `_gate_paths`
+before offering it; this is the one remaining call site with no such gate.
+
+Two things have to hold for the containment check under test to actually
+run: `SUPERTOOL_ALLOW_OUTSIDE_CWD=1` is on for the whole suite (conftest.py,
+its own documented escape hatch is `monkeypatch.delenv`), AND cwd must not be
+this repo's own checkout -- `.supertool.json` here separately sets
+`"allow_outside_cwd": true`, which the env var is not the only route to.
+`monkeypatch.chdir(tmp_path)` clears the second; `tmp_path` carries no config.
+"""
+from __future__ import annotations
+
+import io
+import json
+
+import supertool
+
+
+def test_around_line_hint_omits_pattern_outside_containment(
+    tmp_path, monkeypatch
+) -> None:
+    """The exact repro from #1146: pattern is an absolute path outside cwd."""
+    monkeypatch.delenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", raising=False)
+    monkeypatch.chdir(tmp_path)
+    out = supertool.op_around("/etc/hosts", "3")
+    assert "around_line:/etc/hosts:3" not in out, out
+
+
+def test_around_line_hint_still_fires_when_pattern_is_contained(
+    tmp_path, monkeypatch
+) -> None:
+    """The suggestion is not simply deleted -- it still fires on the shape
+    #734 was filed for, where nothing crosses the containment boundary."""
+    monkeypatch.delenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "presets" / "gitlab").mkdir(parents=True)
+    (tmp_path / "presets" / "gitlab" / "mr.py").write_text("x = 1\n")
+    out = supertool.op_around("presets/gitlab/mr.py", "681")
+    assert "around_line:presets/gitlab/mr.py:681" in out, out
+
+
+def test_around_line_hint_via_payload_route_omits_uncontained_pattern(
+    tmp_path, monkeypatch
+) -> None:
+    """The actual #1146 repro shape: the batch/payload route, which never
+    applies containment to the `pattern` field the way the colon route does
+    to its PATH slot."""
+    monkeypatch.delenv("SUPERTOOL_ALLOW_OUTSIDE_CWD", raising=False)
+    monkeypatch.chdir(tmp_path)
+    payload = json.dumps({"pattern": "/etc/hosts", "path": "3"})
+    monkeypatch.setattr(supertool.sys, "stdin", io.StringIO(payload))
+    out = supertool.dispatch("around:@-")
+    assert "around_line:/etc/hosts:3" not in out, out

--- a/tests/test_retraction_realpath_abspath_1146.py
+++ b/tests/test_retraction_realpath_abspath_1146.py
@@ -1,0 +1,68 @@
+"""The retraction line must spell one file the same way twice (#1146).
+
+`_run_with_validators` computes the rollback's target via `_write_target`,
+which resolves a symlinked PATH through `os.path.realpath` -- and realpath
+also canonicalises any symlinked ANCESTOR directory, not just the leaf link.
+The success line the retraction quotes back (`_receipt_head`) names the file
+the caller actually typed, via `os.path.abspath` elsewhere in this file --
+which does NOT canonicalise ancestor symlinks. Where an ancestor directory of
+the edited symlink is itself a symlink (macOS routes every `/tmp` path
+through `/private/tmp`; this test builds the same shape without relying on
+that), the two lines about the identical retracted write showed two
+different absolute prefixes for what both are pointing at.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from _symlink import require_symlink
+
+import supertool
+
+NL = chr(10)
+Q3 = chr(39) * 3
+BROKEN = "def f(:" + NL + "    pass" + NL
+
+
+def _toml_path(target: Path) -> str:
+    return chr(34) + str(target).replace(chr(92), chr(92) * 2) + chr(34)
+
+
+def _paste(tmp_path: Path, target: Path, content: str) -> str:
+    body = (
+        "path = " + _toml_path(target) + NL
+        + "content = " + Q3 + content + Q3 + NL
+    )
+    p = tmp_path / "p.toml"
+    p.write_text(body, encoding="utf-8")
+    return supertool.dispatch("paste:@" + str(p))
+
+
+def test_retraction_subject_matches_the_quoted_success_lines_own_spelling(
+    tmp_path: Path,
+) -> None:
+    """Build the exact shape macOS's /tmp -> /private/tmp gives for free:
+    an ancestor directory that is itself a symlink, one level above the
+    edited symlink. The retracted write's two lines about that same
+    directory must agree.
+    """
+    require_symlink()
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    alias = tmp_path / "alias"
+    os.symlink(str(real_dir), str(alias))
+    link = alias / "link.py"
+    os.symlink("target.py", str(link))
+
+    out = _paste(tmp_path, link, BROKEN)
+    assert "rolled back" in out, out
+
+    # The two absolute directory spellings this receipt uses for the SAME
+    # directory -- one via the caller's own path (`alias`), one via
+    # `_write_target`'s realpath (`real_dir`) -- must not both appear.
+    alias_dir = str(alias)
+    real_dir_str = str(real_dir)
+    assert not (alias_dir in out and real_dir_str in out), (
+        "the retraction names the same directory two different ways:" + NL + out
+    )

--- a/tests/test_symlink_gating_register_1232.py
+++ b/tests/test_symlink_gating_register_1232.py
@@ -263,6 +263,7 @@ REGISTER = {
     'tests/test_path_meta_bulk_1126.py::test_a_symlink_is_never_answered_from_another_repo': B,
     'tests/test_read.py::test_path_meta_suffix_broken_symlink': B,
     'tests/test_read.py::test_read_meta_symlink': P,
+    'tests/test_retraction_realpath_abspath_1146.py::test_retraction_subject_matches_the_quoted_success_lines_own_spelling': B,
     'tests/test_review_regressions_395.py::test_gate_follows_symlinks_to_the_real_repo': B,
     'tests/test_security_claude_log.py::TestSymlinkInProjectsDir.test_symlink_in_projects_dir_itself': B,
     'tests/test_security_claude_log.py::TestSymlinkInProjectsDir.test_symlink_to_external_jsonl_is_followed': B,

--- a/tests/test_validate_payload_footer_1158.py
+++ b/tests/test_validate_payload_footer_1158.py
@@ -1,0 +1,102 @@
+"""`validate:@-` drops the `[result]`/`[branch:]` footer `validate:PATH` prints (#1158).
+
+The payload route (`_read_op_from_payload`, called from `_dispatch_impl`)
+returned its body directly -- `header + _read_warnings + _read_body` -- before
+dispatch ever reached the footer block #990/#381 built for the colon route.
+Same op, same file, same accumulated `acc_validated`/`acc_not_checked` rows;
+two different verdicts depending on which route carried the call. The payload
+route exists specifically so a path containing ':' or ',' can be validated at
+all (#878) -- exactly the caller for whom the summary line matters most, since
+it is the one who could not have used the colon form to begin with.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import supertool
+
+CLEAN = json.dumps({"tool": "fake", "ok": True, "count": 0, "errors": [],
+                    "duration_ms": 1})
+REAL_FINDING = json.dumps({
+    "tool": "fake", "ok": False, "count": 1,
+    "errors": [{"line": 1, "col": 1, "severity": "error",
+                "code": "E999", "msg": "unterminated object"}],
+    "duration_ms": 1,
+})
+
+
+def _adapter(tmp_path: Path, reply_by_name: dict) -> str:
+    script = tmp_path / "_adapter.py"
+    script.write_text(
+        "import os, sys" + chr(10)
+        + f"replies = {reply_by_name!r}" + chr(10)
+        + "name = os.path.basename(sys.argv[-1])" + chr(10)
+        + f"sys.stdout.write(replies.get(name, {CLEAN!r}))" + chr(10),
+        encoding="utf-8",
+    )
+    return f"{{python}} {script.as_posix()} {{file}}"
+
+
+def _configure(cmd: str) -> None:
+    supertool._CONFIG = {"validators": {
+        "fake": {"cmd": cmd, "match": "*.json", "cache": False, "timeout": 10},
+    }}
+    supertool._CONFIG_CHECKED = True
+
+
+def _result_line(out: str) -> str:
+    for line in out.splitlines():
+        if line.startswith("[result]"):
+            return line
+    return ""
+
+
+def _payload_run(monkeypatch, arg: str, payload: str) -> str:
+    monkeypatch.setattr(supertool.sys, "stdin", io.StringIO(payload))
+    return supertool.dispatch(arg)
+
+
+def test_validate_at_dash_prints_the_result_footer(tmp_path, capsys, monkeypatch) -> None:
+    """The exact side-by-side comparison the issue describes.
+
+    `validate:PATH` (colon route) ends on `[result] ...`; `validate:@-`
+    (payload route), for the identical file and identical config, must too.
+    """
+    _configure(_adapter(tmp_path, {}))
+    (tmp_path / "a.json").write_text('{"a": 1}' + chr(10), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    supertool.main(["validate:a.json"])
+    colon_out = capsys.readouterr().out
+    assert _result_line(colon_out) == \
+        "[result] 1 file, 0 with findings, 0 not checked", colon_out
+
+    payload_out = _payload_run(monkeypatch, "validate:@-", 'path = "a.json"')
+    assert _result_line(payload_out) == \
+        "[result] 1 file, 0 with findings, 0 not checked", payload_out
+
+
+def test_validate_at_dash_counts_findings(tmp_path, capsys, monkeypatch) -> None:
+    _configure(_adapter(tmp_path, {"b.json": REAL_FINDING}))
+    (tmp_path / "a.json").write_text('{"a": 1}' + chr(10), encoding="utf-8")
+    (tmp_path / "b.json").write_text('{"a": 1}' + chr(10), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    payload_out = _payload_run(
+        monkeypatch, "validate:@-", 'paths = ["a.json", "b.json"]')
+    assert _result_line(payload_out) == \
+        "[result] 2 files, 1 with findings, 0 not checked", payload_out
+
+
+def test_validate_at_dash_carries_the_branch_footer(tmp_path, capsys, monkeypatch) -> None:
+    """[branch: X] is #381's own footer -- payload route must carry it too."""
+    _configure(_adapter(tmp_path, {}))
+    (tmp_path / "a.json").write_text('{"a": 1}' + chr(10), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(supertool, "_BRANCH_CACHE", [("main", "")])
+
+    payload_out = _payload_run(monkeypatch, "validate:@-", 'path = "a.json"')
+    lines = payload_out.rstrip(chr(10)).splitlines()
+    assert lines[-1] == "[branch: main]", payload_out


### PR DESCRIPTION
## Summary

Three adjacent misreports about what a validator run reported back.

**Closes #1158.** `validate:@-` (the `@payload`/stdin route for `validate`) dropped the `[result]`/`[branch: X]` footer `validate:PATH` prints for the identical file and config. The payload route (`_read_op_from_payload`, called from inside `_dispatch_impl`) returned its body before dispatch ever reached the footer block #990/#381 built for the colon route. Factored that block into `_depth1_call_footer`, shared by both routes.

**Closes #1146.** Two cosmetic misreports found by a release audit:
1. `around`'s `around_line:` delegation hint (#734) embedded the raw `pattern` string as a PATH argument with no containment check, so the `@payload`/`batch` route (where `pattern` is a regex, not a declared path) could print a suggestion the colon route's own containment gate refuses -- the same shape as the `git-checkout` hint in #850. Gated behind `_containment_error`, mirroring the check `_swap_suggest` (#1711) already applies to its own candidate.
2. A rollback undoing a write through a symlink named the same directory two different ways in one sentence -- `os.path.realpath` (used by `_write_target`, the functional resolver) canonicalises a symlinked ANCESTOR directory as well as the leaf link, while the success line the retraction quotes back uses `os.path.abspath`, which does not. Added `_write_target_display`, which rewrites the DISPLAY spelling only (the functional `_target` used for the actual unlink/write is untouched) to agree with the success line's own convention wherever the divergence is purely ancestor-symlink spelling.

**#2185 -- deliberately not implemented.** Read the full issue and PR #2181's description before starting. #2185 is explicitly framed there as an open design question left for maintainer judgement: whether a `resolve`-class command's crash should escalate the way an adapter's own crash does. Two independent review agents flagged it during #2181's review and the maintainer accepted that judgment at merge time ("a design question, not a mechanical bug in this fix"). Nothing here changes that calculus -- it affects every future `resolve`-class spec, which is a contract-wide decision, not a mechanical fix. Left untouched.

## Self-review finding, below-bar

`oss:auditor`'s review of the first commit raised two items. One (a comment mis-citing `_PATH_ARG_POSITIONS` instead of `_around_line_delegation`'s own gate) was fixed as a follow-up commit -- comment-only, no behavior change. The other -- that `_target_cell`'s "(which the symlink X resolves to)" annotation is still gated on the raw `_target != path` rather than on whether the display rewrite `_target_display` differs from `path`, which could in principle print a symlink as resolving to its own spelling -- is **below-bar**: worked through by hand with several constructed symlink trees, triggering the described divergence (`_target_display` collapsing to literally equal `path` while `_target` differs) requires `_write_target_display`'s ancestor-only-divergence branch to fire with `basename(target) == basename(path)`, and every construction satisfying both conditions requires the leaf symlink to point at itself -- a genuine filesystem loop. Confirmed empirically: building the fixture raised `OSError: [Errno 62] Too many levels of symbolic links` the moment real content was written into the target location. `_atomic_write`'s own `open()` on such a target raises ELOOP before the write ever reaches the rollback code where `_target_cell` is built, so `_run_with_validators` never reaches the annotation for this shape through any real write -- no reachable caller state exercises it.

## Test plan

- [x] New test `tests/test_validate_payload_footer_1158.py` (3 tests) -- red before the fix (payload route returned before the footer block ever ran), green after.
- [x] New test `tests/test_around_line_hint_containment_1146.py` (3 tests) -- red before the fix (uncontained `pattern` reached the hint), green after; includes a positive control confirming the hint still fires on the #734 shape it was built for.
- [x] New test `tests/test_retraction_realpath_abspath_1146.py` (1 test) -- red before the fix (retraction named one directory two ways), green after.
- [x] Targeted regression suite: 287 passed across every adjacent test file touching the same code paths (#734, #1136, #1320, #990, #965, #1109, #969, #625, #876, `test_validators.py`).
- [x] `python3 .github/scripts/assemble_changelog.py --check` passes with the two new fragments (`changelog.d/1158.fixed.md`, `changelog.d/1146.fixed.md`).
- Not run: the repository's full `pytest` suite, per this repo's own developer convention -- CI is the gate for the rest of the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
