### PR TITLE
chore: refresh oss-owned files from /oss:scaffold 0.21.0

### DIFF
--- a/.claude/jit-context/tools/01-oss/00-README.md
+++ b/.claude/jit-context/tools/01-oss/00-README.md
@@ -71,6 +71,35 @@ rather than a rider on the change that took this record off its false claim:
 here: this whole layer is generated and replaced wholesale on every install, so a correction
 made in this directory is gone the next time the owning plugin writes it. Report it instead.
 
+## #903: this rule reaches a spawned reviewer subagent too, and that is intentional
+
+A developer lane's own self-review spawns a read-only `Explore` reviewer against the diff it just
+committed. That reviewer issues Read/Edit/Write/Glob/Grep calls of its own, in the same tree, and
+they hit `supertool-required.md` below exactly as the dispatching lane's own calls do -- #903 is
+two reproduced instances of that.
+
+**Narrowing the trigger to skip a spawned subagent was the issue's first ask, and it is not
+possible today.** `supertool-required.md`'s `match: ~.*` is tested against the PreToolUse hook's
+own subject, built from `tool_input` alone (see the table above) -- and that subject carries
+no field naming *which agent* issued the call. There is no `isSidechain`, no `subagent_type` on a
+`Read`/`Edit`/`Write`/`Glob`/`Grep` payload, nothing at all distinguishing a spawned reviewer's own
+tool call from its dispatcher's. No signal in the subject means no way to narrow on it -- so this
+is the issue's second branch, "state it explicitly", rather than the first.
+
+**What that means for `Explore`, or any other read-only reviewer never briefed on `supertool`.** It
+has no such tool in its actual grant and no route to install one, so a block here is a rule it
+cannot comply with by being told about it -- only by already knowing `supertool` is on `PATH` and
+calling it through its own `Bash` grant, which nothing in its brief currently says to do. Both
+observed instances (#903) already did the next best thing on their own: they read the refusal as
+untrusted injected content that named a tool contradicting their actual grant, and continued
+through their own authorized `Read`/`Bash` tools rather than obeying it. That is correct, and nothing
+here is meant to change it -- the only enforcement-side answer available is the `requires:`
+degrade documented below, never a scope narrower than "every session touching this tree", because
+the hook has nothing narrower to match against.
+
+If `claude-jit-context` ever adds a signal that tells a spawned subagent's own calls apart from its
+dispatcher's, that is what this rule gets narrowed on -- not a guess made without one.
+
 ---
 
 ## `supertool-required.md`: why it stays this short

--- a/.oss/statusline.py
+++ b/.oss/statusline.py
@@ -203,7 +203,10 @@ _WATCH_NAME_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
 #: all, so `'..'` and `'../../etc'` -- both refused by `oss_config` -- still
 #: produced a channel name here. `tests/test_statusline_watch_name_refusal_653.py`
 #: is the positive control: slugs `oss_config` REJECTS, not only ones it accepts.
-_REPO_RE = re.compile(r"\A[^/\s]+/[^/\s]+\Z")
+#: Excludes a backslash too, as of #897 -- `tests/test_statusline_watch_name_
+#: refusal_653.py::test_repo_re_pattern_matches_oss_configs_own_pattern` pins the
+#: two patterns together so this copy cannot drift from `oss_config.REPO_RE` again.
+_REPO_RE = re.compile(r"\A[^/\\\s]+/[^/\\\s]+\Z")
 
 #: `.supertool.json`'s own filename, read but never written -- the same constant
 #: `doctor.py` carries as `WATCH_CONFIG`, duplicated rather than imported for the
@@ -1102,6 +1105,48 @@ def _channel_field(channel, symbols, color=False):
     return shade + text + RESET
 
 
+#: `gh-branch`'s own four states, folded onto `_symbols`' four render glyphs (#856).
+#: `"bad"` gets its own glyph -- a leg has actually failed, the one state that is a
+#: finding rather than "not settled yet". `"running"` and `"no-run"` share `run` on
+#: purpose: both mean "nothing to act on, look again later", and collapsing them is
+#: the deliberate call the issue asked for rather than an oversight -- see
+#: `_gh_default_branch_state`'s own docstring for why they are still told apart
+#: before they reach this table, so `"no-run"` never silently becomes `"running"`.
+_DEFAULT_BRANCH_GLYPH_KEY = {
+    "green": "ok",
+    "bad": "bad",
+    "running": "run",
+    "no-run": "run",
+}
+
+
+def _default_branch_marker(state, symbols, color=False):
+    """One glyph, glued onto the repository name, for whether the default branch's
+    head commit is green right now (#856) -- the reading nothing on this line said
+    anything about, including the moment right after this loop's own merge, when
+    the branch has a fresh commit and no concluded run yet.
+
+    `None` -- rendering nothing, never `?` -- when `state` is `None`: either the
+    config declares no default branch to compare against (a deliberate absence of
+    the question, the channel field's own convention, #613), or `gather()` has
+    already folded a stale reading into `"unknown"` before this function ever
+    sees it, in which case `state == "unknown"` reaches here and DOES render --
+    the `unk` glyph -- because a stale reading is a real answer ("we cannot
+    currently say"), not the same absence as never having asked at all.
+
+    Colour reinforces the glyph and is never its only carrier (#549/#550): every
+    state below is a distinct shape in `_symbols`, monochrome or not.
+    """
+    if state is None:
+        return None
+    key = _DEFAULT_BRANCH_GLYPH_KEY.get(state, "unk")
+    text = symbols[key]
+    if not color:
+        return text
+    shade = {"ok": GREEN, "bad": RED, "run": YELLOW}.get(key, DIM)
+    return shade + text + RESET
+
+
 def render(facts, ascii_only=False, color=False):
     """The whole line, from facts already gathered. No I/O, so it is testable.
 
@@ -1123,6 +1168,14 @@ def render(facts, ascii_only=False, color=False):
 
     repo_name = facts.get("repo_name")
     repo_name = _one_line(str(repo_name)) if repo_name else "?"
+    # Glued onto the repo name with no separator, beside it rather than its own block
+    # (#856) -- the identity block is already `name branch vversion`, one glance, and
+    # this is one more glyph about the same subject rather than a fourth fact needing
+    # its own width. `None` here means nothing rendered at all: see
+    # `_default_branch_marker`'s own docstring for the two different reasons it can be.
+    branch_marker = _default_branch_marker(facts.get("default_branch_state"), symbols, color)
+    if branch_marker is not None:
+        repo_name = repo_name + branch_marker
     # The branch only when it is not the declared default (#509): in the clone that field
     # said `main` on every render, and this loop works in worktrees, so it cost width in
     # the one place it carried nothing and was identical in the place it carries news.
@@ -1515,6 +1568,193 @@ def _gh_rollups(repo):
     return rows if isinstance(rows, list) else None
 
 
+#: Concluded check-run outcomes read as a failure, for `_reading_from_check_runs`.
+#: Matches `gh-branch`'s own red/benign split exactly (supertool's
+#: `presets/_checks.py`: `FAILED_STATES` plus everything in `bucket()`'s
+#: "other" catch-all except its own `BENIGN_STATES`) -- `startup_failure` is a
+#: documented `conclusion` value (a run that failed before it could even
+#: start) and belongs beside `failure`/`timed_out`, not omitted from it; a
+#: `neutral`/`skipped`/`manual` conclusion is deliberately left out (a run
+#: explicitly opting out of pass/fail is not a failure, the same call
+#: `gh-branch`'s own `BENIGN_STATES` makes). Review found the omission of
+#: `startup_failure` on this same round (#914).
+_BAD_CHECK_RUN_CONCLUSIONS = frozenset(
+    {"failure", "timed_out", "action_required", "cancelled", "stale",
+     "startup_failure"}
+)
+
+
+def _reading_from_check_runs(repo, branch):
+    """One raw reading off the check-runs endpoint (#914): total entries, and
+    whether any of them are failed / still in flight / passed.
+
+    GitHub Actions writes check-runs, not legacy commit statuses -- on an
+    Actions-only repository the combined-status endpoint's `total_count` is `0`
+    on every commit, always, which is #914's whole defect. This is the source
+    that actually carries Actions data.
+
+    Returns ``None`` when the call did not answer or produced something this
+    function cannot parse -- never confused with a reading that genuinely came
+    back empty, which is a dict with ``total == 0`` and every flag ``False``.
+    """
+    out = _run(
+        [
+            "gh",
+            "api",
+            "-X",
+            "GET",
+            "repos/{}/commits/{}/check-runs".format(repo, branch),
+            "-f",
+            "per_page=100",
+            "--jq",
+            "{total: .total_count, "
+            "entries: [.check_runs[] | {status: .status, conclusion: .conclusion}]}",
+        ],
+        timeout=25,
+    )
+    if not out:
+        return None
+    try:
+        data = json.loads(out)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    total = data.get("total")
+    entries = data.get("entries")
+    if not isinstance(total, int) or not isinstance(entries, list):
+        return None
+    # `gh api` does not auto-paginate. `per_page=100` covers the ordinary case, but a
+    # commit with more check-runs than that still has a truncated `entries` here while
+    # `total` (read straight from `.total_count`) stays correct -- the same "counted
+    # right, read wrong" shape `_gh_external_issue_count` already guards against one
+    # function over. Read as `None` (could not look) rather than scanning a partial
+    # page and guessing "green" from entries that happen to all be `success`.
+    if len(entries) != total:
+        return None
+    bad = False
+    running = False
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("status") in ("queued", "in_progress"):
+            running = True
+            continue
+        if entry.get("conclusion") in _BAD_CHECK_RUN_CONCLUSIONS:
+            bad = True
+    # Conjunctive, matching `gh-branch`'s own `verdict()`: green is "nothing
+    # failed and nothing is still moving", not "at least one entry said
+    # success". A commit whose only check-runs are `skipped`/`neutral` is
+    # GREEN there too (review found this divergence on this same round,
+    # #914) -- a per-entry `conclusion == "success"` requirement would read
+    # that same commit as neither green nor bad nor running (it has no
+    # `"success"` entry either) and fall through to `None`, an unknown that
+    # `gh-branch` does not share.
+    green = total > 0 and not bad and not running
+    return {"total": total, "bad": bad, "running": running, "green": green}
+
+
+def _reading_from_combined_status(repo, branch):
+    """The same shape as `_reading_from_check_runs`, off the legacy
+    combined-status endpoint (`repos/{repo}/commits/{ref}/status`).
+
+    Kept alongside the check-runs reading rather than replaced by it (#914): a
+    repository could carry legacy commit statuses posted by an external CI with
+    no GitHub Actions runs at all, and this is the only source that would ever
+    see those. Neither source alone can answer `"no-run"` on its own -- see
+    `_gh_default_branch_state`, which is where the two readings are merged.
+
+    `error` is read the same as `failure`. GitHub's own docs give the COMBINED
+    summary's top-level `state` a three-value enum -- `failure`/`pending`/`success`
+    -- so this is a defensive extra rather than a documented fourth value: `error`
+    is the spelling an INDIVIDUAL entry in the legacy `statuses[]` array can carry,
+    one level below what this function's own `--jq` filter reads. Kept anyway,
+    because a top-level `state` outside its documented enum is exactly the shape
+    an undocumented API change would take, and reading it as bad -- rather than
+    falling through to `None`, which the merge below reads as "this source did
+    not answer" -- is the conservative direction to guess wrong in.
+    """
+    out = _run(
+        [
+            "gh",
+            "api",
+            "repos/{}/commits/{}/status".format(repo, branch),
+            "--jq",
+            "{state: .state, total: .total_count}",
+        ],
+        timeout=25,
+    )
+    if not out:
+        return None
+    try:
+        data = json.loads(out)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    total = data.get("total")
+    if not isinstance(total, int):
+        return None
+    state = data.get("state")
+    return {
+        "total": total,
+        "bad": state in ("failure", "error"),
+        "running": state == "pending" and total > 0,
+        "green": state == "success",
+    }
+
+
+def _gh_default_branch_state(repo, branch):
+    """Is the default branch's head commit green? One of the four states `gh-branch`
+    itself answers, read off two cheaper calls (#856, and #914 for the second one).
+
+    `gh-branch` (supertool) enumerates every workflow run on the head SHA and
+    collapses re-runs and multi-run workflows to answer conjunctively -- machinery
+    this render does not need, because it produces one glyph, not a table.
+
+    **Two sources, not one (#914).** The combined-status endpoint alone answers
+    `total_count == 0` on every commit of an Actions-only repository, because
+    GitHub Actions writes check-runs, not legacy commit statuses -- so a repo
+    whose CI is entirely Actions (this one) could never read anything but
+    `"no-run"` off it. Check-runs alone has the opposite gap: a repository
+    carrying legacy statuses from an external CI, with no Actions runs at all,
+    would show up as empty there. Neither reading is read as authoritative on
+    its own; both are taken and merged below.
+
+    Returns ``"green"``, ``"bad"``, ``"running"``, ``"no-run"``, or ``None`` when
+    the branch or repo is not configured, or the call did not answer.
+
+    **Merge order is bad, then running, then green, then no-run/None** -- the
+    same "worst wins" shape `gh-branch` itself uses across workflows. A failure
+    on either source is a failure; a leg still in flight on either source means
+    "not settled" even if the other source is quiet; `"no-run"` is reserved for
+    the case both sources answered and both came back with `total == 0`. If one
+    source did not answer at all (`None`) and the other came back empty, this is
+    read as `None` rather than guessed as `"no-run"` -- the unanswered source
+    could carry data this function never saw, and `None` is what every caller
+    here already reads as "no answer", never as "confirmed idle" (mirrors the
+    `total_count == 0` vs `state` distinction the combined-status reading always
+    made, one level up: an absence this function produced must not render as an
+    absence on the branch).
+    """
+    if not repo or not branch:
+        return None
+    check_runs = _reading_from_check_runs(repo, branch)
+    status = _reading_from_combined_status(repo, branch)
+    if check_runs is None and status is None:
+        return None
+    if (check_runs and check_runs["bad"]) or (status and status["bad"]):
+        return "bad"
+    if (check_runs and check_runs["running"]) or (status and status["running"]):
+        return "running"
+    if (check_runs and check_runs["green"]) or (status and status["green"]):
+        return "green"
+    if check_runs is not None and status is not None:
+        if check_runs["total"] == 0 and status["total"] == 0:
+            return "no-run"
+    return None
+
+
 def _latest_release(repo):
     """The version a plugin's own manifest declares on its default branch.
 
@@ -1695,6 +1935,21 @@ def refresh(root, now=None):
         document["issues"] = _gh_count(repo, "issue")
         document["issues_external"] = _gh_external_issue_count(repo, document["issues"])
         document["pr_checks"] = check_rollup_counts(_gh_rollups(repo), document["prs"])
+        # Same call group, same `fetched_at`, same `stale_after` (#856): the default
+        # branch's own CI state is exactly as time-sensitive as the pull-request board
+        # it sits beside, and it shares the moment (a merge or an issue close in this
+        # session) that already invalidates the rest of the board (#516). A second,
+        # independent clock for one more field would be the interval this repository's
+        # own history already argues against (#515's own reasoning, one field over).
+        # `None` (no default branch configured, or the call did not answer) is a real
+        # value here, not skipped -- `gather()` reads it back and a missing key would
+        # be indistinguishable from a cache written before this field existed, which
+        # is exactly the ambiguity `pr_checks`' own `isinstance` guard exists to avoid.
+        # `_gh_default_branch_state` itself already answers `None` for an unconfigured
+        # `default_branch`, so no separate `if` is needed here.
+        document["default_branch_state"] = _gh_default_branch_state(
+            repo, config.get("default_branch")
+        )
     carried = previous.get("latest")
     carried = dict(carried) if isinstance(carried, dict) else {}
     carried_stamp = previous.get("latest_fetched_at")
@@ -1920,8 +2175,25 @@ def gather(payload, root, now=None):
     config = repo_config(root)
     cache = read_cache(cache_path(config.get("repo")))
     board = board_from_cache(cache, now=now)
-    if board_is_due(cache, now):
+    board_stale = board_is_due(cache, now)
+    if board_stale:
         _fork_refresh(root, config.get("repo"))
+    # Same fold `plugin_facts`/`version_status` already do for `latest` (#550), on
+    # the same board clock `board_is_due` already computes above -- `default_branch`
+    # itself present-but-unconfigured stays `None` (never asked, #613's own
+    # convention), and a configured one whose reading has outlived `board_is_due`'s
+    # own interval (or was marked stale by this session's own merge/close, #516)
+    # folds to `"unknown"` rather than rendering whatever it last said. This is the
+    # one field on this line where a stale `ok` is actively dangerous: #856's own
+    # motivating case is the moment right after a merge, when the previous reading
+    # is confidently green about a commit that no longer exists.
+    default_branch_state = None
+    if config.get("default_branch"):
+        raw_branch_state = (cache or {}).get("default_branch_state")
+        if board_stale or raw_branch_state not in ("green", "bad", "running", "no-run"):
+            default_branch_state = "unknown"
+        else:
+            default_branch_state = raw_branch_state
     latest = (cache or {}).get("latest") or {}
     # `latest_fetched_at` used to be read here and dropped, so `plugin_facts` decided
     # `current`/`behind`/`ahead` with no knowledge of the reading's own age -- the
@@ -1976,6 +2248,7 @@ def gather(payload, root, now=None):
         "last": _render_stamp(now),
         "plugins": plugin_facts(loop_name, installed_plugins(root), latest, stale=stale_latest),
         "channel": channel,
+        "default_branch_state": default_branch_state,
     }
 
 


### PR DESCRIPTION
`.oss/statusline.py` and the `01-oss` jit layer are plugin-owned and replaced wholesale by `/oss:scaffold`, so a fix shipped upstream reaches this repo only when the command is re-run here. `/oss:doctor` reported the drift as `would change what it does -- _channel_field, _default_branch_marker, render, _gh_rollups, and 5 more`. No issue tracks it: the doctor line is the trigger, which is what that line is for.

## What changed

**`.oss/statusline.py`** -- claude-oss #856: a default-branch green marker glued onto the repository name, so the line says whether master's head commit is green right now. That is the reading nothing on it carried before, including the moment right after a merge, when the branch has a fresh commit and no concluded run yet. `gh-branch`'s four states fold onto four glyphs, with `running` and `no-run` sharing one on purpose (both mean "nothing to act on, look again later") and told apart before they reach the table.

`_channel_field` is named by the doctor because the new code lands next to it. Nothing inside it changed, so this does not touch the `ch?` reading -- that is claude-supertool#2208, and #2209 is the open fix.

**`.claude/jit-context/tools/01-oss/00-README.md`** -- claude-oss #903: `supertool-required.md` reaches a spawned read-only reviewer's own tool calls, and the PreToolUse subject carries no field naming which agent issued the call, so there is nothing to narrow the trigger on. Stated rather than fixed.

## What was deliberately not committed

The changelog trio (`.oss/README.md`, `.oss/assemble_changelog.py`, `.github/workflows/oss-changelog.yml`) stays declined -- this repo runs its own gate under `.github/workflows/changelog.yml` with `.github/scripts/assemble_changelog.py`.

`.claude/jit-context/tools/01-oss/00-index.tsv` is reverted to empty, and the three rule bodies scaffold wrote beside it (`merge-gate.md`, `pr-create-gate.md`, `supertool-required.md`) stay untracked, per `CLAUDE.md` and `tests/test_harness_tools_do_not_ship_1791.py`: the row and the file move together, and `harness-tools-blocked.md` in the `00-manual` layer already does that job here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXafvfZNDG68VKRK4UuK8J