### PR TITLE
test(#2120): cover the interpreter-quoting branch no CI leg reaches

### DIFF
--- a/tests/test_read_edit_hint_worktree_2120.py
+++ b/tests/test_read_edit_hint_worktree_2120.py
@@ -106,3 +106,46 @@ def test_footer_still_carries_the_at_dash_alternative_and_the_harness_note(
     _worktree(monkeypatch, tmp_path)
     hint = supertool._read_edit_hint("README.md", "body")
     assert "(or edit:@- ; no harness Read needed)" in hint, hint
+
+
+def test_an_interpreter_path_with_a_space_is_quoted(monkeypatch, tmp_path):
+    """`_modify_hint_quoted_interpreter`'s second branch, which no CI leg
+    reaches incidentally (#1017, and its sibling test
+    `tests/test_st_hint_interpreter_1017.py::test_an_interpreter_path_with_a_space_is_quoted`).
+
+    `sys.executable` on all three GitHub runners is a plain path with no
+    space, so the unquoted branch is the only one any leg exercises unless
+    a test patches it. An interpreter path WITH a space is the ordinary
+    Windows install (`C:\\Program Files\\...`) and any POSIX box whose user
+    has one in `$HOME`; printed unquoted, the remedy asks the shell to run
+    a program named `C:\\Program`.
+
+    Asserted per `os.name` rather than as one substring: the two branches
+    quote differently on purpose (a double-quote wrap on Windows, where
+    `shlex` is a POSIX lexer and its escaping is wrong; `shlex.quote`
+    elsewhere), so a single expectation would be vacuous on one platform.
+    """
+    _worktree(monkeypatch, tmp_path)
+    spaced = str(tmp_path / "py thon" / "bin" / "python3")
+    monkeypatch.setattr(supertool.sys, "executable", spaced)
+    hint = supertool._read_edit_hint("README.md", "body")
+
+    if supertool.os.name == "nt":
+        expected = chr(34) + spaced + chr(34)
+    else:
+        expected = supertool.shlex.quote(spaced)
+    assert expected in hint, hint
+    # The bare, unquoted path must NOT be what got printed -- that is the
+    # defect, and asserting only "the path appears" would pass on it.
+    assert f" {spaced} supertool.py" not in hint, hint
+
+
+def test_an_interpreter_path_without_a_space_is_left_alone(monkeypatch, tmp_path):
+    """The first branch: nothing to quote, so nothing is quoted -- a hint
+    wrapping every path in quotes would pass the test above while making
+    the ordinary case uglier for no reason."""
+    _worktree(monkeypatch, tmp_path)
+    plain = str(tmp_path / "python3")
+    monkeypatch.setattr(supertool.sys, "executable", plain)
+    hint = supertool._read_edit_hint("README.md", "body")
+    assert f"{plain} supertool.py 'edit:::OLD:::NEW:::README.md'" in hint, hint


### PR DESCRIPTION
Not tied to an open issue -- both #2267 and #2120 are already closed, via #2268.

## What this is

A self-review finding (`oss:auditor`) from the #2120 lane's work, produced after #2268 had
already been reviewed, merged and its worktree torn down. The commit
(`369e40fd21cd7b1dc1c1a1636403c567632ccd1c`) was made locally but never reached the remote
before the worktree it lived in was force-removed as part of that merge's own cleanup -- a
maintainer process error, not a defect in the commit itself. Recovered by hash from the git
reflog (object unchanged) and cherry-picked cleanly onto current `master`.

## The finding

`_modify_hint_quoted_interpreter` (added by #2120, `_supertool.py`) has two branches: quote an
interpreter path containing a space, or leave a plain one alone. `sys.executable` on all three
GitHub runners is a plain path with no space, so no CI leg exercises the quoting branch
incidentally -- only an explicit `monkeypatch` does, and nothing did.

The sibling function this one's own docstring says it mirrors, `presets/_st_hint.py`'s
`_quoted_interpreter`, already has exactly this test
(`tests/test_st_hint_interpreter_1017.py`), filed as #1017 because the unquoted case broke a
real Windows install and a `$HOME`-with-a-space POSIX one. This closes the same gap for the
newer, duplicated copy #2120 added.

## Verification

Independently re-verified by me (the maintainer) before pushing, not only inherited from the
original lane's own report:

- Cherry-pick applied clean onto current `master` (9e4a312f).
- `tests/test_read_edit_hint_worktree_2120.py`: 8 passed (6 original + 2 new).
- Non-vacuous, checked directly: temporarily patched `_modify_hint_quoted_interpreter` to always
  return the interpreter path unquoted, re-ran the new test -- it failed. Restored the file,
  re-ran -- 8 passed again, working tree clean.

No production code change; test-only.