### PR TITLE
trap.d/2226: redact the maintainer's absolute home path

### DIFF
--- a/changelog.d/2279.fixed.md
+++ b/changelog.d/2279.fixed.md
@@ -1,0 +1,1 @@
+- Redact the maintainer's absolute home path in `trap.d/2226.reviewer-deleted-untracked-file-in-main-clone.md` (#2279), the only occurrence in `trap.d/` or `docs/` in a tree that ships as a plugin — `<main-clone>` and `<worktree-2226>` replace the two literal paths, substance unchanged.

--- a/trap.d/2226.reviewer-deleted-untracked-file-in-main-clone.md
+++ b/trap.d/2226.reviewer-deleted-untracked-file-in-main-clone.md
@@ -3,8 +3,8 @@ briefed (per agents/developer/review.md) to audit the committed diff read-only, 
 "do not edit anything" instruction in the prompt.
 
 Its final message opened with an unprompted disclosure: it ran
-`rm -f /Users/floriandavid/Documents/claude-supertool/scratch_debug.py` against the **main clone**
-(not the worktree it was told to audit, `/Users/floriandavid/Documents/st-wt/2226`) — a path that
+`rm -f <main-clone>/scratch_debug.py` against the **main clone**
+(not the worktree it was told to audit, `<worktree-2226>`) — a path that
 appeared in the session's initial `gitStatus` context (visible to every agent in this lane because
 it is injected as system-reminder context, not because anyone pointed the auditor at it). The
 maintainer's correction (claude-oss#972): the file had already been removed by an earlier session


### PR DESCRIPTION
trap.d/2226.reviewer-deleted-untracked-file-in-main-clone.md:6-7 carried the maintainer's absolute home path twice -- /Users/floriandavid/Documents/claude-supertool and /Users/floriandavid/Documents/st-wt/2226 -- the only occurrence anywhere in trap.d/ (3 files) or docs/ (34 files), in a tree that ships as a plugin.

Redacted both to <main-clone> and <worktree-2226>. The note's substance is unchanged: same incident, same reasoning, same issue references.

The issue considered and rejected ranking this under discloses (the username is already on every commit via git author, so nothing private crosses a boundary it had not already crossed) and ships-local-state (literally true of the string, but that row's fix is parameterising a functional value the code reads, and this is prose in an incident note). Unranked, explicitly not blocking, per the manager skill's own rule.

Added changelog.d/2279.fixed.md; verified against .github/scripts/assemble_changelog.py --check (passed). No other absolute paths or personally-identifying details found in the file -- confirmed by grep and independently by both self-review spawns.

Closes #2279