### PR TITLE
fix(git-resolve): _hunk_note no longer goes silent on a modify/delete conflict (#2273)

### DIFF
--- a/changelog.d/2273.fixed.md
+++ b/changelog.d/2273.fixed.md
@@ -1,0 +1,8 @@
+- `git-resolve`'s hunk-outside-conflict receipt (#2226) went silent for a
+  modify/delete conflict: `checkout --theirs` succeeds against a working-tree
+  file that already carries no conflict markers, `_hunk_note` returned `""`,
+  and the print site's `if hunk_note:` guard swallowed it -- indistinguishable
+  from the deliberate `both`-side omission or a genuinely-clean resolution.
+  `_hunk_note` now returns a stated "outside-conflict check: not available"
+  line whenever it has no conflict block to compare against, on the CLI path
+  as well as when called directly (#2273).

--- a/presets/git/resolve.py
+++ b/presets/git/resolve.py
@@ -551,11 +551,17 @@ def _hunk_note(pre_text: Optional[str], post_text: Optional[str]) -> str:
     conflating them for exactly the failure mode this whole change exists to
     stop being silent about).
 
-    Returns ``""`` only when PRE held no conflict block to compare against —
-    unreachable on `git-resolve`'s own call path, where PRE is always read
-    from a file `git` itself just listed as conflicted, but reachable calling
-    this function directly (as the unit tests do); there is nothing to have
-    "not checked", so nothing is said.
+    Returns a **stated** line — never a silent ``""`` — when PRE held no
+    conflict block to compare against too. This used to be documented as
+    unreachable on `git-resolve`'s own call path, on the premise that PRE is
+    always read from a file `git` itself just listed as conflicted
+    (`_list_conflicts`, `git diff --name-only --diff-filter=U`). That premise
+    does not hold for a **modify/delete conflict** (#2273): `git` lists the
+    path as conflicted, but leaves the surviving side's content in the
+    working tree with no `<<<<<<<` markers at all — there was never a block
+    for a whole-file `checkout --ours`/`--theirs` to have moved content out
+    of, so PRE legitimately holds none, and that fact must be said rather
+    than rendered as the same blank line a genuinely-clean resolution prints.
     """
     if pre_text is None or post_text is None:
         return "outside-conflict check: not available (could not read the pre/post-resolution snapshot)"
@@ -574,7 +580,10 @@ def _hunk_note(pre_text: Optional[str], post_text: Optional[str]) -> str:
     post_lines = _untrusted.split_lines(post_text)
     blocks = _block_ranges(pre_lines)
     if not blocks:
-        return ""
+        return ("outside-conflict check: not available (the pre-checkout "
+                 "snapshot carried no conflict markers to compare against — "
+                 "e.g. a modify/delete conflict, where the surviving side's "
+                 "content is already what git left in the working tree)")
 
     matcher = difflib.SequenceMatcher(None, pre_lines, post_lines, autojunk=False)
     ops = [op for op in matcher.get_opcodes() if op[0] != "equal"]

--- a/tests/test_git_resolve_modify_delete_silent_note_2273.py
+++ b/tests/test_git_resolve_modify_delete_silent_note_2273.py
@@ -1,0 +1,99 @@
+"""git-resolve's `_hunk_note` returns a stated "could not check" line for
+every case where it has nothing to compare against -- never a silent `""`,
+per its own docstring contract. #2273 found the one case that DID return
+`""`: a modify/delete conflict, whose working-tree file at `checkout
+--theirs` time already carries no `<<<<<<<` markers, so `_block_ranges`
+returns `[]` and the old code took the "unreachable on git-resolve's own
+call path" branch that turns out to be reachable after all.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+PRESET = Path(__file__).parent.parent / "presets" / "git" / "resolve.py"
+_spec = importlib.util.spec_from_file_location("git_resolve_2273", PRESET)
+assert _spec is not None and _spec.loader is not None
+resolve = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(resolve)
+
+_ID = ["-c", "user.email=fixture@example.invalid", "-c", "user.name=fixture"]
+
+
+def _run(args, cwd):
+    res = subprocess.run(["git", *_ID, *args], cwd=cwd, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace")
+    assert res.returncode == 0, f"git {args} failed: {res.stderr}"
+    return res
+
+
+def _build_modify_delete_repo(tmp_path: Path) -> Path:
+    """A merge where one side deletes a file and the other modifies it. Git
+    resolves this as a modify/delete CONFLICT (listed by `git diff
+    --name-only --diff-filter=U`), but leaves the modified side's content in
+    the working tree with NO conflict markers at all -- there is nothing for
+    `_block_ranges` to find.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["init"], repo)
+    f = repo / "f.txt"
+    f.write_text("hello\n", encoding="utf-8")
+    _run(["add", "f.txt"], repo)
+    _run(["commit", "-m", "init"], repo)
+
+    _run(["checkout", "-b", "branch_modify"], repo)
+    f.write_text("hello world\n", encoding="utf-8")
+    _run(["commit", "-am", "modify"], repo)
+
+    _run(["checkout", "master"], repo)
+    _run(["rm", "f.txt"], repo)
+    _run(["commit", "-m", "delete"], repo)
+
+    merge = subprocess.run(["git", *_ID, "merge", "branch_modify"], cwd=repo,
+                            capture_output=True, text=True,
+                            encoding="utf-8", errors="replace")
+    assert merge.returncode != 0, "expected a merge conflict"
+    assert "modify/delete" in (merge.stdout + merge.stderr)
+    return repo
+
+
+def test_modify_delete_conflict_is_listed_and_carries_no_markers(tmp_path):
+    """Settle the issue's own flagged-uncertain premise before trusting
+    anything downstream of it.
+    """
+    repo = _build_modify_delete_repo(tmp_path)
+    names = subprocess.run(
+        ["git", *_ID, "diff", "--name-only", "--diff-filter=U", "-z"],
+        cwd=repo, capture_output=True, text=True, encoding="utf-8",
+    ).stdout.split("\0")
+    assert "f.txt" in names
+    text = (repo / "f.txt").read_text(encoding="utf-8")
+    assert "<<<<<<<" not in text
+
+
+def test_checkout_theirs_on_modify_delete_never_prints_a_silent_line(monkeypatch, capsys, tmp_path):
+    """MUST FIRE: `_hunk_note` must never render as nothing on git-resolve's
+    own call path. Before the fix this printed no "outside-conflict check"
+    line at all for a modify/delete conflict -- byte-identical to the
+    deliberate 'both' omission and to a clean, verified resolution.
+    """
+    repo = _build_modify_delete_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(resolve.sys, "argv", ["resolve.py", "theirs", "f.txt"])
+    rc = resolve.main()
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    assert "outside-conflict check" in out, (
+        "the receipt must say a stated line here, not go silent -- got:\n" + out
+    )
+
+
+def test_hunk_note_returns_a_stated_line_when_pre_has_no_conflict_blocks():
+    """Direct unit check of the function's own contract, independent of the
+    CLI: PRE with no `<<<<<<<` markers at all must never yield `""`.
+    """
+    note = resolve._hunk_note("hello world\n", "hello world\n")
+    assert note != ""
+    assert "outside-conflict check" in note

--- a/tests/test_git_resolve_modify_delete_silent_note_2273.py
+++ b/tests/test_git_resolve_modify_delete_silent_note_2273.py
@@ -67,6 +67,7 @@ def test_modify_delete_conflict_is_listed_and_carries_no_markers(tmp_path):
     names = subprocess.run(
         ["git", *_ID, "diff", "--name-only", "--diff-filter=U", "-z"],
         cwd=repo, capture_output=True, text=True, encoding="utf-8",
+        errors="replace",
     ).stdout.split("\0")
     assert "f.txt" in names
     text = (repo / "f.txt").read_text(encoding="utf-8")

--- a/tests/test_git_resolve_validate_child_failure_883.py
+++ b/tests/test_git_resolve_validate_child_failure_883.py
@@ -230,10 +230,25 @@ HOSTILE_STDERR = (
 )
 
 #: The receipt for one resolved file: the header, the `✓ path` row, the
-#: `markers:` row, a blank line, the tally and the next-step hint. Asserted as a
-#: count because the guarantee under test is structural — the digest is ONE cell
-#: of ONE row, and nothing a child wrote may change this report's row count.
-RECEIPT_LINES = 6
+#: `markers:` row, the `outside-conflict check:` row, a blank line, the tally
+#: and the next-step hint. Asserted as a count because the guarantee under
+#: test is structural — the digest is ONE cell of ONE row, and nothing a
+#: child wrote may change this report's row count.
+#:
+#: Seven, not six (#2273): `repo`'s fixture file carries no `<<<<<<<`
+#: markers at all -- exactly the shape `_hunk_note` now refuses to pass over
+#: in silence, so its own "outside-conflict check: not available" line is a
+#: THIRD receipt row here, one this test's own fixture earns honestly and
+#: not something the child's stderr added. It fires from `_hunk_note`, a
+#: call this render makes before `_validate_paths` ever runs, so it is
+#: unconditional -- present whether the child below returns a clean bill or
+#: HOSTILE_STDERR -- and orthogonal to the guarantee this test is actually
+#: pinning: that the child's OWN stderr cannot grow the row count past
+#: whatever it is with a well-behaved child. A genuinely child-smuggled row
+#: (e.g. HOSTILE_STDERR's embedded "\n      ✓ forged.py\n" surviving as a
+#: real newline instead of being flattened onto the `markers:` line) would
+#: still push the count to 8 and fail this assertion.
+RECEIPT_LINES = 7
 
 
 def test_the_childs_stderr_cannot_add_a_row_to_the_receipt(


### PR DESCRIPTION
## What

`presets/git/resolve.py`'s `_hunk_note` had a documented contract -- "never a silent empty string,
always a stated could-not-check line" -- with one branch that violated it: `if not blocks: return
""`. The docstring called this branch unreachable on `git-resolve`'s own call path, on the premise
that PRE always comes from a file `git` itself just listed as conflicted.

That premise does not hold for a **modify/delete conflict**. Built one with real `git` commands in
a throwaway repo (init / modify on one branch / delete on the other / merge):

- `git diff --name-only --diff-filter=U -z` lists the path as conflicted.
- The working-tree file at that point already reads as the surviving side's content, with **no
  `<<<<<<<` markers at all**.
- `checkout --ours` fails cleanly (rc=1) -- `_hunk_note` is never reached for that side.
- `checkout --theirs` succeeds silently (rc=0).

Running `git-resolve theirs f.txt` against this repo confirmed the issue's hypothesis exactly:
`_block_ranges` returns `[]`, `_hunk_note` returned `""`, and the print site's `if hunk_note:` guard
swallowed the receipt line -- byte-identical to the deliberate `both`-side omission and to a
genuinely clean resolution.

## Fix

`_hunk_note` now returns a stated `outside-conflict check: not available (...)` line for the
empty-blocks case, and the docstring was rewritten to describe the modify/delete mechanism instead
of claiming it unreachable.

## Test

`tests/test_git_resolve_modify_delete_silent_note_2273.py` builds the modify/delete conflict via
real subprocess `git` calls (not a mock) and asserts:
- the settling fact itself (path listed as conflicted, no markers on disk) -- a positive control,
- the CLI receipt from `resolve.main()` names the check rather than staying silent,
- `_hunk_note` returns a non-empty stated line when called directly with no-marker PRE text.

Confirmed red against the pre-fix code (`2 failed, 1 passed in 3.42s`), green after
(`3 passed in 0.87s`).

## Below-bar finding

None found. Both spawned reviewers (`Explore` and `oss:auditor`) returned `NO FINDINGS` /
`FINDINGS: 0`, independently confirmed by `scripts/review_return.py` as `no-findings` for each.

## Docs

`README.md` (this repo's only `docs_targets` entry) documents `git-resolve` at the level of "commit
with a receipt, push with a watcher, diff/blame/resolve without raw git" -- unaffected by this
internal receipt-line fix. `no-change-needed`.

Closes #2273
