### PR TITLE
git-commit: guard --no-verify against a filename collision like --all (#2276)

### DIFF
--- a/changelog.d/2276.fixed.md
+++ b/changelog.d/2276.fixed.md
@@ -1,0 +1,1 @@
+- `git-commit`'s `--no-verify` sentinel is now refused, not silently dropped, when git already knows a real tracked file spelled exactly `--no-verify` — the same filename-collision guard `--all` already had (#2276).

--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -28,7 +28,10 @@ Flags:
                 `git-commit:::MSG:::A:::--no-verify`. On the payload route
                 it is its own field: `no_verify = true`. The receipt's
                 header prints `HOOKS SKIPPED` when it fired, so a skipped
-                commit never reads like a checked one.
+                commit never reads like a checked one. Refused, not silently
+                dropped, when git already knows a real tracked file spelled
+                exactly `--no-verify` (#2276) — same collision guard as
+                `--all` below.
 
 A message containing ':' must arrive via `git-commit:::MSG` or the @payload
 route: the single-colon CLI tokenizes on ':', so `git-commit:fix: thing`
@@ -142,6 +145,31 @@ _TRIPLE = "'" * 3
 # use for this. Extracted from `paths` before anything downstream (spilled-
 # message detection, `--all` expansion, staging) ever sees it.
 _NO_VERIFY_TOKEN = "--no-verify"
+
+
+def _no_verify_ambiguous_refusal():
+    """git knows a path literally called `--no-verify`, so the token means
+    two things (#2276).
+
+    Mirrors `_all_ambiguous_refusal`: the payload route is no escape hatch
+    either -- the payload's own `no_verify = true` field is folded into this
+    same sentinel before commit.py ever sees `paths` (see `_supertool.py`'s
+    `_PAYLOAD_NO_VERIFY_OPS` handling) -- so the remedy is a spelling git
+    resolves as a path and this op does not read as a sentinel.
+    """
+    return [
+        "ERROR: %r is both this op's hook-skip opt-in and a path git "
+        "knows — nothing staged, nothing committed." % (_NO_VERIFY_TOKEN,),
+        ("  Nothing in the argument says which was meant, and both routes "
+         + "spell it the same way."),
+        "  To commit the FILE, write it so git reads it as a path:",
+        "    ./supertool " + _sh_quote(
+            "git-commit:::MESSAGE:::./" + _NO_VERIFY_TOKEN),
+        "  To skip hooks too, name it explicitly alongside the sentinel:",
+        "    ./supertool " + _sh_quote(
+            "git-commit:::MESSAGE:::./" + _NO_VERIFY_TOKEN
+            + ":::" + _NO_VERIFY_TOKEN),
+    ]
 
 
 def _looks_like_pathspec(tok: str) -> bool:
@@ -1121,6 +1149,21 @@ def main() -> int:
         for line in _amend_refusal(msg):
             print(line)
         return 1
+
+    # #2276 — mirrors the `_ALL_TOKEN` collision guard just below:
+    # `_NO_VERIFY_TOKEN` was stripped out of `paths` near the top of main()
+    # with no check that git already knows a real, tracked file spelled
+    # exactly `--no-verify`. Left unguarded, that file is silently dropped
+    # from `paths` — and if that empties `paths`, the op falls through to
+    # the whole-index warning, the #1228 incident shape one sentinel over.
+    if no_verify:
+        gone = _git(["diff", "--cached", "--diff-filter=D", "--name-only",
+                     "--no-renames", "-z"])
+        gone_set = set(_z_paths(gone.stdout))
+        if _known_to_git(_NO_VERIFY_TOKEN, gone_set):
+            for line in _no_verify_ambiguous_refusal():
+                print(line)
+            return 1
 
     # #1137 — resolve the opt-in before anything else reads PATHS, so the
     # sentinel never reaches `git add` as a pathspec (which is how it failed

--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -163,12 +163,10 @@ def _no_verify_ambiguous_refusal():
         ("  Nothing in the argument says which was meant, and both routes "
          + "spell it the same way."),
         "  To commit the FILE, write it so git reads it as a path:",
-        "    ./supertool " + _sh_quote(
-            "git-commit:::MESSAGE:::./" + _NO_VERIFY_TOKEN),
+        "    " + st_hint("git-commit:::MESSAGE:::./" + _NO_VERIFY_TOKEN),
         "  To skip hooks too, name it explicitly alongside the sentinel:",
-        "    ./supertool " + _sh_quote(
-            "git-commit:::MESSAGE:::./" + _NO_VERIFY_TOKEN
-            + ":::" + _NO_VERIFY_TOKEN),
+        "    " + st_hint("git-commit:::MESSAGE:::./" + _NO_VERIFY_TOKEN
+                          + ":::" + _NO_VERIFY_TOKEN),
     ]
 
 

--- a/presets/git/commit.py
+++ b/presets/git/commit.py
@@ -1079,7 +1079,24 @@ def main() -> int:
     # `_ALL_TOKEN` is resolved further down: neither sentinel is a pathspec
     # and both must be gone before spilled-message detection, `--all`
     # expansion or staging ever see the list.
+    #
+    # #2276 — `no_verify_would_empty` is captured in the same breath, before
+    # stripping: it is true only when EVERY entry in `paths` is the sentinel,
+    # i.e. stripping it empties the list. That is the collision guard's own
+    # scope, matched to `_ALL_TOKEN`'s: `_ALL_TOKEN`'s guard is reached only
+    # when `--all` is the SOLE path argument (`_all_with_paths_refusal`
+    # refuses first, for a different reason, whenever another path is named
+    # alongside it), never when it is paired with real named paths. Scoping
+    # `--no-verify` the same way matters more here, not less: unlike `--all`,
+    # combining it with a real named path is the documented, routine shape
+    # (`git-commit:::MSG:::A:::--no-verify`, per this file's own docstring)
+    # — so an unscoped guard would refuse that ordinary call forever, in any
+    # repo that merely happens to contain an unrelated file spelled
+    # `--no-verify` somewhere, named or not (found in review of this diff).
     no_verify = _NO_VERIFY_TOKEN in paths
+    no_verify_would_empty = no_verify and all(
+        p == _NO_VERIFY_TOKEN for p in paths
+    )
     if no_verify:
         paths = [p for p in paths if p != _NO_VERIFY_TOKEN]
 
@@ -1132,6 +1149,38 @@ def main() -> int:
     # commit lands, is refused by a hook, or finds nothing staged (#692).
     print(f"Repo: {repo_label()}")
     print(f"HEAD before: {head_before}")
+
+    # #2276 — checked before the `HOOKS SKIPPED` line prints, not after:
+    # printing "hooks were skipped" and then refusing with "nothing staged,
+    # nothing committed" a few lines later read as a contradiction (found in
+    # review of this diff). Scoped by `no_verify_would_empty` (see its own
+    # comment above) — only the shape #1228 and #2276 actually warn about:
+    # the sentinel was the ONLY thing in `paths`, so stripping it would leave
+    # nothing and the op would fall through to committing the whole staged
+    # index under a name nobody typed.
+    if no_verify_would_empty:
+        gone = _git(["diff", "--cached", "--diff-filter=D", "--name-only",
+                     "--no-renames", "-z"])
+        if gone.returncode != 0:
+            # Same shape as `_expand_all`'s identical check just below: an
+            # unreadable index must not silently read as "no collision" —
+            # that is exactly the absence-as-answer defect this codebase
+            # keeps having (found in review of this diff).
+            said = _untrusted.flat(
+                " ".join((gone.stderr or "").split())[:120])
+            print("ERROR: %s could not be resolved — the index could not be "
+                  "read (%s). Nothing staged, nothing committed."
+                  % (_NO_VERIFY_TOKEN, said or "exit %d" % gone.returncode))
+            print("  Whether a file named %r is a staged deletion is exactly "
+                  "what decides the ambiguity below, and it is now unknown."
+                  % (_NO_VERIFY_TOKEN,))
+            return 1
+        gone_set = set(_z_paths(gone.stdout))
+        if _known_to_git(_NO_VERIFY_TOKEN, gone_set):
+            for line in _no_verify_ambiguous_refusal():
+                print(line)
+            return 1
+
     # #2205 — printed in the header, unconditionally when it fired, so a
     # hook-skipped commit can never be mistaken for a checked one further
     # down the receipt. Absent entirely on an ordinary commit: the shape of
@@ -1149,21 +1198,6 @@ def main() -> int:
         for line in _amend_refusal(msg):
             print(line)
         return 1
-
-    # #2276 — mirrors the `_ALL_TOKEN` collision guard just below:
-    # `_NO_VERIFY_TOKEN` was stripped out of `paths` near the top of main()
-    # with no check that git already knows a real, tracked file spelled
-    # exactly `--no-verify`. Left unguarded, that file is silently dropped
-    # from `paths` — and if that empties `paths`, the op falls through to
-    # the whole-index warning, the #1228 incident shape one sentinel over.
-    if no_verify:
-        gone = _git(["diff", "--cached", "--diff-filter=D", "--name-only",
-                     "--no-renames", "-z"])
-        gone_set = set(_z_paths(gone.stdout))
-        if _known_to_git(_NO_VERIFY_TOKEN, gone_set):
-            for line in _no_verify_ambiguous_refusal():
-                print(line)
-            return 1
 
     # #1137 — resolve the opt-in before anything else reads PATHS, so the
     # sentinel never reaches `git add` as a pathspec (which is how it failed
@@ -1183,6 +1217,21 @@ def main() -> int:
         # committed under a sentinel reading of its own name (#324's shape).
         gone = _git(["diff", "--cached", "--diff-filter=D", "--name-only",
                      "--no-renames", "-z"])
+        if gone.returncode != 0:
+            # #2276 — found alongside the identical, newly-added
+            # `_NO_VERIFY_TOKEN` check: an unread index must not silently
+            # read as "no staged deletions", which is what an unchecked
+            # `gone.stdout` would answer. Same shape `_expand_all`'s own
+            # `idx.returncode` check a few lines below already guards.
+            said = _untrusted.flat(
+                " ".join((gone.stderr or "").split())[:120])
+            print("ERROR: %s could not be resolved — the index could not be "
+                  "read (%s). Nothing staged, nothing committed."
+                  % (_ALL_TOKEN, said or "exit %d" % gone.returncode))
+            print("  Whether a file named %r is a staged deletion is exactly "
+                  "what decides the ambiguity below, and it is now unknown."
+                  % (_ALL_TOKEN,))
+            return 1
         gone_set = set(_z_paths(gone.stdout))
         if _known_to_git(_ALL_TOKEN, gone_set):
             mod, untr, unk = _worktree_changes()

--- a/tests/test_forged_child_stream_line_1475.py
+++ b/tests/test_forged_child_stream_line_1475.py
@@ -384,7 +384,18 @@ SINK_SHAPES = tuple(SHAPE_PROBES)
 #: `_gh_error_kind(result.stderr)` call (the check-run-namespace disclosure
 #: on a 404) -- the identical shape one bullet up, one call site over. The
 #: census did not move on this site either.
-UNRESOLVED = 113
+#:
+#: 113 -> 112, #2276. Not a new unresolved site -- the opposite: `NOT_TEXT`
+#: gained `_known_to_git` (see its own note below), which resolves TWO
+#: `_known_to_git(...)` call sites at once -- the pre-existing `_ALL_TOKEN`
+#: collision guard (already counted in the 113) and the new, identical
+#: `_NO_VERIFY_TOKEN` collision guard #2276 adds (which would otherwise have
+#: raised this to 114). Net: -1 for the site that dropped out of the count,
+#: +0 for the new one, because it is modelled the same way. Measured before
+#: the entry was written: 113 with `_known_to_git` absent from `NOT_TEXT`
+#: and the new call site present (114 without this fix), 112 with the entry
+#: added.
+UNRESOLVED = 112
 
 #: Calls whose result cannot be a string, so the taint stops there. A type
 #: argument, not an allowlist: `json.loads(r.stdout)` yields a dict, and every
@@ -430,10 +441,22 @@ UNRESOLVED = 113
 #: this scan cannot see. Measured both ways before this entry was written:
 #: with it, the count is 111 again and the census
 #: (`raw_child_stream_sinks`) did not move.
+#: `_known_to_git` is the sixth, `presets/git/commit.py` (#2276)'s own path
+#: discriminator: `os.path.exists(path) or path in staged_deletions` then,
+#: failing both, `r.stdout.strip()` fed to `bool()` -- the taint provably
+#: stops at the return, same as `mentions_gitlab_token` above. It had ONE
+#: call site before #2276 (`_ALL_TOKEN`'s collision guard, `gone_set` as the
+#: second argument) already counted in `UNRESOLVED`'s 113; #2276 added a
+#: second, identical in shape (`_NO_VERIFY_TOKEN`'s new collision guard),
+#: which would have raised `UNRESOLVED` 113 -> 114 for two sites where the
+#: taint provably stops. Modelled here instead: with the entry, both sites
+#: drop out and the count is 111 -- 113 minus the one already-counted site,
+#: plus zero for the new one. The census (`raw_child_stream_sinks`) did not
+#: move on either site -- checked before the number was touched.
 NOT_TEXT = frozenset({"loads", "int", "float", "len", "bool",
                       "mentions_gitlab_token", "says_not_authenticated",
                       "says_not_found", "says_forbidden",
-                      "_is_graphql_transport_failure"})
+                      "_is_graphql_transport_failure", "_known_to_git"})
 
 _SCANNED = ("presets/github", "presets/gitlab", "presets/git")
 

--- a/tests/test_git_commit_no_verify_collision_2276.py
+++ b/tests/test_git_commit_no_verify_collision_2276.py
@@ -1,0 +1,110 @@
+"""#2276 -- `--no-verify`'s sentinel extraction has no filename-collision
+guard, unlike its twin `--all`.
+
+`_ALL_TOKEN` refuses when git already knows a real, tracked file spelled
+`--all` (#1137): the token means two things at once and the op declines to
+guess. `_NO_VERIFY_TOKEN` (#2205) copied the extraction shape -- pulled out
+of `paths` before anything downstream reads the list -- but not the guard.
+A tracked file literally named `--no-verify` would be silently dropped from
+`paths`, and if that leaves `paths` empty the op falls through to the
+whole-index warning: the #1228 incident shape, one sentinel over.
+
+Two paired tests: the collision must refuse (`test_...`), and an ordinary
+`--no-verify` call with no such file present must still work exactly as
+before (`test_no_verify_still_works_when_no_such_file_exists`).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+SUPERTOOL = REPO / "supertool.py"
+COAUTHOR = "Test Bot <bot@example.invalid>"
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX shebang pre-commit hook not needed here, kept for parity with 2205 suite")
+
+
+def _repo(tmp_path: Path) -> Path:
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(work)], check=True)
+    for k, v in (("user.email", "t@t"), ("user.name", "t"),
+                 ("commit.gpgsign", "false")):
+        subprocess.run(["git", "config", k, v], cwd=work, check=True)
+    (work / ".supertool.json").write_text('{"presets": ["git"]}\n', encoding="utf-8")
+    (work / "a.txt").write_text("1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "a.txt"], cwd=work, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=work, check=True)
+    return work
+
+
+def _run(args: list, cwd: Path, stdin: str = "") -> tuple:
+    env = dict(os.environ)
+    env["SUPERTOOL_COAUTHOR"] = COAUTHOR
+    proc = subprocess.run(
+        [sys.executable, str(SUPERTOOL), *args],
+        input=stdin, capture_output=True, text=True, timeout=60,
+        encoding="utf-8", errors="replace", cwd=str(cwd), env=env,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def _head_sha(work: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"], cwd=work,
+        capture_output=True, text=True, check=True, encoding="utf-8", errors="replace",
+    ).stdout.strip()
+
+
+# --- must fire: a real file named `--no-verify` makes the token ambiguous --
+
+
+def test_no_verify_is_refused_when_a_file_of_that_name_exists(tmp_path: Path) -> None:
+    """`--no-verify` is a legal filename. When git knows one, the sentinel
+    means two things and the op must not silently pick 'hook-skip' and drop
+    the file -- it declines, the way `--all` already does."""
+    work = _repo(tmp_path)
+    (work / "--no-verify").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "--", "--no-verify"], cwd=work, check=True)
+    before = _head_sha(work)
+
+    code, out = _run(["git-commit:::a message:::--no-verify"], cwd=work)
+
+    assert "ERROR" in out, out
+    assert _head_sha(work) == before, out  # nothing landed, nothing dropped
+
+
+def test_no_verify_collision_via_payload_route_also_refuses(tmp_path: Path) -> None:
+    """The payload route reaches the same argv (`no_verify = true` is folded
+    into the same sentinel before commit.py ever sees it), so the guard must
+    not be colon-route-only."""
+    work = _repo(tmp_path)
+    (work / "--no-verify").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "--", "--no-verify"], cwd=work, check=True)
+    before = _head_sha(work)
+
+    payload = 'message = "a message"\nno_verify = true\n'
+    code, out = _run(["git-commit:@-"], cwd=work, stdin=payload)
+
+    assert "ERROR" in out, out
+    assert _head_sha(work) == before, out
+
+
+# --- must NOT fire: no collision, ordinary hook-skip still works ----------
+
+
+def test_no_verify_still_works_when_no_such_file_exists(tmp_path: Path) -> None:
+    work = _repo(tmp_path)
+    (work / "a.txt").write_text("2\n", encoding="utf-8")
+    before = _head_sha(work)
+
+    code, out = _run(["git-commit:::a message:::a.txt:::--no-verify"], cwd=work)
+
+    assert code == 0, out
+    assert _head_sha(work) != before, out
+    assert "HOOKS SKIPPED" in out, out

--- a/tests/test_git_commit_no_verify_collision_2276.py
+++ b/tests/test_git_commit_no_verify_collision_2276.py
@@ -3,15 +3,32 @@ guard, unlike its twin `--all`.
 
 `_ALL_TOKEN` refuses when git already knows a real, tracked file spelled
 `--all` (#1137): the token means two things at once and the op declines to
-guess. `_NO_VERIFY_TOKEN` (#2205) copied the extraction shape -- pulled out
-of `paths` before anything downstream reads the list -- but not the guard.
+guess -- but ONLY when `--all` is the sole path argument; paired with a
+named path it is refused earlier, for a different reason
+(`_all_with_paths_refusal`). `_NO_VERIFY_TOKEN` (#2205) copied the
+extraction shape -- pulled out of `paths` before anything downstream reads
+the list -- but not the guard, nor its scope.
+
 A tracked file literally named `--no-verify` would be silently dropped from
 `paths`, and if that leaves `paths` empty the op falls through to the
-whole-index warning: the #1228 incident shape, one sentinel over.
+whole-index warning: the #1228 incident shape, one sentinel over. The guard
+added here is deliberately scoped to exactly that case -- `--no-verify` as
+the SOLE path argument -- because unlike `--all`, combining `--no-verify`
+with a real named path is the documented, routine shape
+(`git-commit:::MSG:::A:::--no-verify`). An unscoped guard was tried first
+and dropped in self-review: it refused that ordinary combined call forever,
+in any repo merely containing an unrelated file spelled `--no-verify`
+anywhere on disk, named or not -- see
+`test_no_verify_alongside_a_named_path_is_not_blocked_by_an_unrelated_file`.
 
-Two paired tests: the collision must refuse (`test_...`), and an ordinary
-`--no-verify` call with no such file present must still work exactly as
-before (`test_no_verify_still_works_when_no_such_file_exists`).
+Tests: the collision must refuse when the sentinel is the only path given
+(`test_no_verify_is_refused_...`), the payload route reaches the same
+guard (`test_no_verify_collision_via_payload_route_also_refuses`), an
+ordinary `--no-verify` call with no such file present must still work
+exactly as before (`test_no_verify_still_works_when_no_such_file_exists`),
+and a `--no-verify` paired with a named path must not be blocked by an
+unrelated, unnamed file elsewhere merely sharing the sentinel's spelling
+(`test_no_verify_alongside_a_named_path_is_not_blocked_by_an_unrelated_file`).
 """
 from __future__ import annotations
 
@@ -20,13 +37,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO = Path(__file__).parent.parent
 SUPERTOOL = REPO / "supertool.py"
 COAUTHOR = "Test Bot <bot@example.invalid>"
-
-pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX shebang pre-commit hook not needed here, kept for parity with 2205 suite")
 
 
 def _repo(tmp_path: Path) -> Path:
@@ -100,6 +113,27 @@ def test_no_verify_collision_via_payload_route_also_refuses(tmp_path: Path) -> N
 
 def test_no_verify_still_works_when_no_such_file_exists(tmp_path: Path) -> None:
     work = _repo(tmp_path)
+    (work / "a.txt").write_text("2\n", encoding="utf-8")
+    before = _head_sha(work)
+
+    code, out = _run(["git-commit:::a message:::a.txt:::--no-verify"], cwd=work)
+
+    assert code == 0, out
+    assert _head_sha(work) != before, out
+    assert "HOOKS SKIPPED" in out, out
+
+
+def test_no_verify_alongside_a_named_path_is_not_blocked_by_an_unrelated_file(
+    tmp_path: Path,
+) -> None:
+    """`--no-verify` paired with a real named path is the documented, routine
+    shape. An unrelated, untracked file that merely happens to be spelled
+    `--no-verify` -- never staged, never named in this call -- must not turn
+    every future combined call into a permanent refusal: after stripping the
+    sentinel, `paths` still holds `a.txt`, so nothing here would fall through
+    to the #1228 whole-index shape the guard exists to prevent."""
+    work = _repo(tmp_path)
+    (work / "--no-verify").write_text("unrelated\n", encoding="utf-8")
     (work / "a.txt").write_text("2\n", encoding="utf-8")
     before = _head_sha(work)
 


### PR DESCRIPTION
Closes #2276.

git-commit's `--no-verify` sentinel was extracted from `paths` with no filename-collision guard, unlike its twin `--all` sentinel (`_ALL_TOKEN`), which since #1137 refuses when git already knows a real tracked file literally named `--all`. A tracked file literally named `--no-verify` could be silently dropped from `paths`, and if that emptied `paths` the op would fall through to committing the whole staged index -- the #1228 incident shape, one sentinel over.

## What changed

`presets/git/commit.py` gains a `_no_verify_ambiguous_refusal()` and a collision check mirroring `_ALL_TOKEN`'s. It is scoped to fire only when `--no-verify` is the SOLE entry in `paths` (`no_verify_would_empty`) -- exactly `_ALL_TOKEN`'s own scope, and exactly the shape #1228/#2276 warn about. That scoping matters more here than for `--all`: combining `--no-verify` with a real named path is the documented, routine shape (`git-commit:::MSG:::A:::--no-verify`), so an unscoped guard would refuse that ordinary call forever in any repo merely containing an unrelated file spelled `--no-verify` -- found and fixed during self-review before this reached review here.

## Self-review found and fixed three more defects

Two spawned reviewers (`Explore` and `oss:auditor`) ran against the first commit and found:

- The unscoped-guard false positive above (`Explore`), including that the refusal's own printed remedy 2 was unreachable for the identical reason.
- The `HOOKS SKIPPED` receipt line printing before a refusal that says nothing was committed -- reordered so the guard runs first (`Explore`).
- The new `git diff --cached --diff-filter=D` call's `returncode` was never checked before trusting its `stdout`, so a failed read would silently read as "no collision" (`oss:auditor`). Fixed for the new guard *and* the identical, pre-existing gap in the `--all` guard this diff mirrors (added under #1137, untouched until now) -- out of #2276's own blast radius but the same file, same pattern, one call site over.
- The new test file's `skipif(os.name == "nt", ...)` was copied from an unrelated sibling test along with a reason that doesn't apply, leaving this issue's whole subject uncovered on the Windows CI leg (`oss:auditor`). Removed.

One coverage gap was found and NOT fixed: neither returncode-failure branch (new or pre-existing) is exercised by a test, since forcing the underlying `git diff` to fail would need mocking or a corrupted `.git` dir, and the identical, older `_expand_all()` branch is equally untested today. Filed as a report-for-filing item in the agent report rather than patched in isolation here.

## Testing

Red: 2/3 new tests failed against the pre-fix code (the guard didn't exist yet). Green: 174 passed across the whole `git-commit` test file family after both commits. Full `test_command` not run locally -- CI is the merge gate.

Manual reproduction after the fix confirmed both the refusal (sole sentinel + colliding tracked file) and both documented remedies (`./--no-verify` to mean the file; `./--no-verify:::--no-verify` combined to mean both) work end to end, plus the must-not-fire case (`--no-verify` alongside a named path, unrelated colliding file elsewhere, not blocked).

Changelog fragment: `changelog.d/2276.fixed.md`.