### PR TITLE
Hedge the edit op's "already present" hint instead of asserting a re-run

### DIFF
--- a/_supertool.py
+++ b/_supertool.py
@@ -11140,13 +11140,22 @@ def _edit_miss_diagnostic(old: str, content: str, new: str = "",
     """
     hints: List[str] = []
 
-    # 0. The replacement is ALREADY in the file — a re-run of a payload that
-    #    landed. #701 covers the case where `new` contains `old` (the anchor
-    #    survives and the edit applies a second time); this is the other half,
-    #    where it does not, and the second run reports a bare no-match that is
-    #    character-for-character what a genuinely wrong anchor prints (#984).
-    #    The two have opposite remedies — one is done, the other needs a new
-    #    anchor — and the reader could not recover which from the message.
+    # 0. The replacement is ALREADY in the file — consistent with (but not
+    #    proof of) a re-run of a payload that already landed. #701 covers the
+    #    case where `new` contains `old` (the anchor survives and the edit
+    #    applies a second time); this is the other half, where it does not,
+    #    and the second run reports a bare no-match that is character-for-
+    #    character what a genuinely wrong anchor prints (#984).
+    #
+    #    A substring search cannot tell a genuine re-run (the whole
+    #    replacement sitting where the edit targeted) from a coincidental
+    #    match elsewhere in the file — one relayed report found a line that
+    #    merely resembled the replacement, reported it as "this looks like a
+    #    re-run", and the reader concluded there was nothing to do when the
+    #    anchor was in fact simply missing (#2118). The two explanations have
+    #    opposite remedies — one is done, the other needs a new anchor — and
+    #    stating one as settled collapses the case where the tool genuinely
+    #    cannot tell.
     #
     #    A located fact, not a verdict: the ERROR stands, the exit code stands,
     #    the op is still counted as skipped. Downgrading a failure to a note
@@ -11155,8 +11164,9 @@ def _edit_miss_diagnostic(old: str, content: str, new: str = "",
         at = content.count("\n", 0, content.index(new)) + 1
         hints.append(
             f"the replacement text is ALREADY present at line {at} — this "
-            f"looks like a re-run of an edit that already applied, not a "
-            f"broken anchor"
+            f"may be a re-run of an edit that already applied, but it could "
+            f"also be a coincidental match; if line {at} is not where you "
+            f"meant to edit, the anchor is likely just missing"
         )
 
     # 1. Doubled backslashes, in EITHER direction. TOML literal strings

--- a/changelog.d/2118.fixed.md
+++ b/changelog.d/2118.fixed.md
@@ -1,0 +1,7 @@
+- The `edit` op's "already present" hint stated a cause it could not
+  establish: finding the whole replacement text somewhere in the file was
+  reported as `this looks like a re-run of an edit that already applied, not
+  a broken anchor`, ruling out the alternative that the match was merely
+  coincidental and the anchor genuinely missing. The hint now says the
+  replacement text is present and hedges between the two explanations rather
+  than asserting one (#2118).

--- a/docs/operations/edits.md
+++ b/docs/operations/edits.md
@@ -66,10 +66,10 @@ The first of those is the other half of the re-run problem (#984). `re-applied` 
 
 ```
 ERROR: old string not found in a.py
-  ↳ the replacement text is ALREADY present at line 12 — this looks like a re-run of an edit that already applied, not a broken anchor
+  ↳ the replacement text is ALREADY present at line 12 — this may be a re-run of an edit that already applied, but it could also be a coincidental match; if line 12 is not where you meant to edit, the anchor is likely just missing
 ```
 
-A located fact, not a verdict. The `ERROR` stands, the op is still counted in `K skipped`, and the call still exits non-zero — downgrading a failure because it is probably benign is how a loud bug becomes a quiet one.
+A located fact, not a verdict, and deliberately not a settled cause: `new in content` proves the whole replacement sits somewhere in the file, not that it sits *where the edit targeted* — a substring search cannot tell those apart, and one relayed report found a line that merely resembled the replacement, was told "this looks like a re-run", and concluded there was nothing to do when the anchor was in fact simply missing (#2118). The `ERROR` stands, the op is still counted in `K skipped`, and the call still exits non-zero — downgrading a failure because it is probably benign is how a loud bug becomes a quiet one.
 
 ## The nearest match, and when it declines to name one
 

--- a/tests/test_rollback_receipt_952_984.py
+++ b/tests/test_rollback_receipt_952_984.py
@@ -416,3 +416,28 @@ def test_already_applied_hint_survives_a_crlf_checkout(tmp_path: Path, monkeypat
 
     assert block.startswith("ERROR: old string not found"), (eol, block)
     assert "already" in block.lower(), (eol, block)
+
+
+def test_the_already_present_hint_does_not_rule_out_a_missing_anchor(
+        tmp_path: Path, monkeypatch) -> None:
+    """#2118: the old wording asserted 'this looks like a re-run ... not a
+    broken anchor' as a settled cause -- but a substring search cannot tell a
+    genuine re-run (the whole replacement, at the position the edit targeted)
+    from a coincidental match elsewhere in the file. A relayed report from
+    another lane hit exactly this: the anchor genuinely did not exist, a
+    coincidentally similar line sat at the reported position, and the message
+    told the reader there was nothing to do. The hint must not rule the
+    missing-anchor explanation out."""
+    _no_branch(monkeypatch)
+    supertool._CONFIG = {"validators": {}}
+    supertool._CONFIG_CHECKED = True
+    f = tmp_path / "a.py"
+    f.write_text("A = 1\nB = 2\nC = 3\nD = 4\n", encoding="utf-8")
+
+    supertool.dispatch(f"edit:::C = 3:::C = 999:::{f}")
+    block = _error_block(supertool.dispatch(f"edit:::C = 3:::C = 999:::{f}"))
+
+    assert "already" in block.lower(), block
+    assert "not a broken anchor" not in block, block
+    assert ("may" in block.lower() or "coincidence" in block.lower()
+            or "could" in block.lower()), block


### PR DESCRIPTION
The `edit` op's diagnostic for a failed anchor match (`_edit_miss_diagnostic` in `_supertool.py`) has a branch that fires when the entire `new` replacement text is found somewhere in the file: it reported `the replacement text is ALREADY present at line N -- this looks like a re-run of an edit that already applied, not a broken anchor`.

That states a settled cause the substring search cannot establish. `new in content` proves the whole replacement text sits *somewhere* in the file, not that it sits at the position the edit targeted -- and since this branch only fires when `old` was NOT found anywhere in the file, there is no target position to compare the match against in the first place. A relayed report from another lane hit this: the anchor genuinely did not exist, a coincidentally similar line sat at the reported position, and the message told the reader there was nothing to do when the anchor was in fact simply missing.

## Fix

Hedged the wording rather than building full positional disambiguation. The hint now says the replacement text is present at line N and that it *may* be a re-run but *could also be a coincidental match*, suggesting the anchor is likely just missing if line N is not where the edit was meant to land. The `ERROR`, exit code and `skipped` count are unchanged -- this is a wording change to a located fact, not a downgrade of the failure.

**Scope decision (stated per the issue's own request):** the issue offered two options -- (a) hedge the wording, or (b) verify whether the whole replacement sits at the position the edit targeted vs. a coincidental substring elsewhere. I went with (a). This branch only runs when `old` was not found anywhere in `content` at all, so there is no known "target position" for a genuine edit to compare the `new` match against -- true positional disambiguation (the kind `_edit_already_applied`, used for the *different* #701 re-applied signal, can do) needs `old` to be locatable and bracketed inside `new`, which by construction does not hold in this branch. Building (b) would need something outside a plain substring search (e.g. diffing against VCS history), materially more expensive and less reliable than the hedge for the case this hint targets.

## Testing

TDD: added `test_the_already_present_hint_does_not_rule_out_a_missing_anchor` to `tests/test_rollback_receipt_952_984.py`, watched it fail against the old wording (`1 failed in 3.45s` -- the old text still asserted `not a broken anchor`), then implemented the fix and watched it pass along with the other 19 tests in the file (`20 passed in 0.60s`).

Self-review: spawned `Explore` and `oss:auditor` against the committed diff, both NO FINDINGS (classified via `review_return.py --framed`). Tree snapshot before/after both spawns: clean, nothing mutated.

## Docs and changelog

`docs/operations/edits.md`'s worked example and surrounding prose updated to match the hedge wording. `README.md` (this repo's only `docs_targets` entry) checked -- no change needed, it does not document this error message. Changelog fragment added at `changelog.d/2118.fixed.md`; `.github/scripts/assemble_changelog.py --check` and `--check-links` both pass.

Closes #2118