### PR TITLE
trap.d: log #2296's fake-page substring-match test stub bug

### DIFF
--- a/trap.d/2296.fake-api-page-substring-match.md
+++ b/trap.d/2296.fake-api-page-substring-match.md
@@ -1,0 +1,31 @@
+Writing tests for gl-runners' `annotate_systemic_failures`/poller events (#2296),
+I hand-rolled a fake `_api` stub for GitLab's paginated job-history calls, matching
+the requested page number by checking `"page=1" in endpoint` against endpoint
+strings like `"projects/:id/jobs?per_page=100&page=1"`.
+
+This silently matched every page, not just page 1: `"per_page=100&page=2"` also
+contains the substring `"page=1"`, because `"per_page=100"` itself contains
+`"page=100"`, whose first six characters are `"page=1"`. So a stub meant to
+return a fixture on page 1 and an empty list on every later page (to terminate
+`fetch_recent_finished`'s real pagination loop) returned the same fixture on
+every one of the 5 pages the loop tried, and every count in the test came out
+5x too high (a 3-job fixture read back as 15). The test didn't crash or error —
+it just asserted the wrong number, and only failed because the assertion
+happened to be specific (`== 3`) rather than a truthy/nonzero check, which
+would have passed silently at the wrong magnitude.
+
+Confirmed by rewriting the match to parse the actual trailing page number
+(`endpoint.rsplit("page=", 1)[-1] == "1"`) rather than substring-matching a
+literal page marker — this is the general trap: an endpoint or query string
+that itself encodes one numeric parameter as a *substring of another*
+(`per_page=100` containing `page=100` containing `page=1`) makes naive
+substring matching on query-string fragments unreliable in test stubs, and
+the existing sibling test file (`tests/test_gl_runners_false_liveness_unknown_1112.py`)
+avoided the bug only because its own stub never needed to distinguish pages —
+it always returned `[]` for job history regardless of page, so the collision
+never had a chance to matter there.
+
+Not sure this is worth a jit-context rule on its own (it may be narrow enough
+to this one pagination shape), but logging it since it cost a full RED
+investigation cycle to find (the first failure looked like a counting bug in
+the *implementation*, not the test fixture).


### PR DESCRIPTION
A hand-rolled GitLab job-history stub in the #2296 tests matched requested pages by substring (`"page=1" in endpoint`), which also matches `"per_page=100&page=2"` because `"per_page=100"` itself contains `"page=1"` as a substring. Every page returned the page-1 fixture, inflating counts 5x -- caught only because the assertion happened to be an exact count rather than a truthy check.

This fragment was written by the #2296 developer lane during PR #2323 and left uncommitted in that worktree after the PR merged (squash merges leave the worktree's own history behind). Landing it now via its own branch so the finding is not lost when the worktree is reaped, per curate's workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNrcPGzCQDZfFhtZKY93Vu

[AI-generated]