### PR TITLE
chore(jit): carry oss 0.26.0's lane-release step into pr-create-gate

### DIFF
--- a/.claude/jit-context/tools/01-oss/pr-create-gate.md
+++ b/.claude/jit-context/tools/01-oss/pr-create-gate.md
@@ -22,8 +22,10 @@ Pushing and opening is one read plus one call, not a document you write:
   report path, never the payload path. Three answers: `ok`, a finding, and
   `UNVALIDATABLE` at exit 2, which is a statement about the validator and not the report.
 - **Release what a lane did not finish.** A lane with no commit, or a pull request closed
-  without merging, both leave an assignment behind: `gh issue edit <N> --remove-assignee
-  @me`. *Could not read the pull request state* must never render as released.
+  without merging, both leave an assignment behind:
+  `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/lane_setup.py" <N> --release`, which releases
+  the lane record and the GitHub assignee together. *Could not read the pull request
+  state* must never render as released.
 
 Full argument -- the fragment-rename procedure, the three states of `pr_body`, how far
 the validator actually gets on each field, and the two ways a body silently references


### PR DESCRIPTION
## What

The `oss` plugin moved 0.24.0 to 0.26.0 and `/oss:doctor` reported `.oss/statusline.py` and the `01-oss` jit layer as drifted. `/oss:scaffold --apply` rewrote 12 files. **One of them is here.** The other two are deliberately left out, and why is the point of this PR.

## The one change

`.claude/jit-context/tools/01-oss/pr-create-gate.md`: releasing an unfinished lane is now

```
python3 "${CLAUDE_PLUGIN_ROOT}/scripts/lane_setup.py" <N> --release
```

which releases the lane record and the GitHub assignee together. The old text named `gh issue edit <N> --remove-assignee @me`, which clears the assignee and leaves the lane record behind.

## What is NOT here, and why

**`.oss/statusline.py` is reverted.** 0.26.0's copy regresses this repo's own guards. Measured on this branch:

| tree | result |
| --- | --- |
| master | `26 passed` |
| with 0.26.0's statusline.py | `20 failed, 9 passed` |
| reverted (this PR) | `29 passed` |

over `tests/test_statusline_api_ref_validation_2245.py` and `tests/test_statusline_repo_only_api_ref_validation_2278.py`. Both assert that a malformed repo or ref **still reaches** the `gh api` call, so the server answers rather than the statusline silently rendering nothing:

```
tests/test_statusline_repo_only_api_ref_validation_2278.py:70: in test_gh_count_still_reaches_the_api_call_for_a_malformed_repo
    assert len(calls) == 1
E   assert 0 == 1
```

That is #2245, #2278 and #2281, taken back into the plugin's file by #2298. 0.26.0 does not carry it and bails early instead. Since `.oss/statusline.py` is replaced wholesale on every scaffold run, patching it here again only buys until the next `/oss:scaffold`; this belongs upstream in `Digital-Process-Tools/claude-oss`.

**`tools/01-oss/supertool-required.md` and its index row are removed again**, per `.claude/jit-context/paths/00-manual/oss-owned-jit-layer.md` and `tests/test_harness_tools_do_not_ship_1791.py` (#1791, #1793). Scaffold writes them on every run; they must not be tracked.

## Verified

- `59 passed` — `test_jit_index_round_trips_1579`, `test_jit_tools_index_seven_columns_1992`, `test_jit_rule_body_budget_1433`, `test_harness_tools_do_not_ship_1791`, `test_shipped_guard_rules_1698`
- `29 passed` — the three statusline tests
- No user-visible path changed (`_?supertool.py|presets/|validators/|formatters/|notifiers/|.claude-plugin/`), so the changelog gate reports `skipped`. No fragment.

## Also done outside the diff

`/oss:doctor` went from `usable with gaps -- 4 warning(s)` to `VERDICT: ok`, via three repo/machine settings that are not files here: the `oss-workspace` symlink was repointed at 0.26.0, and secret-scanning push protection plus automated security fixes were enabled on the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151LUi6h6agrN37X9dvEuDQ

[AI-generated]