### PR TITLE
fix(jit): track tools/01-oss/supertool-required.md, narrow the ban to what ships

### DIFF
--- a/.claude/jit-context/paths/00-manual/oss-owned-jit-layer.md
+++ b/.claude/jit-context/paths/00-manual/oss-owned-jit-layer.md
@@ -1,12 +1,19 @@
 ---
-title: "The 01-oss layer is /oss:scaffold's, and one file of it is deliberately untracked"
+title: "The 01-oss layer is /oss:scaffold's, and it is tracked whole"
 match: \.claude/jit-context/(paths|tools|vocabulary)/01-oss/
 ---
 
-`/oss:scaffold --apply` replaces this whole layer wholesale on every run, so an edit here is lost at the next one. Two consequences, and the second is the one that costs time.
+`/oss:scaffold --apply` replaces this whole layer wholesale on every run, so an edit here is lost at the next one. Run it, then read the diff: what it changes is the plugin's, and what you wanted is somewhere else.
 
-**`tools/01-oss/supertool-required.md` is written on disk and NOT tracked here, on purpose.** It is the plugin's own `PreToolUse` block naming `Read`/`Edit`/`Write`/`Glob`/`Grep` — the same job `.claude/jit-context/tools/00-manual/harness-tools-blocked.md` already does locally (which is why that one sits in `hooks/shipped_rules.NOT_SHIPPED`). Its text has already been read twice by a spawned reviewer as a fabricated prompt-injection payload rather than a first-party tool constraint (#1793). A second tracked copy buys nothing and reproduces the read that goes wrong.
+**All eleven files are tracked, `tools/01-oss/supertool-required.md` included.** This rule said the opposite until 2026-09-06 and cost a hand `git rm` after every scaffold run. Two claims stood behind it and neither survived being checked:
 
-So after any `/oss:scaffold --apply`: `git rm` it and clear its row from `tools/01-oss/00-index.tsv` again. **The row and the file move together**, or the row points at nothing. `tools/01-oss/00-index.tsv` is committed empty and that is the correct state.
+- *A tracked copy re-ships the rule.* It does not. `hooks/shipped_rules.py:90` reads one directory — `_RULE_DIR = (".claude", "jit-context", "tools", "00-manual")` — so nothing under `01-oss` travels to another repository through the plugin's guard at all. That is what #1791 is about, and this layer was never in it.
+- *`tools/01-oss/00-index.tsv` is committed empty.* It never was. It has carried `merge-gate.md` and `pr-create-gate.md` since the layer existed.
 
-`tests/test_harness_tools_do_not_ship_1791.py::test_the_rule_the_issue_describes_is_not_in_this_tree` asserts this against `git ls-files`, not a filesystem walk, precisely so the untracked copy scaffold writes does not redden it.
+What is still true is the read that goes wrong: `supertool-required.md`'s text has twice been taken by a spawned reviewer for a fabricated prompt-injection payload rather than a first-party tool constraint (#1793). Tracking it makes that read cheaper to settle, not likelier — the file now has a commit, a blame and a diff against the plugin's own copy.
+
+It overlaps `.claude/jit-context/tools/00-manual/harness-tools-blocked.md`, which does the same job locally and sits in `hooks/shipped_rules.NOT_SHIPPED` for the reasons recorded there. Two rules, one behaviour, and the `01-oss` one is replaced by scaffold while the `00-manual` one is not.
+
+**The row and the file move together.** A row in `tools/01-oss/00-index.tsv` naming a file that is not there points at nothing, and the `.md` alone is inert — `00-index.tsv` is what the hook reads.
+
+`tests/test_harness_tools_do_not_ship_1791.py` holds the narrowed claim against `git ls-files`: no `supertool-required.md` under `00-manual/`, and one under `01-oss/`. The second row is the positive control — without it the first passes when the file exists nowhere at all, which is exactly the state this rule used to enforce.

--- a/.claude/jit-context/tools/01-oss/00-index.tsv
+++ b/.claude/jit-context/tools/01-oss/00-index.tsv
@@ -1,2 +1,3 @@
 Bash	~gh-pr-merge	merge-gate.md	remind			
 Bash	~gh-pr-create	pr-create-gate.md	remind			
+Read|Edit|Write|Glob|Grep	~.*	supertool-required.md	block			supertool

--- a/.claude/jit-context/tools/01-oss/supertool-required.md
+++ b/.claude/jit-context/tools/01-oss/supertool-required.md
@@ -1,0 +1,23 @@
+---
+title: "Read, Edit, Write, Glob and Grep go through supertool"
+description: "supertool has an op for each of these; the refusal names the replacement, and 00-README.md covers the rest."
+tool: Read|Edit|Write|Glob|Grep
+match: ~.*
+mode: block
+requires: supertool
+---
+
+No read, edit, write, glob or grep bypasses `supertool`. Use the op that replaces
+the refused call:
+
+- **Read** -- `supertool 'read:PATH'`
+- **Edit** -- `supertool 'edit:@-'` (TOML on stdin) or `supertool 'edit:::OLD:::NEW:::PATH'`
+- **Write** -- `supertool 'paste:@-'` (TOML on stdin, `path`/`content`) or
+  `supertool 'paste:::PATH:::CONTENT'` -- creates missing dirs, rewrites an
+  existing file, so it covers both halves of a Write
+- **Glob** -- `supertool 'glob:PATTERN'`
+- **Grep** -- `supertool 'grep:PATTERN:PATH'`
+
+If none of those run, triage with `./supertool 'ops'` then `supertool 'ops'` --
+see `00-README.md` here for what each answer means and why this rule stays
+this wide.

--- a/tests/test_harness_tools_do_not_ship_1791.py
+++ b/tests/test_harness_tools_do_not_ship_1791.py
@@ -109,18 +109,26 @@ def _hook(tool_name: str, tool_input: dict, project: Path, tmp_path: Path):
     return envelope(proc.stdout)["hookSpecificOutput"]
 
 
-def test_the_rule_the_issue_describes_is_not_in_this_tree() -> None:
-    """#1791 names a file. Nothing here ships that, at any tracked path.
+def test_the_rule_the_issue_describes_is_not_in_the_shipped_layer() -> None:
+    """#1791 names a file. Nothing ships that, from the one directory that ships.
 
-    Asserted against `git ls-files`, not a filesystem walk. `/oss:scaffold
-    --apply` writes an untracked `.claude/jit-context/tools/01-oss/` layer
-    into a maintainer's own checkout for reasons that have nothing to do with
-    this test (#1956) -- a plugin-owned rule file sitting on disk, unshipped,
-    is not the state this test exists to catch. What ships to a clone, and
-    what CI sees, is the tracked set.
+    Asserted against `git ls-files`, not a filesystem walk: what reaches a
+    clone, and what CI sees, is the tracked set.
 
-    Reddens if a `supertool-required.md` is ever tracked: at that point the
-    issue stops being a non-reproduction and the rest of this file stops
+    **This used to ban the filename at every path**, on the reasoning that
+    `/oss:scaffold --apply` writes `.claude/jit-context/tools/01-oss/` into a
+    maintainer's checkout and a plugin-owned file sitting there untracked is
+    not the state this test is about (#1956). The ban was wider than the
+    guarantee. `shipped_rules._RULE_DIR` is
+    `.claude/jit-context/tools/00-manual`, and nothing else -- so a rule under
+    `01-oss` is read by `claude-jit-context` in THIS checkout and travels to no
+    other repository through the plugin's guard at all. Banning it there
+    protected nothing and cost the layer a file it is scaffolded with on every
+    run, which then had to be deleted again by hand after each one.
+
+    So the assertion is now the directory that actually ships. Reddens if a
+    `supertool-required.md` is ever tracked under `00-manual/`: at that point
+    the issue stops being a non-reproduction and the rest of this file stops
     describing the shipped set.
     """
     proc = subprocess.run(
@@ -130,8 +138,31 @@ def test_the_rule_the_issue_describes_is_not_in_this_tree() -> None:
     tracked = [p for p in
                proc.stdout.decode("utf-8", "surrogateescape").split("\0")
                if p]
-    assert tracked == [], tracked
+    shipped_dir = "/".join(shipped_rules._RULE_DIR) + "/"
+    assert [p for p in tracked if p.startswith(shipped_dir)] == [], tracked
     assert (_MANUAL / _RULE).is_file(), "the rule it really means moved"
+
+
+def test_the_ban_is_narrower_than_the_filename_and_says_where() -> None:
+    """The positive control for the narrowing above.
+
+    A test asserting "no such path under 00-manual" also passes when the file
+    exists nowhere at all, which is the state the previous version of this file
+    enforced -- so the narrowing is unproven without a row that fails when the
+    layer is empty. This one fails then.
+
+    Mutation that reddens it: delete
+    `.claude/jit-context/tools/01-oss/supertool-required.md`.
+    """
+    proc = subprocess.run(
+        ["git", "ls-files", "-z", "--", "*supertool-required.md"],
+        cwd=str(_ROOT), capture_output=True, timeout=60)
+    assert proc.returncode == 0, proc.stderr
+    tracked = [p for p in
+               proc.stdout.decode("utf-8", "surrogateescape").split("\0")
+               if p]
+    assert tracked == [
+        ".claude/jit-context/tools/01-oss/supertool-required.md"], tracked
 
 
 def test_the_harness_tool_rule_stays_a_recorded_absence() -> None:


### PR DESCRIPTION
## What

`/oss:scaffold --apply` writes eleven files into `.claude/jit-context/*/01-oss/`. Ten were tracked. The eleventh, `tools/01-oss/supertool-required.md`, was banned at **every** path by a test, so every scaffold run left a file and an index row to `git rm` by hand — and the note telling you to do that was a rule this repo carried.

Now tracked, with the ban narrowed to the directory that actually ships.

## Why the ban was wider than the guarantee

`hooks/shipped_rules.py:90` reads exactly one directory:

```python
_RULE_DIR = (".claude", "jit-context", "tools", "00-manual")
```

So nothing under `01-oss` reaches another repository through the plugin's guard, and tracking it there cannot reproduce #1791 — which is about a rule the plugin ships to everyone, not about a rule `claude-jit-context` reads in this checkout. `hooks/guard-selftest.py` still reports `harness-tools-blocked.md` as a recorded absence with its reason intact; that is the rule #1791 really means and nothing here touches it.

The assertion is now keyed on `shipped_rules._RULE_DIR` rather than on the filename, so it follows the shipped directory if that ever moves instead of going stale beside it.

## The positive control

A negative assertion needs one. "No such path under `00-manual/`" also passes when the file exists nowhere at all — which is precisely the state the old ban enforced, so the narrowing would be unproven without a row that fails then. `test_the_ban_is_narrower_than_the_filename_and_says_where` is that row. Verified by mutation, both directions:

| state | result |
| --- | --- |
| file untracked | `1 failed, 12 passed` — the control fires |
| file tracked | `13 passed` |

## A false line in the rule it replaces

`.claude/jit-context/paths/00-manual/oss-owned-jit-layer.md` stated:

> `tools/01-oss/00-index.tsv` is committed empty and that is the correct state.

It never was. It has carried `merge-gate.md` and `pr-create-gate.md` since the layer existed. Rewritten to say what is tracked, why the ban went, and what does still stand from #1793 — the reviewer misread is real, and a tracked file with a commit, a blame and a diff against the plugin's copy makes it cheaper to settle rather than likelier.

## Verified

- `64 passed` — `test_harness_tools_do_not_ship_1791`, `test_jit_index_round_trips_1579`, `test_jit_tools_index_seven_columns_1992`, `test_jit_rule_body_budget_1433`, `test_shipped_guard_rules_1698`, `test_jit_paths_rules_declare_no_mode_1442`
- `hooks/guard-selftest.py` — `harness-tools-blocked.md` still in the local-only list, reason unchanged, still naming this test file
- No user-visible path changed, so the changelog gate reports `skipped`. No fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151LUi6h6agrN37X9dvEuDQ

[AI-generated]