### PR TITLE
fix(#2345): print xdist's -n auto worker count on every CI leg

### DIFF
--- a/.github/scripts/print_worker_sizing.py
+++ b/.github/scripts/print_worker_sizing.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Print what pytest-xdist "-n auto" resolves to on this runner (#2345).
+
+pyproject.toml addopts carries "-n auto", and tests.yml's "Run tests" step
+overrides the marker expression and --cov but not -n, so all twelve CI legs
+run under xdist with a worker count nobody prints by name. `-q` on that same
+step additionally suppressed xdist's own "N workers [M items]" banner
+(confirmed locally: the banner prints under -n auto with no -q, and is gone
+the moment -q is added, with or without --junit-xml) -- so tests.yml now
+drops -q there instead, and the banner is the primary, measured answer.
+
+This script is not a substitute for that banner and does not try to be: this
+repository already runs -n auto on twelve legs, so it can observe the real
+resolved count directly rather than predict one. What xdist's own banner
+cannot say is WHICH of its four sources decided the number -- and that is
+the half of the issue worth a script for, because the day something pulls
+`psutil` into the CI environment transitively, `-n auto` silently switches
+from counting logical cores (`os.sched_getaffinity`/`os.cpu_count`) to
+counting *physical* ones, halving the worker count on any SMT runner with no
+other visible cause. The banner shows the new, smaller N; only a source
+reading like this one says why it changed.
+
+Nothing here gates anything. This is a `git log` for a number, not a check on
+it: it always exits 0, and it prints "worker sizing unknown" rather than a
+number when none of xdist's own sources can answer, so a reader can tell "I
+looked and nobody had an answer" from "N workers" -- the two must never look
+the same (CLAUDE.md, "The defect this codebase keeps having").
+
+The resolution order below is copied from xdist.plugin's
+pytest_xdist_auto_num_workers hook, because that hook is what -n auto
+actually calls -- there is no public API that returns the number without
+either running the hook or duplicating its four branches:
+
+1. PYTEST_XDIST_AUTO_NUM_WORKERS env var, if set and parses as an int. If it
+   is set to something that does NOT parse, xdist warns and ignores it --
+   the cap is NOT in effect, and resolution falls through to the sources
+   below. This script reports that explicitly rather than silently falling
+   through and reporting a number a reader could mistake for the env var's
+   own value.
+2. psutil.cpu_count(logical=False) -- psutil is not a declared dependency of
+   this repo today (pyproject.toml's [project.optional-dependencies] has no
+   psutil entry), so this branch answers only if something else pulled it in
+   transitively. It uses logical=False here because this repo runs -n auto,
+   not -n logical -- a future switch to -n logical would flip that branch,
+   and this script would report which one answered either way.
+3. os.sched_getaffinity(0) -- POSIX only; not present on macOS or Windows.
+4. os.cpu_count() -- the fallback of last resort.
+
+This is also a transcription of xdist's own logic, and a transcription is a
+claim about a dependency that can go stale if xdist changes its hook --
+`Digital-Process-Tools/claude-oss`'s scripts/doctor.py carries the same
+transcription (xdist_auto_workers) and says so about itself. Accepted the
+same way here: if it drifts, this prints a stale number rather than gating a
+build on a wrong one, and the measured banner above is the fallback truth
+either way.
+
+Whether xdist is even importable in this interpreter is also reported
+separately (`is_xdist_installed()`): a worker count is a number about
+nothing on a machine that could not run -n auto at all, and the two must not
+be conflated -- an environment where xdist failed to install looks, from
+this script's other output alone, exactly like one where `os.cpu_count()`
+happened to answer 1.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import Mapping, Optional, Tuple
+
+Resolution = Tuple[str, Optional[int], Optional[str]]
+
+
+def is_xdist_installed() -> bool:
+    """Is pytest-xdist importable in THIS interpreter? Never raises.
+
+    A broken meta path finder or similarly hostile import machinery is
+    reported as "not installed" rather than propagated -- this script's
+    whole job is to report, never to crash a step that runs before the
+    real test suite does.
+    """
+    try:
+        return importlib.util.find_spec("xdist") is not None
+    except Exception:
+        return False
+
+
+def _psutil_physical_count() -> Optional[int]:
+    """xdist branch 2: psutil.cpu_count(logical=False), falling back to
+    psutil.cpu_count() if the physical count comes back falsy -- the same
+    fallback xdist itself performs, verbatim.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return None
+    count = psutil.cpu_count(logical=False) or psutil.cpu_count()
+    return count or None
+
+
+def _affinity_count() -> Optional[int]:
+    """xdist branch 3: len(os.sched_getaffinity(0)). Absent on non-POSIX
+    platforms, and can raise on a platform that has the name but not a
+    working implementation -- treated the same as "not available".
+    """
+    try:
+        from os import sched_getaffinity
+    except ImportError:
+        return None
+    try:
+        return len(sched_getaffinity(0)) or None
+    except OSError:
+        return None
+
+
+def _os_cpu_count() -> Optional[int]:
+    """xdist branch 4: os.cpu_count()."""
+    return os.cpu_count()
+
+
+def resolve(env: Optional[Mapping[str, str]] = None) -> Resolution:
+    """Walk xdist's own resolution order and report which source answered.
+
+    Returns (source, count, note). count is None exactly when nothing
+    answered -- the third state a reader must be able to tell apart from a
+    real number, never collapsed into 0 or a made-up default.
+
+    `note` carries a finding that survives even when a later source DID
+    answer -- today, only the "env var set but unparseable" case, which
+    xdist itself treats as a warning-and-ignore rather than a fatal error,
+    so resolution correctly continues past it. Silently continuing without
+    saying so would read as "the env var was not set" to anyone scanning
+    the output, which is a different and wrong claim.
+    """
+    env = os.environ if env is None else env
+    note: Optional[str] = None
+
+    raw = env.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
+    if raw:
+        try:
+            return "PYTEST_XDIST_AUTO_NUM_WORKERS env var", int(raw), None
+        except ValueError:
+            note = (
+                f"PYTEST_XDIST_AUTO_NUM_WORKERS is set to {raw!r}, which is not "
+                "a number: xdist warns and ignores it, so the cap is NOT in "
+                "effect -- falling through to the next source"
+            )
+
+    count = _psutil_physical_count()
+    if count:
+        return "psutil.cpu_count(logical=False)", count, note
+
+    count = _affinity_count()
+    if count:
+        return "os.sched_getaffinity(0)", count, note
+
+    count = _os_cpu_count()
+    if count:
+        return "os.cpu_count()", count, note
+
+    unknown_note = (
+        "worker sizing unknown -- none of xdist resolution sources "
+        "(env var, psutil, sched_getaffinity, os.cpu_count) answered"
+    )
+    if note:
+        unknown_note = f"{note}; {unknown_note}"
+    return "none", None, unknown_note
+
+
+def render(resolution: Resolution, xdist_installed: bool) -> str:
+    source, count, note = resolution
+    lines = []
+    if not xdist_installed:
+        lines.append(
+            "xdist -n auto: pytest-xdist is not importable in this "
+            "interpreter -- a worker count would be a number about nothing, "
+            "so none is reported"
+        )
+        if note:
+            lines.append(f"  note: {note}")
+        return "\n".join(lines)
+    if count is None:
+        lines.append(f"xdist -n auto: worker sizing unknown ({note})")
+        return "\n".join(lines)
+    lines.append(f"xdist -n auto would resolve to {count} worker(s) (source: {source})")
+    if note:
+        lines.append(f"  note: {note}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    print(render(resolve(), is_xdist_installed()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/print_worker_sizing.py
+++ b/.github/scripts/print_worker_sizing.py
@@ -188,7 +188,24 @@ def render(resolution: Resolution, xdist_installed: bool) -> str:
 
 
 def main() -> int:
-    print(render(resolve(), is_xdist_installed()))
+    """Print the resolution and always return 0.
+
+    Reviewer finding (#2345 self-review): the module docstring and the
+    workflow step's own comment both promise "never gates a leg", but
+    nothing enforced that -- `resolve()`'s helpers catch the specific
+    exceptions xdist's own hook expects (ImportError, OSError), and an
+    exception of any OTHER shape would have propagated out of `main()` and
+    given the process a non-zero exit, failing the step this script is
+    explicitly meant not to be able to fail. `.github/workflows/tests.yml`
+    also gives this step `continue-on-error: true` as a second, independent
+    layer -- the same pattern this same job already uses for its Windows
+    Defender exclusion step (#2259) -- but a report-only script should not
+    rely solely on its caller to make that guarantee true.
+    """
+    try:
+        print(render(resolve(), is_xdist_installed()))
+    except Exception as exc:  # pragma: no cover - defends the "never gates" promise itself
+        print(f"xdist -n auto: worker sizing could not be read ({exc!r})")
     return 0
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -252,8 +252,12 @@ jobs:
         # answered -- the one thing the real "N workers" banner on the step
         # below cannot say, which matters because a transitive dependency
         # pulling in `psutil` silently changes physical-vs-logical core
-        # counting with no other visible cause. Report only: always exits 0,
-        # never gates a leg.
+        # counting with no other visible cause. Report only, and the script
+        # itself catches everything it can raise -- `continue-on-error`
+        # is a second, independent layer, the same pattern already used a
+        # few steps up for the Windows Defender exclusion (#2259): a step
+        # with no correctness stake must fail open, not take the job with it.
+        continue-on-error: true
         shell: bash
         run: python .github/scripts/print_worker_sizing.py
       - name: Run tests (excludes slow and benchmark — see #891)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,6 +243,19 @@ jobs:
         shell: pwsh
         run: |
           echo "::warning::Windows Defender exclusion step failed (Add-MpPreference) -- continuing without it; this Windows run may be slower than usual, see #2259"
+      - name: Print xdist worker sizing (#2345)
+        # `pyproject.toml`'s `addopts` carries `-n auto`, and the step below
+        # runs on all twelve legs with a worker count nobody has read.
+        # `.github/scripts/print_worker_sizing.py` walks xdist's own
+        # resolution order (env var, `psutil.cpu_count(logical=False)`,
+        # `os.sched_getaffinity(0)`, `os.cpu_count()`) and names which source
+        # answered -- the one thing the real "N workers" banner on the step
+        # below cannot say, which matters because a transitive dependency
+        # pulling in `psutil` silently changes physical-vs-logical core
+        # counting with no other visible cause. Report only: always exits 0,
+        # never gates a leg.
+        shell: bash
+        run: python .github/scripts/print_worker_sizing.py
       - name: Run tests (excludes slow and benchmark — see #891)
         # Override pyproject addopts default. Until #891 this ran the `slow`
         # marker on all twelve legs, on every push — marking a test `slow`
@@ -294,8 +307,23 @@ jobs:
         # encoding defects precisely by leaving the environment alone. A fix
         # whose blast radius includes the tests that would catch its own
         # regression is not a fix. Pinned by `tests/test_ci_encoding_546.py`.
+        # No `-q` (#2345): `-q` suppresses xdist's own "N workers [M items]"
+        # banner along with the platform/rootdir/plugins header -- confirmed
+        # locally, same invocation as this line minus the interpreter flag,
+        # junit-xml and all: the banner prints without `-q` and is gone the
+        # instant `-q` is added. The issue's own "worth checking" note says
+        # the fix is smaller than it assumes if that is true. It is: the
+        # delta is a fixed ~6-line header, not one that scales with this
+        # suite's ~16.5k tests, and nothing in this repo parses this step's
+        # raw stdout downstream -- `junit_summary.py` and
+        # `duration_report.py` both read junit.xml, never this stream.
+        # Dropping `-q` prints the worker count xdist actually resolved to,
+        # on every leg, for free -- a real measurement rather than a
+        # re-derivation of xdist's own resolution logic that could drift
+        # from it (the step above measures the same thing from the outside,
+        # and names *which* source answered, which this banner cannot say).
         shell: bash
-        run: python -X utf8 -m pytest -m 'not slow and not benchmark' --tb=no --no-cov --durations=25 --junit-xml=junit.xml -q
+        run: python -X utf8 -m pytest -m 'not slow and not benchmark' --tb=no --no-cov --durations=25 --junit-xml=junit.xml
       - name: Show failing tests with full messages (always runs)
         # `--tb=no` above means the one-line summary is all there is, and pytest
         # elides the middle of a long one to fit the terminal width — on one real

--- a/tests/test_worker_sizing_2345.py
+++ b/tests/test_worker_sizing_2345.py
@@ -1,0 +1,260 @@
+"""`-n auto` decides worker count on every leg and nothing said it (#2345).
+
+`pyproject.toml`'s `addopts` carries `-n auto`, and `tests.yml`'s "Run tests"
+step overrode the marker expression and `--cov` but not `-n`, so all twelve
+CI legs resolved a worker count through xdist that nobody read. `-q` on that
+same step additionally suppressed xdist's own "N workers [M items]" banner --
+confirmed locally, same invocation as the workflow's "Run tests" step (marker
+expr, `--tb=no`, `--no-cov`, `--durations=25`, `--junit-xml`): the banner
+prints without `-q` and disappears the instant `-q` is added.
+
+## The two-part fix, and why it is two parts
+
+A coordinator message mid-implementation raised a config-shaped alternative
+the issue body does not consider: since this repo already runs `-n auto` on
+twelve legs, it can *observe* the resolved count directly (xdist's own "N
+workers [M items]" banner) rather than predict one with a transcription of
+xdist's resolution hook. That was reproduced here on this repo's real
+`pytest`/`pytest-xdist` versions (9.1.1 / 3.8.0) and the real "Run tests"
+flags, not a throwaway suite:
+
+    -n auto (no -q)     -> "created: 3/3 workers" then "3 workers [54 items]"
+    -n auto -q          -> "bringing up nodes..." and no count anywhere
+
+Grepping `.github/` and `tests/` confirms nothing downstream parses that
+step's raw stdout -- `junit_summary.py` and `duration_report.py` both read
+`junit.xml`, never this stream -- so dropping `-q` is a config-only change
+with no blast radius. `tests.yml`'s "Run tests" step now omits `-q`; this is
+therefore the PRIMARY, measured answer to the issue and is pinned below by
+asserting `-q` is absent from that step's `run:` line.
+
+What the banner cannot say is WHICH source resolved the number -- and that
+is the one thing the issue's own worry (a transitive `psutil` dependency
+silently switching `-n auto` from counting logical cores to counting
+*physical* ones, halving parallelism on an SMT runner with no other visible
+cause) needs named rather than merely observed as a smaller N. That is what
+`.github/scripts/print_worker_sizing.py` is for, kept as a small,
+report-only complement to the banner rather than a bigger replacement of it.
+
+A second coordinator message pointed at `Digital-Process-Tools/claude-oss`'s
+`scripts/doctor.py` (`xdist_auto_workers`) as prior art with a stronger
+transcription and three fixes worth taking regardless of which repo's shape
+is used: (1) an unparseable `PYTEST_XDIST_AUTO_NUM_WORKERS` is xdist's own
+warn-and-ignore case, not a value to silently fall through past without
+saying so; (2) whether `xdist` is importable at all should be reported,
+because a worker count is a number about nothing on an interpreter that
+cannot run `-n auto`; (3) the None-not-0/1 rule for "nothing answered" was
+already right in the salvaged script and stays right. All three are
+implemented in `print_worker_sizing.py` and pinned below.
+
+## Disclosure
+
+The `resolve()`/`is_xdist_installed()`/`render()` unit tests below were NOT
+seen red first in the "watch a broken script fail" sense -- the script's
+core shape was salvaged already-written from a prior session's worktree.
+They *were* driven properly for the two coordinator-requested fixes (the
+unparseable-env-var note, the xdist-installed check): each assertion below
+that exercises those two paths was written and run against the
+pre-coordinator-message version of the script first, where it failed
+(`ValueError` silently swallowed with no note; `render()` took one argument
+and had no not-installed branch), and passes only against the rewritten
+version. The workflow-wiring tests are genuine TDD in the same sense:
+RED against the tree this PR started from (no step called the script, and
+`-q` was still on the "Run tests" line), GREEN only once both workflow edits
+landed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO / ".github" / "scripts" / "print_worker_sizing.py"
+WORKFLOW_PATH = REPO / ".github" / "workflows" / "tests.yml"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("print_worker_sizing_2345", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+
+# ---------------------------------------------------------------------------
+# resolve(): the four-source walk and the "unknown" third state
+# ---------------------------------------------------------------------------
+
+
+def test_env_var_wins_when_set_and_parseable():
+    resolution = mod.resolve(env={"PYTEST_XDIST_AUTO_NUM_WORKERS": "7"})
+    assert resolution == ("PYTEST_XDIST_AUTO_NUM_WORKERS env var", 7, None)
+
+
+def test_env_var_unparseable_falls_through_but_says_the_cap_is_not_in_effect(monkeypatch):
+    """The coordinator-requested fix: xdist warns-and-ignores an unparseable
+
+    value rather than treating it as fatal, and a reader must be told the
+    cap did NOT apply rather than seeing a number with no explanation of
+    where it came from.
+    """
+    monkeypatch.setattr(mod, "_psutil_physical_count", lambda: None)
+    monkeypatch.setattr(mod, "_affinity_count", lambda: None)
+    monkeypatch.setattr(mod, "_os_cpu_count", lambda: 5)
+    source, count, note = mod.resolve(env={"PYTEST_XDIST_AUTO_NUM_WORKERS": "not-a-number"})
+    assert (source, count) == ("os.cpu_count()", 5)
+    assert note is not None
+    assert "not-a-number" in note
+    assert "NOT in effect" in note
+
+
+def test_psutil_source_used_when_env_var_absent(monkeypatch):
+    monkeypatch.setattr(mod, "_psutil_physical_count", lambda: 4)
+    monkeypatch.setattr(mod, "_affinity_count", lambda: 99)
+    monkeypatch.setattr(mod, "_os_cpu_count", lambda: 99)
+    resolution = mod.resolve(env={})
+    assert resolution == ("psutil.cpu_count(logical=False)", 4, None)
+
+
+def test_affinity_used_when_psutil_absent(monkeypatch):
+    monkeypatch.setattr(mod, "_psutil_physical_count", lambda: None)
+    monkeypatch.setattr(mod, "_affinity_count", lambda: 6)
+    monkeypatch.setattr(mod, "_os_cpu_count", lambda: 99)
+    resolution = mod.resolve(env={})
+    assert resolution == ("os.sched_getaffinity(0)", 6, None)
+
+
+def test_os_cpu_count_is_the_last_resort(monkeypatch):
+    monkeypatch.setattr(mod, "_psutil_physical_count", lambda: None)
+    monkeypatch.setattr(mod, "_affinity_count", lambda: None)
+    monkeypatch.setattr(mod, "_os_cpu_count", lambda: 2)
+    resolution = mod.resolve(env={})
+    assert resolution == ("os.cpu_count()", 2, None)
+
+
+def test_none_of_the_sources_answer_reports_unknown_not_a_number(monkeypatch):
+    """The load-bearing case: nothing answered must render distinguishably
+
+    from any real worker count -- not 0, not None silently, but a named
+    third state ('none', None, <explanatory note>).
+    """
+    monkeypatch.setattr(mod, "_psutil_physical_count", lambda: None)
+    monkeypatch.setattr(mod, "_affinity_count", lambda: None)
+    monkeypatch.setattr(mod, "_os_cpu_count", lambda: None)
+    source, count, note = mod.resolve(env={})
+    assert source == "none"
+    assert count is None
+    assert note is not None and "unknown" in note
+
+
+# ---------------------------------------------------------------------------
+# is_xdist_installed(): a count is meaningless on an interpreter without xdist
+# ---------------------------------------------------------------------------
+
+
+def test_xdist_installed_reflects_a_real_import(monkeypatch):
+    monkeypatch.setattr(mod.importlib.util, "find_spec", lambda name: object())
+    assert mod.is_xdist_installed() is True
+    monkeypatch.setattr(mod.importlib.util, "find_spec", lambda name: None)
+    assert mod.is_xdist_installed() is False
+
+
+def test_xdist_installed_never_raises_on_a_hostile_import_system(monkeypatch):
+    def _boom(name):
+        raise RuntimeError("broken meta path finder")
+
+    monkeypatch.setattr(mod.importlib.util, "find_spec", _boom)
+    assert mod.is_xdist_installed() is False
+
+
+# ---------------------------------------------------------------------------
+# render(): the three states must never look alike
+# ---------------------------------------------------------------------------
+
+
+def test_render_of_a_real_count_names_the_source():
+    text = mod.render(("os.sched_getaffinity(0)", 6, None), xdist_installed=True)
+    assert text == "xdist -n auto would resolve to 6 worker(s) (source: os.sched_getaffinity(0))"
+
+
+def test_render_of_unknown_never_looks_like_a_count():
+    """A reader must be able to tell 'nobody could tell' from a real number
+
+    at a glance -- the whole point of the issue. `render()`'s unknown text
+    must not contain a bare digit that could be misread as a worker count.
+    """
+    text = mod.render(("none", None, "worker sizing unknown -- nothing answered"), xdist_installed=True)
+    assert "unknown" in text
+    assert not re.search(r"resolve to \d+ worker", text)
+
+
+def test_render_when_xdist_is_not_installed_reports_that_not_a_count(monkeypatch):
+    """The second coordinator-requested fix: a worker count is a number
+
+    about nothing on an interpreter that cannot import xdist at all -- this
+    must render as its own state, not silently coincide with a real count
+    of 1 or a made-up 0.
+    """
+    text = mod.render(("os.cpu_count()", 1, None), xdist_installed=False)
+    assert "not importable" in text
+    assert not re.search(r"resolve to \d+ worker", text)
+
+
+def test_main_exits_zero_always(capsys):
+    """The module docstring is explicit this never gates a build."""
+    exit_code = mod.main()
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# Workflow wiring: the "Run tests" step must actually print a worker count
+# ---------------------------------------------------------------------------
+
+
+def test_tests_workflow_runs_the_worker_sizing_script_before_pytest():
+    """RED on the tree this PR started from: `.github/scripts/print_worker_sizing.py`
+
+    existed but nothing under `.github/workflows/` referenced it. GREEN once
+    a step invoking the script is added ahead of "Run tests" on the `pytest`
+    job.
+    """
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "print_worker_sizing.py" in text, (
+        "tests.yml has no step invoking .github/scripts/print_worker_sizing.py"
+    )
+
+    sizing_pos = text.find("print_worker_sizing.py")
+    run_tests_pos = text.find('name: Run tests (excludes slow and benchmark')
+    assert run_tests_pos != -1, "the 'Run tests' step this must precede was not found"
+    assert sizing_pos < run_tests_pos, (
+        "print_worker_sizing.py must run BEFORE the 'Run tests' step"
+    )
+
+
+def test_run_tests_step_no_longer_suppresses_the_xdist_banner_with_q():
+    """RED on the tree this PR started from: the pytest invocation carried
+
+    `-q`, which measurably (see module docstring) suppresses xdist's own "N
+    workers [M items]" banner. GREEN once `-q` is removed from that line --
+    the primary, measured fix for #2345, config-only and confirmed to have
+    no downstream reader of this step's raw stdout.
+    """
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"run: python -X utf8 -m pytest -m 'not slow and not benchmark'[^\n]*",
+        text,
+    )
+    assert match is not None, "the 'Run tests' pytest invocation was not found"
+    run_line = match.group(0)
+    assert "--junit-xml=junit.xml" in run_line, "sanity: matched the wrong line"
+    tokens = run_line.split()
+    assert "-q" not in tokens, (
+        f"the 'Run tests' step still passes -q, which suppresses xdist's own "
+        f"worker-count banner: {run_line!r}"
+    )

--- a/tests/test_worker_sizing_2345.py
+++ b/tests/test_worker_sizing_2345.py
@@ -69,6 +69,8 @@ import importlib.util
 import re
 from pathlib import Path
 
+from _workflow_parse import job_blocks, job_steps
+
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO / ".github" / "scripts" / "print_worker_sizing.py"
 WORKFLOW_PATH = REPO / ".github" / "workflows" / "tests.yml"
@@ -214,26 +216,56 @@ def test_main_exits_zero_always(capsys):
 
 # ---------------------------------------------------------------------------
 # Workflow wiring: the "Run tests" step must actually print a worker count
+#
+# Structural, via tests/_workflow_parse.py, not `substring in text` (#731):
+# `tests.yml` is mostly comment explaining the very things these tests check,
+# so a needle search can be satisfied by prose describing the fix rather than
+# by the fix. Reviewer finding (#2345 self-review), reproduced concretely: a
+# text-substring-and-position version of the first test below still passed
+# when the sizing step's `run:` line was replaced with a decoy command while
+# its explanatory comment (which names the script by name) was left in
+# place -- the comment alone satisfied `"print_worker_sizing.py" in text`.
+# Parsing `run:` as its own field, the way `_workflow_parse.Step` does, is
+# what makes that unreachable, and reading `step.run` rather than a raw line
+# is also what survives a legitimate future reflow of the "Run tests" line
+# into a multi-line `run: |` block -- the second reviewer finding, on the
+# `-q` test below.
 # ---------------------------------------------------------------------------
+
+
+def _pytest_job_steps():
+    blocks = job_blocks(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert "pytest" in blocks, "the 'pytest' job was not found in tests.yml"
+    steps = job_steps(blocks["pytest"])
+    assert steps, "the 'pytest' job's steps parsed to an empty list"
+    return steps
 
 
 def test_tests_workflow_runs_the_worker_sizing_script_before_pytest():
     """RED on the tree this PR started from: `.github/scripts/print_worker_sizing.py`
 
     existed but nothing under `.github/workflows/` referenced it. GREEN once
-    a step invoking the script is added ahead of "Run tests" on the `pytest`
-    job.
+    a step whose `run:` field actually invokes the script is added ahead of
+    "Run tests" on the `pytest` job -- checked as a step's parsed `run`
+    field, not as a text search, so a step whose comment merely mentions the
+    script's name without its `run:` line invoking it does not count.
     """
-    text = WORKFLOW_PATH.read_text(encoding="utf-8")
-    assert "print_worker_sizing.py" in text, (
-        "tests.yml has no step invoking .github/scripts/print_worker_sizing.py"
+    steps = _pytest_job_steps()
+    sizing_index = next(
+        (i for i, s in enumerate(steps) if "print_worker_sizing.py" in s.run),
+        None,
     )
-
-    sizing_pos = text.find("print_worker_sizing.py")
-    run_tests_pos = text.find('name: Run tests (excludes slow and benchmark')
-    assert run_tests_pos != -1, "the 'Run tests' step this must precede was not found"
-    assert sizing_pos < run_tests_pos, (
-        "print_worker_sizing.py must run BEFORE the 'Run tests' step"
+    assert sizing_index is not None, (
+        "no step in the 'pytest' job has a run: field invoking "
+        ".github/scripts/print_worker_sizing.py"
+    )
+    run_tests_index = next(
+        (i for i, s in enumerate(steps) if s.name.startswith("Run tests")),
+        None,
+    )
+    assert run_tests_index is not None, "the 'Run tests' step was not found"
+    assert sizing_index < run_tests_index, (
+        "the worker-sizing step must run BEFORE the 'Run tests' step"
     )
 
 
@@ -241,20 +273,24 @@ def test_run_tests_step_no_longer_suppresses_the_xdist_banner_with_q():
     """RED on the tree this PR started from: the pytest invocation carried
 
     `-q`, which measurably (see module docstring) suppresses xdist's own "N
-    workers [M items]" banner. GREEN once `-q` is removed from that line --
-    the primary, measured fix for #2345, config-only and confirmed to have
-    no downstream reader of this step's raw stdout.
+    workers [M items]" banner. GREEN once `-q` is removed from that step's
+    `run:` field -- the primary, measured fix for #2345, config-only and
+    confirmed to have no downstream reader of this step's raw stdout.
+
+    Checked against the step's parsed `run` field (which can span multiple
+    physical lines under a `run: |` block scalar) and tokenised as shell
+    words, not against a single-physical-line regex on raw text -- a future
+    reflow of this long command into a `run: |` block, a pattern already
+    used elsewhere in this same job, would false-red a line-anchored regex
+    on an edit that changed nothing this test is meant to guard.
     """
-    text = WORKFLOW_PATH.read_text(encoding="utf-8")
-    match = re.search(
-        r"run: python -X utf8 -m pytest -m 'not slow and not benchmark'[^\n]*",
-        text,
-    )
-    assert match is not None, "the 'Run tests' pytest invocation was not found"
-    run_line = match.group(0)
-    assert "--junit-xml=junit.xml" in run_line, "sanity: matched the wrong line"
-    tokens = run_line.split()
+    steps = _pytest_job_steps()
+    run_tests = next((s for s in steps if s.name.startswith("Run tests")), None)
+    assert run_tests is not None, "the 'Run tests' step was not found"
+    assert "--junit-xml=junit.xml" in run_tests.run, "sanity: wrong step matched"
+    assert "pytest" in run_tests.run, "sanity: wrong step matched"
+    tokens = run_tests.run.split()
     assert "-q" not in tokens, (
         f"the 'Run tests' step still passes -q, which suppresses xdist's own "
-        f"worker-count banner: {run_line!r}"
+        f"worker-count banner: {run_tests.run!r}"
     )


### PR DESCRIPTION
Closes #2345.

## What was actually wrong

`pyproject.toml`'s `addopts` carries `-n auto`, and every leg of `tests.yml`'s
`pytest` job ran it under xdist with a worker count nobody printed.

## The fix, and why it is config first, script second

A design question came up mid-implementation: does this need a script at all,
or is it a one-line CI config change? Measured rather than assumed, against
this repo's real `pytest`/`pytest-xdist` (9.1.1/3.8.0) and the workflow's
actual flags:

```
python3 -m pytest -n auto ...                          -> "3 workers [54 items]" + header
python3 -m pytest -n auto -q ...                        -> "bringing up nodes...", no count
```

`-q` on the "Run tests" step suppresses xdist's own startup banner along with
the platform/rootdir/plugins header. Nothing downstream parses that step's
raw stdout -- `junit_summary.py` and `duration_report.py` both read
`junit.xml`, never this stream -- so dropping `-q` is a config-only change
that prints the **real, measured** worker count on every leg, for free. That
is the primary fix here.

`.github/scripts/print_worker_sizing.py` (salvaged from a prior session's
worktree, completed here) stays as a small, report-only complement: the real
banner cannot say **which** of xdist's four resolution sources answered, and
that is what the issue's own worry -- a transitive `psutil` dependency
silently switching worker counting from logical to physical cores -- needs
named rather than merely observed as a smaller N. Reviewed
`Digital-Process-Tools/claude-oss`'s `scripts/doctor.py::xdist_auto_workers`
as prior art and took three fixes from it into this script: an unparseable
`PYTEST_XDIST_AUTO_NUM_WORKERS` is now reported as xdist's own
warn-and-ignore case rather than silently falling through; whether `xdist` is
importable at all is checked; and "nothing answered" still renders as a
named third state, never an invented 0 or 1. Never gates a build.

## Self-review

Two reviewers ran against the first commit. `oss:auditor` returned no
findings. `Explore` returned four; two were fixed here (the script's
"never gates a leg" promise now has both a `try/except` in `main()` and
`continue-on-error: true` on the workflow step, matching the pattern this
job already uses for its Windows Defender exclusion step, #2259; both
workflow-wiring tests were rewritten to use `tests/_workflow_parse.py`'s
structural `job_steps()` rather than a raw-text regex, after reproducing the
reviewer's exact false-green scenario -- a decoy `run:` line with the
explanatory comment left in place still passed the old, text-based test).
One was argued down: the script's "worker sizing unknown" third state
models a condition xdist's real hook cannot reach in practice, since xdist's
own fallback always resolves to at least 1. Left as designed -- **the below-bar
call here is that this is a deliberate defensive floor against a hook that
could change, not a claim about today's xdist's exact reachable states, and
the docstring already says the transcription can drift** -- so no further
action beyond recording it here.

## Testing

`tests/test_worker_sizing_2345.py` -- 14 tests. Both workflow-wiring tests
are genuine TDD (RED against the pre-PR tree, GREEN after). The script's
unit tests were largely salvaged already-passing; the two review-requested
fixes (unparseable-env-var note, xdist-installed check) were driven RED
first by swapping in the pre-review script via its `paste` backup, then
GREEN after the fix.

No `changelog.d/` fragment: this PR touches only `.github/` and `tests/`,
outside the paths `changelog.yml`'s own gate treats as user-visible, and
running that gate's logic locally confirms it would report `skipped`.

## Adjacent, not touched

The reviewer noticed a pre-existing, unrelated inaccuracy a few lines above
the "Run tests" step this PR edits: its comment says "bash shell forced so
`|| true` works on Windows", but the actual `run:` line carries no `|| true`
anywhere. **Below the bar for this PR** -- it predates this diff (confirmed
against `HEAD~1`), it is a stale comment rather than a behavioral defect, and
fixing it would be a second, unrelated change riding on this one's diff.
Recorded here rather than fixed or filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKeLFSWdSpSTMasdJsPZSE


[AI-generated]