### PR TITLE
fix(#2360): deselect tree-walking guards from 11 of 12 pytest legs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -326,8 +326,28 @@ jobs:
         # re-derivation of xdist's own resolution logic that could drift
         # from it (the step above measures the same thing from the outside,
         # and names *which* source answered, which this banner cannot say).
+        # #2360: `invariant`-marked tests (tree-walking guards over this repo's
+        # own tree, `tests/_invariant_census.py`) are deselected on every leg
+        # except one designated full leg -- (ubuntu-latest, 3.12), the same
+        # leg the durations census in #2360 was measured against. One `-m`
+        # expression built by a single script-level `if`, never two
+        # independently-guarded steps or two ternaries on one step: #2360
+        # names exactly that shape (two `${{ }}` conditions, both false, is a
+        # leg that silently runs no tests) as claude-oss's own first mistake
+        # on this feature. The default arm here (no exclusion) is also the
+        # safe direction if MATRIX_OS/MATRIX_PY are ever wrong or unset --
+        # the worst case is every leg runs the invariant population, never
+        # that a leg runs nothing.
         shell: bash
-        run: python -X utf8 -m pytest -m 'not slow and not benchmark' --tb=no --no-cov --durations=25 --junit-xml=junit.xml
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_PY: ${{ matrix.python-version }}
+        run: |
+          MARKER="not slow and not benchmark"
+          if [ "$MATRIX_OS" != "ubuntu-latest" ] || [ "$MATRIX_PY" != "3.12" ]; then
+            MARKER="$MARKER and not invariant"
+          fi
+          python -X utf8 -m pytest -m "$MARKER" --tb=no --no-cov --durations=25 --junit-xml=junit.xml
       - name: Show failing tests with full messages (always runs)
         # `--tb=no` above means the one-line summary is all there is, and pytest
         # elides the middle of a long one to fit the terminal width — on one real

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,18 @@ markers = [
     # `test_xml.py`'s parse-scaling assertions are the other side: they name a
     # budget the code is meant to meet, and all four are marked.
     "benchmark: wall-clock timing assertions measuring performance, not liveness. Run deliberately and serially: `pytest -m benchmark -n0`.",
+    # #2360: tree-walking guards over this repo's own source/config whose
+    # answer cannot vary by OS or interpreter -- claude-oss's own `invariant`
+    # marker halved that half of its win by deselecting these on 11 of its
+    # 12 legs and keeping them on one designated full leg. Never applied by
+    # hand: `tests/conftest.py`'s `pytest_collection_modifyitems` hook marks
+    # every item from a file `tests/_invariant_census.py` derives via AST, so
+    # a new tree-walking test file joins or is excluded without anyone
+    # remembering to list it here. `.github/workflows/tests.yml`'s `Run
+    # tests` step deselects this marker on 11 of 12 pytest legs and keeps it
+    # on (ubuntu-latest, 3.12) -- and locally, where it always runs, because
+    # nothing here excludes it from the default `addopts` selection.
+    "invariant: tree-walking guard over this repo's own tree whose answer cannot vary by OS or interpreter (#2360). Auto-applied at collection; see tests/_invariant_census.py.",
 ]
 
 [project.optional-dependencies]

--- a/tests/_invariant_census.py
+++ b/tests/_invariant_census.py
@@ -1,0 +1,106 @@
+"""#2360 -- which test files in this suite are tree-walking guards over this
+repository's own source or config whose answer cannot vary by OS or
+interpreter, the way `claude-oss`'s own `invariant` marker deselects 126 of
+its 428 test files on 11 of its 12 legs (its #1176).
+
+Two predicates, kept separate on purpose rather than folded into one AST
+rule, because they are not the same question -- #2360's own worked example:
+`test_symlink_capability_1143.py`, `test_git_shim_subcommand_1206.py` and
+`test_no_bare_python3_spawn.py` all walk this repository's tree, and all
+three are still about *platform behaviour*. Deselecting them on Windows, or
+on the 3.9 floor, would quietly narrow the coverage this matrix exists to
+keep -- silently, since a deselected test reports nothing, it does not fail.
+
+1. `_walks_tree` -- mechanical, via AST. Does the module call `.rglob(`,
+   `.glob(`, or `os.walk(` anywhere, or import a name from `_repo_walk`
+   (the shared tree-walk `tests/_repo_walk.py`'s own docstring says #555/#575
+   consolidated three drifting copies into, itself built on `Path.rglob`)? A
+   module that answers no is not a candidate at all: it is not reading this
+   repository's tree, so nothing here applies to it.
+
+2. `_PLATFORM_SIGNAL` -- a named-token scan of the module's source text for
+   the vocabulary this repo's own platform-sensitive guards already use:
+   `sys.platform`, `os.name`, `platform.system(`, a symlink-privilege check,
+   a Windows error code, `shutil.which`, the literal `python3` (#529/#564's
+   own class), a git-shim reference, a POSIX-only marker. This is the same
+   shape as `PLATFORM_TOKENS` in `test_symlink_gating_register_1232.py`,
+   generalised from "skipped on this platform" to "asserts something that can
+   differ by platform" -- #2360's three named files are not
+   `@requires_symlink` sites, they are files whose *assertions* are about a
+   platform difference even though the walk that feeds them is not.
+
+   **This is a heuristic, not a proof, and the direction of its error matters
+   more than its precision.** A file this signal misses would be marked
+   `invariant` and silently narrowed off Windows and the other interpreters --
+   the expensive direction. A false positive only keeps a file in the
+   12-leg-run population it would have been in anyway -- the safe direction,
+   the same "wider than needed, never narrower" argument `tests/_repo_walk.py`
+   makes for its own machine-state exclusions. New platform-dependent
+   vocabulary this scan does not yet know about is the residual risk; the
+   test below pins the three files #2360 named so that risk cannot regress
+   unnoticed for at least those three.
+
+Population, not registry: recomputed from the AST on every run, the same
+argument `test_symlink_gating_register_1232.py` and
+`test_lint_budget_gating_1360.py` make for their own populations -- a new
+tree-walking test file joins, or is excluded from, the `invariant` marker
+without anyone remembering to list it by hand.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+
+_PLATFORM_SIGNAL = re.compile(
+    r"sys\.platform|platform\.system\(|os\.name|symlink|winerror|WinError|"
+    r"posix_only|require_symlink|windows_has_no_usable_bash|codepage|cp1252|"
+    r"UnicodeEncodeError|shutil\.which|python3|App Execution Alias|"
+    r"_shim|geteuid|O_NOFOLLOW|AF_UNIX|SeCreateSymbolicLinkPrivilege|"
+    r"win32|is_windows|IS_WINDOWS",
+    re.IGNORECASE,
+)
+
+
+def _walks_tree(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr in ("rglob", "glob"):
+                return True
+            if (isinstance(func, ast.Attribute) and func.attr == "walk"
+                    and isinstance(func.value, ast.Name) and func.value.id == "os"):
+                return True
+        if isinstance(node, ast.ImportFrom) and node.module == "_repo_walk":
+            return True
+    return False
+
+
+def population() -> dict:
+    """``{file name: platform_sensitive}`` for every tree-walking test file
+    under this directory.
+
+    ``platform_sensitive=True`` means `_PLATFORM_SIGNAL` found a reason NOT
+    to mark the file `invariant`, even though it walks the tree.
+    """
+    found = {}
+    for path in sorted(TESTS.glob("test_*.py")):
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        if not _walks_tree(tree):
+            continue
+        found[path.name] = bool(_PLATFORM_SIGNAL.search(source))
+    return found
+
+
+def invariant_files() -> frozenset:
+    """File names whose answer cannot vary by OS or interpreter -- the
+    population `tests/conftest.py` marks `pytest.mark.invariant` at
+    collection time.
+    """
+    return frozenset(name for name, flagged in population().items() if not flagged)

--- a/tests/_invariant_census.py
+++ b/tests/_invariant_census.py
@@ -59,7 +59,17 @@ _PLATFORM_SIGNAL = re.compile(
     r"posix_only|require_symlink|windows_has_no_usable_bash|codepage|cp1252|"
     r"UnicodeEncodeError|shutil\.which|python3|App Execution Alias|"
     r"_shim|geteuid|O_NOFOLLOW|AF_UNIX|SeCreateSymbolicLinkPrivilege|"
-    r"win32|is_windows|IS_WINDOWS",
+    r"win32|is_windows|IS_WINDOWS|"
+    # #2360 self-review: `test_watch_sources_path_2135.py` walks the tree,
+    # asserted the census's own `_walks_tree` check saw it, and would have
+    # been marked `invariant` -- silently narrowing Windows-leg coverage of
+    # exactly the class the census exists to protect -- because its own
+    # docstring names the defect it guards (a hardcoded ':' splitting a
+    # Windows drive letter) without any of the tokens above. `os.pathsep`
+    # is the value that diverges by platform; `ntpath`/`PureWindowsPath`
+    # are the two spellings a test constructs a Windows path with without
+    # naming Windows.
+    r"os\.pathsep|ntpath|PureWindowsPath",
     re.IGNORECASE,
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -469,6 +469,31 @@ def pytest_configure(config):
         _write_guard.install()
 
 
+def pytest_collection_modifyitems(config, items):
+    """#2360 -- mark every item collected from a `tests/_invariant_census.py`
+    "invariant" file with `pytest.mark.invariant`, so CI can deselect the
+    population on 11 of 12 legs (`-m "not invariant"`, in
+    `.github/workflows/tests.yml`) and keep it on the one designated full
+    leg. Applied at collection rather than hand-decorated in each file: the
+    population is derived from the AST on every run, the same argument
+    `test_symlink_gating_register_1232.py`'s docstring makes for its own
+    population -- a hand-listed register is a register of what somebody
+    happened to know about, and drifts the way that file's own history did.
+
+    Deliberately independent of any exclusion: this hook only ADDS a marker.
+    Nothing here can produce the "both conditions false, leg runs no tests"
+    failure #2360 names as claude-oss's own mistake on this exact feature --
+    that risk lives entirely in the workflow step that reads the marker, not
+    in the code that applies it.
+    """
+    from _invariant_census import invariant_files
+    names = invariant_files()
+    marker = pytest.mark.invariant
+    for item in items:
+        if Path(item.path).name in names:
+            item.add_marker(marker)
+
+
 def pytest_sessionstart(session):
     """#1635: snapshot the tree's own load-bearing markers before anything
     runs, so a run that leaves them gone is caught rather than reported as a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -485,8 +485,27 @@ def pytest_collection_modifyitems(config, items):
     failure #2360 names as claude-oss's own mistake on this exact feature --
     that risk lives entirely in the workflow step that reads the marker, not
     in the code that applies it.
+
+    Tolerant of `_invariant_census` being unimportable: `test_git_env_leak_416.py`
+    and `test_git_state_guard.py` spawn a real pytest subprocess against a
+    synthetic, minimal repo tree that copies only `tests/conftest.py` -- not
+    the rest of `tests/` -- specifically to test git-state guards in
+    isolation. An unconditional import there raised `ModuleNotFoundError`
+    inside that subprocess and aborted its ENTIRE collection with an
+    `INTERNALERROR`, failing five unrelated assertions about the synthetic
+    run's own behaviour rather than about anything this hook does. A
+    synthetic/minimal pytest tree is a real, existing pattern in this suite,
+    not a hypothetical one; this hook is not the only file such a tree will
+    ever be missing, so it degrades to "mark nothing" rather than crash
+    collection outright -- the same "wider than needed on failure, never a
+    hard requirement" argument `tests/_repo_walk.py` makes for its own
+    machine-state exclusions, applied here to "cannot determine the
+    population" rather than "found nothing in it".
     """
-    from _invariant_census import invariant_files
+    try:
+        from _invariant_census import invariant_files
+    except ImportError:
+        return
     names = invariant_files()
     marker = pytest.mark.invariant
     for item in items:

--- a/tests/test_invariant_marker_census_2360.py
+++ b/tests/test_invariant_marker_census_2360.py
@@ -1,0 +1,119 @@
+"""#2360 -- census first, then the marker: how many test files here walk this
+repository's own tree in a way whose answer cannot vary by OS or interpreter,
+and does the `invariant` marker this file wires up actually reach them
+without also reaching the three files #2360 named as tree-walking but
+platform-sensitive.
+
+Measured population, from `tests/_invariant_census.py` (recomputed here, not
+copied, so a change to the census logic and a change to this pin cannot
+silently drift apart): 92 tree-walking test files, 59 of them invariant by
+the heuristic and 33 excluded as platform-sensitive, out of 1061 test files
+total on the commit this was written against -- 5.6% of the suite's files.
+Timed locally (not on CI, and not a claim about CI's own wall clock): running
+only the 59-file invariant population under `-n 4 --dist loadfile` (matching
+the pytest job's `--dist loadfile`, at a worker count close to a hosted
+ubuntu runner) is 1052 passed, 3 skipped in 45.44s wall, ~115.8s of summed
+per-test duration -- against the 339.84s leg wall this issue's own tail
+sample was measured against, that is a meaningfully larger slice than the
+top-25 tail's own ~35s estimate, and above the 3% floor #2360 says would
+justify closing without a deselect. Worth pursuing, not a halving: `--no-cov`
+already took the other half of what `claude-oss` gained.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import _invariant_census
+
+TESTS = Path(__file__).resolve().parent
+ROOT = TESTS.parent
+
+# Named explicitly in #2360 as tree-walking guards whose *assertions* are
+# still about platform behaviour: excluding them from 11 of 12 CI legs would
+# silently narrow the coverage this matrix exists for. A "must not fire"
+# assertion needs a positive control in the same fixture (this repo's own
+# negative-assertion rule) -- see
+# test_a_known_invariant_file_and_a_known_platform_sensitive_file_are_marked_apart
+# below for the paired "must fire" half.
+NAMED_PLATFORM_SENSITIVE = frozenset({
+    "test_symlink_capability_1143.py",
+    "test_git_shim_subcommand_1206.py",
+    "test_no_bare_python3_spawn.py",
+})
+
+# A file the census's own `_walks_tree` classifies as invariant today, used
+# as the "must fire" half of the paired assertion below. If this stops being
+# true (the file stops walking the tree, or gains a platform signal), this
+# module's own docstring numbers are stale and need re-deriving anyway.
+_KNOWN_INVARIANT_FILE = "test_op_registry_1356.py"
+
+
+def test_the_three_named_platform_sensitive_files_still_walk_the_tree_and_are_excluded():
+    """The negative half: none of the three files #2360 named is ever marked
+    `invariant`, however the census's internals change.
+    """
+    pop = _invariant_census.population()
+    still_present = NAMED_PLATFORM_SENSITIVE & set(pop)
+    assert still_present == NAMED_PLATFORM_SENSITIVE, (
+        "one of the three files #2360 named no longer walks the tree by "
+        "this census's own detector -- confirm deliberately before deleting "
+        f"it from NAMED_PLATFORM_SENSITIVE: "
+        f"{NAMED_PLATFORM_SENSITIVE - still_present}")
+    invariant = _invariant_census.invariant_files()
+    assert not (NAMED_PLATFORM_SENSITIVE & invariant), (
+        "a file #2360 explicitly named as platform-sensitive despite "
+        "walking the tree is about to be deselected on 11 of 12 CI legs: "
+        f"{NAMED_PLATFORM_SENSITIVE & invariant}")
+
+
+def test_a_known_invariant_file_is_still_classified_that_way():
+    """The positive half, paired with the test above: a file this repo's own
+    heuristic marks `invariant` must still land there, or the "must not
+    fire" assertion above would be satisfied just as well by a census that
+    marks nothing invariant at all -- the silence this repo's own
+    negative-assertion rule exists to catch.
+    """
+    assert _KNOWN_INVARIANT_FILE in _invariant_census.invariant_files(), (
+        f"{_KNOWN_INVARIANT_FILE} was invariant when this test was written; "
+        "if the census logic changed, pick a new known-invariant example "
+        "rather than deleting this half of the pair")
+
+
+def test_invariant_marker_is_registered_in_pyproject():
+    """An unregistered marker is not fatal here (`addopts` carries no
+    `--strict-markers`), but leaving it unregistered means `pytest --markers`
+    cannot describe it and a future `--strict-markers` sweep of this file
+    would break on it silently later rather than declared here now.
+    """
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"invariant:' in text, (
+        "the invariant marker must be registered in pyproject.toml's "
+        "[tool.pytest.ini_options] markers list")
+
+
+def test_a_known_invariant_file_and_a_known_platform_sensitive_file_are_marked_apart():
+    """End-to-end, not just unit-level: run pytest's own collector over one
+    file from each side and check `pytest.mark.invariant` landed on exactly
+    the one the census says it should. This is the test that would have
+    stayed green if `tests/conftest.py` never wired the census into a
+    collection hook at all -- the population module alone proves nothing
+    about what pytest actually does with it.
+    """
+    platform_sensitive_file = "test_symlink_capability_1143.py"
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "-m", "invariant",
+         "--no-cov", "-p", "no:cacheprovider",
+         str(TESTS / _KNOWN_INVARIANT_FILE),
+         str(TESTS / platform_sensitive_file)],
+        cwd=str(ROOT), capture_output=True, text=True, timeout=60,
+        encoding="utf-8", errors="replace",
+    )
+    out = proc.stdout + proc.stderr
+    assert _KNOWN_INVARIANT_FILE in out, (
+        f"collecting with -m invariant found nothing from "
+        f"{_KNOWN_INVARIANT_FILE}, which the census marks invariant:\n{out}")
+    assert platform_sensitive_file not in out, (
+        f"collecting with -m invariant picked up {platform_sensitive_file}, "
+        f"one of the three files #2360 named as platform-sensitive:\n{out}")

--- a/tests/test_invariant_marker_census_2360.py
+++ b/tests/test_invariant_marker_census_2360.py
@@ -36,6 +36,7 @@ the other half of what `claude-oss` gained.
 """
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -132,3 +133,50 @@ def test_a_known_invariant_file_and_a_known_platform_sensitive_file_are_marked_a
     assert platform_sensitive_file not in out, (
         f"collecting with -m invariant picked up {platform_sensitive_file}, "
         f"one of the three files #2360 named as platform-sensitive:\n{out}")
+
+
+def test_the_collection_hook_tolerates_a_synthetic_tree_missing_the_census(tmp_path):
+    """The exact shape `test_git_env_leak_416.py` and `test_git_state_guard.py`
+    already use: a synthetic, minimal repo tree that copies only
+    `tests/conftest.py` -- not the rest of `tests/`, so `_invariant_census.py`
+    is absent -- to test something unrelated in isolation. Before the
+    conftest.py fix, `pytest_collection_modifyitems`'s unconditional `from
+    _invariant_census import invariant_files` raised `ModuleNotFoundError`
+    inside that subprocess and aborted its entire collection with an
+    `INTERNALERROR`, failing five unrelated assertions in those two files
+    about a synthetic run that never actually happened.
+    """
+    project = tmp_path / "synthetic"
+    inner_tests = project / "tests"
+    inner_tests.mkdir(parents=True)
+    target = project / "supertool.py"
+    try:
+        target.symlink_to(ROOT / "supertool.py")
+    except OSError:
+        shutil.copy(ROOT / "supertool.py", target)
+    shutil.copy(TESTS / "conftest.py", inner_tests / "conftest.py")
+    (inner_tests / "test_inner.py").write_text(
+        "def test_trivially_true():\n    assert True\n", encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests/test_inner.py", "-q",
+         "--no-cov", "-p", "no:cacheprovider"],
+        cwd=str(project), capture_output=True, text=True, timeout=30,
+        encoding="utf-8", errors="replace",
+    )
+    out = proc.stdout + proc.stderr
+    assert "INTERNALERROR" not in out, (
+        f"the collection hook crashed a synthetic tree missing "
+        f"_invariant_census.py instead of degrading to 'mark nothing':\n{out}")
+    assert proc.returncode == 0 and "1 passed" in out, (
+        f"synthetic tree's own trivial test did not pass cleanly:\n{out}")
+
+
+def test_normal_collection_still_applies_the_marker_when_the_census_is_importable():
+    """The other half of the same pair (#2360's own negative-assertion rule):
+    the try/except added for the synthetic-tree case above must not silently
+    swallow a real failure to apply the marker in the normal case, where
+    `_invariant_census` genuinely is importable. Re-runs the existing
+    end-to-end check to confirm the tolerant hook still marks a known file.
+    """
+    test_a_known_invariant_file_and_a_known_platform_sensitive_file_are_marked_apart()

--- a/tests/test_invariant_marker_census_2360.py
+++ b/tests/test_invariant_marker_census_2360.py
@@ -6,18 +6,33 @@ platform-sensitive.
 
 Measured population, from `tests/_invariant_census.py` (recomputed here, not
 copied, so a change to the census logic and a change to this pin cannot
-silently drift apart): 92 tree-walking test files, 59 of them invariant by
-the heuristic and 33 excluded as platform-sensitive, out of 1061 test files
-total on the commit this was written against -- 5.6% of the suite's files.
+silently drift apart): 92 tree-walking test files, 58 of them invariant by
+the heuristic and 34 excluded as platform-sensitive, out of 1062 test files
+total in this directory once this file itself exists -- 5.5% of the suite's
+files. (An earlier count of 1061/59 total/invariant, quoted in this PR's own
+commit message, was taken one commit before both this file and the
+`os.pathsep` self-review fix below existed; a total counted from `tests/`
+by a file that is itself a new addition to `tests/` is stale from the
+instant it lands, and there is no fixed number to write here that survives
+its own existence -- `_invariant_census.population()` is the number to
+trust, always, never this docstring.)
+
+Self-review found one gap in the heuristic before this landed:
+`test_watch_sources_path_2135.py` walks the tree and was originally
+classified invariant, despite its own docstring naming the exact defect it
+guards -- a hardcoded `':'` splitting a Windows drive letter -- because
+`_PLATFORM_SIGNAL` had no `os.pathsep` token. Fixed by adding one; this is
+why the population is 58 rather than 59.
+
 Timed locally (not on CI, and not a claim about CI's own wall clock): running
-only the 59-file invariant population under `-n 4 --dist loadfile` (matching
-the pytest job's `--dist loadfile`, at a worker count close to a hosted
-ubuntu runner) is 1052 passed, 3 skipped in 45.44s wall, ~115.8s of summed
-per-test duration -- against the 339.84s leg wall this issue's own tail
-sample was measured against, that is a meaningfully larger slice than the
-top-25 tail's own ~35s estimate, and above the 3% floor #2360 says would
-justify closing without a deselect. Worth pursuing, not a halving: `--no-cov`
-already took the other half of what `claude-oss` gained.
+only the invariant population under `-n 4 --dist loadfile` (matching the
+pytest job's `--dist loadfile`, at a worker count close to a hosted ubuntu
+runner) is 1022 passed, 3 skipped in 31.20s wall, ~75.2s of summed per-test
+duration -- against the 339.84s leg wall this issue's own tail sample was
+measured against, that is a meaningfully larger slice than the top-25 tail's
+own ~35s estimate, and above the 3% floor #2360 says would justify closing
+without a deselect. Worth pursuing, not a halving: `--no-cov` already took
+the other half of what `claude-oss` gained.
 """
 from __future__ import annotations
 

--- a/tests/test_slow_marker_ci_exclusion_891.py
+++ b/tests/test_slow_marker_ci_exclusion_891.py
@@ -30,9 +30,13 @@ file pins that it stays that way until someone touches it on purpose.
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
 import subprocess
 import sys
+
+import pytest
 
 from _workflow_parse import REPO, job_blocks, job_steps, matrix_os, run_blocks
 
@@ -102,19 +106,95 @@ def test_the_ssrf_network_failure_test_is_deliberately_not_marked_slow() -> None
         "test to say so instead of deleting it.")
 
 
-def test_ci_pytest_job_excludes_slow_and_benchmark() -> None:
+def _run_tests_step():
     blocks = job_blocks()
     steps = job_steps(blocks["pytest"])
-    runs = run_blocks(steps)
-    exprs = [expr for run in runs for expr in _dash_m_exprs(run)]
-    assert exprs, "no quoted `-m` expression found in the pytest job's run steps"
-    assert any("not slow" in expr and "not benchmark" in expr for expr in exprs), (
-        f"pytest job's `-m` expressions are {exprs!r}, none of which exclude "
-        "both slow and benchmark. #891's scope change means CI must exclude "
-        "`slow` the same way the local default does — leaving it in the CI "
-        "`-m` override runs these tests on every one of the twelve legs, on "
-        "every push, which is the exact cost the marker was supposed to "
-        "remove.")
+    for step in steps:
+        if step.name.startswith("Run tests"):
+            return step
+    raise AssertionError(
+        "no step named 'Run tests...' found in the pytest job -- #891's own "
+        "step was renamed or removed")
+
+
+def _resolved_marker(matrix_os_value: str, matrix_py_value: str) -> str:
+    """The real `-m` value CI hands to pytest, for one matrix combination.
+
+    #2360 replaced the previous static `-m 'not slow and not benchmark'`
+    with a script-level bash variable (built from `$MATRIX_OS`/`$MATRIX_PY`,
+    to add `and not invariant` on every leg but one), so the quoted-string
+    text search this file used to run (`_dash_m_exprs` against `-m
+    "$MARKER"`) now finds the literal text `$MARKER` — a variable reference,
+    never a marker expression — and reports that as "no exclusion", which is
+    false. #731's own lesson (a comment satisfying a text search meant for
+    behaviour) applies to a shell variable exactly as it applies to a
+    comment: the fix is to run the actual script and read what it computes,
+    not to keep grepping the YAML text for a shape the diff moved.
+
+    This executes the run step's own shell script (with its final `python
+    ... pytest ...` line replaced by an `echo` of the variable it would have
+    passed to `-m`) under the real bash CI uses for this step
+    (`shell: bash` on the step itself), with `MATRIX_OS`/`MATRIX_PY` set the
+    way GitHub Actions' `env:` block would set them for the given matrix
+    entry. This is the shape CI actually runs, not a decoy of it.
+    """
+    step = _run_tests_step()
+    lines = step.run.rstrip("\n").splitlines()
+    assert lines and "pytest" in lines[-1], (
+        f"expected the 'Run tests' step's last line to invoke pytest, so it "
+        f"could be replaced with an echo of the resolved marker; got: "
+        f"{lines[-1]!r}. If the step's shape changed, update this helper to "
+        f"match the new last line.")
+    script = "\n".join(lines[:-1] + ['echo "$MARKER"'])
+    result = subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO, capture_output=True, text=True, timeout=15,
+        encoding="utf-8", errors="replace",
+        env={**os.environ, "MATRIX_OS": matrix_os_value, "MATRIX_PY": matrix_py_value},
+    )
+    assert result.returncode == 0, (
+        f"resolving the 'Run tests' step's own $MARKER computation failed "
+        f"(rc={result.returncode}): {result.stderr}")
+    return result.stdout.strip()
+
+
+# The one designated full leg (#2360) and a representative non-full leg. Not
+# every combination -- the step's own `if` is a single condition on two
+# variables, so two points either side of it cover both branches.
+_FULL_LEG = ("ubuntu-latest", "3.12")
+_NON_FULL_LEG = ("windows-latest", "3.9")
+
+
+@pytest.mark.skipif(shutil.which("bash") is None,
+                     reason="bash not on PATH -- cannot resolve the run "
+                            "step's own shell logic here (CI runs this step "
+                            "with `shell: bash` and has one)")
+def test_ci_pytest_job_excludes_slow_and_benchmark() -> None:
+    for matrix_os_value, matrix_py_value in (_FULL_LEG, _NON_FULL_LEG):
+        expr = _resolved_marker(matrix_os_value, matrix_py_value)
+        assert "not slow" in expr and "not benchmark" in expr, (
+            f"resolved -m expression for ({matrix_os_value}, "
+            f"{matrix_py_value}) is {expr!r}, which does not exclude both "
+            "slow and benchmark. #891's scope change means CI must exclude "
+            "`slow` the same way the local default does — leaving it in "
+            "runs these tests on every push, which is the exact cost the "
+            "marker was supposed to remove.")
+
+
+@pytest.mark.skipif(shutil.which("bash") is None,
+                     reason="bash not on PATH -- cannot resolve the run "
+                            "step's own shell logic here")
+def test_ci_pytest_job_deselects_invariant_everywhere_except_the_full_leg() -> None:
+    """#2360's own claim, checked the same way: `invariant` is excluded on
+    every leg but the designated full one, never on all twelve and never on
+    none — the two failure modes #2360's own commit message names.
+    """
+    full = _resolved_marker(*_FULL_LEG)
+    other = _resolved_marker(*_NON_FULL_LEG)
+    assert "invariant" not in full, (
+        f"the full leg {_FULL_LEG} unexpectedly excludes invariant: {full!r}")
+    assert "not invariant" in other, (
+        f"a non-full leg {_NON_FULL_LEG} does not exclude invariant: {other!r}")
 
 
 def test_ci_pytest_job_reports_durations() -> None:

--- a/tests/test_slow_marker_ci_exclusion_891.py
+++ b/tests/test_slow_marker_ci_exclusion_891.py
@@ -35,7 +35,6 @@ import re
 import shutil
 import subprocess
 import sys
-from typing import List, Optional, Sequence
 
 import pytest
 

--- a/tests/test_slow_marker_ci_exclusion_891.py
+++ b/tests/test_slow_marker_ci_exclusion_891.py
@@ -35,10 +35,16 @@ import re
 import shutil
 import subprocess
 import sys
+from typing import List, Optional, Sequence
 
 import pytest
 
 from _workflow_parse import REPO, job_blocks, job_steps, matrix_os, run_blocks
+
+#: What a bash that actually runs a script prints when asked to.
+_BASH_PROBE = "supertool-891-bash-ok"
+
+_BS = chr(92)
 
 SLOW_WORKFLOW = REPO / ".github" / "workflows" / "slow-tests.yml"
 
@@ -117,6 +123,67 @@ def _run_tests_step():
         "step was renamed or removed")
 
 
+def _bash_candidates():
+    """Where a bash that actually runs scripts might be, most likely first.
+
+    Mirrors `test_guard_interpreter_ladder_1390.py`'s `_bash_candidates` --
+    the same repo already has this exact defect class pinned once, for a
+    different caller (`hooks/pre-bash-guard.sh`'s own subprocess spawn).
+    `windows-latest` carries two files named `bash`: Git for Windows' real
+    shell, and `C:\\Windows\\System32\\bash.exe`, which is the
+    WSL launcher stub. On a runner with no distribution installed (the
+    normal state on hosted runners) the stub exits 1 and writes a UTF-16LE
+    message about installing WSL -- it never opens the script it was
+    handed. `shutil.which` answers "a file named bash is on PATH", which
+    the stub satisfies exactly as well as a real shell, so it is not
+    enough on its own; see `_first_bash_that_runs_a_script` below, which
+    is the actual gate.
+    """
+    git_bin = "C:" + _BS + "Program Files" + _BS + "Git" + _BS
+    git_bin_x86 = "C:" + _BS + "Program Files (x86)" + _BS + "Git" + _BS
+    # `shutil.which("bash")` first, matching `test_guard_interpreter_ladder_1390.py`'s
+    # own candidate order exactly -- NOT `os.environ.get("SHELL")`, which is
+    # the caller's *login* shell (zsh, fish, ...) and would pass the probe
+    # below just as readily as bash does, since the probe only asks "does
+    # `-c 'printf ...'` work", which every POSIX-ish shell answers. That is
+    # not the question this ladder exists to ask; it exists to reject a
+    # non-functional stub, not to prefer bash over another real shell, but
+    # matching the repo's own already-evidenced candidate order removes the
+    # need to reason about a second one.
+    return [shutil.which("bash"),
+            git_bin + "bin" + _BS + "bash.exe",
+            git_bin_x86 + "bin" + _BS + "bash.exe",
+            "/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"]
+
+
+def _first_bash_that_runs_a_script(candidates):
+    """A bash proved by what it does, not by what it is named.
+
+    `subprocess.run(["bash", ...])` on Windows re-searches PATH through
+    CreateProcess, which need not agree with any prior `shutil.which`
+    call -- so probing one executable and then spawning the bare name
+    `"bash"` again proves nothing about the one that actually ran. Each
+    candidate here is both probed and, if it survives, the exact path
+    later executed.
+    """
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            proc = subprocess.run(
+                [candidate, "-c", "printf %s " + _BASH_PROBE],
+                capture_output=True, text=True, encoding="utf-8",
+                errors="replace", timeout=15)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if proc.returncode == 0 and proc.stdout.strip() == _BASH_PROBE:
+            return candidate
+    return None
+
+
+_BASH = _first_bash_that_runs_a_script(_bash_candidates())
+
+
 def _resolved_marker(matrix_os_value: str, matrix_py_value: str) -> str:
     """The real `-m` value CI hands to pytest, for one matrix combination.
 
@@ -124,33 +191,35 @@ def _resolved_marker(matrix_os_value: str, matrix_py_value: str) -> str:
     with a script-level bash variable (built from `$MATRIX_OS`/`$MATRIX_PY`,
     to add `and not invariant` on every leg but one), so the quoted-string
     text search this file used to run (`_dash_m_exprs` against `-m
-    "$MARKER"`) now finds the literal text `$MARKER` — a variable reference,
-    never a marker expression — and reports that as "no exclusion", which is
-    false. #731's own lesson (a comment satisfying a text search meant for
-    behaviour) applies to a shell variable exactly as it applies to a
-    comment: the fix is to run the actual script and read what it computes,
-    not to keep grepping the YAML text for a shape the diff moved.
+    "$MARKER"`) now finds the literal text `$MARKER` -- a variable
+    reference, never a marker expression -- and reports that as "no
+    exclusion", which is false. #731's own lesson (a comment satisfying a
+    text search meant for behaviour) applies to a shell variable exactly
+    as it applies to a comment: the fix is to run the actual script and
+    read what it computes, not to keep grepping the YAML text for a shape
+    the diff moved.
 
-    This executes the run step's own shell script (with its final `python
-    ... pytest ...` line replaced by an `echo` of the variable it would have
-    passed to `-m`) under the real bash CI uses for this step
-    (`shell: bash` on the step itself), with `MATRIX_OS`/`MATRIX_PY` set the
-    way GitHub Actions' `env:` block would set them for the given matrix
-    entry. This is the shape CI actually runs, not a decoy of it.
+    This executes the run step's own shell script (with its final
+    `python ... pytest ...` line replaced by an `echo` of the variable it
+    would have passed to `-m`) under the proved-real bash from `_BASH`,
+    with `MATRIX_OS`/`MATRIX_PY` set the way GitHub Actions' `env:` block
+    would set them for the given matrix entry. This is the shape CI
+    actually runs, not a decoy of it.
     """
     step = _run_tests_step()
     lines = step.run.rstrip("\n").splitlines()
     assert lines and "pytest" in lines[-1], (
-        f"expected the 'Run tests' step's last line to invoke pytest, so it "
-        f"could be replaced with an echo of the resolved marker; got: "
-        f"{lines[-1]!r}. If the step's shape changed, update this helper to "
-        f"match the new last line.")
+        f"expected the 'Run tests' step's last line to invoke pytest, so "
+        f"it could be replaced with an echo of the resolved marker; got: "
+        f"{lines[-1]!r}. If the step's shape changed, update this helper "
+        f"to match the new last line.")
     script = "\n".join(lines[:-1] + ['echo "$MARKER"'])
     result = subprocess.run(
-        ["bash", "-c", script],
+        [_BASH, "-c", script],
         cwd=REPO, capture_output=True, text=True, timeout=15,
         encoding="utf-8", errors="replace",
-        env={**os.environ, "MATRIX_OS": matrix_os_value, "MATRIX_PY": matrix_py_value},
+        env={**os.environ, "MATRIX_OS": matrix_os_value,
+             "MATRIX_PY": matrix_py_value},
     )
     assert result.returncode == 0, (
         f"resolving the 'Run tests' step's own $MARKER computation failed "
@@ -158,36 +227,39 @@ def _resolved_marker(matrix_os_value: str, matrix_py_value: str) -> str:
     return result.stdout.strip()
 
 
-# The one designated full leg (#2360) and a representative non-full leg. Not
-# every combination -- the step's own `if` is a single condition on two
-# variables, so two points either side of it cover both branches.
+# The one designated full leg (#2360) and a representative non-full leg.
+# Not every combination -- the step's own `if` is a single condition on
+# two variables, so two points either side of it cover both branches.
 _FULL_LEG = ("ubuntu-latest", "3.12")
 _NON_FULL_LEG = ("windows-latest", "3.9")
 
+_NO_REAL_BASH_REASON = (
+    "no bash on this host actually runs a script -- `shutil.which(" + chr(39) + "bash" + chr(39) + ")` "
+    "answers " + chr(39) + "a file named bash is on PATH" + chr(39) + ", which on "
+    "windows-latest is satisfied by the WSL launcher stub at "
+    "C:\\Windows\\System32\\bash.exe as readily as by Git Bash; this "
+    "host has neither a real bash nor Git for Windows at either "
+    "well-known install path")
 
-@pytest.mark.skipif(shutil.which("bash") is None,
-                     reason="bash not on PATH -- cannot resolve the run "
-                            "step's own shell logic here (CI runs this step "
-                            "with `shell: bash` and has one)")
+
+@pytest.mark.skipif(_BASH is None, reason=_NO_REAL_BASH_REASON)
 def test_ci_pytest_job_excludes_slow_and_benchmark() -> None:
     for matrix_os_value, matrix_py_value in (_FULL_LEG, _NON_FULL_LEG):
         expr = _resolved_marker(matrix_os_value, matrix_py_value)
         assert "not slow" in expr and "not benchmark" in expr, (
             f"resolved -m expression for ({matrix_os_value}, "
             f"{matrix_py_value}) is {expr!r}, which does not exclude both "
-            "slow and benchmark. #891's scope change means CI must exclude "
-            "`slow` the same way the local default does — leaving it in "
-            "runs these tests on every push, which is the exact cost the "
-            "marker was supposed to remove.")
+            "slow and benchmark. #891's scope change means CI must "
+            "exclude `slow` the same way the local default does -- "
+            "leaving it in runs these tests on every push, which is the "
+            "exact cost the marker was supposed to remove.")
 
 
-@pytest.mark.skipif(shutil.which("bash") is None,
-                     reason="bash not on PATH -- cannot resolve the run "
-                            "step's own shell logic here")
+@pytest.mark.skipif(_BASH is None, reason=_NO_REAL_BASH_REASON)
 def test_ci_pytest_job_deselects_invariant_everywhere_except_the_full_leg() -> None:
     """#2360's own claim, checked the same way: `invariant` is excluded on
-    every leg but the designated full one, never on all twelve and never on
-    none — the two failure modes #2360's own commit message names.
+    every leg but the designated full one, never on all twelve and never
+    on none -- the two failure modes #2360's own commit message names.
     """
     full = _resolved_marker(*_FULL_LEG)
     other = _resolved_marker(*_NON_FULL_LEG)
@@ -206,6 +278,32 @@ def test_ci_pytest_job_reports_durations() -> None:
         "has identified which tests are actually slow on Windows, and "
         "without this flag a stalled-looking leg has nothing in the log to "
         "say which test is running.")
+
+
+def test_the_bash_candidate_ladder_rejects_a_non_functional_stub(monkeypatch) -> None:
+    """Positive control for `_first_bash_that_runs_a_script`: a candidate
+    that exits non-zero and prints nothing useful (the shape a WSL-launcher
+    stub takes, minus the UTF-16 encoding, which is orthogonal to what
+    this function checks) must be rejected rather than accepted, and the
+    ladder must still find a REAL bash behind it. Paired with the "must
+    fire" case above (an actually-working bash IS accepted), so neither
+    assertion could pass on a broken harness that accepts everything, or
+    one that rejects everything.
+    """
+    if _BASH is None:
+        pytest.skip(_NO_REAL_BASH_REASON)
+    real_run = subprocess.run
+
+    def fake_first_candidate_is_a_stub(args, **kwargs):
+        if args[0] == "not-a-real-shell-stub":
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="stub message")
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake_first_candidate_is_a_stub)
+    chosen = _first_bash_that_runs_a_script(["not-a-real-shell-stub", _BASH])
+    assert chosen == _BASH, (
+        f"the ladder did not skip past a stub that exits non-zero and "
+        f"land on the real bash behind it: chose {chosen!r}")
 
 
 def test_a_scheduled_slow_workflow_exists() -> None:

--- a/tests/test_symlink_gating_register_1232.py
+++ b/tests/test_symlink_gating_register_1232.py
@@ -259,6 +259,7 @@ REGISTER = {
     'tests/test_git_timeout_disclosure_650.py::_git_only_path': P,
     'tests/test_glob_containment_1366.py::test_a_wildcard_landing_on_an_outward_symlink_refuses_the_whole_call': B,
     'tests/test_guard_envelope_serialisation_1613.py::_toolbox': P,
+    'tests/test_invariant_marker_census_2360.py::test_the_collection_hook_tolerates_a_synthetic_tree_missing_the_census': E,
     'tests/test_mcp_daemon_dirfd_598.py::TestAFailedLogOpenDoesNotOrphanTheServer.test_a_squatted_stderr_symlink_does_not_leave_the_subprocess_running': P,
     'tests/test_mcp_runtime_dir_nofollow_583.py::TestASymlinkedRuntimeDirStillWorks.test_a_symlink_to_a_missing_dir_is_refused_with_a_sentence': P,
     'tests/test_mcp_runtime_dir_nofollow_583.py::linked': B,

--- a/trap.d/2360.lint-new-not-reproducible-with-bare-ruff-check.md
+++ b/trap.d/2360.lint-new-not-reproducible-with-bare-ruff-check.md
@@ -1,0 +1,48 @@
+Issue #2360 (fix/2360, PR #2368): `ruff check <file>` said clean, CI's
+`lint-new` job said `finding` on the same file, twice in one lane's own CI
+round-trips (and this was the third lint-class round on this pair of
+sibling lanes overall -- F541 hit #898 first).
+
+What happened: `pyproject.toml`'s `[tool.ruff.lint] ignore` list turns off
+F401/F841/F541 repo-wide, deliberately, because 263 pre-existing occurrences
+across ~120 files make a bare `ruff check .` red on master today. A bare
+`ruff check tests/test_slow_marker_ci_exclusion_891.py` therefore reported
+"All checks passed!" on a file that genuinely had three fresh unused
+`typing` imports (`List`, `Optional`, `Sequence`, left behind when a
+file-splice edit dropped the string-quoted annotations that had used them).
+I read the clean local result as "lint is fine" and pushed past it twice.
+
+The actual gate CI runs is `.github/scripts/lint_new_files.py`, a separate
+`lint-new` job that deliberately RE-ENABLES F401/F841/F541 for exactly the
+scope a bare `ruff check` cannot see correctly either way: a path the PR
+*adds* is checked whole (no history, so nothing is "pre-existing"), and a
+path the PR *modifies* is checked only against findings introduced since its
+own merge-base revision (so the tree-wide ignore's rationale -- "don't make
+someone fix 263 old findings to land one line" -- still holds, but a FRESH
+finding in a touched file is no longer hidden inside that debt). Neither
+half of that is a bare `ruff check <path>` -- ignoring per-file config
+entirely misses the re-enable, and running it over the whole tree would
+re-surface the 263 and go permanently red.
+
+The actual local reproduction, confirmed to match CI exactly both before
+and after the fix:
+
+    python3 -X utf8 .github/scripts/lint_new_files.py --base origin/master
+
+Cost: two lint-only CI round-trips (a full `windows-latest` + `lint-new`
+matrix cycle each) that a 5-second local script run would have caught
+before either push.
+
+Not decided here whether this generalizes into a jit-context rule (e.g.
+"before committing anything under `tests/` or a shipped path, run
+`lint_new_files.py --base origin/<default_branch>`, not `ruff check`") --
+that is `/oss:curate`'s call, holding this fragment alongside whatever else
+the #898 F541 round produced from the same tick.
+
+Separately, per the maintainer's own question on this lane: this repo's
+`.githooks/pre-commit` is advisory-only (red flags / forbidden paths / new
+source without x-bit; "commit proceeds" unconditionally, by its own
+comment) and there is no `.githooks/pre-push` at all. Neither runs `ruff`
+or `lint_new_files.py` in any form, so nothing in this repo's own tooling
+would have caught this before CI did -- the gap is real, not a hook I
+missed.


### PR DESCRIPTION
claude-oss cut its CI runner time roughly in half with an `invariant` marker on tests whose answer cannot vary by OS or interpreter, deselected on 11 of its 12 legs and kept on one designated full leg. This repo already had the other half of that saving (`--no-cov` on all twelve legs); the population this marker applies to had never been counted here. Closes #2360.

## Census, derived rather than hand-listed

`tests/_invariant_census.py` walks every `tests/test_*.py` file's AST and classifies it two ways, kept deliberately separate: does it walk this repo's own tree (`.rglob(`/`.glob(`/`os.walk(`, or an import from `_repo_walk`), and does its source carry a platform-signal token (`sys.platform`, `os.name`, a symlink-privilege check, `shutil.which`, the literal `python3`, `os.pathsep`, etc.)?

Measured on the commit this lands: 92 of 1062 test files walk the tree, 58 of them invariant and 34 excluded because their assertions are about platform behaviour even though the walk feeding them is not -- including the three files the issue named explicitly (`test_symlink_capability_1143.py`, `test_git_shim_subcommand_1206.py`, `test_no_bare_python3_spawn.py`), pinned by a regression test so none of them can be silently swept into the marker later.

Locally timed (not a CI number): the invariant population is `1022 passed, 3 skipped in 31.20s` wall under `-n 4 --dist loadfile` -- a meaningfully larger slice of a leg's wall than the issue's own top-25 tail sample (~35s of a 339.84s leg), and above the 3% floor the issue itself says would justify closing without a deselect. Worth pursuing; not a halving, since `--no-cov` already took the other lever.

## The marker

Applied at collection time by a new `pytest_collection_modifyitems` hook in `tests/conftest.py`, reading the derived population -- never hand-listed, so a new tree-walking test file joins or is excluded without anyone remembering to add it. Registered in `pyproject.toml`. `.github/workflows/tests.yml`'s `Run tests` step builds a single `-m` marker expression via one script-level bash `if` reading `$MATRIX_OS`/`$MATRIX_PY`, not two independently-guarded steps or two ternaries on one step -- the shape the issue names as claude-oss's own first mistake on this exact feature, where two conditions both false silently produces a leg that runs no tests and reports green. The default arm here applies no exclusion, so that failure mode is structurally unreachable: the worst case if the env vars are ever wrong is every leg running the invariant population, never a leg running nothing.

## Self-review

Two agents (Explore, oss:auditor) reviewed the first committed diff independently. Both findings were real and both are fixed in the second commit:

- The docstring/commit-message count of "1061 test files total" was stale from the moment it landed, because the file stating it is itself a new file under the directory it counts. Reworded to state the corrected numbers and point at `_invariant_census.population()` as the number to trust.
- `_PLATFORM_SIGNAL` had no token for `os.pathsep`, so `tests/test_watch_sources_path_2135.py` -- whose own docstring names the exact Windows-drive-letter defect it guards -- was classified invariant and would have lost Windows-leg coverage. Added `os.pathsep|ntpath|PureWindowsPath` to the signal; population corrected from 59 to 58.

## Tests

Red: `2 failed, 2 passed` before the marker/hook/registration existed (marker unregistered; `-m invariant` selected 0 of 34 tests). Green: `4 passed` after, re-confirmed after the self-review fixes. Collection-only pass over the whole `tests/` directory confirms no import/collection errors anywhere in the suite from the new hook.

Not run: this repo's full `test_command` -- CI is the authority for the whole 12-leg matrix; the targeted timing runs above are a measurement the issue itself asked for, not a substitute for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKeLFSWdSpSTMasdJsPZSE

[AI-generated]


---

**Maintainer's own verification, before merge:** confirmed the census files (`tests/_invariant_census.py`, `tests/test_invariant_marker_census_2360.py`) are genuinely in this diff, not just the deselect (`git diff master...fix/2360 --stat` on both paths -- 116 and 182 lines added respectively). The load-bearing full leg -- the one that still runs every test, invariant or not -- is **`(ubuntu-latest, 3.12)`**, per `.github/workflows/tests.yml`'s own `if [ "$MATRIX_OS" != "ubuntu-latest" ] || [ "$MATRIX_PY" != "3.12" ]` gate; naming it here since the body above says "one designated full leg" without spelling out which, and a later reader diagnosing a gap the marker missed needs to know which leg to check first.