### PR TITLE
chore: take shared helpers out of lane-containment, acknowledge the coupling spans

### DIFF
--- a/.oss.json
+++ b/.oss.json
@@ -54,10 +54,7 @@
         ".github/scripts"
       ],
       "lane-containment": [
-        "hooks",
-        "presets/_untrusted.py",
-        "presets/_publish_safety.py",
-        "presets/_secrets.py"
+        "hooks"
       ],
       "lane-release": [
         "changelog.d",
@@ -68,7 +65,32 @@
         "presets/git",
         "presets/worktree"
       ]
-    }
+    },
+    "lane_coupling_allowlist": [
+      "tests/conftest.py",
+      "tests/test_around_line_hint_734.py",
+      "tests/test_changelog_fragment_write_receipt_1132.py",
+      "tests/test_ci_non_python_coverage_557.py",
+      "tests/test_empty_filter_value_974.py",
+      "tests/test_encoding_seam_scoped_check_2287.py",
+      "tests/test_forged_child_stream_line_1475.py",
+      "tests/test_gh_branch_missing_trigger_filter_1959.py",
+      "tests/test_gh_branch_undispatched_workflow_846.py",
+      "tests/test_gh_pr_thread_index_1445.py",
+      "tests/test_git_status_display_config_gates_1295.py",
+      "tests/test_git_timeout_defaults_agree_1903.py",
+      "tests/test_no_bare_python3_spawn.py",
+      "tests/test_normalised_refname_1038.py",
+      "tests/test_ops_roster_1231.py",
+      "tests/test_prs_mrs_unknown_token_939.py",
+      "tests/test_radar_gh_scope_1230.py",
+      "tests/test_radar_gl_mrs_unknown_token_961.py",
+      "tests/test_radar_scope_seam_1077.py",
+      "tests/test_radar_tier_unapplied_tokens_973.py",
+      "tests/test_render_sites_superseded_checks_1804.py",
+      "tests/test_repo_target_effective_slug_1701.py",
+      "tests/test_supertool_hint_register_905.py"
+    ]
   },
   "milestones": [
     "backlog"


### PR DESCRIPTION
Follow-on to #2445. Declaring `labels.lane_patterns` there turned `/oss:doctor`'s lane-coupling check from *cannot run* into a `WARN` naming 26 test files. I read all 26. They split three ways and only one is a finding about this repository.

## `lane-containment` was mapped wrong, by me

It listed `presets/_untrusted.py`, `_publish_safety.py` and `_secrets.py` beside `hooks/`. Those are shared helpers every preset may use -- `CLAUDE.md`'s Layout section says exactly that -- so putting them inside a lane made every test that exercises the untrusted boundary or secret redaction span lanes by construction. That was #2445's config generating its own findings, not a fact about the tests.

`lane-containment` is now `hooks/` alone. Drops `test_gh_pr_diff_separator_1081.py` and `test_glab_token_prefix_1645.py`; 26 spans become 24.

## `labels.lane_coupling_allowlist` -- 23 acknowledged, each read

**Four are not coupling at all.** A path used as test data, which a static path-string matcher cannot tell from an import:

| Test | The "reference" |
| --- | --- |
| `test_gh_pr_thread_index_1445.py` | `validators/common/pkg_paths.py` is a fake filename inside a mock review thread |
| `test_around_line_hint_734.py` | `CHANGELOG.md` is an argument to a hint test asserting `ERROR: file not found` |
| `test_changelog_fragment_write_receipt_1132.py` | `docs/validators.md` is the **negative control** -- the path that must *not* trigger the changelog validator |
| `test_encoding_seam_scoped_check_2287.py` | `.oss.json` is written into `tmp_path` as a fixture, not read from the tree |

**Eight sweep the tree by construction** (`rglob`/`glob`/`walk`) -- `conftest.py`, `test_forged_child_stream_line_1475.py`, `test_no_bare_python3_spawn.py`, `test_supertool_hint_register_905.py` and the rest. That is what a whole-repo guard is.

**The remainder is one architectural fact repeated.** `presets/watch/tiers/gh_prs.py` and `gl_mrs.py` wrap `presets/github/prs.py` and `presets/gitlab/mrs.py`; ten spans are that seam, and the tests say so themselves. `test_radar_scope_seam_1077.py`:

> `branch.scope_for` exists, in its own docstring's words, because "a caller that has to remember to compute this will not". `dashboard.py` remembered. `presets/watch/tiers/gh_prs.py` did not, and radar is the surface that reports master's health on every tick.

Those tests are the correct response to the seam, not evidence against it.

## One span deliberately left out

`tests/test_git_no_optional_locks_other_sites_1945.py` is **not** allowlisted. Its own first paragraph is the finding:

> both files define their own thin `_git()` wrapper rather than importing the shared one, so the fix has to land at each wrapper separately

`presets/dashboard/dashboard.py:609` and `presets/github/pr_merge.py:658` each carry a private `_git()`, so neither gets `_with_lock_retry`, the `_stop()` grace, or `git_timeout()`'s `SUPERTOOL_GIT_TIMEOUT` override. Filed as #2447. The `WARN` stays and now points at exactly that one thing, which is what the check is for.

## Verified

`lane_pattern_report` over this tree:

```
{"state": "ok", "overlaps": [], "dead_patterns": [], "refused": [], "malformed": []}
```

`lane_coupling_report` with the allowlist:

```
state: finding
unacknowledged spans:
  tests/test_git_no_optional_locks_other_sites_1945.py => lane-tracker-ops, lane-watch
acknowledged: 23
unreadable: [] malformed: []
```

`validate:.oss.json` -- `jsonlint` ok.

## One number I cannot explain

`uncovered_count` moved from 336 to 152 when the three helper patterns left `lane-containment`. I expected it to go up, not down. It gates nothing (`lane_pattern_coverage.py` says so outright) and I did not chase it, but I would rather record that I do not understand it than let the smaller number read as an improvement.

No test added: this is config, and both checkers that read it are the `oss` plugin's, not this repo's.


[AI-generated]