### PR TITLE
docs(jit): record the lane_patterns trap where editing .oss.json fires

### DIFF
--- a/.claude/jit-context/paths/00-manual/00-index.tsv
+++ b/.claude/jit-context/paths/00-manual/00-index.tsv
@@ -2,6 +2,7 @@ changelog.d/	changelog-d.md
 docs/	docs-index.md
 .github/workflows/	github-workflows.md
 .claude/jit-context/	jit-context.md
+(^|/)\.oss\.json$	oss-lane-patterns.md
 \.claude/jit-context/(paths|tools|vocabulary)/01-oss/	oss-owned-jit-layer.md
 presets/git/	presets-git.md
 presets/github/	presets-github.md

--- a/.claude/jit-context/paths/00-manual/oss-lane-patterns.md
+++ b/.claude/jit-context/paths/00-manual/oss-lane-patterns.md
@@ -1,0 +1,36 @@
+---
+title: "labels.lane_patterns: a shared helper in a lane invents its own findings"
+match: (^|/)\.oss\.json$
+---
+
+`labels.lane_patterns` maps a lane label to the paths it owns. Two checks in the `oss` plugin read
+it and **neither can run until it is declared** -- `lane_pattern_coverage` (overlap, dead globs) and
+`lane_coupling` (tests spanning lanes). Undeclared is the third state, not a pass.
+
+**Never put `presets/_*.py` in a lane.** They are shared helpers every preset may use (`CLAUDE.md`,
+Layout). A lane that claims one makes every test exercising that helper span lanes *by
+construction*, and the coupling check then reports a defect the config invented. Measured
+2026-09-08: `_untrusted.py`, `_publish_safety.py` and `_secrets.py` in `lane-containment` produced
+3 of 26 spans; removing them dropped 2 outright and took the count to 24 (#2448). `lane-containment`
+is `hooks/` and nothing else.
+
+**The coupling check matches path strings statically**, so it cannot tell an import from a filename
+used as data. Four of this repo's spans were a fake path inside a mock review thread, an argument to
+a `file not found` assertion, a fixture written into `tmp_path`, and a **negative control** -- the
+path that must *not* trigger a validator. All four are `labels.lane_coupling_allowlist` material.
+
+**Ten more were one architectural fact**: `presets/watch/tiers/{gh_prs,gl_mrs}.py` wrap
+`presets/{github/prs,gitlab/mrs}.py`. That seam is what radar *is*, and those tests are the correct
+response to it.
+
+**Allowlist what you read, not what is noisy.** The one span left unacknowledged here is
+`test_git_no_optional_locks_other_sites_1945.py` -- `dashboard.py` and `pr_merge.py` each carry a
+private `_git()` instead of the shared chokepoint (#2447). A `WARN` naming one real thing is worth
+more than a clean run.
+
+Run either by hand while editing, with the plugin's `scripts/` on `PYTHONPATH`:
+`lane_pattern_coverage.lane_pattern_report(repo, patterns)` and
+`lane_coupling.lane_coupling_report(repo, patterns, allowlist=...)`.
+
+`uncovered_count` gates nothing and is not a score. It moved 336 -> 152 on a change that should have
+raised it; unexplained, and recorded here so a lower number is not read as an improvement.


### PR DESCRIPTION
Third and last of the `/oss:doctor` sweep, after #2445 and #2448. Those two cost a mistake and its undo; this is the note so the next person does not pay for it again.

## What went wrong, and why a note is the fix

#2445 declared `labels.lane_patterns` and mapped `presets/_untrusted.py`, `_publish_safety.py` and `_secrets.py` into `lane-containment`. Those are shared helpers every preset may use -- `CLAUDE.md`'s Layout section says so -- so claiming them for a lane made every test exercising the untrusted boundary or secret redaction span lanes **by construction**, and the coupling check reported defects the config had invented. #2448 undid it.

Nothing on disk would have stopped that, and nothing would stop it recurring. The rule fires on the same `.oss.json` pattern the scaffold-owned `oss-config` rule already uses, so it arrives when somebody opens the file the mistake lives in -- not in a document read at a moment when it does not apply.

## What it carries

Only what the two runs actually measured:

- **Never map `presets/_*.py` into a lane.** With the number: three helpers in `lane-containment` produced 3 of 26 spans, and removing them dropped 2 outright.
- **The coupling check matches path strings statically**, so it cannot tell an import from a filename used as test data. Four of this repo's spans were exactly that, and one of them was a **negative control** -- the path that must *not* trigger a validator.
- **Ten more were one seam**: `presets/watch/tiers/{gh_prs,gl_mrs}.py` wrapping `presets/{github/prs,gitlab/mrs}.py`.
- **Allowlist what you read, not what is noisy** -- which is why `test_git_no_optional_locks_other_sites_1945.py` is deliberately still warning (#2447). A `WARN` naming one real thing beats a clean run.
- **`uncovered_count` gates nothing and is not a score.** It moved 336 -> 152 on a change that should have raised it. I could not explain that and said so in #2448; recording it here is so a smaller number is not read later as an improvement.

2,228 bytes, a `paths/` body, paid once per session on a match.

## Two mechanical notes

`00-index.tsv` is regenerated with `claude-jit-context` 0.8.0's own `rebuild-tsv.sh`, never hand-typed -- every column there is derived from the entry's frontmatter and a hand-written one is deleted by the next run.

That run also rewrote `.claude/jit-context/vocabulary/01-oss/00-index.tsv` into the 3-column shape and left an empty `01-paths.tsv` beside it. **Both were reverted.** That layer is `/oss:scaffold`-owned and replaced wholesale, `tests/test_jit_vocabulary_index_three_columns_2211.py` deliberately leaves it unpinned for that reason, and this pull request is one rule.

## Verified

- `validate` on both files: `jit-index` ok on the index, `markdownlint` ok on the entry.
- `pytest tests/test_jit_index_round_trips_1579.py tests/test_jit_paths_rules_declare_no_mode_1442.py tests/test_jit_rule_body_budget_1433.py tests/test_jit_vocabulary_index_three_columns_2211.py` -- **21 passed**.
- **The round-trip guard was shown red first.** Appending one hand-typed row to the index gives `1 failed, 3 passed`; restoring the derived file gives `4 passed`. A guard nobody has seen fail is not evidence.

## What I could not verify

**That the rule actually fires.** A paths hook reads `$CLAUDE_PROJECT_DIR/.claude/jit-context/`, which points at the main clone, not at this worktree -- so no call from the session that wrote it can trigger the branch's own copy. What I have instead is a positive control I already observed: the scaffold-owned `oss-config.md` uses the identical `match`, and it fired in this session every time `.oss.json` was edited. Same pattern, same matcher, same dimension. That is reasoned, not observed, and the observation is one session restart away after merge.


[AI-generated]