### PR TITLE
trap.d: 5 findings from the v0.59.0 release audit, round 1

### DIFF
--- a/trap.d/2433.walkup-loaders-do-not-catch-the-same-exceptions.md
+++ b/trap.d/2433.walkup-loaders-do-not-catch-the-same-exceptions.md
@@ -1,0 +1,36 @@
+Five walk-up `.supertool.json` loaders each catch a different exception set, and nothing pins that
+they agree.
+
+`presets/_publish_safety.py:146-148` was rewritten by #2366 (commit 4940259e) to catch
+`UnicodeDecodeError` by name, with a comment stating the trap in as many words: it is a `ValueError`,
+not an `OSError`, so it is not folded into the tuple by inheritance. Commit 35d4ece3 (#2433) then
+rewrote the same `except` clause in a sibling loader to improve its malformed-config diagnostics and
+did not apply the rule.
+
+Measured by the v0.59.0 release audit, round 1:
+
+```
+ESCAPED the slack loader tuple -> UnicodeDecodeError | 'utf-8' codec can't decode byte 0xff in position 7
+CAUGHT by the publish_safety tuple: UnicodeDecodeError
+```
+
+A non-UTF-8 byte anywhere on the walk-up path crashes the slack op with a traceback instead of the
+`{}` fallback its own docstring (`presets/slack/_authorization.py:100-113`) promises. The loader
+walks from cwd, so it is reachable.
+
+State of the class at v0.58.0..HEAD, swept rather than sampled:
+
+| loader | catches UnicodeDecodeError |
+| --- | --- |
+| `presets/_publish_safety.py` | yes |
+| `presets/_mirror.py` | yes |
+| `presets/gitlab/_maintenance.py` | yes |
+| `presets/slack/_authorization.py:125` | **no** |
+| `presets/worktree/_common.py:274`, `:442` | **no** |
+
+The last two are outside the delta and are named so a fix lands on the class rather than the
+instance the audit happened to walk.
+
+What is missing is not the fix, it is the guard: nothing asserts that all five catch the same set,
+which is why one change could fix two loaders and touch a third without closing it. A test over the
+five call sites is the thing that stops this recurring.

--- a/trap.d/2484.a-swallowed-chmod-leaves-a-credential-unprotected-silently.md
+++ b/trap.d/2484.a-swallowed-chmod-leaves-a-credential-unprotected-silently.md
@@ -1,0 +1,14 @@
+`os.chmod(SESSION_FILE, 0o600)` inside `except OSError: pass`
+(`presets/watch/sources/bluesky-engagement/poller.py:206-209`).
+
+A chmod that cannot run leaves the JWT cache at whatever mode its creation gave it, and nothing on
+any channel says so. The poller never reports that the credential file it just wrote is
+unprotected.
+
+Settled by reading the join rather than reasoning about it: `_save_session` returns `None`
+unconditionally, so no caller has a return value to read. There is no surface where this could
+surface.
+
+Found by the v0.59.0 release audit, round 1, ranked `misreports`. The adjacent world-readable
+window in the same function is a separate finding and is filed as #2484 -- that one is `unranked`
+and routes to an issue, this one has a row and routes here.

--- a/trap.d/2484.claude-md-write-class-op-list-is-short-by-two.md
+++ b/trap.d/2484.claude-md-write-class-op-list-is-short-by-two.md
@@ -1,0 +1,19 @@
+`CLAUDE.md:61` enumerates the write-class ops in a parenthetical that reads as exhaustive --
+`paste`, `edit`, `append`, `replace`, `replace_lines`, `vim`, `format`, `format_staged`, `gc`,
+`rename`, `batch`. Measured against `_OP_SAFETY_BUILTIN`, it is short by two: `init` and `json-set`.
+
+`init` was already missing at v0.58.0 (checked with `git show v0.58.0:_supertool.py`, the entry was
+at line 3224), so this is not new; `json-set` was added by the v0.58.0..HEAD delta.
+
+The code is right and only the note is wrong, which is the direction that costs least -- but the
+consequence is specific: a contributor reads that list and believes a `json-set` run from a
+worktree will not decline, when `_supertool.py:1644` branches on `_op_safety_class(op)` rather than
+on a name list and will decline it.
+
+Not fixed in place by the release session that found it: `CLAUDE.md` says no release session edits
+it unless editing it was the task. Found by the v0.59.0 release audit, round 1, ranked
+`misreports`.
+
+The durable fix is not a longer list. It is a list nobody maintains by hand -- either derive the
+parenthetical from `_OP_SAFETY_BUILTIN`, or drop the enumeration and point at `ops:roster`, which
+already answers it per-install.

--- a/trap.d/2484.two-writers-share-one-session-file-non-atomically.md
+++ b/trap.d/2484.two-writers-share-one-session-file-non-atomically.md
@@ -1,0 +1,15 @@
+`~/.config/bluesky/session.json` now has two independent writers:
+`presets/watch/sources/bluesky-engagement/poller.py:80` and `presets/bluesky/_atproto.py:34`.
+
+Neither writes through a temp file plus `os.replace`, so a torn write lands as invalid JSON. The
+new writer is a 300s poller, which makes concurrency the normal case rather than the exception --
+before it, two writers meeting was a coincidence.
+
+Bounded, which is why the row is `misreports` rather than anything louder: `_load_session`'s
+`except (OSError, json.JSONDecodeError): return None` at `:199` self-heals into a re-auth, so the
+cost is a spurious re-authentication rather than a wedge.
+
+Worth logging because the codebase already has the right pattern and this writer did not take it:
+`presets/_mirror.py:320-349`, added in this same delta, does the atomic write correctly.
+
+Found by the v0.59.0 release audit, round 1.

--- a/trap.d/520.channel-consumer-ships-without-its-dependency.md
+++ b/trap.d/520.channel-consumer-ships-without-its-dependency.md
@@ -1,0 +1,41 @@
+`.mcp.json` declares the claude-channel consumer for every plugin install (#520), and a fresh
+plugin install cannot start it.
+
+`notifiers/claude-channel/channel.ts:32-33` imports `@modelcontextprotocol/sdk` at load.
+`node_modules/` is gitignored and untracked -- `git ls-files notifiers/claude-channel/` lists eight
+files and none of them is a dependency tree. The only `npm install --omit=dev` lives in
+`install.sh`, and the README the same commit wrote tells plugin users to skip it:
+
+> A plugin install needs none of this. The install script and the manual wiring below are only for
+> a git clone you are running outside the plugin.
+
+`package.json` declares no `postinstall`, and `.claude-plugin/plugin.json` declares no install hook,
+so nothing else runs it either.
+
+Observed, not reasoned. Copying `channel.ts` to a directory outside any `node_modules` and running
+it exactly as `.mcp.json` does:
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@modelcontextprotocol/sdk'
+```
+
+And on this machine, why it has never been felt: the installed cache at
+`dpt-plugins/supertool/0.58.0/notifiers/claude-channel/` carries every shipped file stamped
+2026-09-08 18:01 and `node_modules` stamped 19:53 -- an hour and fifty-two minutes later, from a
+manual `install.sh` run, not from anything the marketplace shipped.
+
+Found by the v0.59.0 release audit, round 2, ranked `misreports`, non-blocking, carried forward per
+the two-round cap. **The row undersells it and that is worth saying here rather than nowhere:** the
+consequence is not a misleading message, it is a declared server that never starts for anybody who
+installs fresh.
+
+Severity is capped by one thing measured elsewhere: `channel.py` reads `claude mcp get`'s `Status:`
+line rather than its exit code (post-#2208), so a consumer that crashed on import should report
+rather than read green. That arm was not exercised.
+
+Testable and untested: `tests/test_mcp_config_279.py:78` pins that `.mcp.json` names `node` and
+carries `--experimental-strip-types`. Nothing asserts the SDK resolves from a tree with no
+`node_modules`, which is exactly the state the README calls fine.
+
+Also noted in the same commit and folded in here rather than filed apart:
+`notifiers/claude-channel/bun.lock` is still tracked after the Bun runtime was dropped.

--- a/trap.d/691.a-refusal-that-prints-its-own-bypasses.md
+++ b/trap.d/691.a-refusal-that-prints-its-own-bypasses.md
@@ -1,0 +1,18 @@
+`require_confirm` names all three of its own bypasses in the text it writes to stderr before
+`sys.exit(2)` -- `|force`, `SUPERTOOL_NO_PUBLISH_CONFIRM=1`, and `"no_publish_confirm": true`
+(`presets/_publish_safety.py:263-270`).
+
+Against a human that is helpful. Against the caller this gate was written for -- an unsupervised
+model -- the refusal is a set of instructions for getting past itself, so the gate is nominally on
+and effectively off.
+
+Confirmed by the v0.59.0 release audit, round 1, ranked `misdirects`. Not discovered by it: the
+maintainer already self-declared it in `changelog.d/691.security.md` ("reported to the maintainer as
+a design decision rather than fixed inline").
+
+What makes it worth logging now rather than then: commit 1c3bc2b9 (#691) wired `require_confirm`
+onto eight publish siblings that previously had no gate at all, so the same text now reaches eight
+more call sites than when the decision was taken.
+
+The fix the row points at is "stop printing the bypass in the refusal" -- name that an opt-out
+exists and where it is documented, without spelling the three spellings inline.

--- a/trap.d/691.a-refusal-that-prints-its-own-bypasses.md
+++ b/trap.d/691.a-refusal-that-prints-its-own-bypasses.md
@@ -7,8 +7,14 @@ model -- the refusal is a set of instructions for getting past itself, so the ga
 and effectively off.
 
 Confirmed by the v0.59.0 release audit, round 1, ranked `misdirects`. Not discovered by it: the
-maintainer already self-declared it in `changelog.d/691.security.md` ("reported to the maintainer as
-a design decision rather than fixed inline").
+maintainer already self-declared it in #691's own changelog entry ("reported to the maintainer as a
+design decision rather than fixed inline"), which lands in `CHANGELOG.md` under the release that
+ships it.
+
+Pointing at the pending fragment by path was the first draft, and CI refused it: the tag deletes
+`changelog.d/`, so a reference to a file there is green inside the pull request and red on that
+release and every one after. `tests/test_changelog_findable_1293.py` is the guard, and it caught
+this one inside the release that would have broken it.
 
 What makes it worth logging now rather than then: commit 1c3bc2b9 (#691) wired `require_confirm`
 onto eight publish siblings that previously had no gate at all, so the same text now reaches eight


### PR DESCRIPTION
Part of #2484.

`/oss:release` for v0.59.0 reached gate 3 and stopped there. The audit came back `findings` -- 6 of them, none in a blocking row -- and `gate3_disposition.py` answered:

```
DISPOSITION: stop-tag
  round-one findings always stop the tag, regardless of whether any of them block
```

**No tag was created and nothing was published.** This pull request is the filing half of that stop.

Five of the six rank `misreports` or `misdirects`, and both rows answer *can ship behind a trap.d fragment*, so they land in `trap.d/` rather than on the tracker:

- **`2433.walkup-loaders-do-not-catch-the-same-exceptions.md`** -- the five walk-up `.supertool.json` loaders each catch a different exception set. #2366 taught `_publish_safety.py` to catch `UnicodeDecodeError` by name, with a comment stating why inheritance will not do it; #2433 then rewrote the same clause in `presets/slack/_authorization.py:125` without applying the rule. A non-UTF-8 byte on the walk-up path crashes the slack op instead of returning the `{}` its own docstring promises. Two more loaders outside the delta carry it too, named so a fix lands on the class.
- **`691.a-refusal-that-prints-its-own-bypasses.md`** -- `require_confirm` names all three of its own bypasses in the text it exits on. Already self-declared by the maintainer in `changelog.d/691.security.md`; logged now because #691 wired it onto eight more call sites than when that decision was taken.
- **`2484.a-swallowed-chmod-leaves-a-credential-unprotected-silently.md`**
- **`2484.two-writers-share-one-session-file-non-atomically.md`**
- **`2484.claude-md-write-class-op-list-is-short-by-two.md`** -- `init` and `json-set` are missing from the parenthetical at `CLAUDE.md:61`. Not fixed here: `CLAUDE.md` says no release session edits it unless that was the task.

The sixth is `unranked` -- the table has no row for a secret created at a permissive mode and narrowed afterwards -- so it routes to an issue instead: #2484. The missing row is proposed upstream as Digital-Process-Tools/claude-oss#1374.

## Audit provenance

Dispatch token `rel-59-k7qz`, attributed. Checklist in effect 0.30.0; `checklist_skew.py --compare-effect` returned `effect-matches` against the measured `installed_version` 0.30.0. Skew state `not-applicable` (this repo ships none of the 14 definition files), route `resolved-install`.

5 classes checked, 0 `could not check`, 0 `could not rank`, 1 class graded `clean (read)` rather than `clean (exercised)` -- class C's control ran and passed over the 39 changed files, but cannot see a value laundered through a local variable first, which is the gap `presets/_untrusted.py:49-72` documents about its own scanner.

Also filed upstream from this run: claude-oss#1375 -- gate 1 asserts this repository reserves coverage behind a `full_matrix` dispatch, and `tests.yml` has no `workflow_dispatch` at all, so both dispatch steps are unperformable as written and `release_ci_wait.py --require-event workflow_dispatch` would never leave PENDING here.


[AI-generated]