### PR TITLE
trap.d: write-op receipts still wrongly blocked by supertool-no-cut

### DIFF
--- a/trap.d/1221.no-cut-blocks-write-op-receipts.md
+++ b/trap.d/1221.no-cut-blocks-write-op-receipts.md
@@ -1,0 +1,23 @@
+## supertool-no-cut also blocks a write op's own receipt, not just reads
+
+Observed during #1221's investigation, confirmed live against the shipped
+`supertool-no-cut` pattern on 2026-09-10 (test:
+`test_the_write_op_residue_is_confirmed_and_left_alone` in
+`tests/test_jit_no_cut_path_name_1221.py`, PR #2504).
+
+`paste ... | tail -12` is still wrongly blocked. The rule's stated rationale
+(`.claude/jit-context/tools/00-manual/supertool-no-cut.md`) is entirely about
+a **read**'s verdict-then-body layout being cut ("the ops put the meaning at
+the top... `tail` selects against the header"). A `paste` write receipt does
+not have that shape — there is no verdict-at-top to protect — so the rule's
+own reasoning does not cover this case at all.
+
+Confirmed by #1221's original filing (2026-08-14 comment, agent #1669): the
+block discarded a whole compound command, including two already-composed
+heredocs, which is the more expensive half — a legitimate cut anywhere in a
+chain costs everything typed alongside it.
+
+Not fixed here: settling it means deciding whether write-op receipts should
+be exempted from the matcher (and how to tell a write receipt from a read
+apart from an op allowlist), which is a separate change from #1221's own
+scope (a path-name false positive that #1426/#1565/#2257 already fixed).


### PR DESCRIPTION
Recorded from #1221's own audit (PR #2504): the `supertool-no-cut` rule's stated rationale is entirely about a **read**'s verdict-then-body layout being cut, which does not describe a **write** op's receipt. A `paste ... | tail -12` receipt is still wrongly blocked live against the shipped pattern.

Ranked `misdirects`/`misreports` against the release table -- non-blocking, ships behind a trap.d fragment rather than a new issue. Not fixed here; a separate change from #1221's own path-name scope.

Part of #1221

[AI-generated]