### PR TITLE
chore: log 7 gate-3 release-audit findings to trap.d (v0.60.0 prep)

### DIFF
--- a/trap.d/2342.output-format-hardcoded-version-goes-stale.md
+++ b/trap.d/2342.output-format-hardcoded-version-goes-stale.md
@@ -1,0 +1,23 @@
+# `_DEFAULT_OUTPUT_FORMAT` hardcodes a literal version string that goes stale on every release
+
+Found by `oss:release-auditor` during the v0.60.0 release audit (range v0.59.0..HEAD, round 1,
+dispatch token 770cb45060b1154a), joined with #2342/#2510's own default-output-format work in
+this same delta. `_supertool.py:19367` bakes `"supertool 0.59.0\n"` into the shipped default,
+inside a block that describes itself as "Measured from a real batched call".
+
+`tests/test_version_sites_agree_1854.py:96` reads `_supertool.py` only via the
+`^VERSION\s*=\s*"..."` pattern, so it never sees this second, independent version literal a few
+thousand lines later; `grep 0\.59\.0 _supertool.py` returns exactly two hits (the real `VERSION`
+assignment, and this one), and `grep` of `tests/test_output_format.py` for
+`0\.59\.0|VERSION|supertool 0` returns 0 -- nothing guards this string at all.
+
+Every install that has not set its own `output-format` key prints a version line that goes
+false starting with this very release (v0.60.0), on every session start, and stays false until
+whoever notices bumps this one literal by hand at some future release -- exactly the "sweep
+missed a site the version_sites allowlist doesn't cover" defect `CLAUDE.md`'s own "Releasing"
+section warns about, one level removed from the sites list itself.
+
+Ranked `misreports` per `skills/manager/phases/findings.md`'s table -- non-blocking; considered
+and rejected as `ships-local-state` (a version is a fact about the artifact, not about one
+checkout). Fix shape: render this line from `VERSION` at call time instead of a literal, or add
+this exact line to `version_sites` so the release sweep catches it.

--- a/trap.d/2362.no-run-stale-ages-committer-date-not-push.md
+++ b/trap.d/2362.no-run-stale-ages-committer-date-not-push.md
@@ -1,0 +1,27 @@
+# `NO RUN — STALE` ages a commit from its committer date, so pushing an older commit alarms during CI's normal creation window
+
+Found by `oss:release-auditor` during the v0.60.0 release audit (range v0.59.0..HEAD, round 2,
+dispatch token 5272dee6984a088d), on #2362's own stale-NO-RUN escalation in this delta.
+`presets/github/branch.py:1265,1268-1277` computes `age_secs` from `commit.committer.date` (a
+`gh api commits/<ref>` field stamped at `git commit` time, not at push), and the new
+`no_run_verdict` escalates past `NO_RUN_STALE_SECS = 2700` seconds to an unhedged sentence:
+"Something is wrong with how this commit was expected to trigger CI, or a webhook delivery was
+dropped outright." The pre-existing `NO_RUN` sentence it replaces was hedged ("UNKNOWN ... a
+path filter and a workflow that never fired look identical"); the escalation is definite on the
+same committer-date clock.
+
+`presets/watch/sources/gh-branch/poller.py:117` maps this straight to a new channel event
+`no_run_stale`, and `tests/test_gh_branch_no_run_stale_poller_composition_2362.py:92` pins that
+"a fresh sha reading no_run_stale fires immediately" -- which is exactly the false-positive
+case: a branch whose head was committed locally 46+ minutes before `git push` fires
+`no_run_stale` into the channel seconds after the push, while GitHub is still inside its
+ordinary ~15-minute run-creation window. The poller already holds a clock that would settle
+this correctly -- its own first observation of this sha (`first_seen`) -- but the age check
+reads the commit's committer date instead.
+
+Neither of the 2362 test files has a case with a committer date older than the threshold paired
+with a just-observed sha -- reasoned, not observed.
+
+Ranked `misreports` per `skills/manager/phases/findings.md`'s table -- non-blocking. Fix shape:
+age from the poller's own first-observed timestamp for this sha, not from the commit's
+committer date, so a normal push of an older commit does not read as a dropped webhook.

--- a/trap.d/2404.cross-repo-gh-pr-statusline-fragment-mismatch.md
+++ b/trap.d/2404.cross-repo-gh-pr-statusline-fragment-mismatch.md
@@ -1,0 +1,22 @@
+# Cross-repo `gh-pr` publishes another repository's check tally into this worktree's statusline slot
+
+Found by `oss:release-auditor` during the v0.60.0 release audit (range v0.59.0..HEAD, round 1,
+dispatch token 770cb45060b1154a). `presets/github/pr.py:997` calls
+`_statusline_fragments.publish("gh-pr", os.getcwd(), {"summary": ...})`, and `_key` in
+`presets/_statusline_fragments.py:86` keys the fragment on the worktree path alone -- never on
+the repo the call actually targeted.
+
+`repo:OWNER/NAME` (`presets/_repo_target.py`) lets a caller point one call at a different repo
+without leaving the current worktree, and #2404 in this same delta now actively steers callers
+toward exactly that shape (`repo:X gh-pr:N`). Put together: `supertool 'repo:other/repo'
+'gh-pr:5'` writes `checks: <other repo's PR 5>` into the current worktree's fragment, and
+`statusline` then renders that as *this* worktree's `checks:` line for up to `stale_secs` and
+beyond (only a "stale" suffix distinguishes it, nothing names the wrong repo).
+
+Neither `pr.py` nor `_statusline_fragments.py` reads `_repo_target.explicit_target()` anywhere;
+`grep` of `tests/test_gh_pr_publishes_statusline_fragment_1850.py` for
+`SUPERTOOL_REPO|_repo_target|OWNER/NAME|cross-repo` returns 0 hits.
+
+Ranked `misreports` per `skills/manager/phases/findings.md`'s table -- non-blocking. Fix shape:
+skip the publish (or key the fragment on the resolved repo) whenever an explicit repo target is
+set for the call.

--- a/trap.d/2449.force-respawn-reaps-under-autospawn-suppression.md
+++ b/trap.d/2449.force-respawn-reaps-under-autospawn-suppression.md
@@ -1,0 +1,28 @@
+# `force_respawn` reaps a daemon a suppressed caller is forbidden to recreate
+
+Found by `oss:release-auditor` during the v0.60.0 release audit (range v0.59.0..HEAD, round 2,
+dispatch token 5272dee6984a088d), on #2449's own desync-retry work in this delta.
+`presets/mcp/_spawn.py:427-464` (`force_respawn`) calls `reap(existing, ...)` (SIGTERM then
+SIGKILL) under the spawn lock *before* delegating to `ensure_daemon`, which is where the #1743
+autospawn gate lives (`if not autospawn_allowed(): raise AutospawnSuppressed`, line 528). The
+pre-existing comment at lines 516-522 explicitly withheld the reap from suppressed callers
+("Whether a caller forbidden to create may still destroy is a real question, and not one to
+settle on the way past") -- this delta settles it, silently, the other way.
+
+`validators/phpstan-mcp/phpstan-mcp.py:165-168` (and the phpmd/phpunit/rector twins) wire
+`respawn()` straight to `force_respawn` with no gate of their own; the validator runner stamps
+`SUPERTOOL_MCP_AUTOSPAWN=0` by default (`_supertool.py:33331`). One `DesyncDetected` in a
+validator run kills the shared daemon the maintainer warmed via `mcp_daemon:NAME --detach`, the
+follow-up `ensure_daemon` raises `AutospawnSuppressed`, and every later validator call on that
+machine reports NOT CHECKED ("no warm daemon ... forbids starting one") until someone re-warms
+it -- the message never says this caller is the one that killed it. In-flight exchanges of other
+callers sharing the daemon are severed too.
+
+`destroys` considered and rejected -- a process and a regenerable cache, not data with no copy
+anywhere. `tests/test_ndjson_desync_retry_2449.py` monkeypatches `force_respawn` at every call
+site (lines 196-200, 241, 270-274, 379, 399, 482, 559); none exercises it with
+`SUPERTOOL_MCP_AUTOSPAWN=0` set -- reasoned, not observed.
+
+Ranked `fails-to-preserve` per `skills/manager/phases/findings.md`'s table -- non-blocking. Fix
+shape: gate the reap on `autospawn_allowed()` the same way the recreate is gated, or have
+`AutospawnSuppressed` name what was reaped so the caller can tell what happened.

--- a/trap.d/2472.cross-repo-gh-pr-mirror-write-wrong-repo.md
+++ b/trap.d/2472.cross-repo-gh-pr-mirror-write-wrong-repo.md
@@ -1,0 +1,21 @@
+# Cross-repo `gh-pr` writes another repository's PR into this project's own mirror
+
+Found by `oss:release-auditor` during the v0.60.0 release audit (range v0.59.0..HEAD, round 1,
+dispatch token 770cb45060b1154a), joined with #2472's own write-through mirror work in this
+same delta. `presets/github/pr.py:1019-1021` calls `_mirror.write_pr(mirror_cfg.path,
+mirror_number, d)`, and `_mirror._body_path(root, subdir, number)` (`presets/_mirror.py:79`) is
+number-only -- it never folds the repo into the path.
+
+`supertool 'repo:other/repo' 'gh-pr:5'` therefore overwrites (or creates) *this* repo's own
+`prs/5.json`. A later plain `gh-mirror:pr:5` answers `cached (AGE)` with the wrong repository's
+PR body, with no field anywhere distinguishing it -- the mirror module's own docstring promise
+("never answers for the wrong one") holds across issue vs. PR but not across repos.
+
+`grep` of `tests/test_gh_pr_mirror_write_through_2472.py` and `tests/test_gh_mirror_1955.py` for
+a repo-override case returns 0 hits. The identical shape already exists outside this delta at
+`presets/github/issue.py:664-666`, shipped since #1955 in v0.59.0 -- not a regression introduced
+by #2472, but the same fix applies to both write sites.
+
+Ranked `misreports` per `skills/manager/phases/findings.md`'s table -- non-blocking. Fix shape:
+fold the resolved repo into the mirror path (or refuse to mirror-write under an explicit
+cross-repo target).

--- a/trap.d/2478.stranded-header-present-tense-from-clockless-record.md
+++ b/trap.d/2478.stranded-header-present-tense-from-clockless-record.md
@@ -1,0 +1,23 @@
+# `channel:stranded` states a present-tense fleet verdict from a per-watcher record with no clock
+
+Found by `oss:release-auditor` during the v0.60.0 release audit (range v0.59.0..HEAD, round 2,
+dispatch token 5272dee6984a088d), on #2478's own dead-channel-at-session-start work in this
+delta. `presets/watch/channel.py:2306-2311` prints, into every session start: "CHANNEL NOT
+DELIVERING -- this session is armed for a watch channel and no consumer is bound, so events are
+being LOST, not queued."
+
+The only evidence read is `last_emit.state == "no-listener"` (`channel.py:966`), and
+`last_emit` is rewritten only when that poller next emits (`presets/watch/transport.py:1125-
+1129`); `transport.py:175-177` documents the design as deliberately having "no threshold and no
+clock". So a poller that emitted once during a past outage (the 32-minute incident named in the
+docstring) and has been quiet since carries `no-listener` into every later session start, even
+after the consumer is bound again -- and `hooks/session-start.sh:204` prints the header as
+present-tense fact regardless. The per-row "last emit {ts}" lines are honest about when; the
+header overclaims about now.
+
+`tests/test_channel_stranded_session_2478.py` (cases at lines 91-260) has no case where the
+consumer is currently bound and a quiet poller's record is stale -- reasoned, not observed.
+
+Ranked `misreports` per `skills/manager/phases/findings.md`'s table -- non-blocking. Fix shape:
+either the header hedges ("was not delivering as of the last event seen") or the record carries
+enough of a clock to say whether the no-listener state is still current.

--- a/trap.d/2509.rate-limit-digit-collision-in-identifier.md
+++ b/trap.d/2509.rate-limit-digit-collision-in-identifier.md
@@ -1,0 +1,26 @@
+# `is_rate_limit_error` matches the digits "429" inside a run id or branch name, not just a real rate-limit message
+
+Found by `oss:release-auditor` during the v0.60.0 release audit (range v0.59.0..HEAD, round 1,
+dispatch token 770cb45060b1154a), joined with #2509/#2515's own watch-fleet backoff work in this
+same delta. `presets/watch/ratelimit.py:37-50`'s `is_rate_limit_error` tests `"429" in
+error.lower()` against the *whole* poller sentence, and `presets/github/run.py:511` /
+`presets/github/branch.py:1179-1187` render `#{identifier}` / `{what}` (a run id, PR number, or
+branch name) straight into that same not-found sentence.
+
+Exercised directly: `is_rate_limit_error('ERROR: run #4291234 not found ...')` -> `True`;
+`is_rate_limit_error("ERROR: branch 'fix-429-retry' not found ...")` -> `True`;
+`is_rate_limit_error('ERROR: gh timed out')` -> `False` (real negative control). A deleted run
+or a misspelt branch whose identifier happens to contain "429" is reclassified as throttling: an
+extra `gh api rate_limit` call fires, `retry_after` gets attached to a `run_unreachable` /
+`branch_unreachable` event that was never a rate limit, and `dispatcher._retry_after_seconds`
+parks the poller until the token's reset (capped at 3600s) instead of the ordinary `INTERVAL`.
+
+Same class as #1846's `401`-inside-a-user-id note on the same `_format_error` sentence, one
+layer up. `tests/test_watch_ratelimit_budget_2509.py:136-142`'s existing negative cases
+(`"gh timed out"`, `""`) never carry a `429`-bearing identifier, so this false-positive path is
+untested.
+
+Ranked `misreports` per `skills/manager/phases/findings.md`'s table -- non-blocking. Fix shape:
+match on the HTTP-status shape specifically (a rate-limit header field, or a status-code token
+bounded by non-digits / anchored to the part of the message that isn't an echoed identifier)
+rather than a bare substring test.


### PR DESCRIPTION
Non-blocking findings from the v0.60.0 release audit (range v0.59.0..HEAD), rounds 1 and 2
of gate 3. All are `misreports` or `fails-to-preserve` per `skills/manager/phases/findings.md`'s
ranking table -- none in a blocking row -- so they route to `trap.d/` fragments rather than
GitHub issues. `/oss:curate` decides later whether any of these becomes a jit-context rule.

Round 1 (dispatch token `770cb45060b1154a`):
- cross-repo `gh-pr` publishes another repository's check tally into this worktree's statusline slot
- cross-repo `gh-pr` writes another repository's PR into this project's own mirror
- `is_rate_limit_error` matches the digits "429" inside a run id or branch name
- `_DEFAULT_OUTPUT_FORMAT` hardcodes a literal version string that goes stale on every release

Round 2 (dispatch token `5272dee6984a088d`):
- `force_respawn` reaps a daemon a suppressed caller is forbidden to recreate
- `channel:stranded` states a present-tense fleet verdict from a per-watcher record with no clock
- `NO RUN -- STALE` ages a commit from its committer date, not from push time

No code changes; this is release accounting only, landed as its own pull request per
`CLAUDE.md`'s "Who decides" table (committing to the default branch outside a pull request has
no content exception, trap.d/ fragments included).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_017BpVS77BsxrTDyZ1gmE9UN

[AI-generated]