### PR TITLE
supertool-no-cut regression tests no longer silently skip when awk is absent on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,6 +243,41 @@ jobs:
         shell: pwsh
         run: |
           echo "::warning::Windows Defender exclusion step failed (Add-MpPreference) -- continuing without it; this Windows run may be slower than usual, see #2259"
+      - name: Ensure awk is on PATH (Windows) (#2505)
+        # `tests/test_jit_no_cut_word_boundary_2257.py`,
+        # `tests/test_jit_no_cut_span_stops_at_a_separator_1565.py` and
+        # `tests/test_jit_no_cut_path_name_1221.py` shell out to a real `awk`
+        # to reproduce exactly what `pre-tool-hook.sh` compiles the
+        # `supertool-no-cut` jit-context rule with -- awk, not Python `re`;
+        # the two dialects disagree on some escapes (docs/validators.md).
+        # Losing `awk` does not fail a leg: `needs_awk` skips the whole file,
+        # positive controls included, and a green run then reads identical
+        # whether every regression ran or none of them did (#2505).
+        #
+        # `shell: bash` on "Run tests" below already runs under Git Bash,
+        # whose MSYS2 runtime is documented to prepend its own `usr/bin`
+        # (where `awk.exe` ships) to PATH independently of
+        # `--noprofile`/`--norc` -- but that could not be confirmed against a
+        # live `windows-latest` job while this step was written (GitHub API
+        # rate-limited during development; see #2505's PR body for what was
+        # and was not checked). So this step makes the guarantee explicit
+        # and checked rather than assumed: it fails the job loudly, with a
+        # named cause, rather than letting three files' worth of regression
+        # coverage silently not run. `tests/test_jit_no_cut_awk_present_2505.py`
+        # is the matching in-suite check, which reads this exact failure
+        # mode back out of `CI`/`PATH` on whichever leg runs it.
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          if ! command -v awk >/dev/null 2>&1; then
+            printf '%s\n' "C:\Program Files\Git\usr\bin" >> "$GITHUB_PATH"
+            export PATH="/c/Program Files/Git/usr/bin:$PATH"
+            if ! command -v awk >/dev/null 2>&1; then
+              echo "::error::awk not found on PATH even after adding Git's usr/bin -- tests/test_jit_no_cut_*.py will silently skip their positive controls on this leg (#2505)"
+              exit 1
+            fi
+          fi
+          echo "awk resolved to: $(command -v awk)"
       - name: Print xdist worker sizing (#2345)
         # `pyproject.toml`'s `addopts` carries `-n auto`, and the step below
         # runs on all twelve legs with a worker count nobody has read.

--- a/changelog.d/2505.fixed.md
+++ b/changelog.d/2505.fixed.md
@@ -1,0 +1,18 @@
+- `needs_awk` skipped `test_jit_no_cut_word_boundary_2257.py`,
+  `test_jit_no_cut_span_stops_at_a_separator_1565.py` and
+  `test_jit_no_cut_path_name_1221.py` in their entirety -- positive controls
+  included -- on any runner with no `awk` on PATH, and a green leg then read
+  identical whether every `supertool-no-cut` regression ran or none of them
+  did (#2505). Whether `windows-latest` has `awk` on PATH could not be
+  confirmed from a previous session, and could not be re-confirmed here
+  either (GitHub API rate-limited during this work).
+- Fixed with both halves rather than a guess at which one was needed:
+  `tests.yml` now provisions `awk` explicitly for the windows leg and fails
+  the job loudly, naming the cause, if it is still missing after
+  provisioning; and the three files' duplicated
+  `needs_awk`/`_pattern`/`_awk_matches` trio is now one shared module
+  (`tests/_jit_no_cut_awk.py`), so a future fix to the mechanism lands once.
+- A new `test_jit_no_cut_awk_present_2505.py` turns "awk absent under CI"
+  into an explicit, loud pytest failure instead of a silent skip, and
+  `test_ci_windows_awk_provisioned_2505.py` pins the new workflow step
+  through the repo's structural YAML parser rather than a text needle.

--- a/tests/_jit_no_cut_awk.py
+++ b/tests/_jit_no_cut_awk.py
@@ -2,14 +2,19 @@ r"""One awk-matching harness for the `supertool-no-cut` regression suite (#2505)
 
 `test_jit_no_cut_word_boundary_2257.py`, `test_jit_no_cut_span_stops_at_a_separator_1565.py`
 and `test_jit_no_cut_path_name_1221.py` each carried their own copy of `needs_awk`,
-`_pattern()` and `_awk_matches()` -- byte-identical in all three files, checked
-by hand before this module existed. That meant the defect #2505 reports (`needs_awk`
-skips the WHOLE file -- positive controls included -- on any runner with no `awk`
-on PATH, and a green run reads identical whether every regression ran or none of
-them did) had to be reasoned about, and fixed, in three places rather than one.
-This module is the one copy; the three files import from it instead of
-redefining it, and any future `test_jit_no_cut_*` file gets the fix for free by
-importing from here rather than pasting the block again.
+`_pattern()` and `_awk_matches()` -- `needs_awk` and `_pattern()` byte-identical
+in all three files, checked by hand before this module existed. `_awk_matches()`
+was behaviourally identical (same subprocess call, same assertions) in all
+three but carried a longer, file-specific docstring in the span-stops file --
+folded into this module's own `awk_matches()` below rather than dropped, so
+the correction it recorded survives the merge. That meant the defect #2505
+reports (`needs_awk` skips the WHOLE file -- positive controls included -- on
+any runner with no `awk` on PATH, and a green run reads identical whether
+every regression ran or none of them did) had to be reasoned about, and
+fixed, in three places rather than one. This module is the one copy; the
+three files import from it instead of redefining it, and any future
+`test_jit_no_cut_*` file gets the fix for free by importing from here rather
+than pasting the block again.
 
 Deliberately NOT a `conftest.py` fixture: these are ordinary module-level
 helpers a handful of test files import by name (the same shape as this
@@ -63,6 +68,19 @@ def awk_matches(pat, subject):
     thing rather than failing, see `docs/validators.md`), so a Python
     re-implementation of this check would stop being a test of what
     `pre-tool-hook.sh` actually enforces.
+
+    The hook's real match is `jit_fold_latin1(tolower(full_command))` against
+    `jit_fold_latin1(pattern)` (`pre-tool-hook.sh:311`). The fold is omitted
+    here because every subject any `test_jit_no_cut_*` file uses is ASCII,
+    where it is the identity -- stated rather than left for a reader to
+    assume it is not there. `:137` is a comment in that script, not the
+    match site; two other files under this directory
+    (`test_jit_block_match_anchored_1415.py`,
+    `test_jit_rule_retirement_1376.py`) still cite `:137` as if it were, and
+    this note is the only place in the tree that flags that citation as
+    inaccurate -- it lived only in `test_jit_no_cut_span_stops_at_a_separator_1565.py`
+    before this module existed, and moved here rather than being dropped when
+    that file's own copy of this function was replaced by an import (#2505).
     """
     env = dict(os.environ, JIT_PAT=pat, JIT_SUBJ=subject)
     proc = subprocess.run(

--- a/tests/_jit_no_cut_awk.py
+++ b/tests/_jit_no_cut_awk.py
@@ -1,0 +1,90 @@
+r"""One awk-matching harness for the `supertool-no-cut` regression suite (#2505).
+
+`test_jit_no_cut_word_boundary_2257.py`, `test_jit_no_cut_span_stops_at_a_separator_1565.py`
+and `test_jit_no_cut_path_name_1221.py` each carried their own copy of `needs_awk`,
+`_pattern()` and `_awk_matches()` -- byte-identical in all three files, checked
+by hand before this module existed. That meant the defect #2505 reports (`needs_awk`
+skips the WHOLE file -- positive controls included -- on any runner with no `awk`
+on PATH, and a green run reads identical whether every regression ran or none of
+them did) had to be reasoned about, and fixed, in three places rather than one.
+This module is the one copy; the three files import from it instead of
+redefining it, and any future `test_jit_no_cut_*` file gets the fix for free by
+importing from here rather than pasting the block again.
+
+Deliberately NOT a `conftest.py` fixture: these are ordinary module-level
+helpers a handful of test files import by name (the same shape as this
+directory's other `_*.py` shared modules, e.g. `_git_decline.py`), not
+something pytest auto-injects, so a reader of one of the three files can see
+exactly where `_pattern`/`_awk_matches` come from rather than needing to know
+fixture-discovery rules.
+
+This module answers only "how do we ask awk", never "should this CI leg have
+awk" -- that policy question, and the loud-if-missing-on-CI check #2505 asks
+for, lives in `test_jit_no_cut_awk_present_2505.py`, kept separate so a
+reader auditing "is awk actually guaranteed here" does not have to wade
+through the matching harness to find it.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+INDEX = REPO / ".claude" / "jit-context" / "tools" / "00-manual" / "00-index.tsv"
+RULE = "supertool-no-cut.md"
+TAB = chr(9)
+
+AWK = shutil.which("awk")
+
+needs_awk = pytest.mark.skipif(
+    AWK is None,
+    reason="awk absent: no verdict is available, which is not the same as a pass")
+
+
+def pattern():
+    """Column 2 of the live row naming `supertool-no-cut.md`, tilde stripped."""
+    for raw in INDEX.read_text(encoding="utf-8").splitlines():
+        fields = raw.split(TAB)
+        if len(fields) >= 3 and fields[2] == RULE:
+            assert fields[1].startswith("~"), "{0} is a literal row".format(RULE)
+            return fields[1][1:]
+    raise AssertionError("no row for {0} in {1}".format(RULE, INDEX))
+
+
+def awk_matches(pat, subject):
+    r"""What pre-tool-hook.sh does: match(tolower(full_command), pattern).
+
+    Goes through a real subprocess `awk`, not Python `re` -- the two dialects
+    disagree on some escapes (`\s` compiles clean under awk into the wrong
+    thing rather than failing, see `docs/validators.md`), so a Python
+    re-implementation of this check would stop being a test of what
+    `pre-tool-hook.sh` actually enforces.
+    """
+    env = dict(os.environ, JIT_PAT=pat, JIT_SUBJ=subject)
+    proc = subprocess.run(
+        ["awk", 'BEGIN { if (match(tolower(ENVIRON["JIT_SUBJ"]), '
+                'ENVIRON["JIT_PAT"])) print "MATCH"; else print "NO" }'],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", env=env)
+    assert proc.returncode == 0, "awk refused the pattern: {0}".format(proc.stderr)
+    out = proc.stdout.strip()
+    assert out in ("MATCH", "NO"), "awk said {0!r}".format(out)
+    return out == "MATCH"
+
+
+def assert_index_and_frontmatter_agree():
+    """Same drift guard all three `test_jit_no_cut_*` files made independently
+    for the same `supertool-no-cut.md` row: a fix applied to only one of
+    `00-index.tsv` or the rule's own frontmatter is undone by the next
+    `rebuild-tsv.sh` run, silently, because the row that comes back is
+    well-formed."""
+    body = (REPO / ".claude" / "jit-context" / "tools" / "00-manual"
+            / RULE).read_text(encoding="utf-8")
+    declared = [ln[len("match:"):].strip() for ln in body.splitlines()
+                if ln.startswith("match:")]
+    assert declared, "no `match:` line in {0}".format(RULE)
+    assert declared[0] == "~" + pattern(), (
+        "frontmatter and index row disagree; the next rebuild-tsv.sh run wins")

--- a/tests/test_ci_windows_awk_provisioned_2505.py
+++ b/tests/test_ci_windows_awk_provisioned_2505.py
@@ -49,3 +49,28 @@ def test_the_step_runs_before_the_test_step():
     test_at = next(i for i, n in enumerate(names)
                    if n.startswith("Run tests"))
     assert provision_at < test_at
+
+
+def test_the_repair_body_names_the_real_git_for_windows_path():
+    """`command -v awk` and `exit 1` alone only pin that the step CHECKS for
+    awk and fails loudly if it is absent -- not that the repair path it tries
+    first (adding Git's own `usr/bin`, where `awk.exe` ships) is spelled
+    correctly. A typo in either literal would not turn `test_the_step_checks_
+    for_awk_and_fails_loudly_if_still_absent` red, because that test never
+    reads these two lines -- caught in self-review of #2505, not assumed
+    covered by the two checks above.
+
+    Would this pass if the windows-style path written to `GITHUB_PATH` no
+    longer matched the MSYS-style path exported into the current shell's own
+    `PATH`? No -- `GITHUB_PATH` receives Windows steps' PATH (backslash
+    form), the `export PATH=` line affects only the current `shell: bash`
+    process (MSYS `/c/...` form); the two are deliberately different
+    spellings of the same directory, pinned as a pair here rather than
+    separately, because the whole point of the fallback is that both take
+    effect."""
+    steps = _pytest_job_steps()
+    step = next(s for s in steps if s.name == STEP_NAME)
+    assert r"C:\Program Files\Git\usr\bin" in step.run, (
+        "the GITHUB_PATH line's Windows-style path is missing or misspelled")
+    assert "/c/Program Files/Git/usr/bin" in step.run, (
+        "the export PATH= line's MSYS-style path is missing or misspelled")

--- a/tests/test_ci_windows_awk_provisioned_2505.py
+++ b/tests/test_ci_windows_awk_provisioned_2505.py
@@ -1,0 +1,51 @@
+"""Pins the `tests.yml` step that provisions `awk` for the windows-latest leg
+(#2505), through the structural workflow parser (`tests/_workflow_parse.py`)
+rather than a text needle -- `tests.yml` is mostly comment explaining its own
+decisions, and a needle over raw text can be satisfied by the prose describing
+a step rather than by the step itself (see `_workflow_parse.py`'s own
+docstring, #731).
+
+Would this pass if the step were deleted, or if it existed but its `run:`
+body no longer checked `awk`'s presence? No -- `job_steps` would either omit
+the step from the list, or return it with a `run` body that fails the
+`in` checks below.
+"""
+from __future__ import annotations
+
+from _workflow_parse import job_blocks, job_steps
+
+STEP_NAME = "Ensure awk is on PATH (Windows) (#2505)"
+
+
+def _pytest_job_steps():
+    blocks = job_blocks()
+    assert "pytest" in blocks, "no 'pytest' job in tests.yml"
+    steps = job_steps(blocks["pytest"])
+    assert steps, "no steps parsed out of the pytest job"
+    return steps
+
+
+def test_the_awk_provisioning_step_exists():
+    names = [step.name for step in _pytest_job_steps()]
+    assert STEP_NAME in names, (
+        "the windows-only awk-provisioning step is missing from tests.yml's "
+        "pytest job (#2505); names seen: {0}".format(names))
+
+
+def test_the_step_checks_for_awk_and_fails_loudly_if_still_absent():
+    steps = _pytest_job_steps()
+    step = next(s for s in steps if s.name == STEP_NAME)
+    assert "command -v awk" in step.run
+    assert "exit 1" in step.run, (
+        "the step must fail the job when awk is still missing after "
+        "provisioning, not degrade quietly (#2505)")
+
+
+def test_the_step_runs_before_the_test_step():
+    """Provisioning that lands after `Run tests` has already run protects
+    nothing -- pin the ordering, not just the presence."""
+    names = [step.name for step in _pytest_job_steps()]
+    provision_at = names.index(STEP_NAME)
+    test_at = next(i for i, n in enumerate(names)
+                   if n.startswith("Run tests"))
+    assert provision_at < test_at

--- a/tests/test_jit_no_cut_awk_present_2505.py
+++ b/tests/test_jit_no_cut_awk_present_2505.py
@@ -1,0 +1,87 @@
+"""Whether `windows-latest` has `awk` on PATH could not be confirmed from a
+past session (#1221's own developer noted the same gap), so a whole leg's
+`supertool-no-cut` regression coverage -- three files, positive controls
+included -- could silently not run there, and a green Windows leg would read
+identical to full coverage (#2505).
+
+This file makes that silence loud on CI specifically, without touching the
+correctly-quiet local case: a contributor's own machine with no `awk`
+installed should keep skipping the three `test_jit_no_cut_*` files, not fail
+their run over a tool they were never asked to install. `os.environ["CI"]`
+is the split -- GitHub Actions sets it to `"true"` on every job by default
+(no workflow-side opt-in needed), a local shell does not set it at all.
+
+`assert_awk_present_on_ci` is the one function this pins, exercised twice:
+against synthetic `is_ci`/`which_awk` inputs below (both directions --
+`test_it_fires_...` is the positive control paired with
+`test_it_does_not_fire_...`, the same MUST/MUST-NOT shape the three
+`test_jit_no_cut_*` files already use, preserved rather than dropped in this
+refactor), and once for real in `test_awk_is_actually_on_path_under_ci`
+against this machine's own `os.environ` and `shutil.which` -- the assertion
+that actually gates a CI leg.
+
+Would `test_it_fires_when_ci_says_true_and_awk_is_absent` pass if
+`assert_awk_present_on_ci` did nothing (returned `None` unconditionally)? No
+-- that is exactly the case this test exists to catch, and it is the case
+that used to be invisible: nothing before this file turned "CI job, no awk"
+into a failure anywhere in this suite.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+
+def assert_awk_present_on_ci(is_ci, which_awk):
+    """Fail loudly when running on CI and `awk` is not on PATH.
+
+    Local dev machines are deliberately exempt (`is_ci` false leaves this
+    silent) -- the three `test_jit_no_cut_*` files already handle that case
+    correctly via `needs_awk`, skipping only their own tests rather than
+    failing the whole run over an optional local tool. This function is the
+    other half: the environment CI is expected to provision it in.
+    """
+    if not is_ci:
+        return
+    assert which_awk is not None, (
+        "awk is not on PATH on this CI runner. The supertool-no-cut "
+        "regression suite (tests/test_jit_no_cut_word_boundary_2257.py, "
+        "tests/test_jit_no_cut_span_stops_at_a_separator_1565.py, "
+        "tests/test_jit_no_cut_path_name_1221.py) needs a real awk to "
+        "reproduce what pre-tool-hook.sh actually compiles, and will "
+        "otherwise silently skip its positive controls on this leg (#2505). "
+        "See .github/workflows/tests.yml's windows-only "
+        "'Ensure awk is on PATH' step.")
+
+
+def test_it_fires_when_ci_says_true_and_awk_is_absent():
+    with pytest.raises(AssertionError):
+        assert_awk_present_on_ci(is_ci=True, which_awk=None)
+
+
+def test_it_does_not_fire_when_ci_says_true_and_awk_is_present():
+    assert assert_awk_present_on_ci(is_ci=True, which_awk="/usr/bin/awk") is None
+
+
+def test_it_does_not_fire_when_not_running_under_ci():
+    """A contributor's own machine with no awk stays silent here -- the
+    per-file `needs_awk` skip in the three test_jit_no_cut_* files is what
+    handles that case, and this function must not duplicate a failure on
+    top of it."""
+    assert assert_awk_present_on_ci(is_ci=False, which_awk=None) is None
+
+
+def test_awk_is_actually_on_path_under_ci():
+    """The real gate: this machine's own CI-ness and PATH, live.
+
+    Skips (does not fail) off CI, for the same reason the function above
+    stays silent there -- this is a statement about what CI must provision,
+    not about a contributor's own machine."""
+    is_ci = bool(os.environ.get("CI"))
+    if not is_ci:
+        pytest.skip("not running under CI (os.environ['CI'] unset) -- this "
+                     "assertion is about what a CI runner must provision, "
+                     "not about a local dev machine")
+    assert_awk_present_on_ci(is_ci=is_ci, which_awk=shutil.which("awk"))

--- a/tests/test_jit_no_cut_path_name_1221.py
+++ b/tests/test_jit_no_cut_path_name_1221.py
@@ -67,44 +67,11 @@ re-deriving the fix.
 """
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-from pathlib import Path
-
 import pytest
 
-REPO = Path(__file__).resolve().parents[1]
-INDEX = REPO / ".claude" / "jit-context" / "tools" / "00-manual" / "00-index.tsv"
-RULE = "supertool-no-cut.md"
-TAB = chr(9)
-
-needs_awk = pytest.mark.skipif(
-    shutil.which("awk") is None,
-    reason="awk absent: no verdict is available, which is not the same as a pass")
-
-
-def _pattern():
-    """Column 2 of the live row naming the rule, tilde stripped."""
-    for raw in INDEX.read_text(encoding="utf-8").splitlines():
-        fields = raw.split(TAB)
-        if len(fields) >= 3 and fields[2] == RULE:
-            assert fields[1].startswith("~"), "{0} is a literal row".format(RULE)
-            return fields[1][1:]
-    raise AssertionError("no row for {0} in {1}".format(RULE, INDEX))
-
-
-def _awk_matches(pattern, subject):
-    """What pre-tool-hook.sh does: match(tolower(full_command), pattern)."""
-    env = dict(os.environ, JIT_PAT=pattern, JIT_SUBJ=subject)
-    proc = subprocess.run(
-        ["awk", 'BEGIN { if (match(tolower(ENVIRON["JIT_SUBJ"]), '
-                'ENVIRON["JIT_PAT"])) print "MATCH"; else print "NO" }'],
-        capture_output=True, text=True, encoding="utf-8", errors="replace", env=env)
-    assert proc.returncode == 0, "awk refused the pattern: {0}".format(proc.stderr)
-    out = proc.stdout.strip()
-    assert out in ("MATCH", "NO"), "awk said {0!r}".format(out)
-    return out == "MATCH"
+from _jit_no_cut_awk import awk_matches as _awk_matches
+from _jit_no_cut_awk import needs_awk
+from _jit_no_cut_awk import pattern as _pattern
 
 
 # The exact commands #1221 and its first two comments record as wrongly
@@ -175,10 +142,5 @@ def test_the_index_row_and_the_frontmatter_agree():
     """Same drift guard the two sibling files make for the same row, kept
     here too so this file's own claims about the live pattern do not silently
     diverge from the frontmatter the next rebuild-tsv.sh run would restore."""
-    body = (REPO / ".claude" / "jit-context" / "tools" / "00-manual"
-            / RULE).read_text(encoding="utf-8")
-    declared = [ln[len("match:"):].strip() for ln in body.splitlines()
-                if ln.startswith("match:")]
-    assert declared, "no `match:` line in {0}".format(RULE)
-    assert declared[0] == "~" + _pattern(), (
-        "frontmatter and index row disagree; the next rebuild-tsv.sh run wins")
+    from _jit_no_cut_awk import assert_index_and_frontmatter_agree
+    assert_index_and_frontmatter_agree()

--- a/tests/test_jit_no_cut_span_stops_at_a_separator_1565.py
+++ b/tests/test_jit_no_cut_span_stops_at_a_separator_1565.py
@@ -40,51 +40,11 @@ disagree. The pattern arrives via ENVIRON so its escapes are exactly what
 """
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-from pathlib import Path
-
 import pytest
 
-REPO = Path(__file__).resolve().parents[1]
-INDEX = REPO / ".claude" / "jit-context" / "tools" / "00-manual" / "00-index.tsv"
-RULE = "supertool-no-cut.md"
-TAB = "\t"
-
-needs_awk = pytest.mark.skipif(
-    shutil.which("awk") is None,
-    reason="awk absent: no verdict is available, which is not the same as a pass")
-
-
-def _pattern():
-    """Column 2 of the live row naming the rule, tilde stripped."""
-    for raw in INDEX.read_text(encoding="utf-8").splitlines():
-        fields = raw.split(TAB)
-        if len(fields) >= 3 and fields[2] == RULE:
-            assert fields[1].startswith("~"), "{0} is a literal row".format(RULE)
-            return fields[1][1:]
-    raise AssertionError("no row for {0} in {1}".format(RULE, INDEX))
-
-
-def _awk_matches(pattern, subject):
-    """What pre-tool-hook.sh:311 does, less one step that cannot bite here.
-
-    The hook matches `jit_fold_latin1(tolower(full_command))` (built at :184)
-    against `jit_fold_latin1(pattern)`. The fold is omitted because every
-    subject in this file is ASCII, where it is the identity -- but the omission
-    is stated rather than left for a reader to assume it is not there. (The
-    `:137` cited by the three sibling test files is a comment, not the match.)
-    """
-    env = dict(os.environ, JIT_PAT=pattern, JIT_SUBJ=subject)
-    proc = subprocess.run(
-        ["awk", 'BEGIN { if (match(tolower(ENVIRON["JIT_SUBJ"]), '
-                'ENVIRON["JIT_PAT"])) print "MATCH"; else print "NO" }'],
-        capture_output=True, text=True, encoding="utf-8", errors="replace", env=env)
-    assert proc.returncode == 0, "awk refused the pattern: {0}".format(proc.stderr)
-    out = proc.stdout.strip()
-    assert out in ("MATCH", "NO"), "awk said {0!r}".format(out)
-    return out == "MATCH"
+from _jit_no_cut_awk import awk_matches as _awk_matches
+from _jit_no_cut_awk import needs_awk
+from _jit_no_cut_awk import pattern as _pattern
 
 
 # Assembled, never written literally: a line of this file that *began* with a
@@ -186,10 +146,5 @@ def test_the_index_row_and_the_frontmatter_agree():
     declares, and `version-sites.md` loses its second paths row -- so the
     committed index is partly hand-maintained. That is filed separately; it
     does not weaken this assertion, which is about one row's `match`."""
-    body = (REPO / ".claude" / "jit-context" / "tools" / "00-manual"
-            / RULE).read_text(encoding="utf-8")
-    declared = [ln[len("match:"):].strip() for ln in body.splitlines()
-                if ln.startswith("match:")]
-    assert declared, "no `match:` line in {0}".format(RULE)
-    assert declared[0] == "~" + _pattern(), (
-        "frontmatter and index row disagree; the next rebuild-tsv.sh run wins")
+    from _jit_no_cut_awk import assert_index_and_frontmatter_agree
+    assert_index_and_frontmatter_agree()

--- a/tests/test_jit_no_cut_word_boundary_2257.py
+++ b/tests/test_jit_no_cut_word_boundary_2257.py
@@ -78,45 +78,13 @@ refusal this issue reports.
 """
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-from pathlib import Path
-
 import pytest
 
-REPO = Path(__file__).resolve().parents[1]
-INDEX = REPO / ".claude" / "jit-context" / "tools" / "00-manual" / "00-index.tsv"
-RULE = "supertool-no-cut.md"
-TAB = chr(9)
+from _jit_no_cut_awk import awk_matches as _awk_matches
+from _jit_no_cut_awk import needs_awk
+from _jit_no_cut_awk import pattern as _pattern
+
 BAR = chr(124)
-
-needs_awk = pytest.mark.skipif(
-    shutil.which("awk") is None,
-    reason="awk absent: no verdict is available, which is not the same as a pass")
-
-
-def _pattern():
-    """Column 2 of the live row naming the rule, tilde stripped."""
-    for raw in INDEX.read_text(encoding="utf-8").splitlines():
-        fields = raw.split(TAB)
-        if len(fields) >= 3 and fields[2] == RULE:
-            assert fields[1].startswith("~"), "{0} is a literal row".format(RULE)
-            return fields[1][1:]
-    raise AssertionError("no row for {0} in {1}".format(RULE, INDEX))
-
-
-def _awk_matches(pattern, subject):
-    """What pre-tool-hook.sh does: match(tolower(full_command), pattern)."""
-    env = dict(os.environ, JIT_PAT=pattern, JIT_SUBJ=subject)
-    proc = subprocess.run(
-        ["awk", 'BEGIN { if (match(tolower(ENVIRON["JIT_SUBJ"]), '
-                'ENVIRON["JIT_PAT"])) print "MATCH"; else print "NO" }'],
-        capture_output=True, text=True, encoding="utf-8", errors="replace", env=env)
-    assert proc.returncode == 0, "awk refused the pattern: {0}".format(proc.stderr)
-    out = proc.stdout.strip()
-    assert out in ("MATCH", "NO"), "awk said {0!r}".format(out)
-    return out == "MATCH"
 
 
 # The word-boundary false positives: a quoted argument containing "|<word>"
@@ -193,10 +161,5 @@ def test_the_index_row_and_the_frontmatter_agree():
     rebuild, silently, because the row that comes back is well-formed. The
     same check test_jit_no_cut_span_stops_at_a_separator_1565.py makes for
     the same row, kept here too so this file can be read on its own."""
-    body = (REPO / ".claude" / "jit-context" / "tools" / "00-manual"
-            / RULE).read_text(encoding="utf-8")
-    declared = [ln[len("match:"):].strip() for ln in body.splitlines()
-                if ln.startswith("match:")]
-    assert declared, "no `match:` line in {0}".format(RULE)
-    assert declared[0] == "~" + _pattern(), (
-        "frontmatter and index row disagree; the next rebuild-tsv.sh run wins")
+    from _jit_no_cut_awk import assert_index_and_frontmatter_agree
+    assert_index_and_frontmatter_agree()

--- a/trap.d/2505.same-needs-awk-pattern-elsewhere.md
+++ b/trap.d/2505.same-needs-awk-pattern-elsewhere.md
@@ -1,0 +1,43 @@
+Working #2505 (supertool-no-cut regression tests silently skip whole file --
+positive controls included -- when `awk` is absent on CI), I found the same
+`needs_awk` shape in four MORE files that #2505 did not name:
+`tests/test_jit_block_match_anchored_1415.py`,
+`tests/test_jit_index_dead_match_1254.py`,
+`tests/test_jit_merged_prs_not_merged_1977.py`,
+`tests/test_jit_rule_retirement_1376.py`. Three of the four use the exact
+same `shutil.which("awk") is None` inline; `test_jit_index_dead_match_1254.py`
+gates on a pre-computed `HAS_AWK` module constant instead, but the effect
+(whole-file skip, positive controls included, on any runner with no awk) is
+identical.
+
+Issue #2505's own scope named exactly the three `test_jit_no_cut_*` files, and the
+issue's own "reusing whatever mechanism you land on across all three" line
+bounds the fix to those three, so I did not touch the other four in that PR
+-- doing so would have widened the diff's blast radius past what was asked
+and risked colliding with another lane if one of those four files happened
+to be held elsewhere.
+
+`tests/_jit_no_cut_awk.py`, the shared module #2505 introduces (`needs_awk`,
+`pattern()`, `awk_matches()`, `assert_index_and_frontmatter_agree()`), is
+NOT a drop-in replacement for these four files as-is: it is specific to the
+`supertool-no-cut.md` rule (hardcodes `RULE = "supertool-no-cut.md"`), while
+at least some of the four sibling files exercise a DIFFERENT jit-context
+rule/row (I did not check which, for each of the four, before logging this).
+So the mechanical work here is smaller than "delete four duplicate
+functions" but is not zero: whoever picks this up should first check which
+rule each of the four files' `_pattern()`/`_awk_matches()` reads, and either
+(a) generalize `tests/_jit_no_cut_awk.py` to take a `rule` parameter rather
+than hardcoding one, or (b) write a second, differently-named shared module
+for whichever of the four share a rule with each other but not with the
+no-cut trio.
+
+Also worth checking, not done here: whether the SAME loud-on-CI gap #2505's
+`test_jit_no_cut_awk_present_2505.py` closes for the no-cut trio should be
+generalized to cover these four files too, or whether one CI-wide
+`assert_awk_present_on_ci` check (which #2505 already wrote in a form that
+takes no file-specific state) already covers ALL awk-dependent test files in
+one place regardless of which rule they read -- in which case the fix might
+just be "these four files' own `needs_awk` markers are fine as-is, because
+the loud-on-CI check already fires independently of which file's tests it
+gates" and the only remaining question is deduplicating the harness
+functions themselves, not adding more CI-presence checks.


### PR DESCRIPTION
Closes #2505.

`needs_awk` skipped `test_jit_no_cut_word_boundary_2257.py`, `test_jit_no_cut_span_stops_at_a_separator_1565.py` and `test_jit_no_cut_path_name_1221.py` in their entirety -- positive controls included -- on any runner with no `awk` on PATH, and a green leg then read identical whether every supertool-no-cut regression ran or none of them did.

## What changed

- `.github/workflows/tests.yml` now provisions `awk` explicitly for the windows-latest leg and fails the job loudly, naming the cause, if `awk` is still missing after provisioning.
- The three files' duplicated `needs_awk`/`_pattern`/`_awk_matches` trio is now one shared module, `tests/_jit_no_cut_awk.py`.
- `tests/test_jit_no_cut_awk_present_2505.py` turns "awk absent under CI" into an explicit, loud pytest failure instead of a silent skip, exercised both ways (must-fire / must-not-fire).
- `tests/test_ci_windows_awk_provisioned_2505.py` pins the new workflow step through the repo's structural YAML parser rather than a text needle, including that it runs before "Run tests".
- Self-review (Explore + oss:auditor) on the first commit found two gaps, fixed in a follow-up commit: a corrective note unique to the span-stops file's own copy (the real match line for `pre-tool-hook.sh`) had been dropped in the refactor into the shared module, and the new CI-provisioning test never actually read the two literal PATH strings the repair branch writes -- a typo there would not have turned any existing test red.
- A third commit logs the same `needs_awk` shape found in four other jit-context test files to `trap.d/`, out of this issue's own scope (which names exactly the three files above), for the next trap curation pass.

## Testing

`pytest tests/test_jit_no_cut_path_name_1221.py tests/test_jit_no_cut_span_stops_at_a_separator_1565.py tests/test_jit_no_cut_word_boundary_2257.py tests/test_jit_no_cut_awk_present_2505.py tests/test_ci_windows_awk_provisioned_2505.py -q` -- 54 passed, 1 skipped (the CI-only assertion, expected not to fire on a local dev machine), rerun after rebasing this branch onto current master (this lane was cut before #2427 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BpVS77BsxrTDyZ1gmE9UN


[AI-generated]