### PR TITLE
watch dispatcher checks the reload flag during a rate-limit back-off sleep

### DIFF
--- a/changelog.d/2514.fixed.md
+++ b/changelog.d/2514.fixed.md
@@ -1,0 +1,1 @@
+- **watch: a poller mid rate-limit back-off no longer defers a reload signal for up to an hour** (#2514). `_wait_interruptible` now also breaks early on `_RELOAD_FLAG`, the same way it already breaks early on a stop request, so a reload issued during a #2509 back-off (capped at one hour) is picked up within a second rather than at the end of the sleep.

--- a/presets/watch/dispatcher.py
+++ b/presets/watch/dispatcher.py
@@ -1262,9 +1262,17 @@ def _wait_interruptible(seconds: int, stop_flag: dict[str, bool]) -> None:
     returning early. So `unwatch` was honoured within a second by a poller that
     was working and ignored for up to a full interval by one that was not --
     which is exactly the poller an operator is most likely to be stopping.
+
+    Also gives up early on `_RELOAD_FLAG` (#2514): a #2509 rate-limit
+    back-off can sleep here for up to `MAX_RETRY_AFTER_SECONDS` (one hour),
+    and until this checked the flag too, a reload issued mid-back-off sat
+    unapplied for the whole hour -- this was the only place a long sleep
+    ran uninterrupted. The flag is only READ here, never cleared: the outer
+    loop clears it itself, at the top of its own `while`, the one moment it
+    is about to act on it, same as it always has.
     """
     for _ in range(max(0, int(seconds))):
-        if stop_flag["stop"]:
+        if stop_flag["stop"] or _RELOAD_FLAG["reload"]:
             return
         time.sleep(1)
 

--- a/tests/test_watch_reload_midsleep_2514.py
+++ b/tests/test_watch_reload_midsleep_2514.py
@@ -1,0 +1,78 @@
+"""`_wait_interruptible` must also break early on a set `_RELOAD_FLAG` (#2514).
+
+Before this fix it checked only `stop_flag["stop"]` on each 1-second step;
+`_RELOAD_FLAG` was consulted only at the top of the outer poll loop. Since
+#2509 capped a rate-limit back-off at `MAX_RETRY_AFTER_SECONDS` (one hour), a
+poller sleeping through that back-off would not notice a reload signal until
+the whole sleep elapsed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+WATCH_DIR = Path(__file__).parent.parent / "presets" / "watch"
+sys.path.insert(0, str(WATCH_DIR))
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+dispatcher = _load("watch_dispatcher_2514", WATCH_DIR / "dispatcher.py")
+
+
+@pytest.fixture(autouse=True)
+def reset_reload_flag():
+    dispatcher._RELOAD_FLAG["reload"] = False
+    yield
+    dispatcher._RELOAD_FLAG["reload"] = False
+
+
+def test_a_reload_set_mid_backoff_returns_control_well_before_it_elapses(monkeypatch):
+    """A poller parked in a near-max back-off (3600s) must regain control
+    within a handful of seconds of a reload being signalled, not after the
+    whole sleep."""
+    calls = {"n": 0}
+
+    def fake_sleep(_seconds):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            dispatcher._RELOAD_FLAG["reload"] = True
+
+    monkeypatch.setattr(dispatcher.time, "sleep", fake_sleep)
+
+    dispatcher._wait_interruptible(dispatcher.MAX_RETRY_AFTER_SECONDS,
+                                   {"stop": False})
+
+    got = calls["n"]
+    assert got == 3, f"expected the sleep to be interrupted 3 seconds in, got {got} steps"
+
+
+def test_an_ordinary_sleep_with_no_reload_signal_runs_its_full_duration(monkeypatch):
+    """The must-not-fire twin: nothing sets the reload flag or the stop flag,
+    so the full duration must still be slept -- a fix that always returns
+    early would pass the case above for the wrong reason."""
+    calls = {"n": 0}
+
+    def fake_sleep(_seconds):
+        calls["n"] += 1
+
+    monkeypatch.setattr(dispatcher.time, "sleep", fake_sleep)
+
+    dispatcher._wait_interruptible(5, {"stop": False})
+
+    assert calls["n"] == 5
+    assert dispatcher._RELOAD_FLAG["reload"] is False
+
+
+def test_the_change_is_findable():
+    from _changelog_findable import assert_change_is_findable
+    assert_change_is_findable(2514)


### PR DESCRIPTION
Closes #2514.

`_wait_interruptible` checked only `stop_flag["stop"]` on each 1-second sleep step; `_RELOAD_FLAG` was consulted only at the top of the outer poll loop. Since #2509 introduced a rate-limit back-off capped at `MAX_RETRY_AFTER_SECONDS` (one hour), a poller sleeping through that back-off would not notice a reload signal until the whole sleep elapsed -- worst case an hour, versus one ordinary poll interval (commonly 30s) before #2509.

## What changed

`_wait_interruptible` now also returns early on `_RELOAD_FLAG["reload"]`, the same way it already does on a stop. The flag is only read there, never cleared -- the outer loop already clears it itself at the top of its own `while`, the one moment it is about to act on it, so an early return here cannot produce a double-reload or a stuck flag.

Reasoned, not observed in the issue -- confirmed with a test that scripts `time.sleep` to set the flag on its third call during a near-max (3600s) `_wait_interruptible` call and asserts control returns after exactly 3 steps, paired with a must-still-wait control that asserts an ordinary 5-second wait with no signal set runs its full duration.

## Testing

`pytest tests/test_watch_reload_midsleep_2514.py -q` -- 3 passed, rerun after rebasing this branch onto current master (this lane was cut before #2427 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BpVS77BsxrTDyZ1gmE9UN


[AI-generated]